### PR TITLE
Change default pickling behavior

### DIFF
--- a/examples/event_optimize.py
+++ b/examples/event_optimize.py
@@ -325,8 +325,11 @@ if __name__ == '__main__':
         ts.compute_TDBs()
         ts.compute_posvels(ephem="DE421", planets=False)
         ts.pickle()
-    else:  # read the events in as a picke file
-        ts = toa.TOAs(eventfile, usepickle=True)
+    else:  # read the events in as a pickle file
+        picklefile = toa._check_pickle(eventfile)
+        if not picklefile:
+            picklefile = eventfile
+        ts = toa.TOAs(picklefile)
 
     if weightcol is not None:
         if weightcol=='CALC':

--- a/examples/htest_optimize.py
+++ b/examples/htest_optimize.py
@@ -236,8 +236,11 @@ if __name__ == '__main__':
         ts.compute_TDBs()
         ts.compute_posvels(ephem="DE421", planets=False)
         ts.pickle()
-    else:  # read the events in as a picke file
-        ts = toa.TOAs(eventfile, usepickle=True)
+    else:  # read the events in as a pickle file
+        picklefile = toa._check_pickle(eventfile)
+        if not picklefile:
+            picklefile = eventfile
+        ts = toa.TOAs(picklefile)
 
     if weightcol is not None:
         if weightcol=='CALC':

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -408,16 +408,6 @@ class TOAs(object):
             
             # FIXME: work with file-like objects as well
 
-            # Note, this code was included in an earlier version of
-            # TOAs.__init__() however it would not have worked correctly.
-            # I'm leaving it here as a reminder until we either decide we
-            # need this functionality and make it work, or decide to remove
-            # it. PBD 2016/10/10.
-            #if type(toafile) in [tuple, list]:
-            #    self.filename = None
-            #    for infile in toafile:
-            #        self.read_toa_file(infile, usepickle=usepickle)
-
             # Check for a pickle-like filename.  Alternative approach would
             # be to just try opening it as a pickle and see what happens.
             if toafile.endswith('.pickle') or toafile.endswith('pickle.gz'):

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -27,7 +27,7 @@ iers_a_file = None
 iers_a = None
 
 
-def get_TOAs(timfile, ephem="DE421", planets=False, usepickle=True):
+def get_TOAs(timfile, ephem="DE421", planets=False, usepickle=False):
     """Convenience function to load and prepare TOAs for PINT use.
 
     Loads TOAs from a '.tim' file, applies clock corrections, computes
@@ -422,7 +422,7 @@ class TOAs(object):
             if toafile.endswith('.pickle') or toafile.endswith('pickle.gz'):
                 self.read_pickle_file(toafile)
 
-            # Not a picke file, process as a standard set of TOA lines
+            # Not a pickle file, process as a standard set of TOA lines
             else:
                 self.read_toa_file(toafile)
                 self.filename = toafile

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -32,9 +32,17 @@ def get_TOAs(timfile, ephem="DE421", planets=False, usepickle=True):
 
     Loads TOAs from a '.tim' file, applies clock corrections, computes
     key values (like TDB), computes the observatory position and velocity
-    vectors, and pickles the file for later use.
+    vectors, and pickles the file for later use (if requested).
     """
-    t = TOAs(timfile,usepickle=usepickle)
+    updatepickle = False
+    if usepickle:
+        picklefile = _check_pickle(timfile)
+        if picklefile:
+            timfile = picklefile
+        else:
+            # Pickle either did not exist or is out of date
+            updatepickle = True
+    t = TOAs(timfile)
     if not any([f.has_key('clkcorr') for f in t.table['flags']]):
         log.info("Applying clock corrections.")
         t.apply_clock_corrections()
@@ -44,14 +52,43 @@ def get_TOAs(timfile, ephem="DE421", planets=False, usepickle=True):
     if 'ssb_obs_pos' not in t.table.colnames:
         log.info("Computing observatory positions and velocities.")
         t.compute_posvels(ephem, planets)
-    # This should also check if the timfile is newer than the pickle file
-    # and update the pickle in that case
-    if not (os.path.isfile(timfile+".pickle") or
-            os.path.isfile(timfile+".pickle.gz")):
+    # Update pickle if needed:
+    if usepickle and updatepickle:
         log.info("Pickling TOAs.")
         t.pickle()
     return t
 
