### PR TITLE
Fix event_optimize.py bug

### DIFF
--- a/examples/event_optimize.py
+++ b/examples/event_optimize.py
@@ -107,7 +107,7 @@ def get_fit_keyvals(model):
     fiterrs = []
     for p in fitkeys:
         fitvals.append(getattr(model, p).num_value)
-        fiterrs.append(getattr(model, p).uncertainty)
+        fiterrs.append(getattr(model, p).num_uncertainty)
     return fitkeys, np.asarray(fitvals), np.asarray(fiterrs)
 
 class emcee_fitter(fitter.fitter):


### PR DESCRIPTION
One line fix to use @luojing1211's new `parameter.num_uncertainty` to get the uncertainty with no units for the fitter.