### PR TITLE
Add from __future__ import absolute_import

### DIFF
--- a/pint/config.py
+++ b/pint/config.py
@@ -1,7 +1,7 @@
 # config.py
 
 # Functions related to PINT configuration
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import os
 from .extern import appdirs
 

--- a/pint/config.py
+++ b/pint/config.py
@@ -1,7 +1,7 @@
 # config.py
 
 # Functions related to PINT configuration
-
+from __future__ import absolute_import, print_function
 import os
 from .extern import appdirs
 

--- a/pint/erfautils.py
+++ b/pint/erfautils.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from . import utils
 import numpy as np
 import astropy.units as u

--- a/pint/erfautils.py
+++ b/pint/erfautils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 from . import utils
 import numpy as np
 import astropy.units as u

--- a/pint/event_toas.py
+++ b/pint/event_toas.py
@@ -1,5 +1,5 @@
 """Generic function to load TOAs from events files."""
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy as np
 import pint.toa as toa
 from astropy import log

--- a/pint/event_toas.py
+++ b/pint/event_toas.py
@@ -1,6 +1,5 @@
 """Generic function to load TOAs from events files."""
-from __future__ import division, print_function
-
+from __future__ import absolute_import, print_function
 import numpy as np
 import pint.toa as toa
 from astropy import log

--- a/pint/eventstats.py
+++ b/pint/eventstats.py
@@ -4,7 +4,7 @@ test statistics on event data and helper functions.
 
 author: M. Kerr <matthew.kerr@gmail.com>
 """
-
+from __future__ import absolute_import, print_function
 import numpy as np
 
 TWOPI = np.pi*2

--- a/pint/eventstats.py
+++ b/pint/eventstats.py
@@ -4,7 +4,7 @@ test statistics on event data and helper functions.
 
 author: M. Kerr <matthew.kerr@gmail.com>
 """
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy as np
 
 TWOPI = np.pi*2

--- a/pint/fermi_toas.py
+++ b/pint/fermi_toas.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-from __future__ import division, print_function
-
+from __future__ import absolute_import, print_function, division
 import os,sys
 import numpy as np
 import pint.toa as toa

--- a/pint/fits_utils.py
+++ b/pint/fits_utils.py
@@ -1,5 +1,5 @@
 """FITS handling functions"""
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import astropy.io.fits as pyfits
 import numpy as np
 from astropy import log

--- a/pint/fits_utils.py
+++ b/pint/fits_utils.py
@@ -1,5 +1,5 @@
 """FITS handling functions"""
-
+from __future__ import absolute_import, print_function
 import astropy.io.fits as pyfits
 import numpy as np
 from astropy import log

--- a/pint/fitter.py
+++ b/pint/fitter.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 import copy, numbers
 import numpy as np
 import astropy.units as u

--- a/pint/fitter.py
+++ b/pint/fitter.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import copy, numbers
 import numpy as np
 import astropy.units as u

--- a/pint/ltinterface.py
+++ b/pint/ltinterface.py
@@ -1,7 +1,7 @@
 """
 An interface for pint compatible to the interface of libstempo
 """
-
+from __future__ import absolute_import, print_function
 import numpy as np
 import pint.models as pm
 import pint.toa as pt

--- a/pint/ltinterface.py
+++ b/pint/ltinterface.py
@@ -1,7 +1,7 @@
 """
 An interface for pint compatible to the interface of libstempo
 """
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy as np
 import pint.models as pm
 import pint.toa as pt

--- a/pint/models/astrometry.py
+++ b/pint/models/astrometry.py
@@ -1,6 +1,6 @@
 # astrometry.py
 # Defines Astrometry timing model class
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy
 import astropy.coordinates as coords
 import astropy.units as u

--- a/pint/models/astrometry.py
+++ b/pint/models/astrometry.py
@@ -1,5 +1,6 @@
 # astrometry.py
 # Defines Astrometry timing model class
+from __future__ import absolute_import, print_function
 import numpy
 import astropy.coordinates as coords
 import astropy.units as u

