### PR TITLE
Auto-replace tabs with spaces

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -187,7 +187,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'PINT.tex', u'PINT Documentation',
+    ('index', 'PINT.tex', u'PINT Documentation',
    u'Anne Archibald, Paul Demorest, Luo Jing, Rick Jenet, Scott Ransom, Chris Sheehy, Michele Vallisneri, Rutger van Haasteren', 'manual'),
 ]
 
@@ -231,7 +231,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'PINT', u'PINT Documentation',
+    ('index', 'PINT', u'PINT Documentation',
    u'Anne Archibald, Paul Demorest, Luo Jing, Rick Jenet, Scott Ransom, Chris Sheehy, Michele Vallisneri, Rutger van Haasteren', 'PINT', 'One line description of project.',
    'Miscellaneous'),
 ]

--- a/examples/event_optimize.py
+++ b/examples/event_optimize.py
@@ -19,7 +19,7 @@ import argparse
 
 #log.setLevel('DEBUG')
 #np.seterr(all='raise')
-        
+
 def measure_phase(profile, template, rotate_prof=True):
     """
     measure_phase(profile, template):
@@ -129,7 +129,7 @@ class emcee_fitter(fitter.fitter):
         # ensure all postive
         return np.where(phss < 0.0, phss + 1.0, phss)
 
-      
+
     def lnprior(self, theta):
         """
         The log prior evaulated at the parameter values specified
@@ -163,7 +163,7 @@ class emcee_fitter(fitter.fitter):
         if lnpost > maxpost:
             print "New max: ", lnpost
             for name, val in zip(ftr.fitkeys, theta):
-                    print "  %8s: %25.15g" % (name, val)
+                print "  %8s: %25.15g" % (name, val)
             maxpost = lnpost
             self.maxpost_fitvals = theta
         return lnpost
@@ -171,7 +171,7 @@ class emcee_fitter(fitter.fitter):
     def minimize_func(self, theta):
         """
         Returns -log(likelihood) so that we can use scipy.optimize.minimize
-        
+
         """
         # first scale the params based on the errors
         ntheta = (theta * self.fiterrs) + self.fitvals
@@ -245,7 +245,7 @@ class emcee_fitter(fitter.fitter):
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description="PINT tool for MCMC optimization of timing models using event data.")
-    
+
     parser.add_argument("eventfile",help="event file to use")
     parser.add_argument("parfile",help="par file to read model from")
     parser.add_argument("gaussianfile",help="gaussian file that defines template")
@@ -273,7 +273,7 @@ if __name__ == '__main__':
     parser.add_argument("--priorerrfact",help="Multiple par file errors by this factor when setting gaussian prior widths",type=float,default=10.0)
     parser.add_argument("--usepickle",help="Read events from pickle file, if available?",
         default=False,action="store_true")
-   
+
     args = parser.parse_args()
 
     eventfile = args.eventfile
@@ -300,7 +300,7 @@ if __name__ == '__main__':
     # Should probably figure a way to make these not global variables
     maxpost = -9e99
     numcalls = 0
-    
+
     # Read in initial model
     modelin = pint.models.get_model(parfile)
     # Remove the dispersion delay as it is unnecessary
@@ -495,7 +495,7 @@ if __name__ == '__main__':
     ftr.set_params(dict(zip(ftr.fitkeys, ftr.maxpost_fitvals)))
     ftr.phaseogram(file=ftr.model.PSR.value+"_post.png")
     plt.close()
