### PR TITLE
Data file locations for test scripts

### DIFF
--- a/examples/fit_NGC6440E.py
+++ b/examples/fit_NGC6440E.py
@@ -5,10 +5,11 @@ import pint.fitter
 import pint.residuals
 import matplotlib.pyplot as plt
 import astropy.units as u
-import sys
+import os, sys
 
-parfile = 'examples/NGC6440E.par'
-timfile = 'examples/NGC6440E.tim'
+datadir = os.path.dirname(os.path.abspath(__file__))
+parfile = os.path.join(datadir, 'NGC6440E.par')
+timfile = os.path.join(datadir, 'NGC6440E.tim')
 
 # Define the timing model
 m = pint.models.StandardTimingModel()

--- a/tests/pinttestdata.py
+++ b/tests/pinttestdata.py
@@ -1,0 +1,12 @@
+# pinttestdata.py
+
+# import this to get the location of the datafiles for tests.  This file 
+# must be kept in the appropriate location relative to the test data
+# dir for this to work.
+
+import os
+
+# Location of this file and the test data scripts
+testdir = os.path.dirname(os.path.abspath(__file__))
+datadir = os.path.join(testdir, 'datafile')
+

--- a/tests/test_bt.py
+++ b/tests/test_bt.py
@@ -5,8 +5,7 @@ import numpy as np
 import pint.models.bt as bt
 import os
 
-datapath = os.path.join(os.environ['PINT'],'tests','datafile')
-
+from pinttestdata import testdir, datadir
 
 class TestBT():
     """Various tests to assess the performance of the BT model."""
@@ -14,8 +13,8 @@ class TestBT():
     def test_1955(self):
         """Compare delays from the BT model with libstempo and PINT"""
 
-        parfile = os.path.join(datapath, 'J1955.par')
-        timfile = os.path.join(datapath, 'J1955.tim')
+        parfile = os.path.join(datadir, 'J1955.par')
+        timfile = os.path.join(datadir, 'J1955.tim')
 
         # Calculate delays with PINT
         toas = toa.get_TOAs(timfile, planets=False)
@@ -24,7 +23,7 @@ class TestBT():
         pint_delays = newmodel.delay(toas.table)
 
         # Load delays calculated with libstempo
