### PR TITLE
Add ground-based gravitational-wave observatory locations

### DIFF
--- a/pint/observatory/observatories.py
+++ b/pint/observatory/observatories.py
@@ -40,3 +40,15 @@ TopoObs('most',         tempo_code='e', itoa_code='MO',
         clock_fmt='tempo2', clock_dir='TEMPO2', clock_file='mo2gps.clk')
 TopoObs('chime',        tempo_code='y', itoa_code='CH',
         itrf_xyz=[-2058795.0, -3621559.0, 4814280.0])
+
+# ground-based gravitational-wave observatories
+TopoObs('virgo', aliases=['v1'], include_bipm=False,
+        itrf_xyz=[4546374.0990, 842989.6976, 4378576.9624])
+TopoObs('lho', aliases=['h1', 'hanford'], include_bipm=False,
+        itrf_xyz=[-2161414.9264, -3834695.1789, 4600350.2266])
+TopoObs('llo', aliases=['l1', 'livingston'], include_bipm=False,
+        itrf_xyz=[-74276.0447, -5496283.7197, 3224257.0174])
+TopoObs('geo600', aliases=['geo', 'geohf', 'g1'], include_bipm=False,
+        itrf_xyz=[3856309.9493, 666598.9563, 5019641.4172])
+TopoObs('kagra', aliases=['k1', 'lcgt'], include_bipm=False,
+        itrf_xyz=[-3777336.0240, 3484898.411, 3765313.6970])

--- a/pint/observatory/topo_obs.py
+++ b/pint/observatory/topo_obs.py
@@ -56,7 +56,7 @@ class TopoObs(Observatory):
             include_bipm= Set False to disable UTC-> TT BIPM clock
                           correction. If False, it only apply TAI->TT correction
                           TT = TAI+32.184s, the same as TEMPO2 TT(TAI) in the
-                          parfile. If Ture, it will apply the correction from
+                          parfile. If True, it will apply the correction from
                           BIPM TT=TT(BIPMYYYY). See the link:
                           http://www.bipm.org/en/bipm-services/timescales/time-ftp/ttbipm.html
             bipm_version= Set the version of TT BIPM clock correction file to


### PR DESCRIPTION
I'm thinking about using the PINT barycentring routines in a Python-based GW search code, so it would be useful for PINT to contain the locations of the current ground-based gravitational-wave observatories.