### PR TITLE
move chi2 calculation out of for loop

### DIFF
--- a/pint/fitter.py
+++ b/pint/fitter.py
@@ -191,9 +191,9 @@ class WlsFitter(Fitter):
                     un *= u.s
                 pv, dpv = fitpv[pn] * fitp[pn].units, dpars[uind] * un
                 fitpv[pn] = numpy.longdouble((pv+dpv) / fitp[pn].units)
-                #NOTE We need some way to use the parameter limits. 
+                #NOTE We need some way to use the parameter limits.
                 fitperrs[pn] = errs[uind]
-                chi2 = self.minimize_func(list(fitpv.values()), *fitp.keys())
+            chi2 = self.minimize_func(list(fitpv.values()), *fitp.keys())
             # Updata Uncertainties
             self.set_param_uncertainties(fitperrs)
 


### PR DESCRIPTION
This moves chi2 calculation out of the for loop of assign the new parameter values. The old version should be a bug. 