### PR TITLE
A few ephem fixes

### DIFF
--- a/pint/models/absolute_phase.py
+++ b/pint/models/absolute_phase.py
@@ -42,16 +42,18 @@ class AbsPhase(PhaseComponent):
             self.TZRMJD.time_scale = 'tdb'
             log.info("The TZRSITE is set at the solar system barycenter.")
 
-        if self.TZRFRQ.value is None:
-            self.TZRFRQ = float("inf")
-            log.info("The TZRFREQ is set at infinite.")
+        if (self.TZRFRQ.value is None) or (self.TZRFRQ.value == 0.0):
+            self.TZRFRQ.quantity = float("inf")*u.MHz
+            log.info("TZRFRQ was 0.0 or None. Setting to infinite frequency.")
 
 
     def get_TZR_toa(self, toas):
         """ Get the TOAs class for the TZRMJD. We are treating the TZRMJD as a
             special TOA.
         """
-        TZR_toa = toa.TOA(self.TZRMJD.quantity, obs=self.TZRSITE.value,
+        # NOTE: Using TZRMJD.quantity.jd[1,2] so that the time scale can be properly
+        # set to the TZRSITE default timescale (e.g. UTC for TopoObs and TDB for SSB)
+        TZR_toa = toa.TOA((self.TZRMJD.quantity.jd1, self.TZRMJD.quantity.jd2), obs=self.TZRSITE.value,
                           freq=self.TZRFRQ.quantity)
         clkc_info = toas.clock_corr_info
         tz = toa.get_TOAs_list([TZR_toa,], include_bipm=clkc_info['include_bipm'],


### PR DESCRIPTION
This PR cleans up a bit the use of the `ephem` argument in the `TOAs` class.  But, even with this, there are too many places where it is specified and it may be possible to use it inconsistently. 
I think it might be better to have `compute_TDBs` and `compute_posvels` NOT take ephem as an argument, but always use `self.ephem`.  Then, `self.ephem` could be set either at initialization by `get_TOAs()` or by a separate method like `TOAs.set_ephem()`, which would invalidate any previously-computed TDBs and posvels.  Thoughts? @luojing1211 