--- a/pint/models/binary_bt.py
+++ b/pint/models/binary_bt.py
@@ -1,6 +1,7 @@
 
 """This model provides the BT (Blandford & Teukolsky 1976, ApJ, 205, 580) model.
     """
+from __future__ import absolute_import, print_function
 from pint import ls,GMsun,Tsun
 from .stand_alone_psr_binaries.BT_model import BTmodel
 from .pulsar_binary import PulsarBinary

--- a/pint/models/binary_bt.py
+++ b/pint/models/binary_bt.py
@@ -1,7 +1,7 @@
 
 """This model provides the BT (Blandford & Teukolsky 1976, ApJ, 205, 580) model.
     """
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from pint import ls,GMsun,Tsun
 from .stand_alone_psr_binaries.BT_model import BTmodel
 from .pulsar_binary import PulsarBinary

--- a/pint/models/binary_dd.py
+++ b/pint/models/binary_dd.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from pint import ls,GMsun,Tsun
 from .stand_alone_psr_binaries.DD_model import DDmodel
 from .pulsar_binary import PulsarBinary

--- a/pint/models/binary_dd.py
+++ b/pint/models/binary_dd.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 from pint import ls,GMsun,Tsun
 from .stand_alone_psr_binaries.DD_model import DDmodel
 from .pulsar_binary import PulsarBinary

--- a/pint/models/binary_ddk.py
+++ b/pint/models/binary_ddk.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 from pint import ls,GMsun,Tsun
 from .stand_alone_psr_binaries.DDK_model import DDKmodel
 from .binary_dd import BinaryDD

--- a/pint/models/binary_ddk.py
+++ b/pint/models/binary_ddk.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from pint import ls,GMsun,Tsun
 from .stand_alone_psr_binaries.DDK_model import DDKmodel
 from .binary_dd import BinaryDD

--- a/pint/models/binary_ell1.py
+++ b/pint/models/binary_ell1.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy as np
 import time
 from pint import ls,GMsun,Tsun

--- a/pint/models/binary_ell1.py
+++ b/pint/models/binary_ell1.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 import numpy as np
 import time
 from pint import ls,GMsun,Tsun

--- a/pint/models/dispersion_model.py
+++ b/pint/models/dispersion_model.py
@@ -1,6 +1,6 @@
 """This module implements a simple model of a base dispersion delay.
    And DMX dispersion"""
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from warnings import warn
 from . import parameter as p
 from .timing_model import DelayComponent

--- a/pint/models/dispersion_model.py
+++ b/pint/models/dispersion_model.py
@@ -1,6 +1,6 @@
 """This module implements a simple model of a base dispersion delay.
    And DMX dispersion"""
-
+from __future__ import absolute_import, print_function
 from warnings import warn
 from . import parameter as p
 from .timing_model import DelayComponent

--- a/pint/models/frequency_dependent.py
+++ b/pint/models/frequency_dependent.py
@@ -1,4 +1,5 @@
 """This module implements a frequency evolution of pulsar profiles model"""
+from __future__ import absolute_import, print_function
 from warnings import warn
 from . import parameter as p
 from .timing_model import DelayComponent, MissingParameter

--- a/pint/models/frequency_dependent.py
+++ b/pint/models/frequency_dependent.py
@@ -1,5 +1,5 @@
 """This module implements a frequency evolution of pulsar profiles model"""
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from warnings import warn
 from . import parameter as p
 from .timing_model import DelayComponent, MissingParameter

--- a/pint/models/glitch.py
+++ b/pint/models/glitch.py
@@ -2,6 +2,7 @@
 """
 # glitch.py
 # Defines glitch timing model class
+from __future__ import absolute_import, print_function
 import numpy
 import astropy.units as u
 try:

--- a/pint/models/glitch.py
+++ b/pint/models/glitch.py
@@ -2,7 +2,7 @@
 """
 # glitch.py
 # Defines glitch timing model class
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy
 import astropy.units as u
 try:

