### PR TITLE
Fix the erfa warning. 

### DIFF
--- a/pint/models/dispersion_model.py
+++ b/pint/models/dispersion_model.py
@@ -8,7 +8,7 @@ from .timing_model import TimingModel, Cache
 import astropy.units as u
 import numpy as np
 import pint.utils as ut
-import astropy.time as time
+
 # The units on this are not completely correct
 # as we don't really use the "pc cm^3" units on DM.
 # But the time and freq portions are correct

--- a/pint/models/dispersion_model.py
+++ b/pint/models/dispersion_model.py
@@ -89,13 +89,11 @@ class DispersionDMX(Dispersion):
                        paramter_type='float'))
         self.add_param(p.prefixParameter(name='DMXR1_0001',
                        units="MJD",
-                       value=time.Time(0.0, scale='utc', format='pulsar_mjd'),
                        unitTplt=lambda x: "MJD",
                        description='Beginning of DMX interval',
                        descriptionTplt=lambda x: 'Beginning of DMX interval',
                        parameter_type='MJD', time_scale='utc'))
         self.add_param(p.prefixParameter(name='DMXR2_0001', units="MJD",
-                       value=time.Time(0.0, scale='utc', format='pulsar_mjd'),
                        unitTplt=lambda x: "MJD",
                        description='End of DMX interval',
                        descriptionTplt=lambda x: 'End of DMX interval',


### PR DESCRIPTION
Hi @all, 

This is a little fix for the efra warning. The warning shows up when the input MJD time is too big or too small. So I fixed it in the models. But the warning still shows when reading TOAs. The reason for that is due to the last date in the gps2utc.clk file is at 99999.0 which is very far in the future. Should we leave it there?