### PR TITLE
Fixed missing package in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,7 @@ setup(
     packages=['pint',
         'pint.extern',
         'pint.models',
+        'pint.scripts',
         'pint.models.stand_alone_psr_binaries',
         'pint.observatory',
         'pint.orbital'],


### PR DESCRIPTION
I forgot to add pint.scripts to the package list in setup.py. This fixes that.