### PR TITLE
Move pepoch

### DIFF
--- a/pint/models/spindown.py
+++ b/pint/models/spindown.py
@@ -5,16 +5,19 @@
 from __future__ import absolute_import, print_function, division
 import numpy
 import astropy.units as u
+from astropy.time import Time
 try:
     from astropy.erfa import DAYSEC as SECS_PER_DAY
 except ImportError:
     from astropy._erfa import DAYSEC as SECS_PER_DAY
+
 from . import parameter as p
 from .timing_model import PhaseComponent, MissingParameter
 from ..phase import *
 from ..utils import time_from_mjd_string, time_to_longdouble, str2longdouble,\
     taylor_horner, time_from_longdouble, split_prefixed_name, taylor_horner_deriv
 from pint import dimensionless_cycles
+import pint.toa as toa
 
 
 class Spindown(PhaseComponent):
@@ -91,9 +94,7 @@ class Spindown(PhaseComponent):
             phsepoch_ld = time_to_longdouble(tbl['tdb'][0] - delay[0])
         else:
             phsepoch_ld = time_to_longdouble(self.PEPOCH.quantity)
-
         dt = (tbl['tdbld'] - phsepoch_ld) * u.day - delay
-
         return dt
 
     def spindown_phase(self, toas, delay):
@@ -113,21 +114,44 @@ class Spindown(PhaseComponent):
             phs = taylor_horner(dt.to(u.second), fterms)
             return phs.to(u.cycle)
 
-    def move_pepoch(self, new_epoch, toas, delay):
+    def change_pepoch(self, new_epoch, toas=None, delay=None):
         """Move PEPOCH to a new time and change the related paramters.
+
+        Parameter
+        ---------
+        new_epoch: float or `astropy.Time` object
+            The new PEPOCH value.
+        toas: `toa` object, optional.
+            If current PEPOCH is not provided, the first pulsar frame toa will
+            be treated as PEPOCH.
+        delay: `numpy.array` object
+            If current PEPOCH is not provided, it is required for computing the
+            first pulsar frame toa.
         """
-        tbl = toas.table
+        if isinstance(new_epoch, Time):
+            new_epoch = Time(new_epoch, scale='tdb', precision=9)
+        else:
+            new_epoch = Time(new_epoch, scale='tdb', format='mjd', precision=9)
+        # make new_epoch a toa for delay calculation.
+        new_epoch_toa = toa.get_TOAs_list([toa.TOA(new_epoch),],
+                                          ephem=toas.ephem)
+
         if self.PEPOCH.value is None:
+            if toas is None or delay is None:
+                raise ValueError("`PEPOCH` is not in the model, thus, 'toa' and"
+                                 " 'delay' shoule be givne.")
+            tbl = toas.table
             phsepoch_ld = time_to_longdouble(tbl['tdb'][0] - delay[0])
         else:
             phsepoch_ld = time_to_longdouble(self.PEPOCH.quantity)
-        dt = (new_epoch - phsepoch_ld) * u.day
+        dt = ((time_to_longdouble(new_epoch) - phsepoch_ld) * u.day) 
         fterms = [0.0 * u.Unit("")] + self.get_spin_terms()
         # rescale the fterms
         for n in range(len(fterms) - 1):
             f_par = getattr(self, 'F{}'.format(n))
             f_par.value = taylor_horner_deriv(dt.to(u.second), fterms,
                                               deriv_order=n+1)
+        self.PEPOCH.value = new_epoch
 
     def print_par(self,):
         result = ''


### PR DESCRIPTION
This PR adds the functionality of change pepoch (issue #491 ). It will change the related parameters: F0, F1, F2... as well. 
Here is a preliminary test of function.  A unittest will be added in the new commitment. 
```
m = get_model("J0023+0923_NANOGrav_11yv0.gls.par")
t = get_TOAs("J0023+0923_NANOGrav_11yv0.tim")
max_diff = []
epochs = np.linspace(40000, 70000, 1000)

for epoch in epochs:
    m2 = deepcopy(m)
    m2.change_pepoch(epoch, t, m2.delay(t))
    f2 = WlsFitter(t, m2)
    diff = f2.resids.time_resids - f.resids.time_resids
    max_diff.append(np.abs(diff).max())
``` 
The original PEPOCH is 56567.0
The new pepochs vs max residual difference are plot below:
![epoch_diff](https://user-images.githubusercontent.com/5324931/63058708-668a1d00-bebb-11e9-9ddf-cd2c5c4b562a.png)