-    
+
 
     # Write out the output pulse profile
     vs, xs = np.histogram(ftr.get_event_phases(), outprof_nbins, \
@@ -504,12 +504,12 @@ if __name__ == '__main__':
     for x, v in zip(xs, vs):
         f.write("%.5f  %12.5f\n" % (x, v))
     f.close()
-    
+
     # Write out the par file for the best MCMC parameter est
     f = open(ftr.model.PSR.value+"_post.par", 'w')
     f.write(ftr.model.as_parfile())
     f.close()
-    
+
     # Print the best MCMC values and ranges
     ranges = map(lambda v: (v[1], v[2]-v[1], v[1]-v[0]),
         zip(*np.percentile(samples, [16, 50, 84], axis=0)))
@@ -523,7 +523,7 @@ if __name__ == '__main__':
     f.write("Post-MCMC values (50th percentile +/- (16th/84th percentile):\n")
     for name, vals in zip(ftr.fitkeys, ranges):
         f.write("%8s:"%name + " %25.15g (+ %12.5g  / - %12.5g)\n"%vals)
-    
+
     f.write("\nMaximum likelihood par file:\n")
     f.write(ftr.model.as_parfile())
     f.close()

--- a/examples/fermiphaseogram.py
+++ b/examples/fermiphaseogram.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
                 tlnew.append(tt)
         tl=tlnew
         print("post len : ",len(tlnew))
-        
+
     # Now convert to TOAs object and compute TDBs and posvels
     ts = toa.TOAs(toalist=tl)
     ts.filename = args.eventfile

--- a/examples/htest_optimize.py
+++ b/examples/htest_optimize.py
@@ -13,7 +13,7 @@ import scipy.optimize as op
 import sys, os, copy, fftfit
 from astropy.coordinates import SkyCoord
 
-        
+
 # Params you might want to edit
 nwalkers = 200
 burnin = 100
@@ -121,7 +121,7 @@ class emcee_fitter(fitter.fitter):
         if lnpost > maxpost:
             print "New max: ", lnpost
             for name, val in zip(ftr.fitkeys, theta):
-                    print "  %8s: %25.15g" % (name, val)
+                print "  %8s: %25.15g" % (name, val)
             maxpost = lnpost
             self.maxpost_fitvals = theta
         return lnpost
@@ -376,7 +376,7 @@ if __name__ == '__main__':
     ftr.set_params(dict(zip(ftr.fitkeys, ftr.maxpost_fitvals)))
     ftr.phaseogram(file=ftr.model.PSR.value+"_post.png")
     plt.close()
-    
+
 
     # Write out the output pulse profile
     vs, xs = np.histogram(ftr.get_event_phases(), outprof_nbins, \
@@ -385,12 +385,12 @@ if __name__ == '__main__':
     for x, v in zip(xs, vs):
         f.write("%.5f  %12.5f\n" % (x, v))
     f.close()
-    
+
     # Write out the par file for the best MCMC parameter est
     f = open(ftr.model.PSR.value+"_post.par", 'w')
     f.write(ftr.model.as_parfile())
     f.close()
-    
+
     # Print the best MCMC values and ranges
     ranges = map(lambda v: (v[1], v[2]-v[1], v[1]-v[0]),
         zip(*np.percentile(samples, [16, 50, 84], axis=0)))
@@ -404,7 +404,7 @@ if __name__ == '__main__':
     f.write("Post-MCMC values (50th percentile +/- (16th/84th percentile):\n")
     for name, vals in zip(ftr.fitkeys, ranges):
         f.write("%8s:"%name + " %25.15g (+ %12.5g  / - %12.5g)\n"%vals)
-    
+
     f.write("\nMaximum likelihood par file:\n")
     f.write(ftr.model.as_parfile())
     f.close()

--- a/examples/pintempo.py
+++ b/examples/pintempo.py
@@ -30,10 +30,10 @@ if __name__ == '__main__':
     parser.add_argument("--outfile",help="Output figure file name (default=None)", default=None)
     parser.add_argument("--plot",help="Plot residuals",action="store_true",default=False)
     args = parser.parse_args()
-    
+
     log.info("Reading model from {0}".format(args.parfile))
     m = pint.models.get_model(args.parfile)
-    
+
     log.info("Reading TOAs")
     t = pint.toa.get_TOAs(args.timfile)
     prefit_resids = pint.residuals.resids(t, m).time_resids
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     log.info("Fitting...")
     f = pint.fitter.fitter(t, m)
     f.call_minimize()
-    
+
     # Print some basic params
     print( "Best fit has reduced chi^2 of", f.resids.chi2_reduced)
     print( "RMS in phase is", f.resids.phase_resids.std())
@@ -59,13 +59,13 @@ if __name__ == '__main__':
         plt.ylabel('Residual (us)')
         plt.grid()
         plt.show()
-        
+
     if args.outfile is not None:
         fout = file(args.outfile,"w")
     else:
         fout = sys.stdout
         print("\nBest fit model is:")
-    
+
     fout.write(f.model.as_parfile()+"\n")
-    
+
 

--- a/pint/eventstats.py
+++ b/pint/eventstats.py
@@ -18,7 +18,7 @@ def to_array(x):
     x = np.asarray(x)
     if len(x.shape)==0: return np.asarray([x])
     return x
-    
+
 def from_array(x):
     if (len(x.shape)==1) and (x.shape[0]==1): return x[0]
     return x
@@ -30,7 +30,7 @@ def sig2sigma(sig,two_tailed=True,logprob=False):
        probability is sig.  Note that the default is to interpret this number
        as the two-tailed value, as this is the quantity that goes to 0
        when sig goes to 1.
-       
+
        args
        ----
        sig     the chance probability
@@ -91,14 +91,14 @@ def sigma2sig(sigma,two_tailed=True):
     return 1 - 0.5*erfc(-sigma/2**0.5)
 
 def sigma_trials(sigma,trials):
-   # correct a sigmal value for a trials factor
-   if sigma < 20:
-       p = sigma2sig(sigma)*trials
-       if p >= 1: return 0
-       return sig2sigma(p)
-   else:
-      # use an asymptotic expansion -- this needs to be checked!
-      return (sigma**2 - 2*np.log(trials))**0.5
+    # correct a sigmal value for a trials factor
+    if sigma < 20:
+        p = sigma2sig(sigma)*trials
+        if p >= 1: return 0
+        return sig2sigma(p)
+    else:
+        # use an asymptotic expansion -- this needs to be checked!
+        return (sigma**2 - 2*np.log(trials))**0.5
 
 
 def z2m(phases,m=2):
@@ -122,24 +122,24 @@ def z2m(phases,m=2):
     return (2./n)*np.cumsum(s)
 
 def z2mw(phases,weights,m=2):
-   """ Return the Z^2_m test for each harmonic up to the specified m.
+    """ Return the Z^2_m test for each harmonic up to the specified m.
 
-       The user provides a list of weights.  In the case that they are
-       well-distributed or assumed to be fixed, the CLT applies and the
-       statistic remains calibrated.  Nice!
-    """
+        The user provides a list of weights.  In the case that they are
+        well-distributed or assumed to be fixed, the CLT applies and the
+        statistic remains calibrated.  Nice!
+     """
 
-   phases = np.asarray(phases)*(2*np.pi) #phase in radians
+    phases = np.asarray(phases)*(2*np.pi) #phase in radians
 
-   s = (np.asarray([(np.cos(k*phases)*weights).sum() for k in range(1,m+1)]))**2 +\
-       (np.asarray([(np.sin(k*phases)*weights).sum() for k in range(1,m+1)]))**2
+    s = (np.asarray([(np.cos(k*phases)*weights).sum() for k in range(1,m+1)]))**2 +\
+        (np.asarray([(np.sin(k*phases)*weights).sum() for k in range(1,m+1)]))**2
 
-   return np.cumsum(s) * (2./(weights**2).sum())
+    return np.cumsum(s) * (2./(weights**2).sum())
 
 def sf_z2m(ts,m=2):
     """ Return the survival function (chance probability) according to the
         asymptotic calibration for the Z^2_m test.
-        
+
         args
         ----
         ts      result of the Z^2_m test
@@ -154,7 +154,7 @@ def best_m(phases,weights=None,m=100):
 def em_four(phases,m=2,weights=None):
     """ Return the empirical Fourier coefficients up to the mth harmonic.
         These are derived from the empirical trignometric moments."""
-   
+
     phases = np.asarray(phases)*TWOPI #phase in radians
 
     n = len(phases) if weights is None else weights.sum()
@@ -220,7 +220,7 @@ def sf_hm(h,m=20,c=4,logprob=False):
     from numpy import exp,arange,log,empty
     from scipy.special import gamma
     fact = lambda x: gamma(x+1)
-               
+
     # first, calculate the integrals of unity for all needed orders
     ints = empty(m)
     for i in range(m):

--- a/pint/fermi_toas.py
+++ b/pint/fermi_toas.py
@@ -20,7 +20,7 @@ def calc_lat_weights(energies, angseps, logeref=4.1, logesig=0.5):
     It was built by David Smith, based on some code from Lucas Guillemot.
     This computation uses only the PSF as a function of energy, not a full
     spectral model of the region, so is less exact than gtsrcprob.
-    
+
     The input values are:
     energies : Array of photon energies in MeV
     angseps : Angular separations between photon direction and target
@@ -28,7 +28,7 @@ def calc_lat_weights(energies, angseps, logeref=4.1, logesig=0.5):
               SkyCoord_photons.separation(SkyCoord_target)
     logeref : Parameter from SearchPulsation optimization
     logesig : Parameter from SearchPulsation optimization
-    
+
     Returns a numpy array of weights (probabilities that the photons came
     from the target, based on the PSF).
 
@@ -42,9 +42,9 @@ def calc_lat_weights(energies, angseps, logeref=4.1, logesig=0.5):
     scalepsf = 3.
 
     logE = np.log10(energies)
-    
+
     sigma = np.sqrt(psfpar0*psfpar0*np.power(100./energies, 2.*psfpar1) + psfpar2*psfpar2)/scalepsf
-    
+
     fgeom = norm*np.power(1+angseps.degree*angseps.degree/2./gam/sigma/sigma, -gam)
 
     return fgeom * np.exp(-np.power((logE-logeref)/np.sqrt(2.)/logesig,2.))	
@@ -104,13 +104,13 @@ def load_Fermi_TOAs(ft1name,ft2name=None,weightcolumn=None,targetcoord=None,loge
       a list of PINT TOA objects.
       Correctly handles raw FT1 files, or ones processed with gtbary
       to have barycentered or geocentered TOAs.
-      
+
       weightcolumn specifies the FITS column name to read the photon weights
       from.  The special value 'CALC' causes the weights to be computed empirically
       as in Philippe Bruel's SearchPulsation code. 
       logeref and logesig are parameters for the weight computation and are only
       used when weightcolumn='CALC'.
-      
+
       When weights are loaded, or computed, events are filtered by weight >= minweight
     '''
     import pyfits

--- a/pint/ltinterface.py
+++ b/pint/ltinterface.py
@@ -344,7 +344,7 @@ class pintpulsar(object):
 
     def flags(self):
         """Returns the list of flags defined in this dataset (for at least some observations).""" 
-        
+
         return self.flagnames_
 
     # TO DO: setting flags
@@ -501,7 +501,7 @@ class pintpulsar(object):
         M, params, units = self.model.designmatrix(self.t.table, incfrozen=False,
                 incoffset=incoffset)
         return M
-    
+
     def telescope(self):
         """tempopulsar.telescope()
 
@@ -560,7 +560,7 @@ class pintpulsar(object):
     @property
     def pulse_number(self):
         """Return the pulse number relative to PEPOCH, as detected by tempo2
-        
+
         WARNING: Will be deprecated in the future. Use `pulsenumbers`.
         """
         return self.model.phase(self.t.table).int.quantity.value
@@ -584,7 +584,7 @@ class pintpulsar(object):
 
         for ii in range(iters+1):
             f.call_minimize()
-        
+
         fitp = f.get_fitparams()
         # TODO: handle these units correctly
         for p, val in zip(fitp.keys(), fitp.values()):

--- a/pint/models/model_builder.py
+++ b/pint/models/model_builder.py
@@ -152,7 +152,7 @@ class model_builder(object):
                             continue
 
                 if cclass.is_in_parfile(params_inpar):
-                        selected_c = c
+                    selected_c = c
             # One module will have one selected component
             if selected_c is not None and selected_c not in self.select_comp:
                 self.select_comp.append(selected_c)
@@ -170,10 +170,10 @@ class model_builder(object):
         """ Add new components to constructing model.
         """
         if not isinstance(components,list):
-    	   components = [components,]
+            components = [components,]
         for c in components:
-    	    if c not in self.select_comp:
-    	       self.select_comp.append(c)
+            if c not in self.select_comp:
+                self.select_comp.append(c)
 
     def search_prefix_param(self, paramList, prefix_inModel):
         """ Check if the Unrecognized parameter has prefix parameter
@@ -232,7 +232,7 @@ class model_builder(object):
                     for parname in prefix_param[key]:
                         pre,idstr,idx = split_prefixed_name(parname)
                         if idx == exm_par.index:
-                             continue
+                            continue
                         if hasattr(exm_par, 'new_param'):
                             new_par = exm_par.new_param(idx)
                             self.model_instance.add_param(new_par)

--- a/pint/models/parameter.py
+++ b/pint/models/parameter.py
@@ -631,7 +631,7 @@ class MJDParameter(Parameter):
             result = time_from_longdouble(val, self.time_scale)
         elif isinstance(val, str):
             try:
-                 result = time_from_mjd_string(val, self.time_scale)
+                result = time_from_mjd_string(val, self.time_scale)
             except:
                 raise ValueError('String ' + val + 'can not be converted to'
                                  'a time object.' )

--- a/pint/models/polycos.py
+++ b/pint/models/polycos.py
@@ -209,7 +209,7 @@ def tempo_polyco_table_reader(filename):
                         rphase, refF0, nCoeff, coeffs))
     entry_list  = []
     for ii in range(len(entries[0])):
-         entry_list.append([t[ii] for t in entries])
+        entry_list.append([t[ii] for t in entries])
 
     #Construct the polyco data table
     pTable = table.Table(entry_list,
@@ -341,8 +341,8 @@ class Polycos(object):
         for fmt in self.polycoFormat:
             if fmt['format'] not in registry.get_formats()['Format']:
                 if fmt['read_method'] != None:
-                   registry.register_reader(fmt['format'], table.Table,
-                                            fmt['read_method'])
+                    registry.register_reader(fmt['format'], table.Table,
+                                             fmt['read_method'])
 
                 if fmt['write_method'] != None:
                     registry.register_writer(fmt['format'], table.Table,
@@ -470,9 +470,9 @@ class Polycos(object):
         # Make sure the number of nodes is bigger then number of coeffs.
         if numNodes < ncoeff:
             numNodes = ncoeff+1
-    	# generate the ploynomial coefficents
-    	if method == "TEMPO":
-    	    # Using tempo1 method to create polycos
+        # generate the ploynomial coefficents
+        if method == "TEMPO":
+            # Using tempo1 method to create polycos
             for i in range(len(entryIntvl)-1):
                 tStart = entryIntvl[i]
                 tStop = entryIntvl[i+1]
@@ -516,9 +516,9 @@ class Polycos(object):
                                    meta={'name': 'Ployco Data Table'})
             self.polycoTable = pTable
 
-    	else:
-    		#  Reading from an old polycofile
-    		pass
+        else:
+                #  Reading from an old polycofile
+            pass
 
 
     def read_polyco_file(self,filename,format):
@@ -552,9 +552,9 @@ class Polycos(object):
         """
 
         if format not in [f['format'] for f in self.polycoFormat]:
-             raise Exception('Unknown polyco file format \''+ format +'\'\n'
-                            'Plese use function \'self.add_polyco_file_format()\''
-                            ' to register the format\n')
+            raise Exception('Unknown polyco file format \''+ format +'\'\n'
+                           'Plese use function \'self.add_polyco_file_format()\''
+                           ' to register the format\n')
         if filename is not None:
             self.polycoTable.write(filename,format = format)
         else:

--- a/pint/models/priors.py
+++ b/pint/models/priors.py
@@ -16,14 +16,14 @@ import numpy as np
 
 class Prior(object):
     r"""Class for evaluation of prior probability densities
-    
+
      Any Prior object returns the probability density using
     the pdf() and logpdf() methods.  For generality, these 
     are written so that they work on a scalar value or a numpy array
     of values.
-    
+
     """
-    
+
     def __init__(self, rv):
         """
         _rv : rv_frozen
@@ -34,23 +34,23 @@ class Prior(object):
 
         Priors are evaluated at values corresponding to the num_value of the parameter
         and don't currently use units (the num_unit is the assumed unit)
-        
+
         Examples
         --------
         # A uniform prior of F0
         model.F0.prior = Prior(UniformRV())
-        
+
         # A uniform prior on F0 between 50 and 60 Hz (because num_unit is Hz)
         model.F0.prior = Prior(UniformBoundedRV(50.0,60.0))
-        
+
         # A Gaussian prior on PB with mean 32 days and std dev 1.0 day
         model.PB.prior = Prior(scipy.stats.norm(loc=32.0,scale=1.0))
-        
+
 
         """
         self._rv = rv
         pass
-    
+
     def pdf(self,value):
         # The astype() calls prevent unsafe cast messages
         if type(value) == np.ndarray:
@@ -58,19 +58,19 @@ class Prior(object):
         else:
             v = np.float(value)
         return self._rv.pdf(v)
-        
+
     def logpdf(self,value):
         if type(value) == np.ndarray:
             v = value.astype(np.float64,casting='same_kind')
         else:
             v = np.float(value)
         return self._rv.logpdf(v)
-        
+
 class UniformRV(rv_continuous):
     r"""A uniform prior distribution (equivalent to no prior)
-    
+
     """
-    
+
     # The astype() calls prevent unsafe cast messages
     def _pdf(self,x):
         return np.ones_like(x).astype(np.float64,casting='same_kind')
@@ -79,12 +79,12 @@ class UniformRV(rv_continuous):
 
 class UniformBoundedRV(rv_continuous):
     r"""A uniform prior between two bounds
-    
+
     Parameters
     ----------
     lower_bound : number
         Lower bound of allowed parameter range
-        
+
     upper_bound : number
         Upper bound of allowed parameter range
     """
@@ -93,11 +93,11 @@ class UniformBoundedRV(rv_continuous):
         self.lower = lower_bound
         self.upper = upper_bound
         self.norm = np.float64(1.0/(upper_bound-lower_bound))
-                
+
     def _pdf(self,x):
         ret = np.where(np.logical_and(x>=self.lower,x<=self.upper),self.norm,0.0)
         return ret
-        
+
     def _logpdf(self,x):
         ret = np.where(np.logical_and(x>=self.lower,x<=self.upper),
                        np.log(self.norm), -np.inf)
@@ -105,12 +105,12 @@ class UniformBoundedRV(rv_continuous):
 
 class GaussianBoundedRV(rv_continuous):
     r"""A uniform prior between two bounds
-    
+
     Parameters
     ----------
     lower_bound : number
         Lower bound of allowed parameter range
-        
+
     upper_bound : number
         Upper bound of allowed parameter range
     """
@@ -122,14 +122,14 @@ class GaussianBoundedRV(rv_continuous):
         # Norm should be the integral of the gaussian from lower to upper
         # so that integral over allowed range will be == 1.0
         self.norm = 1.0/(self.gaussian.cdf(upper_bound)-self.gaussian.cdf(lower_bound))
-                
+
     def _pdf(self,x):
         ret = np.where(np.logical_and(x>=self.lower,x<=self.upper), 
             self.norm*self.gaussian.pdf(x), 0.0)
         return ret
-        
+
     def _logpdf(self,x):
         ret = np.where(np.logical_and(x>=self.lower,x<=self.upper),
                        np.log(self.norm)*self.gaussian.logpdf(x), -np.inf)
         return ret
-       
+

--- a/pint/models/pulsar_binary.py
+++ b/pint/models/pulsar_binary.py
@@ -81,7 +81,7 @@ class PulsarBinary(TimingModel):
              units="",
              description="Sine of inclination angle"),
              binary_param = True)
