### PR TITLE
Convert uses of np.float128 to np.longdoble

### DIFF
--- a/pint/fermi_toas.py
+++ b/pint/fermi_toas.py
@@ -131,25 +131,25 @@ def load_Fermi_TOAs(ft1name,ft2name=None,weightcolumn=None,targetcoord=None,loge
 
     # Collect TIMEZERO and MJDREF
     try:
-        TIMEZERO = np.float128(ft1hdr['TIMEZERO'])
+        TIMEZERO = np.longdouble(ft1hdr['TIMEZERO'])
     except KeyError:
-        TIMEZERO = np.float128(ft1hdr['TIMEZERI']) + np.float128(ft1hdr['TIMEZERF'])
+        TIMEZERO = np.longdouble(ft1hdr['TIMEZERI']) + np.longdouble(ft1hdr['TIMEZERF'])
     #print >>outfile, "# TIMEZERO = ",TIMEZERO
     log.info("TIMEZERO = {0}".format(TIMEZERO))
     try:
-        MJDREF = np.float128(ft1hdr['MJDREF'])
+        MJDREF = np.longdouble(ft1hdr['MJDREF'])
     except KeyError:
         # Here I have to work around an issue where the MJDREFF key is stored
         # as a string in the header and uses the "1.234D-5" syntax for floats, which
         # is not supported by Python
         if isinstance(ft1hdr['MJDREFF'],basestring):
-            MJDREF = np.float128(ft1hdr['MJDREFI']) + \
-            np.float128(ft1hdr['MJDREFF'].replace('D','E'))
+            MJDREF = np.longdouble(ft1hdr['MJDREFI']) + \
+            np.longdouble(ft1hdr['MJDREFF'].replace('D','E'))
         else:
-            MJDREF = np.float128(ft1hdr['MJDREFI']) + np.float128(ft1hdr['MJDREFF'])
+            MJDREF = np.longdouble(ft1hdr['MJDREFI']) + np.longdouble(ft1hdr['MJDREFF'])
     #print >>outfile, "# MJDREF = ",MJDREF
     log.info("MJDREF = {0}".format(MJDREF))
-    mjds = np.array(ft1dat.field('TIME'),dtype=np.float128)/86400.0 + MJDREF + TIMEZERO
+    mjds = np.array(ft1dat.field('TIME'),dtype=np.longdouble)/86400.0 + MJDREF + TIMEZERO
     energies = ft1dat.field('ENERGY')*u.MeV
     if weightcolumn is not None:
         if weightcolumn == 'CALC':

--- a/pint/models/dd.py
+++ b/pint/models/dd.py
@@ -56,7 +56,7 @@ def DD_delay_func(t, PB, T0, A1, OM=0.0, ECC=0.0, EDOT=0.0, PBDOT=0.0, XDOT=0.0,
     @param sini:    Sine of inclination angle
     """
     # TODO (RvH): How do I get the solMass in seconds using astropy?
-    SUNMASS         = np.float128('4.925490947e-6')
+    SUNMASS         = np.longdouble('4.925490947e-6')
 
     # TODO (RvH):
     # - XPBDOT is completely covariant with PBDOT. Why is it included in Tempo2?

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -264,7 +264,7 @@ class TOA(object):
         """
         if obs == "Barycenter":
             # Barycenter overrides the scale argument with 'tdb' always.
-            if np.isscalar(MJD):
+            if numpy.isscalar(MJD):
                 self.mjd = time.Time(MJD, scale='tdb', format='mjd',
                                     precision=9)
             else:
@@ -278,7 +278,7 @@ class TOA(object):
             # corrected to the Geocenter with gtbary tcorrect=GEO
             # Certainly (0,0,0) is the right answer for the solar system
             # delays and such.
-            if np.isscalar(MJD):
+            if numpy.isscalar(MJD):
                 self.mjd = time.Time(MJD, scale=scale, format='mjd',
                                     location=EarthLocation(0.0,0.0,0.0),
                                     precision=9)
@@ -298,7 +298,7 @@ class TOA(object):
                 raise ValueError("Spacecraft TOAs require gcrslocation to be specified.")
             if not isinstance(kwargs['gcrslocation'],coord.GCRS):
                 raise ValueError("gcrslocation must be an astropy.coordinates.GCRS instance")
-            if np.isscalar(MJD):
+            if numpy.isscalar(MJD):
                 self.mjd = time.Time(MJD, scale=scale, format='mjd',
                                     precision=9)
             else:
@@ -315,7 +315,7 @@ class TOA(object):
                 if self.mjd.precision < 9:
                     log.warning('TOA passed with poor precision ({0})'.format(self.mjd.precision))
                 self.mjd.precision = 9
-            elif np.isscalar(MJD):
+            elif numpy.isscalar(MJD):
                 self.mjd = time.Time(MJD, scale=scale, format='mjd',
                                     location=observatories[obs].loc,
                                     precision=9)

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -264,7 +264,7 @@ class TOA(object):
         """
         if obs == "Barycenter":
             # Barycenter overrides the scale argument with 'tdb' always.
-            if type(MJD) in [float, numpy.float64, numpy.float128]:
+            if np.isscalar(MJD):
                 self.mjd = time.Time(MJD, scale='tdb', format='mjd',
                                     precision=9)
             else:
@@ -278,7 +278,7 @@ class TOA(object):
             # corrected to the Geocenter with gtbary tcorrect=GEO
             # Certainly (0,0,0) is the right answer for the solar system
             # delays and such.
-            if type(MJD) in [float, numpy.float64, numpy.float128]:
+            if np.isscalar(MJD):
                 self.mjd = time.Time(MJD, scale=scale, format='mjd',
                                     location=EarthLocation(0.0,0.0,0.0),
                                     precision=9)
@@ -298,7 +298,7 @@ class TOA(object):
                 raise ValueError("Spacecraft TOAs require gcrslocation to be specified.")
             if not isinstance(kwargs['gcrslocation'],coord.GCRS):
                 raise ValueError("gcrslocation must be an astropy.coordinates.GCRS instance")
-            if type(MJD) in [float, numpy.float64, numpy.float128]:
+            if np.isscalar(MJD):
                 self.mjd = time.Time(MJD, scale=scale, format='mjd',
                                     precision=9)
             else:
@@ -315,7 +315,7 @@ class TOA(object):
                 if self.mjd.precision < 9:
                     log.warning('TOA passed with poor precision ({0})'.format(self.mjd.precision))
                 self.mjd.precision = 9
-            elif type(MJD) in [float, numpy.float64, numpy.float128]:
+            elif np.isscalar(MJD):
                 self.mjd = time.Time(MJD, scale=scale, format='mjd',
                                     location=observatories[obs].loc,
                                     precision=9)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # First, build the documentation
-# Currently this fails with an error about not being able to import numpydoc
 MODULE=pint
+# The make latexpdf is not working at the moment...
 #(cd doc && make html && make latexpdf)
-#(cd doc && make html)
+(cd doc && make html)
 
 PYTHONPATH="`pwd`:$PYTHONPATH"
 NOSETESTS=`which nosetests 2> /dev/null`


### PR DESCRIPTION
Simple PR to remove uses of `float128`, which is not portable to all architectures. Using `np.longdouble` is preferred.