### PR TITLE
"pulsar MJD" time format

### DIFF
--- a/pint/pulsar_mjd.py
+++ b/pint/pulsar_mjd.py
@@ -1,0 +1,37 @@
+from astropy.time.formats import TimeFormat
+from astropy.time.utils import day_frac
+import astropy._erfa as erfa
+import numpy
+
+class TimePulsarMJD(TimeFormat):
+    """MJD using tempo/tempo2 convention for time within leap second days.
+    This is only relevant if scale='utc', otherwise will act like the 
+    standard astropy MJD time format."""
+
+    name = 'pulsar_mjd'
+
+    def set_jds(self, val1, val2):
+        self._check_scale(self._scale)
+        if self._scale == 'utc':
+            # To get around leap second issues, first convert to YMD,
+            # then back to astropy/ERFA-convention jd1,jd2 using the 
+            # ERFA dtf2d() routine which handles leap seconds.
+            v1, v2 = day_frac(val1, val2)
+            (y,mo,d,f) = erfa.jd2cal(erfa.DJM0+v1,v2)
+            # Fractional day to HMS.  Uses 86400-second day always.
+            # Seems like there should be a ERFA routine for this.. 
+            h = numpy.floor(f*24.0)
+            m = numpy.floor(numpy.remainder(f*1440.0,60))
+            s = numpy.remainder(f*86400.0,60)
+            self.jd1, self.jd2 = erfa.dtf2d('UTC',y,mo,d,h,m,s)
+        else:
+            self.jd1, self.jd2 = day_frac(val1, val2)
+            self.jd1 += erfa.DJM0
+
+    @property
+    def value(self):
+        # Note this is not quite right in the UTC case.  I'm not sure 
+        # if this matters, but might want to clean it up.
+        return (self.jd1 - erfa.DJM0) + self.jd2
+
+

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -4,6 +4,7 @@ from . import observatories as obsmod
 from . import erfautils
 import spice
 import astropy.time as time
+from . import pulsar_mjd
 import astropy.table as table
 import astropy.units as u
 from astropy.coordinates import EarthLocation
@@ -263,14 +264,15 @@ class TOA(object):
         Time object passed to the TOA constructor.
 
         """
+        fmt='pulsar_mjd'
         if obs == "Barycenter":
             # Barycenter overrides the scale argument with 'tdb' always.
             if numpy.isscalar(MJD):
-                self.mjd = time.Time(MJD, scale='tdb', format='mjd',
+                self.mjd = time.Time(MJD, scale='tdb', format=fmt,
                                     precision=9)
             else:
                 self.mjd = time.Time(MJD[0], MJD[1],
-                                    scale='tdb', format='mjd',
+                                    scale='tdb', format=fmt,
                                     precision=9)
         elif obs == "Geocenter":
             # Warning(paulr): The location is used in the TT->TDB
@@ -280,13 +282,13 @@ class TOA(object):
             # Certainly (0,0,0) is the right answer for the solar system
             # delays and such.
             if numpy.isscalar(MJD):
-                self.mjd = time.Time(MJD, scale=scale, format='mjd',
+                self.mjd = time.Time(MJD, scale=scale, format=fmt,
                                     location=EarthLocation(0.0,0.0,0.0),
                                     precision=9)
             else:
                 self.mjd = time.Time(MJD[0], MJD[1],
                                     location=EarthLocation(0.0,0.0,0.0),
-                                    scale=scale, format='mjd',
+                                    scale=scale, format=fmt,
                                     precision=9)
         elif obs == "Spacecraft":
             # For TOAs from a spacecraft, a gcrslocation argument is
@@ -300,11 +302,11 @@ class TOA(object):
             if not isinstance(kwargs['gcrslocation'],coord.GCRS):
                 raise ValueError("gcrslocation must be an astropy.coordinates.GCRS instance")
             if numpy.isscalar(MJD):
-                self.mjd = time.Time(MJD, scale=scale, format='mjd',
+                self.mjd = time.Time(MJD, scale=scale, format=fmt,
                                     precision=9)
             else:
                 self.mjd = time.Time(MJD[0], MJD[1],
-                                    scale=scale, format='mjd',
+                                    scale=scale, format=fmt,
                                     precision=9)
         elif obs in observatories:
             # Not sure what I was trying to test for with this. -- paulr
@@ -317,12 +319,12 @@ class TOA(object):
                     log.warning('TOA passed with poor precision ({0})'.format(self.mjd.precision))
                 self.mjd.precision = 9
             elif numpy.isscalar(MJD):
-                self.mjd = time.Time(MJD, scale=scale, format='mjd',
+                self.mjd = time.Time(MJD, scale=scale, format=fmt,
                                     location=observatories[obs].loc,
                                     precision=9)
             else:
                 self.mjd = time.Time(MJD[0], MJD[1],
-                                    scale=scale, format='mjd',
+                                    scale=scale, format=fmt,
                                     location=observatories[obs].loc,
                                     precision=9)
         else:


### PR DESCRIPTION
This fixes an incompatibility between the traditional pulsar definition of UTC MJD that is used in TOA lines, versus what is used in astropy/ERFA/SOFA.  The latter define fractional MJD as "seconds_in_day/length_of_day" where length of day is usually 86400 but is 86401 on leap second days.  Pulsar TOA fractional MJDs are _always_ "seconds_in_day/86400" (which means TOAs can never happen during leap seconds).  The approach is to define a new astropy-compatible TimeFormat class that is then used when initializing Time objects from TOA information.