--- a/pint/models/jump.py
+++ b/pint/models/jump.py
@@ -2,7 +2,7 @@
 """
 # phase_jump.py
 # Defines PhaseJump timing model class
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy
 import astropy.units as u
 from .timing_model import DelayComponent, PhaseComponent, MissingParameter

--- a/pint/models/jump.py
+++ b/pint/models/jump.py
@@ -2,6 +2,7 @@
 """
 # phase_jump.py
 # Defines PhaseJump timing model class
+from __future__ import absolute_import, print_function
 import numpy
 import astropy.units as u
 from .timing_model import DelayComponent, PhaseComponent, MissingParameter

--- a/pint/models/model_builder.py
+++ b/pint/models/model_builder.py
@@ -1,5 +1,6 @@
 # model_builder.py
 # Defines the automatic timing model generator interface
+from __future__ import absolute_import, print_function
 import os
 
 # The timing models that we will be using

--- a/pint/models/model_builder.py
+++ b/pint/models/model_builder.py
@@ -1,6 +1,6 @@
 # model_builder.py
 # Defines the automatic timing model generator interface
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import os
 
 # The timing models that we will be using

--- a/pint/models/noise_model.py
+++ b/pint/models/noise_model.py
@@ -1,5 +1,6 @@
 # noise_model.py
 # Defines the pulsar timing noise model.
+from __future__ import absolute_import, print_function
 from .timing_model import Component,  MissingParameter
 from . import parameter as p
 import numpy as np

--- a/pint/models/noise_model.py
+++ b/pint/models/noise_model.py
@@ -1,6 +1,6 @@
 # noise_model.py
 # Defines the pulsar timing noise model.
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from .timing_model import Component,  MissingParameter
 from . import parameter as p
 import numpy as np

--- a/pint/models/parameter.py
+++ b/pint/models/parameter.py
@@ -1,6 +1,6 @@
 # parameter.py
 # Defines Parameter class for timing model parameters
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from ..utils import fortran_float, time_from_mjd_string, time_to_mjd_string,\
     time_to_longdouble, is_number, time_from_longdouble, str2longdouble, \
     longdouble2string, data2longdouble, split_prefixed_name

--- a/pint/models/parameter.py
+++ b/pint/models/parameter.py
@@ -1,5 +1,6 @@
 # parameter.py
 # Defines Parameter class for timing model parameters
+from __future__ import absolute_import, print_function
 from ..utils import fortran_float, time_from_mjd_string, time_to_mjd_string,\
     time_to_longdouble, is_number, time_from_longdouble, str2longdouble, \
     longdouble2string, data2longdouble, split_prefixed_name

--- a/pint/models/polycos.py
+++ b/pint/models/polycos.py
@@ -1,8 +1,7 @@
 # This program is designed to predict the pulsar's phase and pulse-period over a
 # given interval using polynomial expansion. The return will be some necessary
 # information and the polynomial coefficients
-
-from __future__ import division, print_function
+from __future__ import absolute_import, print_function, division
 import functools
 from ..phase import Phase
 import numpy as np

--- a/pint/models/priors.py
+++ b/pint/models/priors.py
@@ -7,7 +7,7 @@ in the model class, that implements priors on combinations of parameters,
 such as total proper motion, 2-d sky location, etc.
 
 """
-from __future__ import division, absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import scipy.stats
 from scipy.stats import rv_continuous, rv_discrete, norm, uniform
 

--- a/pint/models/pulsar_binary.py
+++ b/pint/models/pulsar_binary.py
@@ -1,5 +1,5 @@
 # This is a wapper for independent binary model. It is a PINT timing model class
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import astropy.units as u
 import numpy as np
 from . import parameter as p

--- a/pint/models/pulsar_binary.py
+++ b/pint/models/pulsar_binary.py
@@ -1,4 +1,5 @@
 # This is a wapper for independent binary model. It is a PINT timing model class
+from __future__ import absolute_import, print_function
 import astropy.units as u
 import numpy as np
 from . import parameter as p

--- a/pint/models/solar_system_shapiro.py
+++ b/pint/models/solar_system_shapiro.py
@@ -1,6 +1,6 @@
 # solar_system_shapiro.py
 # Add in Shapiro delays due to solar system objects
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy
 import astropy.units as u
 import astropy.constants as const

--- a/pint/models/solar_system_shapiro.py
+++ b/pint/models/solar_system_shapiro.py
@@ -1,5 +1,6 @@
 # solar_system_shapiro.py
 # Add in Shapiro delays due to solar system objects
+from __future__ import absolute_import, print_function
 import numpy
 import astropy.units as u
 import astropy.constants as const

--- a/pint/models/spindown.py
+++ b/pint/models/spindown.py
@@ -2,6 +2,7 @@
 """
 # spindown.py
 # Defines Spindown timing model class