-        _, lt_delays = np.genfromtxt(os.path.join(datapath,
+        _, lt_delays = np.genfromtxt(os.path.join(datadir,
                                      'J1955_ltdelays.dat'), unpack=True)
 
         assert np.all(np.abs(pint_delays - lt_delays) < 1e-11), 'BT TEST FAILED'

--- a/tests/test_dd.py
+++ b/tests/test_dd.py
@@ -10,8 +10,8 @@ from pint.models.pint_dd_model import DDwrapper
 import numpy as np
 import os, unittest
 
-testdir=os.path.join(os.getenv('PINT'),'tests');
-datadir = os.path.join(testdir,'datafile')
+from pinttestdata import testdir, datadir
+
 os.chdir(datadir)
 
 class TestDD(unittest.TestCase):

--- a/tests/test_dmx.py
+++ b/tests/test_dmx.py
@@ -8,14 +8,13 @@ import os
 import unittest
 import numpy as np
 
-datapath = os.path.join(os.environ['PINT'], 'tests', 'datafile')
-
+from pinttestdata import testdir, datadir
 
 class TestDMX(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.parf = os.path.join(datapath, 'B1855+09_NANOGrav_dfg+12_DMX.par')
-        self.timf = os.path.join(datapath, 'B1855+09_NANOGrav_dfg+12.tim')
+        self.parf = os.path.join(datadir, 'B1855+09_NANOGrav_dfg+12_DMX.par')
+        self.timf = os.path.join(datadir, 'B1855+09_NANOGrav_dfg+12.tim')
         self.DMXm = mb.get_model(self.parf)
         self.toas = toa.get_TOAs(self.timf, ephem='DE405')
 

--- a/tests/test_fitter.py
+++ b/tests/test_fitter.py
@@ -7,14 +7,14 @@ from pint import fitter
 import matplotlib.pyplot as plt
 import numpy
 
-testdir=os.path.join(os.getenv('PINT'), 'tests', 'datafile');
+from pinttestdata import testdir, datadir
 
 # Get model
 m = tm.StandardTimingModel()
-m.read_parfile(os.path.join(testdir,'NGC6440E.par'))
+m.read_parfile(os.path.join(datadir,'NGC6440E.par'))
 
 # Get TOAs
-t = toa.TOAs(os.path.join(testdir,'NGC6440E.tim'),usepickle=False)
+t = toa.TOAs(os.path.join(datadir,'NGC6440E.tim'),usepickle=False)
 t.apply_clock_corrections()
 t.compute_TDBs()
 try:
@@ -81,4 +81,4 @@ plt.legend([p1,p2,p3,p4,p5,p6],['Initial','4-param','Perturb F1',
                                 'Fit F0,F1,RA,DEC with method="Powell"'],
            loc=3)
 #plt.show()
-plt.savefig(os.path.join(testdir,"test_fitter_plot.pdf"))
+plt.savefig(os.path.join(datadir,"test_fitter_plot.pdf"))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -9,11 +9,11 @@ import matplotlib.pyplot as plt
 import tempo2_utils
 from astropy import log
 
+from pinttestdata import testdir, datadir
+
 log.setLevel('ERROR')
 # for nice output info, set the following instead
 #log.setLevel('INFO')
-testdir=os.path.join(os.getenv('PINT'),'tests');
-datadir = os.path.join(testdir,'datafile')
 os.chdir(datadir)
 
 parfile = 'J1744-1134.basic.par'

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -6,8 +6,7 @@ import astropy.time as time
 import astropy.units as u
 import numpy, os, unittest
 
-testdir=os.path.join(os.getenv('PINT'),'tests');
-datadir = os.path.join(testdir,'datafile')
+from pinttestdata import testdir, datadir
 os.chdir(datadir)
 
 class TestParameters(unittest.TestCase):

--- a/tests/test_prefix.py
+++ b/tests/test_prefix.py
@@ -9,9 +9,10 @@ import sys
 import os
 import unittest
 
-datapath = os.path.join(os.environ['PINT'], 'tests', 'datafile')
-parfile = os.path.join(datapath, 'prefixtest.par')
-timfile = os.path.join(datapath, 'prefixtest.tim')
+from pinttestdata import testdir, datadir
+
+parfile = os.path.join(datadir, 'prefixtest.par')
+timfile = os.path.join(datadir, 'prefixtest.tim')
 
 
 class TestPrefix(unittest.TestCase):

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -7,8 +7,7 @@ from pint.models.priors import *
 from scipy.stats import norm
 import os
 
-testdir=os.path.join(os.getenv('PINT'),'tests');
-datadir = os.path.join(testdir,'datafile')
+from pinttestdata import testdir, datadir
 os.chdir(datadir)
 
 class TestPriors(unittest.TestCase):

--- a/tests/test_times.py
+++ b/tests/test_times.py
@@ -7,8 +7,7 @@ from pint.utils import PosVel
 from astropy import log
 import os
 
-testdir=os.path.join(os.getenv('PINT'),'tests');
-datadir = os.path.join(testdir,'datafile')
+from pinttestdata import testdir, datadir
 
 log.setLevel('ERROR')
 # for nice output info, set the following instead

--- a/tests/test_toa_pickle.py
+++ b/tests/test_toa_pickle.py
@@ -2,8 +2,8 @@
 from pint import toa
 import os
 
-testdir=os.path.join(os.getenv('PINT'),'tests','datafile');
-os.chdir(testdir)
+from pinttestdata import testdir, datadir
+os.chdir(datadir)
 
 class TestTOAReader:
     def setUp(self):

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -1,8 +1,7 @@
 from pint import toa
 import os
 
-testdir = os.path.join(os.getenv('PINT'),'tests');
-datadir = os.path.join(testdir,'datafile')
+from pinttestdata import testdir, datadir
 os.chdir(datadir)
 
 class TestTOAReader:


### PR DESCRIPTION
This uses a `__file__` based approach to find the location of data files for the test scripts, replacing use of the PINT environment variable for this.  Test scripts can "import pinttestdata" to get the full path to the data file directory.

I also edited the examples/fit_NGC6440E.py script similarly so that it does not need to be run from a specific directory.