### PR TITLE
Changed bounded priors to be inclusive of endpoints.  

### DIFF
--- a/examples/event_optimize.py
+++ b/examples/event_optimize.py
@@ -474,9 +474,9 @@ if __name__ == '__main__':
     plot_chains(chains, file=ftr.model.PSR.value+"_chains.png")
 
     # Make the triangle plot.
+    samples = sampler.chain[:, burnin:, :].reshape((-1, ndim))
     try:
         import corner
-        samples = sampler.chain[:, burnin:, :].reshape((-1, ndim))
         # Note, I had to turn off plot_contours because I kept getting
         # errors about how contour levels must be increasing.
         fig = corner.corner(samples, labels=ftr.fitkeys, bins=20,

--- a/pint/models/priors.py
+++ b/pint/models/priors.py
@@ -95,11 +95,11 @@ class UniformBoundedRV(rv_continuous):
         self.norm = np.float64(1.0/(upper_bound-lower_bound))
                 
     def _pdf(self,x):
-        ret = np.where(np.logical_and(x>self.lower,x<self.upper),self.norm,0.0)
+        ret = np.where(np.logical_and(x>=self.lower,x<=self.upper),self.norm,0.0)
         return ret
         
     def _logpdf(self,x):
-        ret = np.where(np.logical_and(x>self.lower,x<self.upper),
+        ret = np.where(np.logical_and(x>=self.lower,x<=self.upper),
                        np.log(self.norm), -np.inf)
         return ret
 
@@ -124,12 +124,12 @@ class GaussianBoundedRV(rv_continuous):
         self.norm = 1.0/(self.gaussian.cdf(upper_bound)-self.gaussian.cdf(lower_bound))
                 
     def _pdf(self,x):
-        ret = np.where(np.logical_and(x>self.lower,x<self.upper), 
+        ret = np.where(np.logical_and(x>=self.lower,x<=self.upper), 
             self.norm*self.gaussian.pdf(x), 0.0)
         return ret
         
     def _logpdf(self,x):
-        ret = np.where(np.logical_and(x>self.lower,x<self.upper),
+        ret = np.where(np.logical_and(x>=self.lower,x<=self.upper),
                        np.log(self.norm)*self.gaussian.logpdf(x), -np.inf)
         return ret
        


### PR DESCRIPTION
This change allows E==0.0 when you set UniformBoundedPrior(0.0,1.0).  It also allows 1.0, so we might want to consider whether we need to implement [lower,upper], (lower,upper], and [lower,upper).  But for now, I think that just allowing inclusive ranges should be OK.  For something like SINI, it is certainly appropriate.