### PR TITLE
Generate Fake TOAs

### DIFF
--- a/examples/zima.py
+++ b/examples/zima.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python -W ignore::FutureWarning -W ignore::UserWarning -W ignore::DeprecationWarning
+"""PINT-based tool for making simulated TOAs
+
+"""
+from __future__ import division, print_function
+
+import os,sys
+import numpy as np
+import pint.toa as toa
+import pint.models
+import pint.fitter
+import pint.residuals
+import astropy.units as u
+import matplotlib.pyplot as plt
+from astropy.time import Time
+import argparse
+
+from astropy import log
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="PINT tool for simulating TOAs")
+    parser.add_argument("parfile",help="par file to read model from")
+    parser.add_argument("timfile",help="Output TOA file name")
+    parser.add_argument("--plot",help="Plot residuals",action="store_true",default=False)
+    args = parser.parse_args()
+
+    log.info("Reading model from {0}".format(args.parfile))
+    m = pint.models.get_model(args.parfile)
+
+    ntoa = 100
+    duration = 400*u.day
+    start = Time(56000.0,scale='utc',format='mjd')
+    error = 1.0e-6*u.s
+    freq = 1400.0*u.MHz
+    scale = 'utc'
+
+    times = np.linspace(0,duration.to(u.day).value,ntoa)*u.day + start
+    
+    tl = [toa.TOA(t,error=error, obs=obs, freq=freq,
+                 scale=scale) for t in times]
+                 
+    ts = toa.TOAs(toalist=tl)
+    
+    

--- a/examples/zima.py
+++ b/examples/zima.py
@@ -12,7 +12,7 @@ import pint.fitter
 import pint.residuals
 import astropy.units as u
 import matplotlib.pyplot as plt
-from astropy.time import Time
+from astropy.time import Time, TimeDelta
 import argparse
 
 from astropy import log
@@ -59,8 +59,17 @@ if __name__ == '__main__':
                  
     
     rs = pint.residuals.resids(ts, m).time_resids
+    plt.plot(ts.get_mjds(),rs.to(u.us),'o')
     
-    
-    ts = ts - rs
+    # Adjust the TOA times to put them where their residuals will be 0.0
+    ts.adjust_TOAs(TimeDelta(-1.0*rs))
+
+    rspost = pint.residuals.resids(ts, m).time_resids
+    plt.plot(ts.get_mjds(),rspost.to(u.us),'x')
+
+     # Write TOAs to a file
+    ts.write_TOA_file(args.timfile,name='fake',format='Tempo2')
+   
+    plt.show()
     
     

--- a/pint/models/timing_model.py
+++ b/pint/models/timing_model.py
@@ -53,7 +53,7 @@ class Cache(object):
                         # Evaluate the function and cache the results
                         log.debug(" ... computing new result")
                         result = function(*args, **kwargs)
-                        setattr(cache, the_func, result)
+                        #setattr(cache, the_func, result)
                         return result
             # Couldn't access the cache, just return the result
             # without caching it.
@@ -84,7 +84,7 @@ class Cache(object):
                     return function(*args, **kwargs)
                 else:
                     # Init the cache, excute the function, then delete cache
-                    setattr(args[0], cls.the_cache, cls())
+                    #setattr(args[0], cls.the_cache, cls())
                     result = function(*args, **kwargs)
                     setattr(args[0], cls.the_cache, None)
                     return result

--- a/pint/models/timing_model.py
+++ b/pint/models/timing_model.py
@@ -53,7 +53,7 @@ class Cache(object):
                         # Evaluate the function and cache the results
                         log.debug(" ... computing new result")
                         result = function(*args, **kwargs)
-                        #setattr(cache, the_func, result)
+                        setattr(cache, the_func, result)
                         return result
             # Couldn't access the cache, just return the result
             # without caching it.
