### PR TITLE
Fixes for photonphase

### DIFF
--- a/pint/event_toas.py
+++ b/pint/event_toas.py
@@ -65,12 +65,12 @@ def _get_columns_from_fits(hdu, cols):
 def _get_timesys_and_timeref(hdu):
     event_hdr = hdu.header
     timesys = event_hdr['TIMESYS']
-    log.info("TIMESYS {0}".format(timesys))
+    log.debug("TIMESYS {0}".format(timesys))
     if timesys not in ['TDB', 'TT']:
         raise ValueError('Timesys has to be TDB or TT')
 
     timeref = event_hdr['TIMEREF']
-    log.info("TIMEREF {0}".format(timeref))
+    log.debug("TIMEREF {0}".format(timeref))
     if timeref not in ['GEOCENTER', 'SOLARSYSTEM', 'LOCAL']:
         raise ValueError('Timeref is invalid')
 

--- a/pint/observatory/nicer_obs.py
+++ b/pint/observatory/nicer_obs.py
@@ -47,13 +47,13 @@ def load_FPorbit(orbit_filename):
     # TIMEREF should be 'LOCAL', since no delays are applied
 
     timesys = FPorbit_hdr['TIMESYS']
-    log.info("FPorbit TIMESYS {0}".format(timesys))
+    log.debug("FPorbit TIMESYS {0}".format(timesys))
     timeref = FPorbit_hdr['TIMEREF']
-    log.info("FPorbit TIMEREF {0}".format(timeref))
+    log.debug("FPorbit TIMEREF {0}".format(timeref))
 
     mjds_TT = read_fits_event_mjds(hdulist[1])
     mjds_TT = mjds_TT*u.d
-    log.info("FPorbit spacing is {0}".format((mjds_TT[1]-mjds_TT[0]).to(u.s)))
+    log.debug("FPorbit spacing is {0}".format((mjds_TT[1]-mjds_TT[0]).to(u.s)))
     X = FPorbit_dat.field('X')*u.m
     Y = FPorbit_dat.field('Y')*u.m
     Z = FPorbit_dat.field('Z')*u.m
@@ -65,7 +65,7 @@ def load_FPorbit(orbit_filename):
             names = ('MJD_TT', 'X', 'Y', 'Z', 'Vx', 'Vy', 'Vz'),
             meta = {'name':'FPorbit'} )
     # Make sure table is sorted by time
-    log.info('Sorting FPorbit table')
+    log.debug('Sorting FPorbit table')
     FPorbit_table.sort('MJD_TT')
     # Now delete any bad entries where the positions are 0.0
     idx = np.where(np.logical_and(FPorbit_table['X'] != 0.0, FPorbit_table['Y'] != 0.0))[0]
@@ -89,8 +89,8 @@ class NICERObs(SpecialLocation):
     tt2tdb_mode: str
         Selection for mode to use for TT to TDB conversion.
         'none' = Give no position to astropy.Time()
+        'pint' = Give no position to astropy.Time() but apply topocentric part of TT->TDB in PINT
         'geo' = Give geocenter position to astropy.Time()