-             
+
         # Set up delay function
         self.binary_delay_funcs += [self.binarymodel_delay,]
         self.delay_funcs['L2'] += [self.binarymodel_delay,]

--- a/pint/models/stand_alone_psr_binaries/BT_model.py
+++ b/pint/models/stand_alone_psr_binaries/BT_model.py
@@ -105,7 +105,7 @@ class BTmodel(PSR_BINARY):
         """Second term of Blandford & Teukolsky (1976), ApJ, 205,
         580-591, eq 2.33/ / Second left-hand term of W.M. Smart, (1962),
         "Spherical Astronomy", p35 delay equation.
-        
+
         (beta + gamma) * sinE
         beta = (1-e^2)*a1*cos(omega)
         Here a1 is in the unit of light second as distance

--- a/pint/models/stand_alone_psr_binaries/binary_generic.py
+++ b/pint/models/stand_alone_psr_binaries/binary_generic.py
@@ -300,7 +300,7 @@ class PSR_BINARY(object):
             result = getattr(self,dername)(x)
 
         else:
-           result = np.longdouble(np.zeros(len(self.tt0)))
+            result = np.longdouble(np.zeros(len(self.tt0)))
 
         if hasattr(result,'unit'):
             return result.to(derU,equivalencies=u.dimensionless_angles())
@@ -354,7 +354,7 @@ class PSR_BINARY(object):
             tt0 = None
             return tt0
         T0 =  self.T0
-    	if not hasattr(barycentricTOA,'unit') or barycentricTOA.unit == None:
+        if not hasattr(barycentricTOA,'unit') or barycentricTOA.unit == None:
             barycentricTOA = barycentricTOA*u.day
         tt0 = (barycentricTOA - T0).to('second')
         return tt0

--- a/pint/observatory/clock_file.py
+++ b/pint/observatory/clock_file.py
@@ -57,7 +57,7 @@ class ClockFile(object):
 
     @property
     def time(self): return self._time
-        
+
     @property
     def clock(self): return self._clock
 
@@ -78,7 +78,7 @@ class ClockFile(object):
 
         # Can't pass Times directly to numpy.interp.  This should be OK:
         return numpy.interp(t.mjd, self.time.mjd, self.clock.to(u.us))*u.us
-        
+
 
 class Tempo2ClockFile(ClockFile):
 

--- a/pint/phase.py
+++ b/pint/phase.py
@@ -8,7 +8,7 @@
 # range is [-0.5,0.5) or (-0.5,0.5].
 from collections import namedtuple
 import numpy
- 
+
 class Phase(namedtuple('Phase', 'int frac')):
     """
     Phase class array version

