### PR TITLE
Assorted Issues and Bug Fixes

### DIFF
--- a/pint/eventstats.py
+++ b/pint/eventstats.py
@@ -135,6 +135,21 @@ def z2mw(phases,weights,m=2):
 
     return np.cumsum(s) * (2./(weights**2).sum())
 
+def cosm(phases,m=2):
+    """ Return the cosine test for each harmonic up to the specified m.
+        See de Jager et al. 1994 for definition
+    """
+
+    phases = np.asarray(phases)*TWOPI   #phase in radians
+    n = len(phases)
+
+    if n < 5e3:
+        s = (np.cos(np.outer(np.arange(1,m+1),phases))).sum(axis=1)
+    else:
+        s = (np.asarray([np.cos(k*phases).sum() for k in range(1,m+1)]))
+
+    return (2./n)*np.cumsum(s)
+
 def sf_z2m(ts,m=2):
     """ Return the survival function (chance probability) according to the
         asymptotic calibration for the Z^2_m test.

--- a/pint/observatory/fermi_obs.py
+++ b/pint/observatory/fermi_obs.py
@@ -150,6 +150,14 @@ class FermiObs(SpecialLocation):
     def tempo_code(self):
         return None
 
+    def get_gcrs(self, t, ephem=None):
+        '''Return position vector of Fermi in GCRS
+        t is an astropy.Time or array of astropy.Time objects
+        Returns a 3-vector of Quantities representing the position
+        in GCRS coordinates.
+        '''
+        return np.array([self.X(t.tt.mjd), self.Y(t.tt.mjd), self.Z(t.tt.mjd)]) * self.FT2['X'].unit 
+
     def posvel(self, t, ephem):
         '''Return position and velocity vectors of Fermi, wrt SSB.
 

--- a/pint/observatory/nicer_obs.py
+++ b/pint/observatory/nicer_obs.py
@@ -152,6 +152,20 @@ class NICERObs(SpecialLocation):
     def tempo_code(self):
         return None
 
+    def get_gcrs(self, t, ephem=None):
+        '''Return position vector of NICER in GCRS
+        t is an astropy.Time or array of astropy.Time objects
+        Returns a 3-vector of Quantities representing the position
+        in GCRS coordinates.
+        '''
+        tmin = np.min(self.FPorb['MJD_TT'])
+        tmax = np.max(self.FPorb['MJD_TT'])
+        if (tmin-np.min(t.tt.mjd) > float(maxextrap)/(60*24) or
+            np.max(t.tt.mjd)-tmax > float(maxextrap)/(60*24)):
+            log.error('Extrapolating NICER position by more than %d minutes!'%maxextrap)
+            raise ValueError("Bad extrapolation of S/C file.")
+        return np.array([self.X(t.tt.mjd), self.Y(t.tt.mjd), self.Z(t.tt.mjd)])*self.FPorb['X'].unit 
+
     def posvel(self, t, ephem, maxextrap=2):
         '''Return position and velocity vectors of NICER.
 

--- a/pint/observatory/rxte_obs.py
+++ b/pint/observatory/rxte_obs.py
@@ -64,19 +64,23 @@ class RXTEObs(SpecialLocation):
             log.warning('Using location geocenter for TT to TDB conversion')
             return EarthLocation.from_geocentric(0.0*u.m,0.0*u.m,0.0*u.m)
         elif self.tt2tdb_mode.lower().startswith('spacecraft'):
+            log.warning('Using location=None for TT to TDB conversion')
+            return None
+        #elif self.tt2tdb_mode.lower().startswith('spacecraft'):
             # First, interpolate ECI geocentric location from orbit file.
             # These are inertial coorinates aligned with ICRF
-            pos_gcrs =  GCRS(CartesianRepresentation(self.X(time.tt.mjd)*u.m,
-                                                     self.Y(time.tt.mjd)*u.m,
-                                                     self.Z(time.tt.mjd)*u.m),
-                             obstime=time)
+            #log.warning('Performing GCRS to ITRS transformation')
+            #pos_gcrs =  GCRS(CartesianRepresentation(self.X(time.tt.mjd)*u.m,
+            #                                         self.Y(time.tt.mjd)*u.m,
+            #                                         self.Z(time.tt.mjd)*u.m),
+            #                 obstime=time)
 
             # Now transform ECI (GCRS) to ECEF (ITRS)
             # By default, this uses the WGS84 ellipsoid
-            pos_ITRS = pos_gcrs.transform_to(ITRS(obstime=time))
+            #pos_ITRS = pos_gcrs.transform_to(ITRS(obstime=time))
 
             # Return geocentric ITRS coordinates as an EarthLocation object
-            return pos_ITRS.earth_location
+            #return pos_ITRS.earth_location
         else:
             log.error('Unknown tt2tdb_mode %s, using None', self.tt2tdb_mode)
             return None
@@ -84,6 +88,14 @@ class RXTEObs(SpecialLocation):
     @property
     def tempo_code(self):
         return None
+
+    def get_gcrs(self, t, ephem=None):
+        '''Return position vector of RXTE in GCRS
+        t is an astropy.Time or array of astropy.Time objects
+        Returns a 3-vector of Quantities representing the position
+        in GCRS coordinates.
+        '''
+        return np.array([self.X(t.tt.mjd), self.Y(t.tt.mjd), self.Z(t.tt.mjd)])*self.FPorb['X'].unit
 
     def posvel(self, t, ephem):
         '''Return position and velocity vectors of RXTE.

--- a/pint/observatory/special_locations.py
+++ b/pint/observatory/special_locations.py
@@ -32,6 +32,11 @@ class BarycenterObs(SpecialLocation):
     @property
     def tempo2_code(self):
         return 'bat'
+    def get_gcrs(self, t, ephem=None):
+        if ephem is None:
+            raise ValueError('Ephemeris needed for BarycenterObs get_gcrs') 
+        ssb_pv = objPosVel_wrt_SSB('earth', t, ephem)
+        return -1 * ssb_pv.pos
     def posvel(self, t, ephem):
         vdim = (3,) + t.shape
         return PosVel(numpy.zeros(vdim)*u.m, numpy.zeros(vdim)*u.m/u.s,
@@ -50,6 +55,9 @@ class GeocenterObs(SpecialLocation):
     @property
     def tempo2_code(self):
         return 'coe'
+    def get_gcrs(self, t, ephem=None):
+        vdim = (3,) + t.shape
+        return np.zeros(vdim) * u.m
     def posvel(self, t, ephem):
         return objPosVel_wrt_SSB('earth', t, ephem)
 

--- a/pint/observatory/topo_obs.py
+++ b/pint/observatory/topo_obs.py
@@ -214,6 +214,16 @@ class TopoObs(Observatory):
                       location=self.earth_location_itrf())
         return result
 
+    def get_gcrs(self, t, ephem=None):
+        '''Return position vector of TopoObs in GCRS
+        t is an astropy.Time or array of astropy.Time objects
+        Returns a 3-vector of Quantities representing the position
+        in GCRS coordinates.
+        '''
+        obs_geocenter_pv = gcrs_posvel_from_itrf(self.earth_location_itrf(), t, \
+                                            obsname=self.name)
+        return obs_geocenter_pv.pos
+
     def posvel(self, t, ephem):
         if t.isscalar: t = Time([t])
         earth_pv = objPosVel_wrt_SSB('earth', t, ephem)

--- a/pint/scripts/photonphase.py
+++ b/pint/scripts/photonphase.py
@@ -33,6 +33,7 @@ def main(argv=None):
     parser.add_argument("--barytime",help="Write FITS file with a column containing the barycentric time as double precision MJD.",default=False,action='store_true')
     parser.add_argument("--outfile",help="Output FITS file name (default=same as eventfile)", default=None)
     parser.add_argument("--ephem",help="Planetary ephemeris to use (default=DE421)", default="DE421")
+    parser.add_argument('--tdbmethod',help="Method for computing TT to TDB (default=astropy)", default="astropy")
     parser.add_argument("--plot",help="Show phaseogram plot.", action='store_true', default=False)
 #    parser.add_argument("--fix",help="Apply 1.0 second offset for NICER", action='store_true', default=False)
     args = parser.parse_args(argv)
@@ -109,7 +110,7 @@ def main(argv=None):
 
     tztoa = toa.TOA(tzrmjd,obs=tzrsite,freq=tzrfrq)
     tz = toa.get_TOAs_list([tztoa],include_bipm=False,include_gps=False,
-        ephem=args.ephem, planets=use_planets)
+        ephem=args.ephem, planets=use_planets, tdb_method=args.tdbmethod)
 
     # Discard events outside of MJD range
     if args.maxMJD is not None:
@@ -124,7 +125,7 @@ def main(argv=None):
         print("post len : ",len(tlnew))
 
     ts = toa.get_TOAs_list(tl, ephem=args.ephem, include_bipm=False,
-        include_gps=False, planets=use_planets)
+        include_gps=False, planets=use_planets, tdb_method=args.tdbmethod)
     ts.filename = args.eventfile
 #    if args.fix:
 #        ts.adjust_TOAs(TimeDelta(np.ones(len(ts.table))*-1.0*u.s,scale='tt'))

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -720,7 +720,7 @@ class TOAs(object):
         self.clock_corr_info.update({'include_bipm':include_bipm,
                                      'bipm_version':bipm_version,
                                      'include_gps':include_gps})
-
+	
     def compute_TDBs(self, method="astropy", ephem=None):
         """Compute and add TDB and TDB long double columns to the TOA table.
         This routine creates new columns 'tdb' and 'tdbld' in a TOA table

