### PR TITLE
Minor Python 3 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ de-403-masses.tpc
 .ipynb_checkpoints
 
 .idea
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,14 @@ language: python
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
+  - "3.5"
+
+
+# https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 
 install:
   - sudo apt-get update
@@ -30,7 +38,7 @@ install:
   # Install dependencies
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install pip nose pytest numpy scipy astropy sphinx cython matplotlib
+  - conda install pip nose pytest coverage numpy scipy astropy sphinx cython matplotlib
   - pip install astropy-helpers
   - pip install jplephem
 

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -1,9 +1,10 @@
-import re, sys, os, cPickle, numpy, gzip
+import re, sys, os, numpy, gzip
 from . import utils
 from .observatory import Observatory
 from . import erfautils
 import astropy.time as time
 from . import pulsar_mjd
+from astropy.extern.six.moves import cPickle as pickle
 import astropy.table as table
 import astropy.units as u
 from astropy.coordinates import EarthLocation
@@ -446,9 +447,9 @@ class TOAs(object):
     def pickle(self, filename=None):
         """Write the TOAs to a .pickle file with optional filename."""
         if filename is not None:
-            cPickle.dump(self, open(filename, "wb"))
+            pickle.dump(self, open(filename, "wb"))
         elif self.filename is not None:
-            cPickle.dump(self, gzip.open(self.filename+".pickle.gz", "wb"))
+            pickle.dump(self, gzip.open(self.filename+".pickle.gz", "wb"))
         else:
             log.warn("TOA pickle method needs a filename.")
 
@@ -672,7 +673,7 @@ class TOAs(object):
             infile = gzip.open(filename,'rb')
         else:
             infile = open(filename,'rb')
-        tmp = cPickle.load(infile)
+        tmp = pickle.load(infile)
         self.filename = tmp.filename
         if hasattr(tmp, 'toas'):
             self.toas = tmp.toas

--- a/tests/test_B1855.py
+++ b/tests/test_B1855.py
@@ -21,7 +21,7 @@ class TestB1855(unittest.TestCase):
         # tempo result
         self.ltres= np.genfromtxt(self.parfileB1855 + \
                                   '.tempo2_test',skip_header=1, unpack=True)
-        print self.ltres
+        print(self.ltres)
     # def test_B1855_binary_delay(self):
     #     # Calculate delays with PINT
     #     pint_binary_delay = self.modelB1855.binarymodel_delay(self.toasB1855.table)

--- a/tests/test_B1855_9yrs.py
+++ b/tests/test_B1855_9yrs.py
@@ -21,7 +21,7 @@ class TestB1855(unittest.TestCase):
         # tempo result
         self.ltres= np.genfromtxt(self.parfileB1855 + \
                                   '.tempo2_test',skip_header=1, unpack=True)
-        print self.ltres
+        print(self.ltres)
     # def test_B1855_binary_delay(self):
     #     # Calculate delays with PINT
     #     pint_binary_delay = self.modelB1855.binarymodel_delay(self.toasB1855.table)

--- a/tests/test_B1953.py
+++ b/tests/test_B1953.py
@@ -21,7 +21,7 @@ class TestB1953(unittest.TestCase):
         # tempo result
         self.ltres, self.ltbindelay = np.genfromtxt(self.parfileB1953 + \
                                      '.tempo2_test',skip_header=1, unpack=True)
-        print self.ltres
+        print(self.ltres)
     def test_B1953_binary_delay(self):
         # Calculate delays with PINT
         pint_binary_delay = self.modelB1953.binarymodel_delay(self.toasB1953.table)

--- a/tests/test_J0613.py
+++ b/tests/test_J0613.py
@@ -21,7 +21,7 @@ class TestJ0613(unittest.TestCase):
         # tempo result
         self.ltres, self.ltbindelay = np.genfromtxt(self.parfileJ0613 + \
                                      '.tempo2_test',skip_header=1, unpack=True)
-        print self.ltres
+        print(self.ltres)
     def test_J0613_binary_delay(self):
         # Calculate delays with PINT
         pint_binary_delay = self.modelJ0613.binarymodel_delay(self.toasJ0613.table)

