### PR TITLE
fermi_obs.py: Fix handling of tt2tdb_mode.

### DIFF
--- a/pint/observatory/fermi_obs.py
+++ b/pint/observatory/fermi_obs.py
@@ -107,7 +107,7 @@ class FermiObs(SpecialLocation):
         self.Vx = InterpolatedUnivariateSpline(self.FT2['MJD_TT'],self.FT2['Vx'])
         self.Vy = InterpolatedUnivariateSpline(self.FT2['MJD_TT'],self.FT2['Vy'])
         self.Vz = InterpolatedUnivariateSpline(self.FT2['MJD_TT'],self.FT2['Vz'])
-        super(FermiObs, self).__init__(name=name)
+        super(FermiObs, self).__init__(name=name,tt2tdb_mode=tt2tdb_mode)
         # Print this warning once, mainly for @paulray
         if self.tt2tdb_mode.lower().startswith('pint'):
             log.warning('Using location=None for TT to TDB conversion (pint mode)')

--- a/pint/observatory/fermi_obs.py
+++ b/pint/observatory/fermi_obs.py
@@ -94,8 +94,9 @@ class FermiObs(SpecialLocation):
     tt2tdb_mode: str
         Selection for mode to use for TT to TDB conversion.
         'none' = Give no position to astropy.Time()
-        'pint' = Give geocenter position to astropy.Time()
-        'spacecraft' = Give spacecraft ITRF position to astropy.Time()
+        'pint' = Use PINT routines for TT to TDB conversion.
+        'geo' = Give geocenter position to astropy.Time()
+        'astropy' = Give spacecraft ITRF position to astropy.Time()
     """
 
     def __init__(self, name, ft2name, tt2tdb_mode = 'pint'):

--- a/pint/observatory/nustar_obs.py
+++ b/pint/observatory/nustar_obs.py
@@ -84,8 +84,9 @@ class NuSTARObs(SpecialLocation):
     tt2tdb_mode: str
         Selection for mode to use for TT to TDB conversion.
         'none' = Give no position to astropy.Time()
+        'pint' = Use PINT routines for TT to TDB conversion.
         'geo' = Give geocenter position to astropy.Time()
-        'spacecraft' = Give spacecraft ITRF position to astropy.Time()
+        'astropy' = Give spacecraft ITRF position to astropy.Time()
     """
 
     def __init__(self, name, FPorbname, tt2tdb_mode='pint'):

--- a/pint/observatory/rxte_obs.py
+++ b/pint/observatory/rxte_obs.py
@@ -34,8 +34,9 @@ class RXTEObs(SpecialLocation):
     tt2tdb_mode: str
         Selection for mode to use for TT to TDB conversion.
         'none' = Give no position to astropy.Time()
+        'pint' = Use PINT routines for TT to TDB conversion.
         'geo' = Give geocenter position to astropy.Time()
-        'spacecraft' = Give spacecraft ITRF position to astropy.Time()
+        'astropy' = Give spacecraft ITRF position to astropy.Time()
     """
 
     def __init__(self, name, FPorbname, tt2tdb_mode='pint'):

--- a/tests/test_fermiphase.py
+++ b/tests/test_fermiphase.py
@@ -44,7 +44,7 @@ class TestFermiPhase(unittest.TestCase):
         tl  = load_Fermi_TOAs(eventfileraw, weightcolumn='PSRJ0030+0451')
         ts = toa.TOAs(toalist=tl)
         ts.filename = eventfileraw
-        ts.compute_TDBs()
+        ts.compute_TDBs(ephem='DE405')
         ts.compute_posvels(ephem='DE405',planets=False)
         phss = modelin.phase(ts)[1]
         phases = np.where(phss < 0.0 * u.cycle, phss + 1.0 * u.cycle, phss)

--- a/tests/test_fermiphase.py
+++ b/tests/test_fermiphase.py
@@ -40,7 +40,7 @@ class TestFermiPhase(unittest.TestCase):
         # computing positions doesn't crash. It doesn't validate any results.
         # Should probably run comparison with GEO or BARY phases.
         modelin = pint.models.get_model(parfile)
-        FermiObs(name='Fermi',ft2name=ft2file,tt2tdb_mode='spacecraft')
+        FermiObs(name='Fermi',ft2name=ft2file)
         tl  = load_Fermi_TOAs(eventfileraw, weightcolumn='PSRJ0030+0451')
         ts = toa.TOAs(toalist=tl)
         ts.filename = eventfileraw


### PR DESCRIPTION
The Fermi observatory does not forward the passed 'tt2tdb_mode' string to the base class constructor. In effect the tt2tdb_mode is always 'pint' regardless of what the user passes.

Also I think that the tt2tdb_mode 'spacecraft' no longer exists and references to it need to be removed.