--- a/pint/solar_system_ephemerides.py
+++ b/pint/solar_system_ephemerides.py
@@ -63,7 +63,7 @@ def objPosVel2SSB(objname, t, ephem):
         vel = vel_pbary_ssb + vel_p_pbary
     # Planets without barycenter computing
     else:
-         _, vel = kernel[0,jpl_obj_code[objname]].compute_and_differentiate(tjd1, tjd2)
+        _, vel = kernel[0,jpl_obj_code[objname]].compute_and_differentiate(tjd1, tjd2)
     return PosVel(pos.xyz, vel / SECS_PER_DAY * u.km/u.second, origin='ssb', obj=objname)
 
 def objPosVel(obj1, obj2, t, ephem):

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -87,7 +87,7 @@ def _check_pickle(toafilename, picklefilename=None):
 
     # All checks passed, return name of pickle.
     return picklefilename
-        
+
 def get_TOAs_list(toa_list,ephem="DE421", planets=False):
     """Load TOAs from a list of TOA objects.
 
@@ -224,7 +224,7 @@ def format_toa_line(toatime, toaerr, freq, dm=0.0, obs='@', name='unk', flags={}
             log.error('Unknown TOA format ({0})'.format(format))
         if dm!=0.0:
             out = obs+" %13s %8.3f %s %8.2f              %9.4f\n" % \
-              (name, freq, toa, toaerr, dm)
+                (name, freq, toa, toaerr, dm)
         else:
             out = obs+" %13s %8.3f %s %8.2f\n" % (name, freq, toa, toaerr)
 
@@ -338,7 +338,7 @@ class TOAs(object):
             log.error('Can not initialize TOAs from both file and list')
 
         if toafile is not None:
-            
+
             # FIXME: work with file-like objects as well
 
             # Check for a pickle-like filename.  Alternative approach would

--- a/tempo2Test/T2spiceTest.py
+++ b/tempo2Test/T2spiceTest.py
@@ -42,19 +42,19 @@ earth2 =[]
 earth3 =[]
 # Read tt2tdb earthposition output
 for l in fp.readlines():
-	l = l.strip()
-	l = l.strip("\n")
-	l = l.split()
+    l = l.strip()
+    l = l.strip("\n")
+    l = l.split()
 # Avoid the column that is not data
-	try:                
-		m = float(l[0]) 
-	except:
-		pass
-	else:
-		tt2tdb.append(l[-1]) 
-		earth1.append(l[0])
-		earth2.append(l[1])
-		earth3.append(l[2])
+    try:                
+        m = float(l[0]) 
+    except:
+        pass
+    else:
+        tt2tdb.append(l[-1]) 
+        earth1.append(l[0])
+        earth2.append(l[1])
+        earth3.append(l[2])
 #### Testing toa mjd to tt
 tt = []
 for i in range(len(toa)):

--- a/tempo2Test/spiceTest.py
+++ b/tempo2Test/spiceTest.py
@@ -2,95 +2,95 @@ import spice
 import numpy as np
 
 def test_lmt(et,step):
-	"""
-	Testing how accurate that spice can distinguish two near by times(et) with littl time step
-	et is the initial time
-	step is the small time step  
-	"""
-	et0 = et
-	et1 = et+step
-	print et0,et1,et1-et0
-	state0,lt0 = spice.spkezr("EARTH",et0,"J2000","NONE","SSB")
-	state1,lt1 = spice.spkezr("EARTH",et1,"J2000","NONE","SSB")
-	diff = np.array(state0)-np.array(state1)
-	print state0,state1
-	return diff
+    """
+    Testing how accurate that spice can distinguish two near by times(et) with littl time step
+    et is the initial time
+    step is the small time step  
+    """
+    et0 = et
+    et1 = et+step
+    print et0,et1,et1-et0
+    state0,lt0 = spice.spkezr("EARTH",et0,"J2000","NONE","SSB")
+    state1,lt1 = spice.spkezr("EARTH",et1,"J2000","NONE","SSB")
+    diff = np.array(state0)-np.array(state1)
+    print state0,state1
+    return diff
 
 
 def spice_Intplt(et,stepBitNum):
-	"""
-	Testing interpolating spice results with two exact numbers 
-	"""
-	step = 1.0/2.0**stepBitNum
-	numStep = 2.0**stepBitNum
-	et0 = np.floor(et) # The first integer before targeting time et
-	et1 = np.ceil(et)  # The first integer after targeting time et
-	exctNumArray = np.linspace(et0,et1,numStep) 
-	exctNumNear = min(exctNumArray, key=lambda x:abs(x-et)) # find the closest exact number
-	# Find two exact number around input time et
-	if(exctNumNear>et):
-		exctNum0 = exctNumNear - step
-		exctNum1 = exctNumNear
-	elif(exctNumNear == et):
-		exctNum0 = et
-		exctNum1 = et
-	else:	
-		exctNum0 = exctNumNear 
-                exctNum1 = exctNumNear - step
-	print exctNum0,exctNum1
-	state0,lt0 = spice.spkezr("EARTH",exctNum0,"J2000","NONE","SSB")
-	state1,lt1 = spice.spkezr("EARTH",exctNum1,"J2000","NONE","SSB")
-	state = []
-	lt = []
-	for i in range(6):
-		state.append(np.interp(et,[exctNum0,exctNum1],[state0[i],state1[i]]))
-	lt.append(np.interp(et,[exctNum0,exctNum1],[lt0,lt1]))
-	
-	stateOr,ltOr = spice.spkezr("EARTH",et,"J2000","NONE","SSB")
+    """
+    Testing interpolating spice results with two exact numbers 
+    """
+    step = 1.0/2.0**stepBitNum
+    numStep = 2.0**stepBitNum
+    et0 = np.floor(et) # The first integer before targeting time et
+    et1 = np.ceil(et)  # The first integer after targeting time et
+    exctNumArray = np.linspace(et0,et1,numStep) 
+    exctNumNear = min(exctNumArray, key=lambda x:abs(x-et)) # find the closest exact number
+    # Find two exact number around input time et
+    if(exctNumNear>et):
+        exctNum0 = exctNumNear - step
+        exctNum1 = exctNumNear
+    elif(exctNumNear == et):
+        exctNum0 = et
+        exctNum1 = et
+    else:	
+        exctNum0 = exctNumNear 
+        exctNum1 = exctNumNear - step
+    print exctNum0,exctNum1
+    state0,lt0 = spice.spkezr("EARTH",exctNum0,"J2000","NONE","SSB")
+    state1,lt1 = spice.spkezr("EARTH",exctNum1,"J2000","NONE","SSB")
+    state = []
+    lt = []
+    for i in range(6):
+        state.append(np.interp(et,[exctNum0,exctNum1],[state0[i],state1[i]]))
+    lt.append(np.interp(et,[exctNum0,exctNum1],[lt0,lt1]))
+
+    stateOr,ltOr = spice.spkezr("EARTH",et,"J2000","NONE","SSB")
 
 
-	return state,stateOr,np.array(state)-np.array(stateOr)
+    return state,stateOr,np.array(state)-np.array(stateOr)
 
 
 
 def spkInterp(et,stepBitNum):
-	"""
-	This function interpolates earth state in one second with seveal exact points. 
-	To increase accuracy, each know point will be the exact number that can be represented 
-	by double precision. 
-	et is the target time
-	stepBitNum determines that how small the step for exact points will be. And it is 
-	calculated by bits 
-	step  = 1.0/2.0**stepBitNum   
-	"""
-	step = 1.0/2.0**stepBitNum   # Step from exact point
-	numStep = 2.0**stepBitNum    # Number of exact point
-	et0 = np.floor(et)           # Start point of interval
-	etExctArray = np.linspace(et0,et0+1,numStep+1) # Exact time point array
-	stateArray = [] # Earth state array for each exact point
-	ltArray = []  # light time state array for each exact point
-	"""
+    """
+    This function interpolates earth state in one second with seveal exact points. 
+    To increase accuracy, each know point will be the exact number that can be represented 
+    by double precision. 
+    et is the target time
+    stepBitNum determines that how small the step for exact points will be. And it is 
+    calculated by bits 
+    step  = 1.0/2.0**stepBitNum   
+    """
+    step = 1.0/2.0**stepBitNum   # Step from exact point
+    numStep = 2.0**stepBitNum    # Number of exact point
+    et0 = np.floor(et)           # Start point of interval
+    etExctArray = np.linspace(et0,et0+1,numStep+1) # Exact time point array
+    stateArray = [] # Earth state array for each exact point
+    ltArray = []  # light time state array for each exact point
+    """
 	Calculate the earth state and lt for each exact point
 	"""