+from __future__ import absolute_import, print_function
 import numpy
 import astropy.units as u
 try:

--- a/pint/models/spindown.py
+++ b/pint/models/spindown.py
@@ -2,7 +2,7 @@
 """
 # spindown.py
 # Defines Spindown timing model class
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy
 import astropy.units as u
 try:

--- a/pint/models/stand_alone_psr_binaries/BT_model.py
+++ b/pint/models/stand_alone_psr_binaries/BT_model.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from .binary_generic import PSR_BINARY
 import numpy as np
 import astropy.units as u

--- a/pint/models/stand_alone_psr_binaries/BT_model.py
+++ b/pint/models/stand_alone_psr_binaries/BT_model.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 from .binary_generic import PSR_BINARY
 import numpy as np
 import astropy.units as u

--- a/pint/models/stand_alone_psr_binaries/DDK_model.py
+++ b/pint/models/stand_alone_psr_binaries/DDK_model.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 from .DD_model import DDmodel
 import numpy as np
 import astropy.units as u

--- a/pint/models/stand_alone_psr_binaries/DDK_model.py
+++ b/pint/models/stand_alone_psr_binaries/DDK_model.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from .DD_model import DDmodel
 import numpy as np
 import astropy.units as u

--- a/pint/models/stand_alone_psr_binaries/DD_model.py
+++ b/pint/models/stand_alone_psr_binaries/DD_model.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from .binary_generic import PSR_BINARY
 import numpy as np
 import astropy.units as u

--- a/pint/models/stand_alone_psr_binaries/DD_model.py
+++ b/pint/models/stand_alone_psr_binaries/DD_model.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 from .binary_generic import PSR_BINARY
 import numpy as np
 import astropy.units as u

--- a/pint/models/stand_alone_psr_binaries/ELL1H_model.py
+++ b/pint/models/stand_alone_psr_binaries/ELL1H_model.py
@@ -1,5 +1,5 @@
 # This Python file uses the following encoding: utf-8
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from .ELL1_model import ELL1BaseModel
 import numpy as np
 import astropy.units as u

--- a/pint/models/stand_alone_psr_binaries/ELL1H_model.py
+++ b/pint/models/stand_alone_psr_binaries/ELL1H_model.py
@@ -1,4 +1,5 @@
 # This Python file uses the following encoding: utf-8
+from __future__ import absolute_import, print_function
 from .ELL1_model import ELL1BaseModel
 import numpy as np
 import astropy.units as u

--- a/pint/models/stand_alone_psr_binaries/ELL1_model.py
+++ b/pint/models/stand_alone_psr_binaries/ELL1_model.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from .binary_generic import PSR_BINARY
 import numpy as np
 import astropy.units as u

--- a/pint/models/stand_alone_psr_binaries/ELL1_model.py
+++ b/pint/models/stand_alone_psr_binaries/ELL1_model.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 from .binary_generic import PSR_BINARY
 import numpy as np
 import astropy.units as u

--- a/pint/models/stand_alone_psr_binaries/binary_generic.py
+++ b/pint/models/stand_alone_psr_binaries/binary_generic.py
@@ -1,5 +1,5 @@
 # This file is a prototype of independent psr binary model class
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy as np
 import functools
 import collections

--- a/pint/models/stand_alone_psr_binaries/binary_generic.py
+++ b/pint/models/stand_alone_psr_binaries/binary_generic.py
@@ -1,4 +1,5 @@
 # This file is a prototype of independent psr binary model class
+from __future__ import absolute_import, print_function
 import numpy as np
 import functools
 import collections

--- a/pint/models/timing_model.py
+++ b/pint/models/timing_model.py
@@ -1,5 +1,6 @@
 # timing_model.py
 # Defines the basic timing model interface classes
+from __future__ import absolute_import, print_function
 import functools
 from .parameter import Parameter, strParameter
 from ..phase import Phase

--- a/pint/models/timing_model.py
+++ b/pint/models/timing_model.py
@@ -1,6 +1,6 @@
 # timing_model.py
 # Defines the basic timing model interface classes
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import functools
 from .parameter import Parameter, strParameter
 from ..phase import Phase

--- a/pint/observatory/clock_file.py
+++ b/pint/observatory/clock_file.py
@@ -1,7 +1,7 @@
 # clock_file.py
 
 # Routines for reading various formats of clock file.
-
+from __future__ import absolute_import, print_function
 import os
 import numpy
 import astropy.units as u

--- a/pint/observatory/clock_file.py
+++ b/pint/observatory/clock_file.py
@@ -1,7 +1,7 @@
 # clock_file.py
 
 # Routines for reading various formats of clock file.
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import os
 import numpy
 import astropy.units as u

--- a/pint/observatory/fermi_obs.py
+++ b/pint/observatory/fermi_obs.py
@@ -1,5 +1,5 @@
 # special_locations.py
-from __future__ import division, print_function
+from __future__ import absolute_import, print_function, division
 
 # Special "site" location for Fermi satelite
 

--- a/pint/observatory/nicer_obs.py
+++ b/pint/observatory/nicer_obs.py
@@ -1,5 +1,5 @@
 # special_locations.py
-from __future__ import division, print_function
+from __future__ import absolute_import, print_function, division
 
 # Special "site" location for NICER experiment
 

--- a/pint/observatory/observatories.py
+++ b/pint/observatory/observatories.py
@@ -2,7 +2,7 @@
 
 # This file contains the basic definitions of observatory sites for
 # PINT.
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from pint.observatory.topo_obs import TopoObs
 
 TopoObs('gbt',          tempo_code='1', itoa_code='GB',

--- a/pint/observatory/observatories.py
+++ b/pint/observatory/observatories.py
@@ -2,7 +2,7 @@
 
 # This file contains the basic definitions of observatory sites for
 # PINT.
-
+from __future__ import absolute_import, print_function
 from pint.observatory.topo_obs import TopoObs
 
 TopoObs('gbt',          tempo_code='1', itoa_code='GB',

--- a/pint/observatory/observatory.py
+++ b/pint/observatory/observatory.py
@@ -1,5 +1,6 @@
 # observatory.py
 # Base class for PINT observatories
+from __future__ import absolute_import, print_function
 import six
 
 

--- a/pint/observatory/observatory.py
+++ b/pint/observatory/observatory.py
@@ -1,6 +1,6 @@
 # observatory.py
 # Base class for PINT observatories
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import six
 
 

--- a/pint/observatory/rxte_obs.py
+++ b/pint/observatory/rxte_obs.py
@@ -1,5 +1,5 @@
 # special_locations.py
-from __future__ import division, print_function
+from __future__ import absolute_import, print_function, division
 
 # Special "site" location for RXTE satellite
 

--- a/pint/observatory/special_locations.py
+++ b/pint/observatory/special_locations.py
@@ -2,7 +2,7 @@
 
 # Special "site" locations (eg, barycenter) which do not need clock
 # corrections or much else done.
-
+from __future__ import absolute_import, print_function
 from . import Observatory
 import numpy
 import astropy.units as u

--- a/pint/observatory/special_locations.py
+++ b/pint/observatory/special_locations.py
@@ -2,7 +2,7 @@
 
 # Special "site" locations (eg, barycenter) which do not need clock
 # corrections or much else done.
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from . import Observatory
 import numpy
 import astropy.units as u

--- a/pint/observatory/topo_obs.py
+++ b/pint/observatory/topo_obs.py
@@ -1,6 +1,6 @@
 # topo_obs.py
 # Code for dealing with "standard" ground-based observatories.
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from . import Observatory
 from .clock_file import ClockFile
 import os

--- a/pint/observatory/topo_obs.py
+++ b/pint/observatory/topo_obs.py
@@ -1,6 +1,6 @@
 # topo_obs.py
 # Code for dealing with "standard" ground-based observatories.
-
+from __future__ import absolute_import, print_function
 from . import Observatory
 from .clock_file import ClockFile
 import os

--- a/pint/orbital/kepler.py
+++ b/pint/orbital/kepler.py
@@ -2,7 +2,7 @@
 
 All times are in days, distances in light-seconds, and masses in solar masses.
 """