+def _check_pickle(toafilename, picklefilename=None):
+    """Checks if pickle file for the given toafilename needs to be updated.
+    Currently only file modification times are compared, note this will
+    give misleading results under some circumstances.
+
+    If picklefilename is not specified, will look for (toafilename).pickle.gz
+    then (toafilename).pickle.
+
+    If the pickle exists and is up to date, returns the pickle file name.
+    Otherwise returns empty string.
+    """
+    if picklefilename is None:
+        for ext in (".pickle.gz", ".pickle"):
+            testfilename = toafilename + ext
+            if os.path.isfile(testfilename):
+                picklefilename = testfilename
+        # It it's still None, no pickles were found
+        if picklefilename is None:
+            return ''
+
+    # Check if TOA is newer than pickle
+    if os.path.getmtime(picklefilename) < os.path.getmtime(toafilename):
+        return ''
+
+    # TODO add more tests.  Some things to consider:
+    #   1. Check file contents via md5sum (will require storing this in pickle).
+    #   2. Check INCLUDEd TOA files (will require some TOA file parsing).
+
+    # All checks passed, return name of pickle.
+    return picklefilename
+        
 def get_TOAs_list(toa_list,ephem="DE421", planets=False):
     """Load TOAs from a list of TOA objects.
 
@@ -365,22 +402,29 @@ class TOAs(object):
 
         if (toalist is not None) and (toafile is not None):
             log.error('Can not initialize TOAs from both file and list')
+
         if toafile is not None:
+            
             # FIXME: work with file-like objects as well
 
-            if type(toafile) in [tuple, list]:
-                self.filename = None
-                for infile in toafile:
-                    self.read_toa_file(infile, usepickle=usepickle)
+            # Note, this code was included in an earlier version of
+            # TOAs.__init__() however would not have worked correctly.
+            # I'm leaving it here as a reminder until we either decide we
+            # need this functionality and make it work, or decide to remove
+            # it. PBD 2016/10/10.
+            #if type(toafile) in [tuple, list]:
+            #    self.filename = None
+            #    for infile in toafile:
+            #        self.read_toa_file(infile, usepickle=usepickle)
+
+            # Check for a pickle-like filename.  Alternative approach would
+            # be to just try opening it as a pickle and see what happens.
+            if toafile.endswith('.pickle') or toafile.endswith('pickle.gz'):
+                self.read_pickle_file(toafile)
+
+            # Not a picke file, process as a standard set of TOA lines
             else:
-                pth, ext = os.path.splitext(toafile)
-                if ext == ".pickle":
-                    toafile = pth
-                elif ext == ".gz":
-                    pth0, ext0 = os.path.splitext(pth)
-                    if ext0 == ".pickle":
-                        toafile = pth0
-                self.read_toa_file(toafile, usepickle=usepickle)
+                self.read_toa_file(toafile)
                 self.filename = toafile
 
         if toalist is not None:
@@ -786,38 +830,35 @@ class TOAs(object):
             cols_to_add += plan_poss.values()
         self.table.add_columns(cols_to_add)
 
-    def read_toa_file(self, filename, process_includes=True, top=True, usepickle=True):
+    def read_pickle_file(self, filename):
+        """Read the TOAs from the pickle file specified in filename.  Note
+        the filename should include any pickle-specific extensions (ie 
+        ".pickle.gz" or similar), these will not be added automatically."""
+
+        log.info("Reading pickled TOAs from '%s'..." % filename)
+        if os.path.splitext(filename)[1] == '.gz':
+            infile = gzip.open(filename,'rb')
+        else:
+            infile = open(filename,'rb')
+        tmp = cPickle.load(infile)
+        self.filename = tmp.filename
+        if hasattr(tmp, 'toas'):
+            self.toas = tmp.toas
+        if hasattr(tmp, 'table'):
+            self.table = tmp.table.group_by("obs")
+        if hasattr(tmp, 'ntoas'):
+            self.ntoas = tmp.ntoas
+        self.commands = tmp.commands
+        self.observatories = tmp.observatories
+        self.last_MJD = tmp.last_MJD
+        self.first_MJD = tmp.first_MJD
+
+    def read_toa_file(self, filename, process_includes=True, top=True):
         """Read the given filename and return a list of TOA objects.
 
         Will process INCLUDEd files unless process_includes is False.
         """
         if top:
-            # Read from a pickle file if available
-            if usepickle and (os.path.isfile(filename+".pickle") or
-                              os.path.isfile(filename+".pickle.gz")):
-                ext = ".pickle.gz" if \
-                  os.path.isfile(filename+".pickle.gz") else ".pickle"
-                if (os.path.getmtime(filename+ext) >
-                    os.path.getmtime(filename)):
-                    log.info("Reading toas from '%s'..." % \
-                             (filename+ext))
-                    # Pickle file is newer, assume it is good and load it
-                    if ext==".pickle.gz":
-                        tmp = cPickle.load(gzip.open(filename+ext, 'rb'))
-                    else:
-                        tmp = cPickle.load(open(filename+ext, 'rb'))
-                    self.filename = tmp.filename
-                    if hasattr(tmp, 'toas'):
-                        self.toas = tmp.toas
-                    if hasattr(tmp, 'table'):
-                        self.table = tmp.table.group_by("obs")
-                    if hasattr(tmp, 'ntoas'):
-                        self.ntoas = tmp.ntoas
-                    self.commands = tmp.commands
-                    self.observatories = tmp.observatories
-                    self.last_MJD = tmp.last_MJD
-                    self.first_MJD = tmp.first_MJD
-                    return
             self.ntoas = 0
             self.toas = []
             self.commands = []

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -74,6 +74,7 @@ def _check_pickle(toafilename, picklefilename=None):
             testfilename = toafilename + ext
             if os.path.isfile(testfilename):
                 picklefilename = testfilename
+                break
         # It it's still None, no pickles were found
         if picklefilename is None:
             return ''

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -392,7 +392,7 @@ class TOA(object):
 class TOAs(object):
     """A class of multiple TOAs, loaded from zero or more files."""
 
-    def __init__(self, toafile=None, toalist=None, usepickle=True):
+    def __init__(self, toafile=None, toalist=None):
         # First, just make an empty container
         self.toas = []
         self.commands = []
@@ -408,7 +408,7 @@ class TOAs(object):
             # FIXME: work with file-like objects as well
 
             # Note, this code was included in an earlier version of
-            # TOAs.__init__() however would not have worked correctly.
+            # TOAs.__init__() however it would not have worked correctly.
             # I'm leaving it here as a reminder until we either decide we
             # need this functionality and make it work, or decide to remove
             # it. PBD 2016/10/10.

--- a/tests/test_fitter.py
+++ b/tests/test_fitter.py
@@ -14,7 +14,7 @@ m = tm.StandardTimingModel()
 m.read_parfile(os.path.join(datadir,'NGC6440E.par'))
 
 # Get TOAs
-t = toa.TOAs(os.path.join(datadir,'NGC6440E.tim'),usepickle=False)
+t = toa.TOAs(os.path.join(datadir,'NGC6440E.tim'))
 t.apply_clock_corrections()
 t.compute_TDBs()
 try:

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -6,7 +6,7 @@ os.chdir(datadir)
 
 class TestTOAReader:
     def setUp(self):
-        self.x = toa.TOAs("test1.tim", usepickle=False)
+        self.x = toa.TOAs("test1.tim")
         self.x.apply_clock_corrections()
         self.x.compute_TDBs()
         self.x.table.sort('index')


### PR DESCRIPTION
This changes default TOA-reading behavior to not pickle by default, as discussed in issue #181 .  The main "top-level" usage changes are:

1. get_TOAs() function: usepickle now defaults to False.  A pickle file will only be created if usepickle=True (previously it was always created).  Otherwise this function acts the same as before.

2. TOAs class: no longer accepts usepickle argument in constructor.  To read a pickle, call with toafile argument set to the name of the pickle file (including extension).

I also did some minor reorganizing of the pickling code.  The only really notable thing is adding the _check_pickle() function which is meant to be a single place to consolidate any tests we want to do to see if a pickle needs to be regenerated.  For now it just compares file modification times same as before.