### PR TITLE
Make Py3 work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ matrix:
         - python: "2.7"
         - python: "3.5"
         - python: "3.6"
-    allow_failures:
-        - python: "3.5"
-        - python: "3.6"
  
 sudo: required
 

--- a/pint/fitter.py
+++ b/pint/fitter.py
@@ -195,7 +195,7 @@ class WlsFitter(Fitter):
                 fitpv[pn] = numpy.longdouble((pv+dpv) / fitp[pn].units)
                 #NOTE We need some way to use the parameter limits.
                 fitperrs[pn] = errs[uind]
-            chi2 = self.minimize_func(list(fitpv.values()), *fitp.keys())
+            chi2 = self.minimize_func(list(fitpv.values()), *list(fitp.keys()))
             # Updata Uncertainties
             self.set_param_uncertainties(fitperrs)
 

--- a/pint/fitter.py
+++ b/pint/fitter.py
@@ -112,13 +112,14 @@ class PowellFitter(Fitter):
     def fit_toas(self, maxiter=20):
         # Initial guesses are model params
         fitp = self.get_fitparams_num()
-        self.fitresult=opt.minimize(self.minimize_func, fitp.values(),
+        self.fitresult=opt.minimize(self.minimize_func, list(fitp.values()),
                                     args=tuple(fitp.keys()),
-                                    options={'maxiter':self.method},
+                                    options={'maxiter':maxiter},
                                     method=self.method)
         # Update model and resids, as the last iteration of minimize is not
         # necessarily the one that yields the best fit
-        self.minimize_func(numpy.atleast_1d(self.fitresult.x), *fitp.keys())
+        self.minimize_func(numpy.atleast_1d(self.fitresult.x),
+                           *list(fitp.keys()))
 
 
 class WlsFitter(Fitter):

--- a/pint/models/dispersion_model.py
+++ b/pint/models/dispersion_model.py
@@ -177,7 +177,7 @@ class DispersionDMX(Dispersion):
         DMXR2_mapping = self.get_prefix_mapping('DMXR2_')
         result += getattr(self, 'DM').as_parfile_line()
         result += getattr(self, 'DMX').as_parfile_line()
-        sorted_list = DMX_mapping.keys()
+        sorted_list = list(DMX_mapping.keys())
         sorted_list.sort()
         for ii in sorted_list:
             result += getattr(self, DMX_mapping[ii]).as_parfile_line()

--- a/pint/models/frequency_dependent.py
+++ b/pint/models/frequency_dependent.py
@@ -27,15 +27,15 @@ class FD(TimingModel):
         super(FD, self).setup()
         # Check if FD terms are in order.
         FD_mapping = self.get_prefix_mapping('FD')
-        FD_terms = FD_mapping.keys()
+        FD_terms = list(FD_mapping.keys())
         FD_terms.sort()
-        FD_in_order = range(1,max(FD_terms)+1)
+        FD_in_order = list(range(1,max(FD_terms)+1))
         if not FD_terms == FD_in_order:
             diff = list(set(FD_in_order) - set(FD_terms))
             raise MissingParameter("FD", "FD%d"%diff[0])
         self.num_FD_terms = len(FD_terms)
         # set up derivative functions
-        for ii, val in FD_mapping.iteritems():
+        for ii, val in FD_mapping.items():
             self.register_deriv_funcs(self.d_delay_FD_d_FDX, 'delay', val)
 
     def FD_delay(self, toas):

--- a/pint/models/model_builder.py
+++ b/pint/models/model_builder.py
@@ -227,8 +227,10 @@ class model_builder(object):
 
             for ptype in ['prefixParameter', 'maskParameter']:
                 prefix_in_model = self.model_instance.get_params_of_type(ptype)
-                prefix_param = self.search_prefix_param(self.param_unrecognized.keys(),
-                                                        prefix_in_model)
+                prefix_param = \
+                    self.search_prefix_param(
+                        list(self.param_unrecognized.keys()),
+                        prefix_in_model)
                 for key in prefix_param.keys():
                     ppnames = [x for x in prefix_in_model if x.startswith(key)]
                     exm_par = getattr(self.model_instance,ppnames[0])

--- a/pint/models/parameter.py
+++ b/pint/models/parameter.py
@@ -684,7 +684,7 @@ class MJDParameter(Parameter):
             try:
                 result = time_from_mjd_string(val, self.time_scale)
             except:
-                raise ValueError('String ' + val + 'can not be converted to'
+                raise ValueError('String ' + val + ' can not be converted to'
                                  'a time object.' )
 
         elif isinstance(val,time.Time):

--- a/pint/models/polycos.py
+++ b/pint/models/polycos.py
@@ -2,6 +2,7 @@
 # given interval using polynomial expansion. The return will be some necessary
 # information and the polynomial coefficients
 
+from __future__ import division, print_function
 import functools
 from ..phase import Phase
 import numpy as np
@@ -183,7 +184,7 @@ def tempo_polyco_table_reader(filename):
             binaryPhase = np.longdouble(0.0)
 
         # Read coefficients
-        nCoeffLines = nCoeff/3
+        nCoeffLines = nCoeff//3
 
         if nCoeff%3>0:
             nCoeffLines += 1

--- a/pint/models/spindown.py
+++ b/pint/models/spindown.py
@@ -53,9 +53,9 @@ class Spindown(TimingModel):
                 raise MissingParameter("Spindown", p)
 
         # Check continuity
-        F_terms = self.get_prefix_mapping('F').keys()
+        F_terms = list(self.get_prefix_mapping('F').keys())
         F_terms.sort()
-        F_in_order = range(1, max(F_terms)+1)
+        F_in_order = list(range(1, max(F_terms)+1))
         if not F_terms == F_in_order:
             diff = list(set(F_in_order) - set(F_terms))
             raise MissingParameter("Spindown", "F%d"%diff[0])
@@ -66,7 +66,7 @@ class Spindown(TimingModel):
                 raise MissingParameter("Spindown", "PEPOCH",
                         "PEPOCH is required if F1 or higher are set")
         self.num_spin_terms = len(F_terms) + 1
-        for fp in self.get_prefix_mapping('F').values() + ['F0',]:
+        for fp in list(self.get_prefix_mapping('F').values()) + ['F0',]:
             self.register_deriv_funcs(self.d_phase_d_F, 'phase', fp)
         self.register_deriv_funcs(self.d_spindown_phase_d_delay, 'd_phase_d_delay')
 

--- a/pint/models/stand_alone_psr_binaries/BT_model.py
+++ b/pint/models/stand_alone_psr_binaries/BT_model.py
@@ -79,7 +79,7 @@ class BTmodel(PSR_BINARY):
     def __init__(self, t=None, input_params=None):
         super(BTmodel, self).__init__()
         self.binary_name = 'BT'
-        self.binary_params = self.param_default_value.keys()
+        self.binary_params = list(self.param_default_value.keys())
         self.set_param_values() # Set parameters to default values.
         self.binary_delay_funcs += [self.BTdelay]
         self.d_binarydelay_d_par_funcs += [self.d_BTdelay_d_par]

--- a/pint/models/stand_alone_psr_binaries/DD_model.py
+++ b/pint/models/stand_alone_psr_binaries/DD_model.py
@@ -36,7 +36,7 @@ class DDmodel(PSR_BINARY):
                                'DR':0*u.Unit(''),'DTH':0*u.Unit(''),})
         # If any parameter has aliases, it should be updated
         #self.param_aliases.update({})
