### PR TITLE
Fix erfa call for pulsar_mjd

### DIFF
--- a/pint/pulsar_mjd.py
+++ b/pint/pulsar_mjd.py
@@ -4,6 +4,15 @@ from astropy.time.utils import day_frac
 import astropy._erfa as erfa
 import numpy
 
+
+def safe_kind_conversion(values, dtype):
+    import collections
+    if isinstance(values, collections.Iterable):
+        return numpy.asarray(values, dtype=dtype)
+    else:
+        return dtype(values)
+
+
 class TimePulsarMJD(TimeFormat):
     """MJD using tempo/tempo2 convention for time within leap second days.
     This is only relevant if scale='utc', otherwise will act like the
@@ -21,8 +30,8 @@ class TimePulsarMJD(TimeFormat):
             (y,mo,d,f) = erfa.jd2cal(erfa.DJM0+v1,v2)
             # Fractional day to HMS.  Uses 86400-second day always.
             # Seems like there should be a ERFA routine for this..
-            h = numpy.asarray(numpy.floor(f*24.0), dtype=int)
-            m = numpy.asarray(numpy.floor(numpy.remainder(f*1440.0,60)),
+            h = safe_kind_conversion(numpy.floor(f*24.0), dtype=int)
+            m = safe_kind_conversion(numpy.floor(numpy.remainder(f*1440.0,60)),
                               dtype=int)
             s = numpy.remainder(f*86400.0,60)
             self.jd1, self.jd2 = erfa.dtf2d('UTC',y,mo,d,h,m,s)

--- a/pint/pulsar_mjd.py
+++ b/pint/pulsar_mjd.py
@@ -6,7 +6,7 @@ import numpy
 
 class TimePulsarMJD(TimeFormat):
     """MJD using tempo/tempo2 convention for time within leap second days.
-    This is only relevant if scale='utc', otherwise will act like the 
+    This is only relevant if scale='utc', otherwise will act like the
     standard astropy MJD time format."""
 
     name = 'pulsar_mjd'
@@ -15,14 +15,14 @@ class TimePulsarMJD(TimeFormat):
         self._check_scale(self._scale)
         if self._scale == 'utc':
             # To get around leap second issues, first convert to YMD,
-            # then back to astropy/ERFA-convention jd1,jd2 using the 
+            # then back to astropy/ERFA-convention jd1,jd2 using the
             # ERFA dtf2d() routine which handles leap seconds.
             v1, v2 = day_frac(val1, val2)
             (y,mo,d,f) = erfa.jd2cal(erfa.DJM0+v1,v2)
             # Fractional day to HMS.  Uses 86400-second day always.
-            # Seems like there should be a ERFA routine for this.. 
-            h = numpy.floor(f*24.0)
-            m = numpy.floor(numpy.remainder(f*1440.0,60))
+            # Seems like there should be a ERFA routine for this..
+            h = int(numpy.floor(f*24.0))
+            m = int(numpy.floor(numpy.remainder(f*1440.0,60)))
             s = numpy.remainder(f*86400.0,60)
             self.jd1, self.jd2 = erfa.dtf2d('UTC',y,mo,d,h,m,s)
         else:
@@ -33,16 +33,16 @@ class TimePulsarMJD(TimeFormat):
     def value(self):
         if self._scale == 'utc':
             # Do the reverse of the above calculation
-            # Note this will return an incorrect value during 
-            # leap seconds, so raise an exception in that 
+            # Note this will return an incorrect value during
+            # leap seconds, so raise an exception in that
             # case.
             y, mo, d, hmsf = erfa.d2dtf('UTC',9,self.jd1,self.jd2)
             if 60 in hmsf[...,2]:
                 raise ValueError('UTC times during a leap second cannot be represented in pulsar_mjd format')
             j1, j2 = erfa.cal2jd(y,mo,d)
-            return (j1 - erfa.DJM0 + j2) + (hmsf[...,0]/24.0 
-                    + hmsf[...,1]/1440.0 
-                    + hmsf[...,2]/86400.0 
+            return (j1 - erfa.DJM0 + j2) + (hmsf[...,0]/24.0
+                    + hmsf[...,1]/1440.0
+                    + hmsf[...,2]/86400.0
                     + hmsf[...,3]/86400.0e9)
         else:
             # As in TimeMJD

--- a/pint/pulsar_mjd.py
+++ b/pint/pulsar_mjd.py
@@ -21,8 +21,9 @@ class TimePulsarMJD(TimeFormat):
             (y,mo,d,f) = erfa.jd2cal(erfa.DJM0+v1,v2)
             # Fractional day to HMS.  Uses 86400-second day always.
             # Seems like there should be a ERFA routine for this..
-            h = int(numpy.floor(f*24.0))
-            m = int(numpy.floor(numpy.remainder(f*1440.0,60)))
+            h = numpy.asarray(numpy.floor(f*24.0), dtype=int)
+            m = numpy.asarray(numpy.floor(numpy.remainder(f*1440.0,60)),
+                              dtype=int)
             s = numpy.remainder(f*86400.0,60)
             self.jd1, self.jd2 = erfa.dtf2d('UTC',y,mo,d,h,m,s)
         else:

--- a/pint/utils.py
+++ b/pint/utils.py
@@ -158,7 +158,7 @@ def time_to_mjd_string(t, prec=15):
     if t.format == 'pulsar_mjd':
         (imjd, fmjd) = day_frac(t.jd1 - DJM0, t.jd2)
         imjd = int(imjd)
-        if fmjd<0.0:
+        if fmjd < 0.0:
             imjd -= 1
         y, mo, d, hmsf = d2dtf('UTC',9,t.jd1,t.jd2)
 

--- a/pint/utils.py
+++ b/pint/utils.py
@@ -141,7 +141,6 @@ def time_from_mjd_string(s, scale='utc'):
         imjd_s, fmjd_s = mjd_s
         imjd = int(imjd_s)
         fmjd = float("0." + fmjd_s)
-
     return astropy.time.Time(imjd, fmjd, scale=scale, format='pulsar_mjd',
                              precision=9)
 
@@ -159,10 +158,13 @@ def time_to_mjd_string(t, prec=15):
     if t.format == 'pulsar_mjd':
         (imjd, fmjd) = day_frac(t.jd1 - DJM0, t.jd2)
         imjd = int(imjd)
-        if fmjd<0.0: 
+        if fmjd<0.0:
             imjd -= 1
         y, mo, d, hmsf = d2dtf('UTC',9,t.jd1,t.jd2)
-        fmjd = (hmsf[...,0]/24.0 + hmsf[...,1]/1440.0 
+
+        if hmsf[0].size == 1:
+            hmsf = np.array([list(hmsf)])
+        fmjd = (hmsf[...,0]/24.0 + hmsf[...,1]/1440.0
                 + hmsf[...,2]/86400.0 + hmsf[...,3]/86400.0e9)
     else:
         (imjd, fmjd) = day_frac(t.jd1 - DJM0, t.jd2)


### PR DESCRIPTION
@luojing1211 @paulray Resolves the issue I raised in the discussion of #450.

The call to erfa.dtf2d was done with floats instead of ints, and it failed. In another function, there was a problem when using single values instead of arrays.