### PR TITLE
change dmx time compare to a low presicion one

### DIFF
--- a/pint/models/dispersion_model.py
+++ b/pint/models/dispersion_model.py
@@ -117,12 +117,13 @@ class DispersionDMX(Dispersion):
         DMXR2_mapping = self.get_prefix_mapping('DMXR2_')
         if 'DMX_section' not in toas.keys():
             toas['DMX_section'] = np.zeros_like(toas['index'])
+            mjds = np.array([t.mjd for t in toas['mjd']])
             epoch_ind = 1
             while epoch_ind in DMX_mapping:
                 # Get the parameters
                 r1 = getattr(self, DMXR1_mapping[epoch_ind]).quantity
                 r2 = getattr(self, DMXR2_mapping[epoch_ind]).quantity
-                msk = np.logical_and(toas['mjd'] >= r1, toas['mjd'] <= r2)
+                msk = np.logical_and(mjds >= r1.mjd, mjds <= r2.mjd)
                 toas['DMX_section'][msk] = epoch_ind
                 epoch_ind = epoch_ind + 1
 

--- a/pint/models/dispersion_model.py
+++ b/pint/models/dispersion_model.py
@@ -117,13 +117,12 @@ class DispersionDMX(Dispersion):
         DMXR2_mapping = self.get_prefix_mapping('DMXR2_')
         if 'DMX_section' not in toas.keys():
             toas['DMX_section'] = np.zeros_like(toas['index'])
-            mjds = np.array([t.mjd for t in toas['mjd']])
             epoch_ind = 1
             while epoch_ind in DMX_mapping:
                 # Get the parameters
                 r1 = getattr(self, DMXR1_mapping[epoch_ind]).quantity
                 r2 = getattr(self, DMXR2_mapping[epoch_ind]).quantity
-                msk = np.logical_and(mjds >= r1.mjd, mjds <= r2.mjd)
+                msk = np.logical_and(toas['mjd_float'] >= r1.mjd, toas['mjd_float'] <= r2.mjd)
                 toas['DMX_section'][msk] = epoch_ind
                 epoch_ind = epoch_ind + 1
 

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -393,13 +393,14 @@ class TOAs(object):
 
         if not hasattr(self, 'table'):
             mjds = self.get_mjds(high_precision=True)
+            mjds_low = self.get_mjds()*u.day
             self.first_MJD = mjds.min()
             self.last_MJD = mjds.max()
             # The table is grouped by observatory
-            self.table = table.Table([numpy.arange(self.ntoas), mjds,
+            self.table = table.Table([numpy.arange(self.ntoas), mjds, mjds_low,
                                       self.get_errors(), self.get_freqs(),
                                       self.get_obss(), self.get_flags()],
-                                      names=("index", "mjd", "error", "freq",
+                                      names=("index", "mjd", "mjd_float", "error", "freq",
                                               "obs", "flags"),
                                       meta = {'filename':self.filename}).group_by("obs")
 

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -393,7 +393,7 @@ class TOAs(object):
 
         if not hasattr(self, 'table'):
             mjds = self.get_mjds(high_precision=True)
-            mjds_low = self.get_mjds()*u.day
+            mjds_low = self.get_mjds()
             self.first_MJD = mjds.min()
             self.last_MJD = mjds.max()
             # The table is grouped by observatory
@@ -446,9 +446,9 @@ class TOAs(object):
                 return numpy.array([t for t in self.table['mjd']])
         else:
             if hasattr(self, "toas"):
-                return numpy.array([t.mjd.value for t in self.toas])
+                return numpy.array([t.mjd.value for t in self.toas]) * u.day
             else:
-                return numpy.array([t.mjd for t in self.table['mjd']])
+                return self.table['mjd_float']
 
 
     def get_errors(self):


### PR DESCRIPTION
A little change. When comparing DMXR1 and DMXR2 using float mjd data type. Avoid comparing two time object directly. 

TODO: Maybe adding a low precision mjd column in the toa table could help a little bit when doing toa selection. 