### PR TITLE
Fixed pintk bugs

### DIFF
--- a/pint/models/timing_model.py
+++ b/pint/models/timing_model.py
@@ -95,6 +95,8 @@ class TimingModel(object):
             description="Tracking Information"), '')
         self.add_param_from_top(strParameter(name="EPHEM",
             description="Ephemeris to use"), '')
+        self.add_param_from_top(strParameter(name="UNITS",
+            description="Units (TDB assumed)"), '')
 
         self.setup_components(components)
 
@@ -789,6 +791,12 @@ class TimingModel(object):
 
             k = l.split()
             name = k[0].upper()
+            
+            if name == 'UNITS' and len(k) > 1 and k[1] != 'TDB':
+                log.error("UNITS %s not yet supported by PINT" % k[1])
+                raise Exception("UNITS %s not yet supported by PINT" % k[1])
+
+            
             if name in checked_param:
                 if name in repeat_param.keys():
                     repeat_param[name] += 1
@@ -805,16 +813,13 @@ class TimingModel(object):
                     cmp = self
                 if cmp.__getattr__(par).from_parfile_line(l):
                     parsed = True
+
             if not parsed:
                 try:
                     prefix,f,v = utils.split_prefixed_name(l.split()[0])
                     if prefix not in ignore_prefix:
                         log.warn("Unrecognized parfile line '%s'" % l)
                 except:
-                    words = l.split()
-                    if words[0] == 'UNITS' and len(words) > 1 and words[1] == 'TCB':
-                        log.error("UNITS TCB not yet supported by PINT")
-                        raise Exception("UNITS TCB not yet supported by PINT")
                     if l.split()[0] not in ignore_params:
                         log.warn("Unrecognized parfile line '%s'" % l)
 

--- a/pint/pintk/plk.py
+++ b/pint/pintk/plk.py
@@ -422,8 +422,8 @@ class PlkWidget(tk.Frame):
         '''
         filename = tkFileDialog.asksaveasfilename(title='Choose output tim file')
         try:
-            print('Chose output file %s' % filename)
-            self.psr.toas.write_TOA_file(filename)
+            print('Choose output file %s' % filename)
+            self.psr.toas.write_TOA_file(filename,format='TEMPO2')
         except:
             print('Count not save file to filename:\t%s' % filename)
 

--- a/pint/pintk/pulsar.py
+++ b/pint/pintk/pulsar.py
@@ -50,7 +50,7 @@ class Pulsar(object):
         self.prefit_model = pint.models.get_model(self.parfile)
         print("prefit_model.as_parfile():")
         print(self.prefit_model.as_parfile())
-        
+
         if ephem is not None:
             self.toas = pint.toa.get_TOAs(self.timfile, ephem=ephem)
             self.prefit_model.EPHEM.value = ephem
@@ -89,7 +89,12 @@ class Pulsar(object):
         self.update_resids()
 
     def reset_TOAs(self):
-        self.toas = pint.toa.get_TOAs(self.timfile)
+
+        if getattr(self.prefit_model, 'EPHEM').value is not None:
+            self.toas = pint.toa.get_TOAs(self.timfile, ephem=self.prefit_model.EPHEM.value)
+        else:
+            self.toas = pint.toa.get_TOAs(self.timfile)
+
         if self.track_added:
             self.prefit_model.TRACK.value = ''
             if self.fitted:
@@ -102,7 +107,12 @@ class Pulsar(object):
         self.postfit_model = None
         self.postfit_resids = None
         self.fitted = False
-        self.toas = pint.toa.get_TOAs(self.timfile)
+
+        if getattr(self.prefit_model, 'EPHEM').value is not None:
+            self.toas = pint.toa.get_TOAs(self.timfile, ephem=self.prefit_model.EPHEM.value)
+        else:
+            self.toas = pint.toa.get_TOAs(self.timfile)
+        
         self.update_resids()
    
     def update_resids(self):

--- a/pint/scripts/zima.py
+++ b/pint/scripts/zima.py
@@ -42,7 +42,7 @@ def main(argv=None):
                     type=float, default=1400.0)
     parser.add_argument("--error",help="Random error to apply to each TOA (us, default=1.0)",
                     type=float, default=1.0)
-    parser.add_argument("--fuzzdays",help="Standard deviation of 'fuzz' distribution (jd) (default: 0.01)",type=float, default=0.01)
+    parser.add_argument("--fuzzdays",help="Standard deviation of 'fuzz' distribution (jd) (default: 0.0)",type=float, default=0.0)
     parser.add_argument("--plot",help="Plot residuals",action="store_true",default=False)
     parser.add_argument("--ephem",help="Ephemeris to use",default="DE421")
     parser.add_argument("--planets",help="Use planetary Shapiro delay",action="store_true",
@@ -68,8 +68,9 @@ def main(argv=None):
         times = np.linspace(0,duration.to(u.day).value,args.ntoa)*u.day + start
 
         # 'Fuzz' out times
-        fuzz = np.random.normal(scale=args.fuzzdays,size=len(times))*u.day
-        times += fuzz
+        if args.fuzzdays > 0.0:
+            fuzz = np.random.normal(scale=args.fuzzdays,size=len(times))*u.day
+            times += fuzz
 
         # Add mulitple frequency
         freq_array = get_freq_array(freq, len(times))

--- a/pint/scripts/zima.py
+++ b/pint/scripts/zima.py
@@ -42,7 +42,7 @@ def main(argv=None):
                     type=float, default=1400.0)
     parser.add_argument("--error",help="Random error to apply to each TOA (us, default=1.0)",
                     type=float, default=1.0)
-    parser.add_argument("--fuzzdays",help="Standard deviation of 'fuzz' distribution (jd) (default: 0.0)",type=float, default=0.0)
+    parser.add_argument("--fuzzdays",help="Standard deviation of 'fuzz' distribution (jd) (default: 0.01)",type=float, default=0.01)
     parser.add_argument("--plot",help="Plot residuals",action="store_true",default=False)
     parser.add_argument("--ephem",help="Ephemeris to use",default="DE421")
     parser.add_argument("--planets",help="Use planetary Shapiro delay",action="store_true",
@@ -88,7 +88,7 @@ def main(argv=None):
         ts.apply_clock_corrections()
     if 'tdb' not in ts.table.colnames:
         log.info("Getting IERS params and computing TDBs.")
-        ts.compute_TDBs()
+        ts.compute_TDBs(ephem=args.ephem)
     if 'ssb_obs_pos' not in ts.table.colnames:
         log.info("Computing observatory positions and velocities.")
         ts.compute_posvels(args.ephem, args.planets)


### PR DESCRIPTION
Fixed 2 pintk bugs: empty tim file being written by clicking the 'Write tim' button under the residuals plot; and pintk reverting to the default DE421 ephemeris when 'Reset' was clicked instead of continuing to use the ephemeris specified in the par file. 