-        self.binary_params = self.param_default_value.keys()
+        self.binary_params = list(self.param_default_value.keys())
 
         self.dd_interVars = ['er','eTheta','beta','alpha','Dre','Drep','Drepp',
                              'nhat', 'TM2']

--- a/pint/models/stand_alone_psr_binaries/ELL1_model.py
+++ b/pint/models/stand_alone_psr_binaries/ELL1_model.py
@@ -18,7 +18,7 @@ class ELL1model(PSR_BINARY):
                                          'EPS1DOT': 0/u.second,
                                          'EPS2DOT': 0/u.second,
                                          'TASC': np.longdouble(54000.0)*u.day})
-        self.binary_params = self.param_default_value.keys()
+        self.binary_params = list(self.param_default_value.keys())
         self.set_param_values() # Set parameters to default values.
         self.ELL1_interVars = ['eps1', 'eps2', 'Phi', 'Dre', 'Drep', 'Drepp', 'nhat']
         self.add_inter_vars(self.ELL1_interVars)

--- a/pint/models/stand_alone_psr_binaries/binary_generic.py
+++ b/pint/models/stand_alone_psr_binaries/binary_generic.py
@@ -113,7 +113,7 @@ class PSR_BINARY(object):
                                         })
         self.param_aliases = {'ECC':['E'],'EDOT':['ECCDOT'],
                               'A1DOT':['XDOT']}
-        self.binary_params = self.param_default_value.keys()
+        self.binary_params = list(self.param_default_value.keys())
         self.inter_vars = ['E','M','nu','ecc','omega','a1','TM2']
         self.binary_delay_funcs = []
         self.d_binarydelay_d_par_funcs = []

--- a/pint/models/timing_model.py
+++ b/pint/models/timing_model.py
@@ -465,7 +465,7 @@ class TimingModel(object):
         param_phase_derivs = []
         if param in self.phase_derivs.keys():
             for df in self.phase_derivs[param]:
