### PR TITLE
tempo1 clock file parsing

### DIFF
--- a/pint/observatories.py
+++ b/pint/observatories.py
@@ -8,6 +8,63 @@ from pint import pintdir
 class observatory(object):
     pass
 
+def load_tempo1_clock_file(filename,site=None):
+    """
+    Given the specified full path to the tempo1-format clock file, 
+    will return two numpy arrays containing the MJDs and the clock
+    corrections.  All computations here are done as in tempo, with
+    the exception of the 'F' flag (to disable interpolation), which
+    is currently not implemented.
+
+    INCLUDE statments are not currently processed (they will be 
+    ignored).
+
+    If the 'site' argument is set to an appropriate one-character tempo
+    site code, only values for that site will be returned, otherwise all
+    values found in the file will be returned.
+    """
+    mjds = []
+    clkcorrs = []
+    for l in open(filename).readlines():
+        # Ignore comment lines
+        if l.startswith('#'): continue
+        # Parse MJD
+        try:
+            mjd = float(l[0:9])
+            if mjd<39000 or mjd>100000: mjd=None
+        except (ValueError, IndexError):
+            mjd = None
+        # Parse two clkcorr values
+        try:
+            clkcorr1 = float(l[9:21])
+        except (ValueError, IndexError):
+            clkcorr1 = None
+        try:
+            clkcorr2 = float(l[21:33])
+        except (ValueError, IndexError):
+            clkcorr2 = None
+
+        # Site code on clock file line must match
+        try:
+            csite = l[34].lower()
+        except IndexError:
+            csite = None
+        if (site is not None) and (site.lower()!=csite): continue
+
+        # Need MJD and at least one of the two clkcorrs
+        if mjd is None: continue
+        if (clkcorr1 is None) and (clkcorr2 is None): continue
+        # If one of the clkcorrs is missing, it defaults to zero
+        if clkcorr1 is None: clkcorr1 = 0.0
+        if clkcorr2 is None: clkcorr2 = 0.0
+        # This adjustment is hard-coded in tempo:
+        if clkcorr1>800.0: clkcorr1 -= 818.8
+        # Add the value to the list
+        mjds.append(mjd)
+        clkcorrs.append(clkcorr2 - clkcorr1)
+
+    return numpy.array(mjds), numpy.array(clkcorrs)
+    
 def get_clock_corr_vals(obsname, **kwargs):
     """
     get_clock_corr_vals(obsname, **kwargs)
@@ -37,17 +94,14 @@ def get_clock_corr_vals(obsname, **kwargs):
     else:
         log.error("No clock correction valus for %s" % obsname)
         return (numpy.array([0.0, 100000.0]), numpy.array([0.0, 0.0]))
+
     # The following works for simple linear interpolation
     # of normal TEMPO-style clock correction files
-    if obsname == "Parkes":
-        # Parkes clock correction file changes which column is used part way through
-        # This skips all pre-GPS data (50844.73 = 1998 Jan 31),
-        # and goes to the point where the 'GPS-PKS' column is populated
-        mjds, ccorr = numpy.loadtxt(filenm, skiprows=1003,
-                                    usecols=(0, 2), unpack=True)
-    else:
-        mjds, ccorr = numpy.loadtxt(filenm, skiprows=2,
-                                    usecols=(0, 2), unpack=True)
+    # Find the 1-character tempo code, this is necessary for properly
+    # reading the file.
+    obs = read_observatories()
+    site = next((x for x in obs[obsname].aliases if len(x)==1), None)
+    mjds, ccorr = load_tempo1_clock_file(filenm,site=site)
     return mjds, ccorr
 
 def read_observatories():

--- a/tests/test_clockcorr.py
+++ b/tests/test_clockcorr.py
@@ -1,0 +1,17 @@
+import pint.observatories
+import numpy
+import unittest
+
+class TestClockcorrection(unittest.TestCase):
+    # Note, these tests currently depend on external data (TEMPO clock
+    # files, which could potentially change.  Values here are taken
+    # from tempo version 2016-01-27 2bb9277
+    def test_Parkes(self):
+        mjd, corr = pint.observatories.get_clock_corr_vals('Parkes')
+        assert numpy.isclose(mjd.min(), 44000.0)
+
+        idx = numpy.where(numpy.isclose(mjd,49990.0))[0][0]
+        assert numpy.isclose(corr[idx],-2.506)
+
+        idx = numpy.where(numpy.isclose(mjd,55418.27))[0][0]
+        assert numpy.isclose(corr[idx],-0.586)


### PR DESCRIPTION
This function parses tempo1 clock files in a way more consistent with how tempo actually does it.  The main differences are:  to parse values based on fixed character offsets within the line (fortran-style) rather than expecting a certain number of columns; and use the info provided in both clock offset columns.  I don't know the historical reasons for having two columns, but it doesn't really matter.  If we are going to read these files we should use them the same way tempo does.

Features in tempo that are not currently implemented here are the ability to have INCLUDE statements in time files, and to disable interpolation for  certain data points (via the 'f' flag).