@@ -84,7 +84,7 @@ class Cache(object):
                     return function(*args, **kwargs)
                 else:
                     # Init the cache, excute the function, then delete cache
-                    #setattr(args[0], cls.the_cache, cls())
+                    setattr(args[0], cls.the_cache, cls())
                     result = function(*args, **kwargs)
                     setattr(args[0], cls.the_cache, None)
                     return result

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -260,6 +260,25 @@ class TOA(object):
                  error=0.0, obs='Barycenter', freq=float("inf"),
                  scale='utc', # with defaults
                  **kwargs):  # keyword args that are completely optional
+        r"""
+        Construct a TOA object
+        
+        Parameters
+        ----------
+        MJD : astropy Time, float, or tuple of floats
+            The time of the TOA, which can be expressed as an astropy Time,
+            a floating point MJD (64 or 128 bit precision), or a tuple
+            of (MJD1,MJD2) whose sum is the full precision MJD (usually the 
+            integer and fractional part of the MJD)
+        obs : string
+            The observatory code for the TOA
+        freq : float or astropy Quantity
+            Frequency corresponding to the TOA.  Either a Quantity with frequency
+            units, or a number for which MHz is assumed.
+        scale : string
+            Time scale for the TOA time.  Usually 'utc'
+                    
+        """
         if obs == "Barycenter":
             # Barycenter overrides the scale argument with 'tdb' always.
             if type(MJD) in [float, numpy.float64, numpy.float128]:
@@ -307,7 +326,9 @@ class TOA(object):
             # Not sure what I was trying to test for with this. -- paulr
             #if  location is not None:
             #    raise ValueError("Specifying location for observatory TOAs is not currently supported.")
-            if type(MJD) in [float, numpy.float64, numpy.float128]:
+            if type(MJD) == time.Time:
+                self.mjd = MJD
+            elif type(MJD) in [float, numpy.float64, numpy.float128]:
                 self.mjd = time.Time(MJD, scale=scale, format='mjd',
                                     location=observatories[obs].loc,
                                     precision=9)

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -327,7 +327,13 @@ class TOA(object):
             units, or a number for which MHz is assumed.
         scale : string
             Time scale for the TOA time.  Usually 'utc'
-                    
+
+        Notes
+        -----
+        It is VERY important that all astropy.Time() objects are created
+        with precision=9. This is ensured in the code and is checked for any
+        Time object passed to the TOA constructor.
+                            
         """
         if obs == "Barycenter":
             # Barycenter overrides the scale argument with 'tdb' always.
@@ -378,6 +384,10 @@ class TOA(object):
             #    raise ValueError("Specifying location for observatory TOAs is not currently supported.")
             if type(MJD) == time.Time:
                 self.mjd = MJD
+                # Make sure precision is high enough!
+                if self.mjd.precision < 9:
+                    log.warning('TOA passed with poor precision ({0})'.format(self.mjd.precision))
+                self.mjd.precision = 9
             elif type(MJD) in [float, numpy.float64, numpy.float128]:
                 self.mjd = time.Time(MJD, scale=scale, format='mjd',
                                     location=observatories[obs].loc,
@@ -421,6 +431,7 @@ class TOAs(object):
         self.commands = []
         self.observatories = set()
         self.filename = None
+        self.planets = False
         if toaTable is not None:
             self.table = toaTable
             self.ntoas = len(self.table)


### PR DESCRIPTION
Generating fake TOAs is useful for several things, including making datasets for doing tests.
This PR includes:
* The ability to format TOAs as Tempo2 or Princeton format strings for output to a .tim file
* The ability to init a `TOA()` with an `astropy.Time`
* The ability to apply a vector of time adjustments to a TOA table
* A very simple top level script (currently called `zima.py`, as in fake beer) that generates a set of TOAs for a given frequency, observatory, and cadence, with 0 residual for a specific model, and writes them out as a .tim file.  This could be expanded to do a lot more things, like adding white and red noise and so on.
