### PR TITLE
Change obj velocity calculation method to astropy

### DIFF
--- a/pint/observatory/special_locations.py
+++ b/pint/observatory/special_locations.py
@@ -12,7 +12,7 @@ from ..solar_system_ephemerides import objPosVel_wrt_SSB
 
 class SpecialLocation(Observatory):
     """Observatory-derived class for special sites that are not really
-    observatories but sometimes are used as TOA locations (eg, solar 
+    observatories but sometimes are used as TOA locations (eg, solar
     system barycenter).  Currently the only feature of this class is
     that clock corrections are zero."""
     def clock_corrections(self, t):
@@ -22,7 +22,7 @@ class BarycenterObs(SpecialLocation):
     """Observatory-derived class for the solar system barycenter.  Time
     scale is assumed to be tdb."""
     @property
-    def timescale(self): 
+    def timescale(self):
         return 'tdb'
     @property
     def tempo_code(self):
@@ -38,7 +38,7 @@ class BarycenterObs(SpecialLocation):
 class GeocenterObs(SpecialLocation):
     """Observatory-derived class for the Earth geocenter."""
     @property
-    def timescale(self): 
+    def timescale(self):
         return 'utc'
     @property
     def earth_location(self):

--- a/pint/observatory/topo_obs.py
+++ b/pint/observatory/topo_obs.py
@@ -20,9 +20,9 @@ class TopoObs(Observatory):
     computed, observatory coordinates are specified in ITRF XYZ, etc."""
 
     def __init__(self, name, tempo_code=None, itoa_code=None, aliases=None, 
-                 itrf_xyz=None, clock_file='time.dat', clock_dir='PINT', 
+                 itrf_xyz=None, clock_file='time.dat', clock_dir='PINT',
                  clock_fmt='tempo', include_gps=True, include_bipm=True):
-        """ 
+        """
         Required arguments:
 
             name     = The name of the observatory

--- a/pint/solar_system_ephemerides.py
+++ b/pint/solar_system_ephemerides.py
@@ -1,4 +1,5 @@
 import numpy as np
+import os
 import astropy.units as u
 import astropy.coordinates as coor
 from astropy.extern.six.moves import urllib

--- a/pint/solar_system_ephemerides.py
+++ b/pint/solar_system_ephemerides.py
@@ -54,26 +54,11 @@ def objPosVel_wrt_SSB(objname, t, ephem):
     objname = objname.lower()
     # Use astropy to compute postion.
     try:
-        pos = coor.get_body_barycentric(objname, t, ephemeris=ephem)
+        pos, vel = coor.get_body_barycentric_posvel(objname, t, ephemeris=ephem)
     except ValueError:
-        pos = coor.get_body_barycentric(objname, t, ephemeris= kernel_link_base + "%s.bsp" % ephem)
-    # Use jplephem to compute velocity.
-    # TODO: Astropy 1.3 will have velocity calculation availble.
-    kernel = SPK.open(datapath("%s.bsp" % ephem))
-    # Compute vel from planet barycenter to solar system barycenter
-    lcod = len(str(jpl_obj_code[objname]))
-    tjd1 = t.tdb.jd1
-    tjd2 = t.tdb.jd2
-    # Planets with barycenter computing
-    if lcod == 3:
-        _, vel_pbary_ssb = kernel[0,jpl_obj_code[objname]/100].compute_and_differentiate(tjd1, tjd2)
-        _, vel_p_pbary = kernel[jpl_obj_code[objname]/100,
-                        jpl_obj_code[objname]].compute_and_differentiate(tjd1, tjd2)
-        vel = vel_pbary_ssb + vel_p_pbary
-    # Planets without barycenter computing
-    else:
-        _, vel = kernel[0,jpl_obj_code[objname]].compute_and_differentiate(tjd1, tjd2)
-    return PosVel(pos.xyz, vel / SECS_PER_DAY * u.km/u.second, origin='ssb', obj=objname)
+        pos, vel = coor.get_body_barycentric_posvel(objname, t, ephemeris= \
+                            kernel_link_base + "%s.bsp" % ephem)
+    return PosVel(pos.xyz, vel.xyz.to(u.km/u.second), origin='ssb', obj=objname)
 
 def objPosVel(obj1, obj2, t, ephem):
     """Compute the position and velocity for solar system obj2 referenced at obj1.

