### PR TITLE
Use six directly, not astropy.extern.six

### DIFF
--- a/pint/fermi_toas.py
+++ b/pint/fermi_toas.py
@@ -7,7 +7,7 @@ import pint.models
 import pint.residuals
 import astropy.units as u
 from astropy.coordinates import SkyCoord, EarthLocation
-from astropy.extern import six
+import six
 from pint.fits_utils import read_fits_event_mjds, read_fits_event_mjds_tuples
 from pint.observatory import get_observatory
 

--- a/pint/fits_utils.py
+++ b/pint/fits_utils.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function, division
 import astropy.io.fits as pyfits
 import numpy as np
 from astropy import log
-from astropy.extern import six
+import six
 try:
     from astropy.erfa import DAYSEC as SECS_PER_DAY
 except ImportError:

--- a/pint/observatory/fermi_obs.py
+++ b/pint/observatory/fermi_obs.py
@@ -14,7 +14,7 @@ import numpy as np
 from astropy.time import Time
 from astropy.table import Table
 import astropy.io.fits as pyfits
-from astropy.extern import six
+import six
 from astropy import log
 from scipy.interpolate import InterpolatedUnivariateSpline
 

--- a/pint/observatory/nicer_obs.py
+++ b/pint/observatory/nicer_obs.py
@@ -14,7 +14,7 @@ import numpy as np
 from astropy.time import Time
 from astropy.table import Table, vstack
 import astropy.io.fits as pyfits
-from astropy.extern import six
+import six
 from astropy import log
 from scipy.interpolate import InterpolatedUnivariateSpline
 

--- a/pint/observatory/rxte_obs.py
+++ b/pint/observatory/rxte_obs.py
@@ -14,7 +14,7 @@ import numpy as np
 from astropy.time import Time
 from astropy.table import Table
 import astropy.io.fits as pyfits
-from astropy.extern import six
+import six
 from astropy import log
 from scipy.interpolate import interp1d
 from .nicer_obs import load_FPorbit

--- a/pint/solar_system_ephemerides.py
+++ b/pint/solar_system_ephemerides.py
@@ -3,7 +3,7 @@ import numpy as np
 import os
 import astropy.units as u
 import astropy.coordinates as coor
-from astropy.extern.six.moves import urllib
+from six.moves import urllib
 from astropy.time import Time
 from .utils import PosVel
 from astropy import log

--- a/pint/toa.py
+++ b/pint/toa.py
@@ -6,7 +6,7 @@ from .observatory.topo_obs import TopoObs
 from . import erfautils
 import astropy.time as time
 from . import pulsar_mjd
-from astropy.extern.six.moves import cPickle as pickle
+from six.moves import cPickle as pickle
 import astropy.table as table
 import astropy.units as u
 from astropy.coordinates import EarthLocation


### PR DESCRIPTION
Replaces astropy.extern.six with the direct import of six package where applicable. Fixes issue #493.