### PR TITLE
Fix for photonphase to avoid ephem=None bug

### DIFF
--- a/pint/scripts/photonphase.py
+++ b/pint/scripts/photonphase.py
@@ -95,14 +95,12 @@ def main(argv=None):
     if len(tl) == 0:
         log.error("No TOAs, exiting!")
         sys.exit(0)
-    ts = toa.TOAs(toalist=tl)
+    # Could add a check here to only compute planet positions if PLANET_SHAPIRO is true.
+    # For now, just being lazy and always computing planet positions.
+    ts = toa.get_TOAs_list(tl,ephem=args.ephem,planets=True)
     ts.filename = args.eventfile
     if args.fix:
         ts.adjust_TOAs(TimeDelta(np.ones(len(ts.table))*-1.0*u.s,scale='tt'))
-    ts.compute_TDBs()
-    # Could add a check here to only compute planet positions if PLANET_SHAPIRO is true.
-    # For now, just being lazy and always computing planet positions.
-    ts.compute_posvels(ephem=args.ephem,planets=True)
 
     print(ts.get_summary())
     mjds = ts.get_mjds()


### PR DESCRIPTION
@luojing1211 changed the code in `adjust_TOAs` to reference `self.ephem`. This fails if you create a `TOAs` object and have not yet run `compute_posvels`, since that is where `self.ephem` is set. This PR makes sure that photonphase calls `compute_posvels` before `adjust_TOAs`.

Probably there should be a fix to `adjust_TOAs()` to not try to "recompute" the derived columns if they were not there in the first place.