-from __future__ import division
+from __future__ import absolute_import, print_function, division
 import collections
 import numpy as np
 from scipy.optimize import newton, fsolve

--- a/pint/phase.py
+++ b/pint/phase.py
@@ -6,7 +6,7 @@
 # I think I understand it, but it would be good to have it stated.
 # Also, probably one of the comparisons below should be <= or >=, so the
 # range is [-0.5,0.5) or (-0.5,0.5].
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from collections import namedtuple
 import numpy
 import astropy.units as u

--- a/pint/phase.py
+++ b/pint/phase.py
@@ -6,6 +6,7 @@
 # I think I understand it, but it would be good to have it stated.
 # Also, probably one of the comparisons below should be <= or >=, so the
 # range is [-0.5,0.5) or (-0.5,0.5].
+from __future__ import absolute_import, print_function
 from collections import namedtuple
 import numpy
 import astropy.units as u

--- a/pint/plot_utils.py
+++ b/pint/plot_utils.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import division, print_function
+from __future__ import absolute_import, print_function, division
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/pint/pulsar_ecliptic.py
+++ b/pint/pulsar_ecliptic.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import numpy as np
 from astropy.coordinates import frame_transform_graph, DynamicMatrixTransform
 from astropy.coordinates.matrix_utilities import rotation_matrix

