### PR TITLE
Fix likelihood in event_optimize

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,3 +15,4 @@
 2017-03-06 (jellis18) Added TT(BIPM) clock corrections
 2017-03-08 (luojing1211) Using astropy 1.3 for velocity calculations so no longer need to download .bsp files
 2017-03-08 (paulr) Tag: 0.5.2
+2017-03-09 (kerrm) Fixed template normalization in event_optimize to get correct log Likelihoods

--- a/pint/scripts/event_optimize.py
+++ b/pint/scripts/event_optimize.py
@@ -461,7 +461,7 @@ def main(argv=None):
 
     # Now load in the gaussian template and normalize it
     gtemplate = read_gaussfitfile(gaussianfile, nbins)
-    gtemplate /= gtemplate.sum()
+    gtemplate /= gtemplate.mean()
 
     # Set the priors on the parameters in the model, before
     # instantiating the emcee_fitter


### PR DESCRIPTION
This corrects the normalization of the gaussian template used in event_optimize so that log Likelihood values can be compared with others (e.g the E@H people). This bug was reported by @kerrm
