### PR TITLE
Fix a bug in computing TDB times for barycentric TOAs 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: python
 matrix:
     include:
         - python: "2.7"
-        - python: "3.5"
         - python: "3.6"
 
 sudo: required

--- a/pint/observatory/observatory.py
+++ b/pint/observatory/observatory.py
@@ -128,7 +128,7 @@ class Observatory(object):
         at that time will be returned.
         """
         return None
-    
+
     def get_gcrs(self, t, ephem=None):
         '''Return position vector of observatory in GCRS
         t is an astropy.Time or array of astropy.Time objects
@@ -136,7 +136,7 @@ class Observatory(object):
         Returns a 3-vector of Quantities representing the position
         in GCRS coordinates.
         '''
-        raise NotImplementedError 
+        raise NotImplementedError
 
     @property
     def timescale(self):
@@ -176,6 +176,8 @@ class Observatory(object):
                 'ephemeris' method.
         """
         if t.isscalar: t = Time([t])
+        if t.scale == 'tdb':
+            return t
         # Check the method. This pattern is from numpy minize
         if callable(method):
             meth = "_custom"
@@ -208,10 +210,10 @@ class Observatory(object):
     def _get_TDB_PINT(self, t, ephem):
         """Uses astropy.Time location to add the topocentric correction term to
             the Time object. The topocentric correction is given as (r/c).(v/c),
-            with r equal to the geocentric position of the observer, v being the 
+            with r equal to the geocentric position of the observer, v being the
             barycentric velocity of the earth, and c being the speed of light.
 
-            The geocentric observer position can be obtained from Time object. 
+            The geocentric observer position can be obtained from Time object.
             The barycentric velocity can be obtained using solar_system_ephemerides
             objPosVel_wrt_SSB
         """

--- a/pint/solar_system_ephemerides.py
+++ b/pint/solar_system_ephemerides.py
@@ -57,7 +57,7 @@ def _load_kernel_link(ephem, link=''):
             #log.info('Exception! {0} {1} {2}'.format(type(ex), ex.args, ex))
             try:
                 log.info('Trying to download and set astropy ephemeris to {0}'.format(ephem_link))
-                aut.data.download_file(ephem_link, timeout=60, cache=True)
+                aut.data.download_file(ephem_link, timeout=300, cache=True)
                 coor.solar_system_ephemeris.set(ephem_link)
                 load_kernel = True
             except Exception as ex2:

--- a/pint/solar_system_ephemerides.py
+++ b/pint/solar_system_ephemerides.py
@@ -38,8 +38,8 @@ def _load_kernel_link(ephem, link=''):
     load_kernel = False # a flag for checking if the kernel has been loaded
     # search_list = [link,jpl_kernel_http, jpl_kernel_ftp]
     # NOTE the JPL ftp site is disabled. Instead, we duplicated the JPL ftp
-    # site on nanograv server. 
-    search_list = [link, nanograv_http ,jpl_kernel_http]
+    # site on nanograv server.
+    search_list = [link, nanograv_http, jpl_kernel_http, jpl_kernel_ftp]
     if link != '':
         search_list.append('')
     for l in search_list:

--- a/tests/test_solar_system_body.py
+++ b/tests/test_solar_system_body.py
@@ -22,7 +22,7 @@ class TestSolarSystemDynamic(unittest.TestCase):
         ets = np.random.uniform(0.0, 9000.0, 10000) * SECPERJULDAY
         mjd = J2000_MJD + ets / SECPERJULDAY
         self.tdb_time = time.Time(mjd, scale='tdb', format='mjd')
-        self.ephem = ['de405', 'de421', 'de434', 'de430','de436']
+        self.ephem = ['de405', 'de421', 'de430']
         self.planets = ['jupiter', 'saturn', 'venus', 'uranus']
 
     # Here we only test if any errors happens.

--- a/tests/test_solar_system_body.py
+++ b/tests/test_solar_system_body.py
@@ -22,7 +22,7 @@ class TestSolarSystemDynamic(unittest.TestCase):
         ets = np.random.uniform(0.0, 9000.0, 10000) * SECPERJULDAY
         mjd = J2000_MJD + ets / SECPERJULDAY
         self.tdb_time = time.Time(mjd, scale='tdb', format='mjd')
-        self.ephem = ['de405', 'de421', 'de430']
+        self.ephem = ['de405', 'de421', 'de434', 'de430', 'de436']
         self.planets = ['jupiter', 'saturn', 'venus', 'uranus']
 
     # Here we only test if any errors happens.


### PR DESCRIPTION
A bug was introduced in the speedup of TDB calculation.  For TOAs that were already at the SSB, it still tried to add the topocentric part of the TT to TDB conversion. This fix makes compute_TDBs not do anything for TOAs that are already on the TDB timescale.