### PR TITLE
Update timescale to UTC for Geocentric TOAs and add leap second test

### DIFF
--- a/pint/observatory/special_locations.py
+++ b/pint/observatory/special_locations.py
@@ -34,7 +34,7 @@ class GeocenterObs(SpecialLocation):
     """Observatory-derived class for the Earth geocenter."""
     @property
     def timescale(self): 
-        return 'tt'
+        return 'utc'
     @property
     def earth_location(self):
         return EarthLocation.from_geocentric(0.0,0.0,0.0,unit=u.m)

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -274,7 +274,7 @@ class TOA(object):
     """
     def __init__(self, MJD, # required
                  error=0.0, obs='Barycenter', freq=float("inf"),
-                 scale='utc', # with defaults
+                 scale=None, 
                  **kwargs):  # keyword args that are completely optional
         r"""
         Construct a TOA object
@@ -292,7 +292,8 @@ class TOA(object):
             Frequency corresponding to the TOA.  Either a Quantity with frequency
             units, or a number for which MHz is assumed.
         scale : string
-            Time scale for the TOA time.  Usually 'utc'
+            Time scale for the TOA time.  Defaults to the timescale appropriate
+            to the site, but can be overridden
 
         Notes
         -----
@@ -306,7 +307,9 @@ class TOA(object):
             arg1, arg2 = MJD, None
         else:
             arg1, arg2 = MJD[0], MJD[1]
-        self.mjd = time.Time(arg1, arg2, scale=site.timescale,
+        if scale is None:
+            scale = site.timescale
+        self.mjd = time.Time(arg1, arg2, scale=scale,
                 location=site.earth_location,
                 format='pulsar_mjd', precision=9)
 

--- a/tests/test_leapsec.py
+++ b/tests/test_leapsec.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+from __future__ import print_function, division
+
+import numpy as np
+from astropy.time import Time
+
+# This test is to make sure that astropy is correctly including recent leap seconds.
+# It should be updated whenever a new leap second occurs. Just add a new check.
+
+# Test that 2008 Dec 31 leap second is correctly included
+t1 = Time('2008-12-31T23:59:00',scale='utc')
+t2 = Time('2009-01-01T00:00:00',scale='utc')
+assert np.isclose((t2-t1).sec, 61.0)
+
+# Test that 2016 Dec 31 leap second is correctly included
+t1 = Time('2016-12-31T23:59:00',scale='utc')
+t2 = Time('2017-01-01T00:00:00',scale='utc')
+assert np.isclose((t2-t1).sec, 61.0)
+
+


### PR DESCRIPTION
The site default for Geocenter TOAs is now UTC, to correspond with how Tempo2 interprets MJDs in .tim lines with site=coe. 

Added ability for TOA() objects to override the default timescale for the site

Added test to verify that PINT is correctly using the latest leap second