### PR TITLE
Fixed attribute name so binary model should get written out by as_parfile

### DIFF
--- a/pint/models/timing_model.py
+++ b/pint/models/timing_model.py
@@ -572,8 +572,8 @@ class TimingModel(object):
             result += getattr(self, par).as_parfile_line()
         # Always include UNITS in par file. For now, PINT only supports TDB
         result += "UNITS TDB\n"
-        if hasattr(self,'BinaryModelName'):
-            result += "BINARY {0}\n".format(self.BinaryModelName)
+        if hasattr(self,'binary_model_name'):
+            result += "BINARY {0}\n".format(self.binary_model_name)
         return result
 
     def read_parfile(self, filename):


### PR DESCRIPTION
This should at least allow binary model names to get written out by `TimingModel.as_parfile()`, as noted in issue #78 

It still does not address other issues with `as_parfile()`, like reasonable sorting.
