### PR TITLE
FIXED: high_precision=False in test_model.py. Otherwise we cannot plot.

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -33,7 +33,7 @@ if log.level < 25:
     t.print_summary()
 log.info("Read/corrected TOAs in %.3f sec" % time_toa)
 
-mjds = t.get_mjds()
+mjds = t.get_mjds(high_precision=False)
 errs = t.get_errors()
 
 log.info("Computing residuals...")


### PR DESCRIPTION
matplotlib cannot convert the astropy time objects to doubles. Setting high_precision=False makes get_mjds() return a numpy array of doubles.