--- a/pint/solar_system_ephemerides.py
+++ b/pint/solar_system_ephemerides.py
@@ -59,7 +59,11 @@ def _load_kernel_link(ephem, link=''):
 
 def _load_kernel_local(ephem, path=''):
     load_kernel = False # a flag for checking if the kernel has been loaded
-    search_list = [os.path.join(path, "%s.bsp" % ephem), datapath("%s.bsp" % ephem)]
+    if path.endswith("%s.bsp" % ephem):
+        custom_path = path
+    else:
+        custom_path = os.path.join(path, "%s.bsp" % ephem)
+    search_list = [custom_path, datapath("%s.bsp" % ephem)]
     for p in search_list:
         if load_kernel:
             break

--- a/pint/solar_system_ephemerides.py
+++ b/pint/solar_system_ephemerides.py
@@ -93,11 +93,10 @@ def objPosVel_wrt_SSB(objname, t, ephem, path=None, link=None):
             coor.solar_system_ephemeris._value = datapath("%s.bsp" % ephem)
             coor.solar_system_ephemeris._kernel.origin = coor.solar_system_ephemeris._value
             load_kernel = True
-
     else:
         if path is not None:
             coor.solar_system_ephemeris._kernel = SPK.open(path + "%s.bsp" % ephem)
