### PR TITLE
Update Fermi FT2 handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,13 @@ matrix:
 sudo: required
 
 # https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
-before_script:
-    - "export DISPLAY=:99.0"
-    - "sh -e /etc/init.d/xvfb start"
-    - sleep 3 # give xvfb some time to start
+#before_script:
+#    - "export DISPLAY=:99.0"
+#    - "sh -e /etc/init.d/xvfb start"
+#    - sleep 3 # give xvfb some time to start
+
+services:
+    - xvfb
 
 install:
     - pip install -r requirements.txt

--- a/pint/fermi_toas.py
+++ b/pint/fermi_toas.py
@@ -115,9 +115,9 @@ def load_Fermi_TOAs(ft1name,weightcolumn=None,targetcoord=None,logeref=4.1,
     if timesys == 'TDB':
         log.info("Building barycentered TOAs")
         if weightcolumn is None:
-            toalist=[toa.TOA(m,obs='Barycenter',scale='tdb',energy=e) for m,e in zip(mjds,energies)]
+            toalist=[toa.TOA(m,obs='Barycenter',scale='tdb',energy=e,error=1.0*u.us) for m,e in zip(mjds,energies)]
         else:
-            toalist=[toa.TOA(m,obs='Barycenter',scale='tdb',energy=e,weight=w) for m,e,w in zip(mjds,energies,weights)]
+            toalist=[toa.TOA(m,obs='Barycenter',scale='tdb',energy=e,weight=w,error=1.0*u.us) for m,e,w in zip(mjds,energies,weights)]
     else:
         if timeref == 'LOCAL':
             log.info('Building spacecraft local TOAs, with MJDs in range {0} to {1}'.format(mjds[0],mjds[-1]))
@@ -130,10 +130,10 @@ def load_Fermi_TOAs(ft1name,weightcolumn=None,targetcoord=None,logeref=4.1,
 
             try:
                 if weightcolumn is None:
-                    toalist=[toa.TOA(m, obs='Fermi', scale='tt',energy=e)
+                    toalist=[toa.TOA(m, obs='Fermi', scale='tt',energy=e,error=1.0*u.us)
                             for m,e in zip(mjds,energies)]
                 else:
-                    toalist=[toa.TOA(m, obs='Fermi', scale='tt',energy=e,weight=w)
+                    toalist=[toa.TOA(m, obs='Fermi', scale='tt',energy=e,weight=w,error=1.0*u.us)
                             for m,e,w in zip(mjds,energies,weights)]
             except KeyError:
                 log.error('Error processing Fermi TOAs. You may have forgotten to specify an FT2 file with --ft2')

--- a/pint/observatory/fermi_obs.py
+++ b/pint/observatory/fermi_obs.py
@@ -59,22 +59,29 @@ def load_FT2(ft2_filename):
     X = SC_POS[:,0]*u.m
     Y = SC_POS[:,1]*u.m
     Z = SC_POS[:,2]*u.m
-    # Compute velocities by differentiation because FT2 does not have velocities
-    # This is not the best way. Should fit an orbit and determine velocity from that.
-    dt = mjds_TT[1]-mjds_TT[0]
-    log.info('FT2 spacing is '+str(dt.to(u.s)))
-    # Trim off last point because array.diff() is one shorter
-    #Vx = np.gradient(X)[:-1]/(mjds_TT.diff().to(u.s))
-    #Vy = np.gradient(Y)[:-1]/(mjds_TT.diff().to(u.s))
-    # Hack to fix gradient failing on example data file for reasons I don't understand. -- paulr
-    #Vz = np.gradient(Z)[:-1]/(mjds_TT.diff().to(u.s))
-    Vx = (np.gradient(X.value)[:-1])*u.m/(mjds_TT.diff().to(u.s))
-    Vy = (np.gradient(Y.value)[:-1])*u.m/(mjds_TT.diff().to(u.s))
-    Vz = (np.gradient(Z.value)[:-1])*u.m/(mjds_TT.diff().to(u.s))
-    X = X[:-1]
-    Y = Y[:-1]
-    Z = Z[:-1]
-    mjds_TT = mjds_TT[:-1]
+    try:
+        # If available, get the velocities from the FT2 file
+        SC_VEL = FT2_dat.field('SC_VELOCITY')
+        Vx = SC_VEL[:,0]*u.m/u.s
+        Vy = SC_VEL[:,1]*u.m/u.s
+        Vz = SC_VEL[:,2]*u.m/u.s
+    except:
+        # Otherwise, compute velocities by differentiation because FT2 does not have velocities
+        # This is not the best way. Should fit an orbit and determine velocity from that.
+        dt = mjds_TT[1]-mjds_TT[0]
+        log.info('FT2 spacing is '+str(dt.to(u.s)))
+        # Trim off last point because array.diff() is one shorter
+        #Vx = np.gradient(X)[:-1]/(mjds_TT.diff().to(u.s))
+        #Vy = np.gradient(Y)[:-1]/(mjds_TT.diff().to(u.s))
+        # Hack to fix gradient failing on example data file for reasons I don't understand. -- paulr
+        #Vz = np.gradient(Z)[:-1]/(mjds_TT.diff().to(u.s))
+        Vx = (np.gradient(X.value)[:-1])*u.m/(mjds_TT.diff().to(u.s))
+        Vy = (np.gradient(Y.value)[:-1])*u.m/(mjds_TT.diff().to(u.s))
+        Vz = (np.gradient(Z.value)[:-1])*u.m/(mjds_TT.diff().to(u.s))
+        X = X[:-1]
+        Y = Y[:-1]
+        Z = Z[:-1]
+        mjds_TT = mjds_TT[:-1]
     log.info('Building FT2 table covering MJDs {0} to {1}'.format(mjds_TT.min(), mjds_TT.max()))
     FT2_table = Table([mjds_TT, X, Y, Z, Vx, Vy, Vz],
             names = ('MJD_TT', 'X', 'Y', 'Z', 'Vx', 'Vy', 'Vz'),

--- a/pint/observatory/fermi_obs.py
+++ b/pint/observatory/fermi_obs.py
@@ -64,10 +64,12 @@ def load_FT2(ft2_filename):
     dt = mjds_TT[1]-mjds_TT[0]
     log.info('FT2 spacing is '+str(dt.to(u.s)))
     # Trim off last point because array.diff() is one shorter
-    Vx = np.gradient(X)[:-1]/(mjds_TT.diff().to(u.s))
-    Vy = np.gradient(Y)[:-1]/(mjds_TT.diff().to(u.s))
+    #Vx = np.gradient(X)[:-1]/(mjds_TT.diff().to(u.s))
+    #Vy = np.gradient(Y)[:-1]/(mjds_TT.diff().to(u.s))
     # Hack to fix gradient failing on example data file for reasons I don't understand. -- paulr
     #Vz = np.gradient(Z)[:-1]/(mjds_TT.diff().to(u.s))
+    Vx = (np.gradient(X.value)[:-1])*u.m/(mjds_TT.diff().to(u.s))
+    Vy = (np.gradient(Y.value)[:-1])*u.m/(mjds_TT.diff().to(u.s))
     Vz = (np.gradient(Z.value)[:-1])*u.m/(mjds_TT.diff().to(u.s))
     X = X[:-1]
     Y = Y[:-1]

--- a/pint/plot_utils.py
+++ b/pint/plot_utils.py
@@ -59,7 +59,7 @@ def phaseogram_binned(mjds, phases, weights=None, title=None, bins=64, rotate=0.
     """
     years = (mjds.value - 51544.0) / 365.25 + 2000.0
     phss = phases + rotate
-    phss[phss > 1.0] -= 1.0
+    phss[phss >= 1.0] -= 1.0
     fig = plt.figure(figsize=(width, 8))
     ax1 = plt.subplot2grid((3, 1), (0, 0))
     ax2 = plt.subplot2grid((3, 1), (1, 0), rowspan=2)

--- a/pint/scripts/htest_optimize.py
+++ b/pint/scripts/htest_optimize.py
@@ -26,11 +26,11 @@ nsteps = 1000
 nbins = 256 # For likelihood calculation based on gaussians file
 outprof_nbins = 256 # in the text file, for pygaussfit.py, for instance
 minMJD = 54680.0 # Earliest MJD (limited by LAT data)
-maxMJD = 57250.0 # latest MJD to use (limited by IERS file usually)
+maxMJD = 58250.0 # latest MJD to use (limited by IERS file usually)
 # Set minWeight to 0.0 to get plots about how significant the
 # pulsations are before doing an expensive MCMC.  This allows
 # you to set minWeight intelligently.
-minWeight = 0.01 # if using weights, this is the minimum to include
+minWeight = 0.02 # if using weights, this is the minimum to include
 errfact = 10.0 # multiplier for gaussian priors based TEMPO errors
 do_opt_first = True
 # Raise the calculated weights to this power

--- a/pint/templates/lcfitters.py
+++ b/pint/templates/lcfitters.py
@@ -245,7 +245,7 @@ class UnweightedLCFitter(object):
         print('Improved log likelihood by %.2f'%(self.ll-ll0))
         return True
 
-    def fit_position(self, unbinned=True):
+    def fit_position(self, unbinned=True, track=False):
         """ Fit overall template position.  Return shift and its error."""
         self._set_unbinned(unbinned)
         ph0 = self.template.get_location()
@@ -253,7 +253,10 @@ class UnweightedLCFitter(object):
             self.template.set_overall_phase(phase)
             return self.loglikelihood(self.template.get_parameters())
         # coarse grained search
-        dom = np.linspace(0,1,101)
+        if track:
+            dom = np.concatenate((np.linspace(0,0.2,25),np.linspace(0.8,1.0,25)))
+        else:
+            dom = np.linspace(0,1,101)
         cod = map(logl,0.5*(dom[1:]+dom[:-1]))
         idx = np.argmin(cod)
         ph1 = fmin(logl,[dom[idx]],full_output=True,disp=0)[0][0]

--- a/pint/templates/lcfitters.py
+++ b/pint/templates/lcfitters.py
@@ -34,9 +34,9 @@ def weighted_light_curve(nbins,phases,weights,normed=False,phase_shift=0):
     """ Return a set of bins, values, and errors to represent a
         weighted light curve."""
     bins = np.linspace(0+phase_shift,1+phase_shift,nbins+1)
-    counts = np.histogram(phases,bins=bins,normed=False)[0]
-    w1 = (np.histogram(phases,bins=bins,weights=weights,normed=False)[0]).astype(float)
-    w2 = (np.histogram(phases,bins=bins,weights=weights**2,normed=False)[0]).astype(float)
+    counts = np.histogram(phases,bins=bins,density=False)[0]
+    w1 = (np.histogram(phases,bins=bins,weights=weights,density=False)[0]).astype(float)
+    w2 = (np.histogram(phases,bins=bins,weights=weights**2,density=False)[0]).astype(float)
     errors = np.where(counts > 1, w2**0.5, counts)
     norm = w1.sum()/nbins if normed else 1.
     return bins,w1/norm,errors/norm
@@ -743,7 +743,7 @@ def make_err_plot(template,totals=[10,20,50,100,500],n=1000):
     for tot in totals:
         f,e = get_errors(template,tot,n=n)
         fvals += [f]; errs += [e]
-        pl.hist(f/e,bins=np.arange(-5,5.1,0.5),histtype='step',normed=True,label='N = %d'%tot);
+        pl.hist(f/e,bins=np.arange(-5,5.1,0.5),histtype='step',density=True,label='N = %d'%tot);
     g = lambda x: (np.pi*2)**-0.5*np.exp(-x**2/2)
     dom = np.linspace(-5,5,101)
     pl.plot(dom,g(dom),color='k')

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function, division
+from __future__ import absolute_import, print_function, division, unicode_literals
 import re, sys, os, numpy, gzip, copy
 from . import utils
 from .observatory import Observatory, get_observatory


### PR DESCRIPTION
This PR does a couple small things:
* Uses the new SC_VELOCITY column in Fermi FT2 files (if present), instead of trying to compute the velocities as the gradient of the position.
* Adds a track mode in LCFitters.fit_position() to handle cases where you have two peaks at 0.5 in phase apart.
* A couple of tiny fixes like deprecated "normed" keyword and stuff like that.