### PR TITLE
Update timing_model.py

### DIFF
--- a/pint/models/timing_model.py
+++ b/pint/models/timing_model.py
@@ -112,6 +112,7 @@ class TimingModel(object):
         s = "Available parameters for %s\n" % self.__class__
         for par in self.params:
             s += "%s\n" % getattr(self, par).help_line()
+        return s
 
     @Cache.use_cache
     def phase(self, toa):


### PR DESCRIPTION
param_help did not actually return the help string. Now it does