-        'spacecraft' = Give spacecraft ITRF position to astropy.Time()
 """
 
     def __init__(self, name, FPorbname, tt2tdb_mode = 'pint'):
@@ -117,7 +117,7 @@ class NICERObs(SpecialLocation):
         super(NICERObs, self).__init__(name=name, tt2tdb_mode=tt2tdb_mode)
         # Print this warning once, mainly for @paulray
         if self.tt2tdb_mode.lower().startswith('pint'):
-            log.warning('Using location=None for TT to TDB conversion')
+            log.debug('Using location=None for TT to TDB conversion (pint mode)')
         elif self.tt2tdb_mode.lower().startswith('geo'):
             log.warning('Using location geocenter for TT to TDB conversion')
 

--- a/pint/scripts/photonphase.py
+++ b/pint/scripts/photonphase.py
@@ -141,8 +141,8 @@ def main(argv=None):
         if args.absphase:
             data_to_add['ABS_PHASE'] = [iphss-negmask*u.cycle,'K']
         if args.barytime:
-            tdbs = np.asarray([t.mjd for t in ts.table['tdb']])
-            data_to_add['BARY_TIME'] = [tdbs,'D']
+            bats = modelin.get_barycentric_toas(ts)
+            data_to_add['BARY_TIME'] = [bats,'D']
         datacol = []
         for key in data_to_add.keys():
             if key in hdulist[1].columns.names:

--- a/pint/scripts/photonphase.py
+++ b/pint/scripts/photonphase.py
@@ -143,6 +143,7 @@ def main(argv=None):
         if args.barytime:
             tdbs = np.asarray([t.mjd for t in ts.table['tdb']])
             data_to_add['BARY_TIME'] = [tdbs,'D']
+        datacol = []
         for key in data_to_add.keys():
             if key in hdulist[1].columns.names:
                 log.info('Found existing %s column, overwriting...'%key)
@@ -151,12 +152,15 @@ def main(argv=None):
             else:
                 # Construct and append new column, preserving HDU header and name
                 log.info('Adding new %s column.'%key)
-                datacol = pyfits.ColDefs([pyfits.Column(name=key,
-                    format=data_to_add[key][1], array=data_to_add[key][0])])
-                bt = pyfits.BinTableHDU.from_columns(
-                    hdulist[1].columns + datacol, header=hdulist[1].header,
-                    name=hdulist[1].name)
-                hdulist[1] = bt
+                datacol.append(pyfits.ColDefs([pyfits.Column(name=key,
+                    format=data_to_add[key][1], array=data_to_add[key][0])]))
+        if len(datacol)>0:
+            cols = hdulist[1].columns
+            for c in datacol:
+                cols = cols + c
+            bt = pyfits.BinTableHDU.from_columns(c, header=hdulist[1].header,
+                name=hdulist[1].name)
+            hdulist[1] = bt
         if args.outfile is None:
             # Overwrite the existing file
             log.info('Overwriting existing FITS file '+args.eventfile)

--- a/pint/solar_system_ephemerides.py
+++ b/pint/solar_system_ephemerides.py
@@ -50,13 +50,13 @@ def _load_kernel_link(ephem, link=''):
         if load_kernel:
             break
         try:
-            log.info('Trying to set astropy ephemeris to {0}'.format(ephem_link))
+            log.debug('Trying to set astropy ephemeris to {0}'.format(ephem_link))
             coor.solar_system_ephemeris.set(ephem_link)
             load_kernel = True
         except Exception as ex:
             #log.info('Exception! {0} {1} {2}'.format(type(ex), ex.args, ex))
             try:
-                log.info('Trying to download and set astropy ephemeris to {0}'.format(ephem_link))
+                log.debug('Trying to download and set astropy ephemeris to {0}'.format(ephem_link))
                 aut.data.download_file(ephem_link, timeout=300, cache=True)
                 coor.solar_system_ephemeris.set(ephem_link)
                 load_kernel = True

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -581,7 +581,7 @@ class TOAs(object):
             else:
                 log.warning('No pulse numbers for TOAs')
                 return None
-                
+
 
     def get_flags(self):
         """Return a numpy array of the TOA flags"""
@@ -639,7 +639,7 @@ class TOAs(object):
     def print_summary(self):
         """Write a summary of the TOAs to stdout."""
         print(self.get_summary())
-    
+
     def pulse_column_from_flags(self):
         '''
         Create a pulse numbers column if possible from the TOAs flags
@@ -655,7 +655,7 @@ class TOAs(object):
             for flags in self.table['flags']:
                 del flags['pn']
         except:
-            log.info('No pn flags in model')
+            log.debug('No pn flags in model')
 
     def compute_pulse_numbers(self, model):
         phases = model.phase(self)
@@ -715,7 +715,7 @@ class TOAs(object):
         # NOTE(@paulray): This really should REMOVE any(?) clock corrections
         # that have been applied!
         # NOTE clock corrections has been removed.
-        
+
         # Add pulse numbers to flags temporarily if there is a pulse number column
         pnChange = False
         if 'pn' in self.table.colnames:
@@ -799,7 +799,7 @@ class TOAs(object):
         self.clock_corr_info.update({'include_bipm':include_bipm,
                                      'bipm_version':bipm_version,
                                      'include_gps':include_gps})
-	
+
     def compute_TDBs(self, method="default", ephem=None):
         """Compute and add TDB and TDB long double columns to the TOA table.
         This routine creates new columns 'tdb' and 'tdbld' in a TOA table
@@ -937,7 +937,7 @@ class TOAs(object):
         cols_to_add = [ssb_obs_pos, ssb_obs_vel, obs_sun_pos]
         if planets:
             cols_to_add += plan_poss.values()
-        log.info('Adding columns ' + ' '.join([cc.name for cc in cols_to_add]))
+        log.debug('Adding columns ' + ' '.join([cc.name for cc in cols_to_add]))
         self.table.add_columns(cols_to_add)
 
     def read_pickle_file(self, filename):


### PR DESCRIPTION
This fixes #427 so that the BARY_TIME column is now computed with the solar system delays included. It also fixes a bug in the code that added columns to the output FITS file. This worked for adding one column but failed when you tried to add multiple columns (e.g. PULSE_PHASE and BARY_TIME). This PR also reduces the verbosity in places by changing some `log.info()` to `log.debug()`