-                if df.func_name.endswith(param):
+                if df.__name__.endswith(param):
                     result += df(toas, delay).to(result.unit,
                                          equivalencies=u.dimensionless_angles())
                 else: # Then this is a general derivative function.
@@ -545,7 +545,7 @@ class TimingModel(object):
                                  " or not registred. "%param)
         for df in self.delay_derivs[param]:
             # The derivative function is for a specific parameter.
-            if df.func_name.endswith(param):
+            if df.__name__.endswith(param):
                 result += df(toas).to(result.unit, equivalencies=u.dimensionless_angles())
             else: # Then this is a general derivative function.
                 result += df(toas, param).to(result.unit, equivalencies=u.dimensionless_angles())
@@ -694,7 +694,7 @@ class TimingModel(object):
             False : bool
                 The subclass is not inculded in the parfile.
         """
-        pNames_inpar = para_dict.keys()
+        pNames_inpar = list(para_dict.keys())
 
         pNames_inModel = self.params
 

--- a/pint/models/timing_model.py
+++ b/pint/models/timing_model.py
@@ -11,6 +11,7 @@ import astropy.units as u
 from astropy.table import Table
 import copy
 import abc
+from six import add_metaclass
 
 # parameters or lines in parfiles to ignore (for now?), or at
 # least not to complain about
@@ -114,6 +115,7 @@ class ModelMeta(abc.ABCMeta):
         super(ModelMeta, cls).__init__(name, bases, dct)
 
 
+@add_metaclass(ModelMeta)
 class TimingModel(object):
     """
     Base-level object provides an interface for implementing pulsar timing
@@ -158,7 +160,7 @@ class TimingModel(object):
     phase_derivs_wrt_delay : list
         All the phase derivatives respect to delay.
     """
-    __metaclass__ = ModelMeta
+
     def __init__(self):
         self.params = []  # List of model parameter names
         self.prefix_params = []  # List of model parameter names
@@ -271,7 +273,7 @@ class TimingModel(object):
 
     def sort_model_components(self):
         # initiate the sorted_components
-        sorted_list = ['']*len(self.components.keys())
+        sorted_list = ['']*len(list(self.components.keys()))
         in_placed = []
         not_in_placed = []
         for cp, cpv in self.components.items():

--- a/pint/observatory/clock_file.py
+++ b/pint/observatory/clock_file.py
@@ -9,6 +9,8 @@ from astropy.time import Time
 from astropy import log
 from astropy.utils.exceptions import AstropyWarning
 import warnings
+from six import add_metaclass
+
 
 class ClockFileMeta(type):
     """Metaclass that provides a registry for different clock file formats.
@@ -23,6 +25,7 @@ class ClockFileMeta(type):
         super(ClockFileMeta, cls).__init__(name, bases, members)
 
 
+@add_metaclass(ClockFileMeta)
 class ClockFile(object):
     """The ClockFile class provides a way to read various formats of clock
     files.  It will provide the clock information from the file as arrays
@@ -47,8 +50,6 @@ class ClockFile(object):
            2.10000000e-08   2.30000000e-08] s
 
     """
-
-    __metaclass__ = ClockFileMeta
 
     @classmethod
     def read(cls, filename, format='tempo', **kwargs):

--- a/pint/scripts/zima.py
+++ b/pint/scripts/zima.py
@@ -53,7 +53,7 @@ def main(argv=None):
 
     # WARNING! I'm not sure how clock corrections should be handled here!
     # Do we apply them, or not?
-    if not any([f.has_key('clkcorr') for f in ts.table['flags']]):
+    if not any(['clkcorr' in f for f in ts.table['flags']]):
         log.info("Applying clock corrections.")
         ts.apply_clock_corrections()
     if 'tdb' not in ts.table.colnames:

--- a/pint/scripts/zima.py
+++ b/pint/scripts/zima.py
@@ -48,7 +48,7 @@ def main(argv=None):
 
     tl = [toa.TOA(t,error=error, obs=args.obs, freq=freq,
                  scale=scale) for t in times]
