### PR TITLE
Base_value add valueError

### DIFF
--- a/pint/models/parameter.py
+++ b/pint/models/parameter.py
@@ -144,7 +144,7 @@ class Parameter(object):
     def base_value(self,val):
         self._base_value = val
         if not isinstance(val, numbers.Number):
-            return
+            raise ValueError('Base_value has to be a pure number.')
         if self.get_value is None:
             self.value = self._base_value*self.base_unit
         else:


### PR DESCRIPTION
Add a valueError for base_value. Make sure base_value is a number. 

-Luo Jing