-	for data in etExctArray:
-		stateExct,ltExct = spice.spkezr("EARTH",data,"J2000","NONE","SSB")
-		stateArray.append(stateExct)
-		ltArray.append(ltExct)
+    for data in etExctArray:
+        stateExct,ltExct = spice.spkezr("EARTH",data,"J2000","NONE","SSB")
+        stateArray.append(stateExct)
+        ltArray.append(ltExct)
 
-	stateArray = np.array(stateArray) # Transfer to numpy array
-	ltArray = np.array(ltArray)	  # Transfer to numpy array	
-	state = []    # Earth state for target time
-	lt = []       # lt for target time
-	"""
+    stateArray = np.array(stateArray) # Transfer to numpy array
+    ltArray = np.array(ltArray)	  # Transfer to numpy array	
+    state = []    # Earth state for target time
+    lt = []       # lt for target time
+    """
 	Interpolate for target time
 	"""
-	for i in range(6):  
-		state.append(np.interp(et,etExctArray,stateArray[:,i]))	
-		lt.append(np.interp(et,etExctArray,ltArray))	
-	"""
+    for i in range(6):  
+        state.append(np.interp(et,etExctArray,stateArray[:,i]))	
+        lt.append(np.interp(et,etExctArray,ltArray))	
+    """
 	Return earth state and light time as list
 	"""