-    del t
+
     ts = toa.TOAs(toalist=tl)
 
     # WARNING! I'm not sure how clock corrections should be handled here!

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -47,7 +47,7 @@ def get_TOAs(timfile, ephem="DE421", include_bipm=True,
             # Pickle either did not exist or is out of date
             updatepickle = True
     t = TOAs(timfile)
-    if not any([f.has_key('clkcorr') for f in t.table['flags']]):
+    if not any(['clkcorr' in f for f in t.table['flags']]):
         log.info("Applying clock corrections.")
         t.apply_clock_corrections(include_gps=include_gps,
                                   include_bipm=include_bipm)
@@ -647,7 +647,7 @@ class TOAs(object):
             loind, hiind = self.table.groups.indices[ii:ii+2]
             # First apply any TIME statements
             for jj in range(loind, hiind):
-                if flags[jj].has_key('to'):
+                if 'to' in flags[jj]:
                     # TIME commands are in sec
                     # SUGGESTION(paulr): These time correction units should
                     # be applied in the parser, not here. In the table the time

--- a/pint/utils.py
+++ b/pint/utils.py
@@ -11,6 +11,11 @@ import astropy.units as u
 from astropy import log
 from .str2ld import str2ldarr1
 import re
+try:
+    maketrans = ''.maketrans
+except AttributeError:
+    # fallback for Python 2
+    from string import maketrans
 
 # Define prefix parameter pattern
 pp1 = re.compile(r'([a-zA-Z0-9]+_*)(\d+)')  # For the prefix like DMXR1_3
@@ -101,7 +106,7 @@ def fortran_float(x):
     """
     try:
         # First treat it as a string, wih d->e
-        return float(x.translate(string.maketrans('Dd', 'ee')))
+        return float(x.translate(maketrans('Dd', 'ee')))
     except AttributeError:
         # If that didn't work it may already be a numeric type
         return float(x)
@@ -111,7 +116,7 @@ def time_from_mjd_string(s, scale='utc'):
     """Returns an astropy Time object generated from a MJD string input."""
     ss = s.lower()
     if "e" in ss or "d" in ss:
-        ss = ss.translate(string.maketrans("d", "e"))
+        ss = ss.translate(maketrans("d", "e"))
         num, expon = ss.split("e")
         expon = int(expon)
         if expon < 0:
@@ -132,6 +137,7 @@ def time_from_mjd_string(s, scale='utc'):
         imjd_s, fmjd_s = mjd_s
         imjd = int(imjd_s)
         fmjd = float("0." + fmjd_s)
+
     return astropy.time.Time(imjd, fmjd, scale=scale, format='pulsar_mjd',
                              precision=9)
 
@@ -311,8 +317,8 @@ def ddouble2ldouble(t1, t2, format='jd'):
 def str2longdouble(str_data):
     """Return a numpy long double scalar from the input string, using strtold()
     """
-    input_str = str_data.translate(string.maketrans('Dd', 'ee'))
-    return str2ldarr1(input_str)[0]
+    input_str = str_data.translate(maketrans('Dd', 'ee'))
+    return str2ldarr1(input_str.encode())[0]
 
 
 def split_prefixed_name(name):

--- a/tests/test_event_optimize-DISABLED.py
+++ b/tests/test_event_optimize-DISABLED.py
@@ -3,7 +3,10 @@
 # to get the fftfit module.  It can be run manually by people who have PRESTO
 from __future__ import division, print_function
 import sys, os
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import unittest
 import numpy as np
 import pint.scripts.event_optimize as event_optimize

--- a/tests/test_fermiphase.py
+++ b/tests/test_fermiphase.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 from __future__ import division, print_function
 import sys, os
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import unittest
 import numpy as np
 import pint.scripts.fermiphase as fermiphase

--- a/tests/test_photonphase.py
+++ b/tests/test_photonphase.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 from __future__ import division, print_function
 import sys, os
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import unittest
 import numpy as np
 import pint.scripts.photonphase as photonphase

--- a/tests/test_pintbary.py
+++ b/tests/test_pintbary.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 from __future__ import division, print_function
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import pint.scripts.pintbary as pintbary
 import unittest
 import numpy as np

--- a/tests/test_pintempo.py
+++ b/tests/test_pintempo.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 from __future__ import division, print_function
 import sys, os
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import unittest
 import numpy as np
 import pint.scripts.pintempo as pintempo

--- a/tests/test_prefix.py
+++ b/tests/test_prefix.py
@@ -23,7 +23,7 @@ class TestPrefix(unittest.TestCase):
         print("Test prefix parameter via a glitch model")
         rs = pint.residuals.resids(self.t, self.m).phase_resids
         # Now do the fit
-        print "Fitting..."
+        print("Fitting...")
         f = pint.fitter.PowellFitter(self.t, self.m)
         f.fit_toas()
         emsg = "RMS of " + self.m.PSR.value + " is too big."

--- a/tests/test_zima.py
+++ b/tests/test_zima.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 from __future__ import division, print_function
 import sys, os
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import unittest
 import numpy as np
 import pint.scripts.zima as zima


### PR DESCRIPTION
This is a series of fixes that should make tests work on Py3. 
A large part of them is about using dictionary keys as lists, which is not the case by default in Py3. There are a few minor subtleties, like modules with changed names, a different way to use metaclasses, integer division (Which is generally the most complicated thing to detect). 