--- a/pint/pulsar_ecliptic.py
+++ b/pint/pulsar_ecliptic.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy as np
 from astropy.coordinates import frame_transform_graph, DynamicMatrixTransform
 from astropy.coordinates.matrix_utilities import rotation_matrix

--- a/pint/pulsar_mjd.py
+++ b/pint/pulsar_mjd.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 from astropy.time.formats import TimeFormat
 from astropy.time.utils import day_frac
 import astropy._erfa as erfa

--- a/pint/pulsar_mjd.py
+++ b/pint/pulsar_mjd.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from astropy.time.formats import TimeFormat
 from astropy.time.utils import day_frac
 import astropy._erfa as erfa

--- a/pint/residuals.py
+++ b/pint/residuals.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 import astropy.units as u
 import numpy as np
 from .phase import Phase

--- a/pint/residuals.py
+++ b/pint/residuals.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import astropy.units as u
 import numpy as np
 from .phase import Phase

--- a/pint/scripts/event_optimize.py
+++ b/pint/scripts/event_optimize.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python -W ignore::FutureWarning -W ignore::UserWarning -W ignore::DeprecationWarning
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy as np
 import pint.toa as toa
 import pint.models

--- a/pint/scripts/event_optimize.py
+++ b/pint/scripts/event_optimize.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python -W ignore::FutureWarning -W ignore::UserWarning -W ignore::DeprecationWarning
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 import numpy as np
 import pint.toa as toa
 import pint.models