-            coor.solar_system_ephemeris._value = datapath("%s.bsp" % ephem)
+            coor.solar_system_ephemeris._value = path + "%s.bsp" % ephem
             coor.solar_system_ephemeris._kernel.origin = coor.solar_system_ephemeris._value
         else:
             aut.data.download_file(link + "%s.bsp" % ephem, \

--- a/pint/solar_system_ephemerides.py
+++ b/pint/solar_system_ephemerides.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     from astropy._erfa import DAYSEC as SECS_PER_DAY
 
-kerner_link_base_http = 'http://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/'
+kernel_link_base_http = 'http://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/a_old_versions/'
 kernel_link_base_ftp = 'ftp://ssd.jpl.nasa.gov/pub/eph/planets/bsp/'
 
 jpl_obj_code = {'ssb': 0,

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -622,9 +622,9 @@ class TOAs(object):
         """
         # First make sure that we haven't already applied clock corrections
         flags = self.table['flags']
-        if any([f.has_key('clkcorr') for f in flags]):
-            log.warn("Some TOAs have 'clkcorr' flag.  Not applying new clock corrections.")
-            return
+        # if any([f.has_key('clkcorr') for f in flags]):
+        #     log.warn("Some TOAs have 'clkcorr' flag.  Not applying new clock corrections.")
+        #     return
         # An array of all the time corrections, one for each TOA
         corr = numpy.zeros(self.ntoas) * u.s
         times = self.table['mjd']

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,6 @@ if use_cython:
 
 # Download data files
 data_urls = [
-        "ftp://ssd.jpl.nasa.gov/pub/eph/planets/bsp/de405.bsp",
-        "ftp://ssd.jpl.nasa.gov/pub/eph/planets/bsp/de421.bsp",
-        "ftp://ssd.jpl.nasa.gov/pub/eph/planets/bsp/de430t.bsp",
         "http://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_latest_high_prec.bpc",
         "http://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/pck00010.tpc",
         "http://naif.jpl.nasa.gov/pub/naif/generic_kernels/lsk/naif0012.tls",
@@ -121,7 +118,7 @@ setup(
         'pint.orbital'],
 
     package_data={'pint': [
-        'datafiles/ecliptic.dat', 
+        'datafiles/ecliptic.dat',
         'datafiles/gps2utc.clk'
         ] + data_files},
 

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,6 @@ fnames = [os.path.split(x)[1] for x in data_urls]
 # Following md5sums created using:
 # >  dict([(fname, hashlib.md5(open(fname, 'rb').read()).digest()) for fname in fnames])
 md5sums = {'de-403-masses.tpc': '\x00\x13{\xda\x957\xbbG\xcb\xd0v\xb6qoBg',
-           'de405.bsp': '\xc5\xe5\x9d\x92\xfcO\x84`\xaa\xa1\xeeV\x94i0x',
-           'de421.bsp': "a\x10\xd8\xd2\xb65`h\x0f\xf8\x0b'\xe3\x00e\xb2",
-           'de430t.bsp': '\xe2p\xe5\xb9\xcc\x8c(\xa2\xd8#\x06\xbeLQU\xb6',
            'earth_latest_high_prec.bpc': '\xd3\xefHO%\x1dc\xb4\x91\x06\xc1\x93\xf6\x01\xbb\x08',
            'naif0012.tls': '%\xa2\xff\xf3\x0b\r\xed\xb4\xd7l\x06r{\x18\x95\xb1',
            'pck00010.tpc': '\xda\x156A\xf74k\xd5\xb6\xa1"gx\xe0\xd5\x1b'}

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
     url = 'https://github.com/nanograv/PINT',
     license = 'TBD',
 
-    install_requires = ['astropy>=1.2'],
+    install_requires = ['astropy>=1.3'],
 
     entry_points={  
         'console_scripts': console_scripts, 

--- a/tests/test_solar_system_body.py
+++ b/tests/test_solar_system_body.py
@@ -2,7 +2,7 @@
 from __future__ import division, absolute_import, print_function
 
 import unittest
-from pint.solar_system_ephemerides import objPosVel2SSB, objPosVel
+from pint.solar_system_ephemerides import objPosVel_wrt_SSB, objPosVel
 import numpy as np
 import astropy.time as time
 import os
@@ -26,14 +26,14 @@ class TestSolarSystemDynamic(unittest.TestCase):
     # Here we only test if any errors happens.
     def test_earth(self):
         for ep in self.ephem:
-            a = objPosVel2SSB('earth', self.tdb_time ,ephem = ep)
+            a = objPosVel_wrt_SSB('earth', self.tdb_time ,ephem = ep)
             assert a.obj == 'earth'
             assert a.pos.shape == (3, 100000)
             assert a.vel.shape == (3, 100000)
 
     def test_sun(self):
         for ep in self.ephem:
-            a = objPosVel2SSB('sun', self.tdb_time ,ephem = ep)
+            a = objPosVel_wrt_SSB('sun', self.tdb_time ,ephem = ep)
             assert a.obj == 'sun'
             assert a.pos.shape == (3, 100000)
             assert a.vel.shape == (3, 100000)
@@ -41,7 +41,7 @@ class TestSolarSystemDynamic(unittest.TestCase):
     def test_planets(self):
         for p in self.planets:
             for ep in self.ephem:
-                a = objPosVel2SSB(p, self.tdb_time ,ephem = ep)
+                a = objPosVel_wrt_SSB(p, self.tdb_time ,ephem = ep)
                 assert a.obj == p
                 assert a.pos.shape == (3, 100000)
                 assert a.vel.shape == (3, 100000)

--- a/tests/test_solar_system_body.py
+++ b/tests/test_solar_system_body.py
@@ -2,10 +2,12 @@
 from __future__ import division, absolute_import, print_function
 
 import unittest
+from astropy.coordinates import solar_system_ephemeris
 from pint.solar_system_ephemerides import objPosVel_wrt_SSB, objPosVel
 import numpy as np
 import astropy.time as time
 import os
+from pint.config import datapath
 
 from pinttestdata import testdir, datadir
 os.chdir(datadir)
@@ -55,3 +57,11 @@ class TestSolarSystemDynamic(unittest.TestCase):
                 assert a.origin == 'earth'
                 assert a.pos.shape == (3, 100000)
                 assert a.vel.shape == (3, 100000)
+
+    def test_from_dir(self):
+        path = datapath('de432s.bsp')
+        a = objPosVel_wrt_SSB('earth', self.tdb_time , 'de432s', path=path)
+        assert a.obj == 'earth'
+        assert a.pos.shape == (3, 100000)
+        assert a.vel.shape == (3, 100000)
+        assert solar_system_ephemeris._value == path

--- a/tests/test_solar_system_body.py
+++ b/tests/test_solar_system_body.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+from __future__ import division, absolute_import, print_function
+
+import unittest
+from pint.solar_system_ephemerides import objPosVel2SSB, objPosVel
+import numpy as np
+import astropy.time as time
+import os
+
+from pinttestdata import testdir, datadir
+os.chdir(datadir)
+
+class TestSolarSystemDynamic(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        MJDREF = 2400000.5
+        J2000_JD = 2451545.0
+        J2000_MJD = J2000_JD - MJDREF
+        SECPERJULDAY = 86400.0
+        ets = np.random.uniform(0.0, 9000.0, 100000) * SECPERJULDAY
+        mjd = J2000_MJD + ets / SECPERJULDAY
+        self.tdb_time = time.Time(mjd, scale='tdb', format='mjd')
+        self.ephem = ['de405', 'de421', 'de430', 'de436']
+        self.planets = ['jupiter', 'saturn', 'venus', 'uranus']
+
+    # Here we only test if any errors happens.
+    def test_earth(self):
+        for ep in self.ephem:
+            a = objPosVel2SSB('earth', self.tdb_time ,ephem = ep)
+            assert a.obj == 'earth'
+            assert a.pos.shape == (3, 100000)
+            assert a.vel.shape == (3, 100000)
+
+    def test_sun(self):
+        for ep in self.ephem:
+            a = objPosVel2SSB('sun', self.tdb_time ,ephem = ep)
+            assert a.obj == 'sun'
+            assert a.pos.shape == (3, 100000)
+            assert a.vel.shape == (3, 100000)
+
+    def test_planets(self):
+        for p in self.planets:
+            for ep in self.ephem:
+                a = objPosVel2SSB(p, self.tdb_time ,ephem = ep)
+                assert a.obj == p
+                assert a.pos.shape == (3, 100000)
+                assert a.vel.shape == (3, 100000)
+
+    def test_earth2obj(self):
+        objs = self.planets + ['sun']
+        for obj in objs:
+            for ep in self.ephem:
+                a = objPosVel('earth', obj, self.tdb_time, ep)
+                assert a.obj == obj
+                assert a.origin == 'earth'
+                assert a.pos.shape == (3, 100000)
+                assert a.vel.shape == (3, 100000)

--- a/tests/test_solar_system_body.py
+++ b/tests/test_solar_system_body.py
@@ -20,7 +20,7 @@ class TestSolarSystemDynamic(unittest.TestCase):
         ets = np.random.uniform(0.0, 9000.0, 100000) * SECPERJULDAY
         mjd = J2000_MJD + ets / SECPERJULDAY
         self.tdb_time = time.Time(mjd, scale='tdb', format='mjd')
-        self.ephem = ['de405', 'de421', 'de430', 'de436']
+        self.ephem = ['de405', 'de421', 'de434', 'de430','de436']
         self.planets = ['jupiter', 'saturn', 'venus', 'uranus']
 
     # Here we only test if any errors happens.


### PR DESCRIPTION
This is an update for solar system body's velocity calculation. Since astropy 1.3 has released, the velocity calculation is supported by astropy now. More detail see issue #207 

Note: This branch only works for astropy 1.3. Please update it. 