### PR TITLE
Enable str2longdouble handle fortun format

### DIFF
--- a/pint/utils.py
+++ b/pint/utils.py
@@ -314,10 +314,11 @@ def ddouble2ldouble(t1, t2, format='jd'):
     return t[0]+t[1]
 
 
-def str2longdouble(str):
+def str2longdouble(str_data):
     """Return a numpy long double scalar from the input string, using strtold()
     """
-    return str2ldarr1(str)[0]
+    input_str = str_data.translate(string.maketrans('Dd', 'ee'))
+    return str2ldarr1(input_str)[0]
 
 
 def split_prefixed_name(name):


### PR DESCRIPTION
In the old version, str2longdouble can not handle a fortran format data , for example 1.8D-5. This change will enable str2longdouble to handle this type of data. 