### PR TITLE
Update observatories.py

### DIFF
--- a/pint/observatories.py
+++ b/pint/observatories.py
@@ -8,6 +8,22 @@ from pint import pintdir
 class observatory(object):
     pass
 
+def read_clock_file(filen):
+    file = open(filen)
+    mjds = []
+    ccorr = []
+    for l in file.readlines():
+        try:
+            m = float(l[0:9])
+            c = float(l[24:33])
+            mjds.append(m)
+            ccorr.append(c)
+        except:
+            pass
+
+    return numpy.asarray(mjds), numpy.asarray(ccorr)
+
+
 def get_clock_corr_vals(obsname, **kwargs):
     """
     get_clock_corr_vals(obsname, **kwargs)
@@ -34,9 +50,11 @@ def get_clock_corr_vals(obsname, **kwargs):
         return (numpy.array([0.0, 100000.0]), numpy.array([0.0, 0.0]))
     # The following works for simple linear interpolation
     # of normal TEMPO-style clock correction files
-    mjds, ccorr = numpy.loadtxt(filenm, skiprows=2,
-                                usecols=(0, 2), unpack=True)
+
+    mjds, ccorr = read_clock_file(filenm)
+
     return mjds, ccorr
+
 
 def read_observatories():
     """Load observatory data files and return them.


### PR DESCRIPTION
The clock corrections were read with a numpy.loadtxt call, and this only works if the clock file has no unexpected entries. Alas, in the Parkes file and maybe in others there are empty clock values and other problems, and so it crashes. 
If we stick to TEMPO-style clock files, we should tell the clock file reader the exact number of digits to read into the float values. This is a quick and dirty solution; there are probably faster ways you can imagine, in which case feel free to discard this pull request and change it with your preferred solution.