-	return state,lt
+    return state,lt
 
 
 

--- a/tempo2Test/tt2tdbT2.py
+++ b/tempo2Test/tt2tdbT2.py
@@ -26,37 +26,37 @@ def mjd2tdt(mjd):
     if (mjd >= 44239.0):
         dt = 19.0;     #/* 1980 Jan 1 */
     if (mjd >= 44786.0):
-    	dt = 20.0;     #/* 1981 Jul 1 */
+        dt = 20.0;     #/* 1981 Jul 1 */
     if (mjd >= 45151.0):
-    	dt = 21.0;     #/* 1982 Jul 1 */
+        dt = 21.0;     #/* 1982 Jul 1 */
     if (mjd >= 45516.0):
-    	dt = 22.0;     #/* 1983 Jul 1 */
+        dt = 22.0;     #/* 1983 Jul 1 */
     if (mjd >= 46247.0):
-    	dt = 23.0;     #/* 1985 Jul 1 */
+        dt = 23.0;     #/* 1985 Jul 1 */
     if (mjd >= 47161.0):
-    	dt = 24.0;     #/* 1988 Jan 1 */
+        dt = 24.0;     #/* 1988 Jan 1 */
     if (mjd >= 47892.0):
-    	dt = 25.0;     #/* 1990 Jan 1 */
+        dt = 25.0;     #/* 1990 Jan 1 */
     if (mjd >= 48257.0):
