### PR TITLE
Astrop3.1 compatibility

### DIFF
--- a/pint/pulsar_mjd.py
+++ b/pint/pulsar_mjd.py
@@ -21,7 +21,7 @@ class TimePulsarMJD(TimeFormat):
     name = 'pulsar_mjd'
     # This can be removed once we only support astropy >=3.1.
     # The str(c) is necessary for python2/numpy -> no unicode literals...
-    _new_ihmsfs_dtype = np.dtype([(str(c), np.intc) for c in 'hmsf'])
+    _new_ihmsfs_dtype = numpy.dtype([(str(c), numpy.intc) for c in 'hmsf'])
 
     def set_jds(self, val1, val2):
         self._check_scale(self._scale)
@@ -52,15 +52,16 @@ class TimePulsarMJD(TimeFormat):
             y, mo, d, hmsf = erfa.d2dtf('UTC',9,self.jd1,self.jd2)
             # For ASTROPY_LT_3_1, convert to the new structured array dtype that
             # is returned by the new erfa gufuncs.
-            if not hmsfs.dtype.names:
-                hmsfs = hmsfs.view(self._new_ihmsfs_dtype)
-            if 60 in hmsf[...,2]:
+            if not hmsf.dtype.names:
+                hmsf = hmsf.view(self._new_ihmsfs_dtype)
+            print(hmsf)
+            if 60 in hmsf['s']:
                 raise ValueError('UTC times during a leap second cannot be represented in pulsar_mjd format')
             j1, j2 = erfa.cal2jd(y,mo,d)
-            return (j1 - erfa.DJM0 + j2) + (hmsf[...,0]/24.0
-                    + hmsf[...,1]/1440.0
-                    + hmsf[...,2]/86400.0
-                    + hmsf[...,3]/86400.0e9)
+            return (j1 - erfa.DJM0 + j2) + (hmsf['h']/24.0
+                    + hmsf['m']/1440.0
+                    + hmsf['s']/86400.0
+                    + hmsf['f']/86400.0e9)
         else:
             # As in TimeMJD
             return (self.jd1 - erfa.DJM0) + self.jd2

--- a/pint/pulsar_mjd.py
+++ b/pint/pulsar_mjd.py
@@ -54,8 +54,7 @@ class TimePulsarMJD(TimeFormat):
             # is returned by the new erfa gufuncs.
             if not hmsf.dtype.names:
                 hmsf = hmsf.view(self._new_ihmsfs_dtype)
-            print(hmsf)
-            if 60 in hmsf['s']:
+            if numpy.any(hmsf['s'] == 60):
                 raise ValueError('UTC times during a leap second cannot be represented in pulsar_mjd format')
             j1, j2 = erfa.cal2jd(y,mo,d)
             return (j1 - erfa.DJM0 + j2) + (hmsf['h']/24.0

--- a/tests/test_pulsar_mjd.py
+++ b/tests/test_pulsar_mjd.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+from __future__ import division, absolute_import, print_function
+
+import unittest
+import numpy as np
+import os
+from astropy.time import Time
+from pint import pulsar_mjd
+from pinttestdata import testdir, datadir
+
+
+os.chdir(datadir)
+
+
+class TestPsrMjd(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.leap_second_days = ["2016-12-31T12:00:00", "2015-06-30T12:00:00"]
+        self.normal_days = ["2016-12-11T12:00:00", "2015-06-02T12:00:00"]
+
+    def test_leap_day(self):
+        one_mjd = Time(self.leap_second_days[0], scale='utc')
+        mjds = Time(self.leap_second_days, scale='utc')
+        # convert to pulsar mjd
+        p_one_mjd = Time(one_mjd, format='pulsar_mjd')
+        p_mjds = Time(mjds, format='pulsar_mjd')
+
+        assert np.isscalar(p_one_mjd.value), \
+            "Pulsar one mjd did not return the right lenght."
+        assert np.isclose(np.modf(p_one_mjd.value)[0], 0.5, atol=1e-14), \
+            "Pulsar mjd did not give the right fractional day at leapsecond day"
+        assert len(p_mjds) == 2, \
+            "Pulsar mjds did not return the right lenght."
+        assert np.all(np.isclose(np.modf(p_mjds.value)[0], 0.5, atol=1e-14)),\
+            "Pulsar mjd did not give the right fractional day at leapsecond day"
+        assert not np.all(np.isclose(np.modf(mjds.mjd)[0], 0.5, atol=1e-14)), \
+            "Astropy time did not have correct leapsecond setup."
+
+    def test_normal_day(self):
+        one_mjd = Time(self.normal_days[0], scale='utc')
+        mjds = Time(self.normal_days, scale='utc')
+        # convert to pulsar mjd
+        p_one_mjd = Time(one_mjd, format='pulsar_mjd')
+        p_mjds = Time(mjds, format='pulsar_mjd')
+
+        assert np.isscalar(p_one_mjd.value), \
+            "Pulsar one mjd did not return the right lenght."
+        assert np.isclose(np.modf(p_one_mjd.value)[0], 0.5, atol=1e-14), \
+            "Pulsar mjd did not give the right fractional day at leapsecond day"
+        assert len(p_mjds) == 2, \
+            "Pulsar mjds did not return the right lenght."
+        assert np.all(np.isclose(np.modf(p_mjds.value)[0], 0.5, atol=1e-14)),\
+            "Pulsar mjd did not give the right fractional day at leapsecond day"
+        assert np.all(np.isclose(np.modf(mjds.mjd)[0], 0.5, atol=1e-14)), \
+            "Astropy time did not have correct leapsecond setup."


### PR DESCRIPTION
Astropy 3.1's time format has API changes. This pull request allows the pulsar_mjd work with astropy3.1