### PR TITLE
Require astropy<3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.11.0
 Cython>=0.25.2
-astropy>=2.0 
+astropy>=2.0,<3.0
 scipy>=0.18.1
 jplephem>=2.6
 matplotlib>=1.5.3


### PR DESCRIPTION
The automated tests with python3 seem to be picking up astropy 3.0 now.  It seems PINT is not working with astropy 3, so I've put a requirement for astropy<3.0 into requirements.txt.  Putting in this PR to check if the tests pass after this change.
