### PR TITLE
Remove TZRMJD from Spindown

### DIFF
--- a/pint/models/spindown.py
+++ b/pint/models/spindown.py
@@ -29,9 +29,6 @@ class Spindown(PhaseComponent):
                        unit_template=self.F_unit,
                        description_template=self.F_description,
                        type_match='float', long_double=True))
-        self.add_param(p.MJDParameter(name="TZRMJD",
-                       description="Reference epoch for phase = 0.0",
-                       time_scale='tdb'))
         self.add_param(p.MJDParameter(name="PEPOCH",
                        description="Reference epoch for spin-down",
                        time_scale='tdb'))
@@ -80,27 +77,24 @@ class Spindown(PhaseComponent):
                 range(self.num_spin_terms)]
 
     def get_dt(self, toas, delay):
-        """Return dt, the time from the phase 0 epoch to each TOA
-
-        Currently this uses a buggy version of TZRMJD to define the
-        phase 0 epoch. This needs to change to a real phase 0 epoch
+        """Return dt, the time from the phase 0 epoch to each TOA.  The
+        phase 0 epoch is assumed to be PEPOCH.  If PEPOCH is not set,
+        the first TOA in the table is used instead.
+        
+        Note, the phase 0 epoch as used here is only intended for
+        computation internal to the Spindown class.  The "traditional"
+        tempo-style TZRMJD and related parameters for specifying absolute
+        pulse phase will be handled at a higher level in the code.
         """
-        # If TZRMJD is not defined, use the first time as phase reference
-        # NOTE, all of this ignores TZRSITE and TZRFRQ for the time being.
-        # TODO: TZRMJD should be set by default somewhere in a standard place,
-        #       after the TOAs are loaded (RvH -- June 2, 2015)
-        # NOTE: Should we be using barycentric arrival times, instead of TDB?
-        if self.TZRMJD.value is None:
-            self.TZRMJD.value = toas['tdb'][0] - delay[0]
-        # Warning(paulr): This looks wrong.  You need to use the
-        # TZRFREQ and TZRSITE to compute a proper TDB reference time.
-        if not hasattr(self, "TZRMJDld"):
-            self.TZRMJDld = time_to_longdouble(self.TZRMJD.value)
 
-        dt_tzrmjd = (toas['tdbld'] - self.TZRMJDld) * u.day - delay
-        # TODO: what timescale should we use for pepoch calculation? Does this even matter?
-        dt_pepoch = (time_to_longdouble(self.PEPOCH.value) - self.TZRMJDld) * u.day
-        return dt_tzrmjd, dt_pepoch
+        if self.PEPOCH.value is None:
+            phsepoch_ld = time_to_longdouble(toas['tdb'][0] - delay[0])
+        else:
+            phsepoch_ld = time_to_longdouble(self.PEPOCH.quantity)
+
+        dt = (toas['tdbld'] - phsepoch_ld)*u.day - delay
+
+        return dt
 
     def spindown_phase(self, toas, delay):
         """Spindown phase function.
@@ -112,14 +106,12 @@ class Spindown(PhaseComponent):
 
         returns an array of phases in long double
         """
-        dt_tzrmjd, dt_pepoch = self.get_dt(toas, delay)
+        dt = self.get_dt(toas, delay)
         # Add the [0.0] because that is the constant phase term
         fterms = [0.0 * u.cycle] + self.get_spin_terms()
         with u.set_enabled_equivalencies(dimensionless_cycles):
-            phs_tzrmjd = taylor_horner((dt_tzrmjd-dt_pepoch).to(u.second), \
-                                       fterms)
-            phs_pepoch = taylor_horner(-dt_pepoch.to(u.second), fterms)
-            return (phs_tzrmjd - phs_pepoch).to(u.cycle)
+            phs = taylor_horner(dt.to(u.second), fterms)
+            return phs.to(u.cycle)
 
     def print_par(self,):
         result = ''
@@ -147,17 +139,14 @@ class Spindown(PhaseComponent):
         # make the choosen fterms 1 others 0
         fterms = [ft * numpy.longdouble(0.0)/unit for ft in fterms]
         fterms[order] += numpy.longdouble(1.0)
-        dt_tzrmjd, dt_pepoch = self.get_dt(toas, delay)
+        dt = self.get_dt(toas, delay)
         with u.set_enabled_equivalencies(dimensionless_cycles):
-            d_ptzrmjd_d_f = taylor_horner((dt_tzrmjd-dt_pepoch).to(u.second), \
-                                          fterms)
-            d_ppepoch_d_f = taylor_horner(-dt_pepoch.to(u.second), fterms)
-            return (d_ptzrmjd_d_f - d_ppepoch_d_f).to(u.cycle/unit)
+            d_pphs_d_f = taylor_horner(dt.to(u.second), fterms)
+            return d_pphs_d_f.to(u.cycle/unit)
 
     def d_spindown_phase_d_delay(self, toas, delay):
-        dt_tzrmjd, dt_pepoch = self.get_dt(toas, delay)
+        dt = self.get_dt(toas, delay)
         fterms = [0.0] + self.get_spin_terms()
         with u.set_enabled_equivalencies(dimensionless_cycles):
-            d_ptzrmjd_d_delay = taylor_horner_deriv((dt_tzrmjd-dt_pepoch).to( \
-                                                     u.second), fterms)
-            return -d_ptzrmjd_d_delay.to(u.cycle/u.second)
+            d_pphs_d_delay = taylor_horner_deriv(dt.to(u.second), fterms)
+            return -d_pphs_d_delay.to(u.cycle/u.second)


### PR DESCRIPTION
This removes `TZRMJD` from the `Spindown` class, in prep for implementing `TZRMJD` elsewhere in the code.