### PR TITLE
Cache ish kepler

### DIFF
--- a/pint/models/stand_alone_psr_binaries/BT_model.py
+++ b/pint/models/stand_alone_psr_binaries/BT_model.py
@@ -122,9 +122,12 @@ class BTmodel(PSR_BINARY):
         and delayL2
         """
         a1 = self.a1()/c.c
-        num = a1*np.cos(self.omega())*np.sqrt(1-self.ecc()**2)*np.cos(self.E()) -\
-              a1*np.sin(self.omega())*np.sin(self.E())
-        den = 1.0 - self.ecc()*np.cos(self.E())
+        omega = self.omega()
+        ecc = self.ecc()
+        E = self.E()
+        num = a1 * np.cos(omega)* np.sqrt(1 - ecc**2)*np.cos(E) -\
+              a1 * np.sin(omega) * np.sin(E)
+        den = 1.0 - ecc * np.cos(E)
 
         # In BTmodel.C, they do not use pbprime here, just pb...
         # Is it not more appropriate to include the effects of PBDOT?

--- a/pint/models/stand_alone_psr_binaries/binary_generic.py
+++ b/pint/models/stand_alone_psr_binaries/binary_generic.py
@@ -114,6 +114,7 @@ class PSR_BINARY(object):
                               'A1DOT':['XDOT']}
         self.binary_params = list(self.param_default_value.keys())
         self.inter_vars = ['E','M','nu','ecc','omega','a1','TM2']
+        self.cache_vars = ['E', 'nu']
         self.binary_delay_funcs = []
         self.d_binarydelay_d_par_funcs = []
 
@@ -151,8 +152,10 @@ class PSR_BINARY(object):
         # Update parameters
         if param_dict is not None:
             self.set_param_values(param_dict)
-        # Switch the eccentric_anomaly cache off
-        self._E = None
+        # Switch the cache off
+        # NOTE Having cache is needs to be very careful. 
+        for cv in self.cache_vars:
+            setattr(self, '_' + cv, None)
 
     def set_param_values(self, valDict = None):
         """A function that sets the parameters and assign values
@@ -483,19 +486,27 @@ class PSR_BINARY(object):
     def nu(self):
         """True anomaly  (Ae)
         """
-        nu = 2*np.arctan(np.sqrt((1.0+self.ecc())/(1.0-self.ecc()))*np.tan(self.E()/2.0))
-        # Normalize True anomaly to on orbit.
-        nu[nu<0] += 2*np.pi*u.rad
-        nu2 = 2*np.pi*self.orbits()*u.rad + nu - self.M()
-        return nu2
+        if not hasattr(self, '_nu') or self._nu is None:
+            ecc = self.ecc()
+            nu = 2*np.arctan(np.sqrt((1.0+ ecc)/(1.0- ecc)) * np.tan(self.E()/2.0))
+            # Normalize True anomaly to on orbit.
+            nu[nu<0] += 2*np.pi*u.rad
+            nu2 = 2*np.pi*self.orbits()*u.rad + nu - self.M()
+            self._nu = nu2
+        return self._nu
 
     def d_nu_d_E(self):
-        brack1 = (1 + self.ecc()*np.cos(self.nu())) / (1 - self.ecc()*np.cos(self.E()))
-        brack2 = np.sin(self.E()) / np.sin(self.nu())
+        nu = self.nu()
+        E = self.E()
+        ecc = self.ecc()
+        brack1 = (1 + ecc * np.cos(nu)) / (1 - ecc * np.cos(E))
+        brack2 = np.sin(E) / np.sin(nu)
         return brack1*brack2
 
     def d_nu_d_ecc(self):
-        return np.sin(self.E())**2/(self.ecc()*np.cos(self.E())-1)**2/np.sin(self.nu())
+        ecc = self.ecc()
+        E = self.E()
+        return np.sin(E)**2/(ecc*np.cos(E)-1)**2/np.sin(self.nu())
 
     def d_nu_d_T0(self):
         """dnu/dT0 = dnu/de*de/dT0+dnu/dE*dE/dT0

--- a/pint/models/stand_alone_psr_binaries/binary_generic.py
+++ b/pint/models/stand_alone_psr_binaries/binary_generic.py
@@ -151,6 +151,8 @@ class PSR_BINARY(object):
         # Update parameters
         if param_dict is not None:
             self.set_param_values(param_dict)
+        # Switch the eccentric_anomaly cache off
+        self._E = None
 
     def set_param_values(self, valDict = None):
         """A function that sets the parameters and assign values
@@ -437,7 +439,9 @@ class PSR_BINARY(object):
     def E(self):
         """Eccentric Anomaly
         """
-        return self.compute_eccentric_anomaly(self.ecc(),self.M())
+        if not hasattr(self, '_E') or self._E is None:
+            self._E = self.compute_eccentric_anomaly(self.ecc(),self.M())
+        return self._E
 
     # Analytically calculate derivtives.
 


### PR DESCRIPTION
This PR is for optimizing binary model by a simple caching for some intermedia values. This PR speeds up the computation.
For running B1855+09 9 years data with fit for all parameter(Not included the noise the parameters), this speeds up the computation for 6 seconds. 