--- a/pint/scripts/fermiphase.py
+++ b/pint/scripts/fermiphase.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-from __future__ import division, print_function
-
+from __future__ import absolute_import, print_function, division
 import os,sys
 import numpy as np
 import pint.toa as toa

--- a/pint/scripts/htest_optimize.py
+++ b/pint/scripts/htest_optimize.py
@@ -2,8 +2,7 @@
 
 # At the moment, this code is kind of an unsupported hack.
 # It will not be installed by setup.py and not tested by nosetests.
-
-from __future__ import print_function
+from __future__ import absolute_import, print_function, division
 import numpy as np
 import pint.toa as toa
 import pint.models

--- a/pint/scripts/photonphase.py
+++ b/pint/scripts/photonphase.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-from __future__ import division, print_function
-
+from __future__ import absolute_import, print_function, division
 import os,sys
 import numpy as np
 import pint.toa as toa

--- a/pint/scripts/pintbary.py
+++ b/pint/scripts/pintbary.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python -W ignore::FutureWarning -W ignore::UserWarning -W ignore::DeprecationWarning
-from __future__ import division, print_function
+from __future__ import absolute_import, print_function, division
 import sys
 import numpy as np
 import pint.toa as toa

--- a/pint/scripts/pintempo.py
+++ b/pint/scripts/pintempo.py
@@ -8,8 +8,7 @@ specify '-f parfile' to those codes -- I mean, who runs TEMPO without a timing m
 This is currently just a stub and should be added to and expanded, as desired.
 
 """
-from __future__ import division, print_function
-
+from __future__ import absolute_import, print_function, division
 import os,sys
 import numpy as np
 import pint.toa as toa

--- a/pint/scripts/zima.py
+++ b/pint/scripts/zima.py
@@ -2,8 +2,7 @@
 """PINT-based tool for making simulated TOAs
 
 """
-from __future__ import division, print_function
-
+from __future__ import absolute_import, print_function, division
 import os,sys
 import numpy as np
 import pint.toa as toa

--- a/pint/solar_system_ephemerides.py
+++ b/pint/solar_system_ephemerides.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy as np
 import os
 import astropy.units as u

--- a/pint/solar_system_ephemerides.py
+++ b/pint/solar_system_ephemerides.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 import numpy as np
 import os
 import astropy.units as u

--- a/pint/templates/lcfitters.py
+++ b/pint/templates/lcfitters.py
@@ -14,9 +14,7 @@ $Header: /nfs/slac/g/glast/ground/cvs/pointlike/python/uw/pulsar/lcfitters.py,v 
 author: M. Kerr <matthew.kerr@gmail.com>
 
 """
-
-from __future__ import print_function
-
+from __future__ import absolute_import, print_function
 import numpy as np
 from copy import deepcopy
 import scipy

--- a/pint/templates/lcfitters.py
+++ b/pint/templates/lcfitters.py
@@ -14,7 +14,7 @@ $Header: /nfs/slac/g/glast/ground/cvs/pointlike/python/uw/pulsar/lcfitters.py,v 
 author: M. Kerr <matthew.kerr@gmail.com>
 
 """
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy as np
 from copy import deepcopy
 import scipy

--- a/pint/templates/lcnorm.py
+++ b/pint/templates/lcnorm.py
@@ -10,7 +10,7 @@ $Header: /nfs/slac/g/glast/ground/cvs/pointlike/python/uw/pulsar/lcnorm.py,v 1.9
 
 author: M. Kerr <matthew.kerr@gmail.com>
 """
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy as np
 from math import sin,cos,asin,acos,pi
 

