### PR TITLE
Add nustar

### DIFF
--- a/pint/observatory/nustar_obs.py
+++ b/pint/observatory/nustar_obs.py
@@ -35,6 +35,7 @@ def load_orbit(orb_filename):
                  "a solution precise only to the ~0.5ms level. Use the "
                  "pipeline-produced attitude-orbit file ('*.attorb.gz') for"
                  "better precision.")
+
     hdulist = pyfits.open(orb_filename)
     orb_hdr=hdulist[1].header
     orb_dat=hdulist[1].data

--- a/pint/observatory/nustar_obs.py
+++ b/pint/observatory/nustar_obs.py
@@ -29,6 +29,12 @@ def load_orbit(orb_filename):
 
     '''
     # Load photon times from FT1 file
+
+    if '_orb' in orb_filename:
+        log.warn("The NuSTAR orbit file you are providing is known to give"
+                 "a solution precise only to the ~0.5ms level. Use the "
+                 "pipeline-produced attitude-orbit file ('*.attorb.gz') for"
+                 "better precision.")
     hdulist = pyfits.open(orb_filename)
     orb_hdr=hdulist[1].header
     orb_dat=hdulist[1].data
@@ -38,7 +44,11 @@ def load_orbit(orb_filename):
     # TIMEREF should be 'LOCAL', since no delays are applied
     timesys = orb_hdr['TIMESYS']
     log.info("orb TIMESYS {0}".format(timesys))
-    timeref = orb_hdr['TIMEREF']
+    try:
+        timeref = orb_hdr['TIMEREF']
+    except KeyError:
+        timeref = 'LOCAL'
+
     log.info("orb TIMEREF {0}".format(timeref))
 
     # The X, Y, Z position are for the START time


### PR DESCRIPTION
These modifications allow to load any time column from fits files. The basic changes are the possibility to specify the timeref and timesys from the command line (in which case these keywords are not read from the file), and to not force the event extension name in load_event_TOAs
`load_event_TOAs` still works as before: it now just calls this more generic function, load_fits_TOAs.
This completes the machinery necessary to load all NuSTAR files and allows to run NuSTAR's advanced clock correction under development at Caltech