--- a/tests/test_ell1h.py
+++ b/tests/test_ell1h.py
@@ -36,7 +36,11 @@ class TestELL1H(unittest.TestCase):
     def test_J1853(self):
         pint_resids_us = resids(self.toasJ1853, self.modelJ1853, False).time_resids.to(u.s)
         # Due to PINT has higher order of ELL1 model, Tempo2 gives a difference around 3e-8
-        assert np.all(np.abs(pint_resids_us.value - self.ltres) < 3e-8), 'J1853 residuals test failed.'
+        # Changed to 4e-8 since modification to get_PSR_freq() makes this 3.1e-8
+        log=logging.getLogger( "TestJ1853.J1853_residuals")
+        diffs = np.abs(pint_resids_us.value - self.ltres)
+        log.debug('Diffs: %s\nMax: %s' % (diffs, np.max(diffs)))
+        assert np.all(diffs < 4e-8), 'J1853 residuals test failed.'
 
     def test_J1853_binary_delay(self):
         # Calculate delays with PINT

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -62,7 +62,7 @@ diff_t2 -= diff_t2.mean()
 log.info("Max resid diff between PINT and T2: %.2f ns" % numpy.fabs(diff_t2).max().value)
 log.info("Std resid diff between PINT and T2: %.2f ns" % diff_t2.std().value)
 
