### PR TITLE
Fixed import issue caused by move of sphinx stuff 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+coverage
+doc/_build
+doc/api
 
 # Translations
 *.mo
@@ -43,6 +46,9 @@ datafiles/naif0010.tls
 datafiles/naif0011.tls
 datafiles/pck00010.tpc
 datafiles/de-403-masses.tpc
+
+# Pickles of .tim files
+*.tim.pickle.gz
 
 # TEMPO stuff
 *matrix.tmp

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,9 +27,9 @@ sys.path.insert(0, os.path.abspath('..'))
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.coverage',
               'sphinx.ext.mathjax', 'sphinx.ext.viewcode',
-              'astropy.sphinx.ext.numpydoc',
-              'astropy.sphinx.ext.automodapi',
-              'astropy.sphinx.ext.automodsumm']
+              'astropy_helpers.sphinx.ext.numpydoc',
+              'astropy_helpers.sphinx.ext.automodapi',
+              'astropy_helpers.sphinx.ext.automodsumm']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
With astropy 1.0, the sphinx extensions have been moved from astropy itself to astropy_helpers
This fix allows "make html" to work in the doc directory with astropy 1.0 and later.
@scottransom 