--- a/tests/test_astropy_times.py
+++ b/tests/test_astropy_times.py
@@ -58,4 +58,4 @@ def test_iers_a_now():
     iers_a = IERS_A.open(IERS_A_URL)
     t2 = astropy.time.Time.now()
     t2.delta_ut1_utc = t2.get_delta_ut1_utc(iers_a)
-    print t2.tdb.iso
+    print(t2.tdb.iso)

--- a/tests/test_dmx.py
+++ b/tests/test_dmx.py
@@ -17,7 +17,7 @@ class TestDMX(unittest.TestCase):
         self.toas = toa.get_TOAs(self.timf, ephem='DE405')
 
     def test_DMX(self):
-        print "Testing DMX module."
+        print("Testing DMX module.")
         rs = residuals.resids(self.toas, self.DMXm).time_resids.to(u.s).value
         ltres, _ = np.genfromtxt(self.parf+ '.tempo_test', unpack=True)
         resDiff = rs-ltres

--- a/tests/test_fd.py
+++ b/tests/test_fd.py
@@ -18,7 +18,7 @@ class TestFD(unittest.TestCase):
         # libstempo result
         self.ltres, self.ltbindelay = np.genfromtxt(self.parf + '.tempo_test', unpack=True)
     def test_FD(self):
-        print "Testing FD module."
+        print("Testing FD module.")
         rs = pint.residuals.resids(self.toas, self.FDm).time_resids.to(u.s).value
         resDiff = rs - self.ltres
         #NOTE : This prescision is a lower then 1e-7 seconds level, due to some

--- a/tests/test_parfile.py
+++ b/tests/test_parfile.py
@@ -9,18 +9,18 @@ parfile = os.path.join(datadir,'J1744-1134.basic.par')
 TestModel = tm.generate_timing_model("TestModel",(tm.AstrometryEquatorial,tm.Dispersion,tm.SolarSystemShapiro,tm.Spindown))
 m = TestModel()
 
-print "model.param_help():"
+print("model.param_help():")
 m.param_help()
-print
+print()
 
-print "calling model.read_parfile():"
+print("calling model.read_parfile():")
 m.read_parfile(parfile)
-print
+print()
 
-print "print model:"
-print m
-print
+print("print model:")
+print(m)
+print()
 
-print "model.as_parfile():"
-print m.as_parfile()
-print
+print("model.as_parfile():")
+print(m.as_parfile())
+print()

--- a/tests/test_prefix.py
+++ b/tests/test_prefix.py
@@ -21,10 +21,10 @@ class TestPrefix(unittest.TestCase):
         self.m = pint.models.get_model(parfile)
         self.t = pint.toa.get_TOAs(timfile,ephem="DE405")
     def test_prefix(self):
-        print "Test prefix parameter via a glitch model"
+        print("Test prefix parameter via a glitch model")
         rs = pint.residuals.resids(self.t, self.m).phase_resids
         # Now do the fit
-        print "Fitting..."
+        print("Fitting...")
         f = pint.fitter.fitter(self.t, self.m)
         f.call_minimize()
         emsg = "RMS of " + self.m.PSR.value + " is too big."

--- a/tests/test_toa_pickle.py
+++ b/tests/test_toa_pickle.py
@@ -28,6 +28,6 @@ class TestTOAReader:
 if __name__ == '__main__':
     t = TestTOAReader()
     t.setUp()
-    print 'Tests are set up.'
+    print('Tests are set up.')
 
     t.test_pickle()

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -34,7 +34,7 @@ class TestTOAReader:
 if __name__ == '__main__':
     t = TestTOAReader()
     t.setUp()
-    print 'Tests are set up.'
+    print('Tests are set up.')
 
     t.test_commands()
     t.test_count()


### PR DESCRIPTION
This PR

- [x] fixes Python 2 issues on travis-ci by installing `coverage` and setting DISPLAY / xvfb so that matplotlib can run
- [x] contains some minor Python 3 fixes (trying to get the tests to run / pass on Python 3)
- [x] adds a Python 3 build on travis-ci (not passing yet)
