### PR TITLE
Remove spiceutils from utils.rst

### DIFF
--- a/doc/utils.rst
+++ b/doc/utils.rst
@@ -6,8 +6,5 @@ These modules provide various utility functions, often adapters to libraries.
 .. automodapi:: pint.utils
     :no-inheritance-diagram:
 
-.. automodapi:: pint.spiceutils
-    :no-inheritance-diagram:
-
 .. automodapi:: pint.erfautils
     :no-inheritance-diagram:


### PR DESCRIPTION
spiceutils no longer exists, so it needs to be removed from the docs as well.