-    	dt = 26.0;     #/* 1991 Jan 1 */
+        dt = 26.0;     #/* 1991 Jan 1 */
     if (mjd >= 48804.0):
-    	dt = 27.0;     #/* 1992 July 1 */
+        dt = 27.0;     #/* 1992 July 1 */
     if (mjd >= 49169.0):
-    	dt = 28.0;     #/* 1993 July 1 */
+        dt = 28.0;     #/* 1993 July 1 */
     if (mjd >= 49534.0):
-    	dt = 29.0;     #/* 1994 July 1 */
+        dt = 29.0;     #/* 1994 July 1 */
     if (mjd >= 50083.0):
-    	dt = 30.0;     #/* 1996 Jan 1 */
+        dt = 30.0;     #/* 1996 Jan 1 */
     if (mjd >= 50630.0):
-    	dt = 31.0;     #/* 1997 Jul 1 */
+        dt = 31.0;     #/* 1997 Jul 1 */
     if (mjd >= 51179.0):
-    	dt = 32.0;     #/* 1999 Jan 1 */
+        dt = 32.0;     #/* 1999 Jan 1 */
     if (mjd >= 53736.0):
-    	dt = 33.0;     #/* 2006 Jan 1 */
+        dt = 33.0;     #/* 2006 Jan 1 */
     if (mjd >= 54832.0):