-assert numpy.fabs(diff_t2).max() < 5.0 * u.ns
+assert numpy.fabs(diff_t2).max() < 10.0 * u.ns
 
 # run tempo1 also, if the tempo_utils module is available
 did_tempo1 = False
@@ -91,7 +91,7 @@ def do_plot():
     plt.clf()
     plt.subplot(211)
     plt.hold(False)
-    plt.errorbar(mjds, resids_us.value, errs.to(u.us).value, fmt=None, label='PINT')
+    plt.errorbar(mjds.value, resids_us.value, errs.to(u.us).value, fmt=None, label='PINT')
     plt.title("J1744-1134 GBT/GASP timing")
     plt.xlabel('MJD')
     plt.ylabel('Residual (us)')

--- a/tests/test_photonphase.py
+++ b/tests/test_photonphase.py
@@ -9,6 +9,7 @@ import unittest
 import numpy as np
 import pint.scripts.photonphase as photonphase
 from pinttestdata import testdir, datadir
+from astropy import log
 
 parfile = os.path.join(datadir, 'J1513-5908_PKS_alldata_white.par')
 eventfile = os.path.join(datadir, 'B1509_RXTE_short.fits')
@@ -17,18 +18,19 @@ orbfile = os.path.join(datadir, 'FPorbit_Day6223')
 class TestPhotonPhase(unittest.TestCase):
 
     def test_result(self):
-        pass
-        # saved_stdout, photonphase.sys.stdout = photonphase.sys.stdout, StringIO('_')
-        # cmd = '--plot --plotfile photontest.png --outfile photontest.fits {0} {1} --orbfile={2} '.format(eventfile,parfile,orbfile)
-        # photonphase.main(cmd.split())
-        # lines = photonphase.sys.stdout.getvalue()
-        # v = 999.0
-        # for l in lines.split('\n'):
-        #     if l.startswith('Htest'):
-        #         v = float(l.split()[2])
-        # # Check that H-test is greater than 725
-        # self.assertTrue(v>725)
-        # photonphase.sys.stdout = saved_stdout
+        #pass
+        saved_stdout, photonphase.sys.stdout = photonphase.sys.stdout, StringIO('_')
+        cmd = '--plot --plotfile photontest.png --outfile photontest.fits {0} {1} --orbfile={2} --tdbmethod astropy_corrected '.format(eventfile,parfile,orbfile)
+        photonphase.main(cmd.split())
+        lines = photonphase.sys.stdout.getvalue()
+        v = 999.0
+        for l in lines.split('\n'):
+            if l.startswith('Htest'):
+                v = float(l.split()[2])
+        # Check that H-test is greater than 725
+        log.warning('V:\t%f' % v)
+        self.assertTrue(v>725)
+        photonphase.sys.stdout = saved_stdout
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The new correction factor in computeTDBs can be used with the method='astropy_corrected' argument. Should this be relabeled? 
earth_location_itrf now returns None for spacecraft
Correction factor was compared with the old results from test_photonphase and the pulse phases agree to within 10e-6, pulse times agree to within 10e-7s
These changes together address Issue #330 

Added cosine test function as requested by Issue #361 

Added zima features - input tim file and data fuzzing as requested by Issue #384 

Added Parkes format loading as requested by Issue #391 

Enhanced residuals.py as requested by Issue #290 
Note: the change to get_PSR_freq() very slightly increases the differences from Tempo2 and caused some tests to fail. The thresholds have been updated after discussion with @paulray . In addition, the change significantly slows down calls to resids.calc_time_resids(), so it will be useful in the future to find ways to speed up model.d_phase_d_toas()