### PR TITLE
GLS: Fix Chi2 forumula

### DIFF
--- a/pint/fitter.py
+++ b/pint/fitter.py
@@ -282,7 +282,7 @@ class GLSFitter(Fitter):
             if full_cov:
                 chi2 = np.dot(newres, sl.cho_solve(cf, newres))
             else:
-                chi2 = np.dot(newres, cinv*newres)
+                chi2 = np.dot(newres, cinv*newres) + np.dot(xhat,phiinv*xhat)
 
             # compute absolute estimates, normalized errors, covariance matrix
             dpars = xhat/norm


### PR DESCRIPTION
This is a one-line change that makes the chi-squared returned by `GLSFitter` in the `full_cov=False` (default) case agree with the calculation done when `full_cov=True`.