--- a/pint/templates/lcnorm.py
+++ b/pint/templates/lcnorm.py
@@ -10,7 +10,7 @@ $Header: /nfs/slac/g/glast/ground/cvs/pointlike/python/uw/pulsar/lcnorm.py,v 1.9
 
 author: M. Kerr <matthew.kerr@gmail.com>
 """
-
+from __future__ import absolute_import, print_function
 import numpy as np
 from math import sin,cos,asin,acos,pi
 

--- a/pint/templates/lcprimitives.py
+++ b/pint/templates/lcprimitives.py
@@ -13,7 +13,7 @@ author: M. Kerr <matthew.kerr@gmail.com>
 # Monte Carlo variables because they don't account for the uniform approx.
 # perhaps this isn't a big deal
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import numpy as np
 from scipy.special import erf,i0,i1

--- a/pint/templates/lcprimitives.py
+++ b/pint/templates/lcprimitives.py
@@ -13,7 +13,7 @@ author: M. Kerr <matthew.kerr@gmail.com>
 # Monte Carlo variables because they don't account for the uniform approx.
 # perhaps this isn't a big deal
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 
 import numpy as np
 from scipy.special import erf,i0,i1

--- a/pint/templates/lctemplate.py
+++ b/pint/templates/lctemplate.py
@@ -6,13 +6,12 @@ $Header: /nfs/slac/g/glast/ground/cvs/pointlike/python/uw/pulsar/lctemplate.py,v
 author: M. Kerr <matthew.kerr@gmail.com>
 
 """
-
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import numpy as np
 from copy import deepcopy
-from lcnorm import NormAngles
-from lcprimitives import *
+from .lcnorm import NormAngles
+from .lcprimitives import *
 from astropy import log
 
 class LCTemplate(object):

--- a/pint/templates/lctemplate.py
+++ b/pint/templates/lctemplate.py
@@ -6,7 +6,7 @@ $Header: /nfs/slac/g/glast/ground/cvs/pointlike/python/uw/pulsar/lctemplate.py,v
 author: M. Kerr <matthew.kerr@gmail.com>
 
 """
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 
 import numpy as np
 from copy import deepcopy

--- a/pint/tmtestfuncs.py
+++ b/pint/tmtestfuncs.py
@@ -1,5 +1,5 @@
 # Test timing model functions to test out the residuals class
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 from astropy.time import Time
 import numpy
 

--- a/pint/tmtestfuncs.py
+++ b/pint/tmtestfuncs.py
@@ -1,4 +1,5 @@
 # Test timing model functions to test out the residuals class
+from __future__ import absolute_import, print_function
 from astropy.time import Time
 import numpy
 

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, print_function
 import re, sys, os, numpy, gzip, copy
 from . import utils
 from .observatory import Observatory, get_observatory

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import re, sys, os, numpy, gzip, copy
 from . import utils
 from .observatory import Observatory, get_observatory

--- a/pint/toa_select.py
+++ b/pint/toa_select.py
@@ -1,5 +1,8 @@
+from __future__ import absolute_import, print_function
 import numpy as np
 import copy
+
+
 class TOASelect(object):
     """
     This class is designed for select toas from toa table based on a given

--- a/pint/toa_select.py
+++ b/pint/toa_select.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy as np
 import copy
 

--- a/pint/utils.py
+++ b/pint/utils.py
@@ -1,4 +1,5 @@
 """Miscellaneous potentially-helpful functions."""
+from __future__ import absolute_import, print_function
 import numpy as np
 from scipy.misc import factorial
 import string

--- a/pint/utils.py
+++ b/pint/utils.py
@@ -1,5 +1,5 @@
 """Miscellaneous potentially-helpful functions."""
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, division
 import numpy as np
 from scipy.misc import factorial
 import string


### PR DESCRIPTION
This PR adds `from __future__ import absolute_import` at the top of each file. This makes Python 2 behave the same as Python 3, which can prevent some problems.

Concretely, I think the only problem with imports in the current pint codebase I found when adding this was in `pint/templates/lctemplate.py`, which had this "implicit relative import" before
```
from lcnorm import NormAngles
from lcprimitives import *
```
which doesn't work on Python 3, and which I rewrote as an "explicit relative import"
```
from .lcnorm import NormAngles
from .lcprimitives import *
```
which works the same on Python 2 and 3, guaranteed in the way the import was intended (i.e. a package `lcnorm` or `lcprimitives` outside `pint` in `site-packages` won't break `pint`.