-    	dt = 34.0;     #/* 2009 Jan 1 */
+        dt = 34.0;     #/* 2009 Jan 1 */
     if (mjd >= 56109.0):
-    	dt = 35.0;     #/* 2012 July 1 */
+        dt = 35.0;     #/* 2012 July 1 */
 
     delta_TT = mp.mpf(dt)+32.184
     delta_TT_DAY = mp.mpf(delta_TT)/mp.mpf(86400.0)
@@ -77,7 +77,7 @@ def mjd2et(mjd,tt2tdb):
     mjdTT = mjd2tdt(mjd)
     et = (mjdTT-mjdJ2000)*secDay+mp.mpf(tt2tdb)
     return et
- 
+
 #### Read tempo2 tim file
 fname1 = "J0000+0000.tim"
 fp1 = open(fname1,"r")
@@ -101,19 +101,19 @@ earth2 =[]
 earth3 =[]
 # Read tt2tdb earthposition output
 for l in fp.readlines():
-	l = l.strip()
-	l = l.strip("\n")
-	l = l.split()
+    l = l.strip()
+    l = l.strip("\n")
+    l = l.split()
 # Avoid the column that is not data
-	try:                
-		m = float(l[0]) 
-	except:
-		pass
-	else:
-		tt2tdb.append(l[-1]) 
-		earth1.append(l[0])
-		earth2.append(l[1])
-		earth3.append(l[2])
+    try:                
+        m = float(l[0]) 
+    except:
+        pass
+    else:
+        tt2tdb.append(l[-1]) 
+        earth1.append(l[0])
+        earth2.append(l[1])
+        earth3.append(l[2])
 
 et = []
 # Convert toa mjd to toa et
@@ -144,5 +144,5 @@ print mp.mpf(earth1[0])*mp.mpf(spice.clight()),\
 
 
 
-		
+
 

--- a/tests/test_clockcorr.py
+++ b/tests/test_clockcorr.py
@@ -14,7 +14,7 @@ class TestClockcorrection(unittest.TestCase):
                 obscode=obs.tempo_code)
         mjd = cf.time.mjd
         corr = cf.clock.to(u.us).value
-        
+
         assert numpy.isclose(mjd.min(), 44000.0)
 
         idx = numpy.where(numpy.isclose(mjd,49990.0))[0][0]

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -20,11 +20,11 @@ class TestPriors(unittest.TestCase):
         # Call prior_pdf using parameter values set in model
         assert self.m.F0.prior_pdf() == 1.0
         assert self.m.F0.prior_pdf(logpdf=True) == 0.0
-        
+
         # Now try overriding the parameter values
         assert self.m.F0.prior_pdf(10.0) == 1.0
         assert self.m.F0.prior_pdf(10.0, logpdf=True) == 0.0
-        
+
     def test_uniform_bounded(self):
         print("test_uniform_bounded")
         self.m.ECC.prior = Prior(UniformBoundedRV(0.0,1.0))
@@ -34,7 +34,7 @@ class TestPriors(unittest.TestCase):
         assert self.m.ECC.prior_pdf(-0.1,logpdf=True) == -np.inf
         assert self.m.ECC.prior_pdf(1.1) == 0.0
         assert self.m.ECC.prior_pdf(1.1,logpdf=True) == -np.inf
-        
+
     def test_gaussian(self):
         print("test_gaussian")
         v = -6.2e-16
@@ -43,7 +43,7 @@ class TestPriors(unittest.TestCase):
         self.m.F1.prior = Prior(norm(loc=v,scale=s))
         print(self.m.F1.prior_pdf(v))
         assert np.isclose(self.m.F1.prior_pdf(v), 1.0/(s*np.sqrt(2.0*np.pi)))
-    
+
     def test_gaussian_bounded(self):
         print("test_gaussian_bounded")
         self.m.M2.prior = Prior(GaussianBoundedRV(loc=0.26,scale=0.10,lower_bound=0.0,upper_bound=0.6))

--- a/tests/test_times.py
+++ b/tests/test_times.py
@@ -39,7 +39,7 @@ goodlines = lines[1:]
 # Get the output lines from the TOAs
 for line, TOA in zip(goodlines, ts.table):
     assert len(line.split()) == 19, \
-      "tempo2 general2 does not support all needed outputs"
+        "tempo2 general2 does not support all needed outputs"
     oclk, gps_utc, tai_utc, tt_tai, ttcorr, tt2tb, \
           ep0, ep1, ep2, ev0, ev1, ev2, \
           tp0, tp1, tp2, tv0, tv1, tv2, Ttt = \


### PR DESCRIPTION
This is to follow the Python PEP8 style guide and to avoid
issues with mixes tabs and spaces.

Following the recommendation at
http://stackoverflow.com/a/26643477/498873
I just ran this command and committed the changes:
```
autopep8 . --recursive --select=E101,E121 --in-place
```

I'll follow up with other Python 3 PRs in the next day, but this is a long diff, so I wanted to do this first and as a separate PR. If you prefer, you can just run the command yourself of course and close this PR.
