### PR TITLE
Warnings cleanup

### DIFF
--- a/pint/fitter.py
+++ b/pint/fitter.py
@@ -266,7 +266,7 @@ class GlsFitter(Fitter):
                 c = sl.cho_factor(mtcm)
                 xhat = sl.cho_solve(c, mtcy)
                 xvar = sl.cho_solve(c, np.eye(len(mtcy)))
-            except:
+            except sl.LinAlgError:
                 U, s, Vt = sl.svd(mtcm, full_matrices=False)
 
                 if threshold:

--- a/pint/models/model_builder.py
+++ b/pint/models/model_builder.py
@@ -164,7 +164,7 @@ class ModelBuilder(object):
                     pre,idxstr,idxV = split_prefixed_name(p)
                     if pre in [par.prefix,] + par.prefix_aliases:
                         prefixs[par.prefix].append(p)
-                except:
+                except: # FIXME: is this meant to catch KeyErrors?
                     continue
 
         return prefixs

--- a/pint/models/pulsar_binary.py
+++ b/pint/models/pulsar_binary.py
@@ -45,7 +45,7 @@ class PulsarBinary(DelayComponent):
         # take both.
         self.add_param(p.floatParameter(name = "A1DOT", aliases = ['XDOT'],
             units=ls/u.s,
-            description="Derivitve of projected semi-major axis, da*sin(i)/dt", \
+            description="Derivative of projected semi-major axis, da*sin(i)/dt", \
             unit_scale=True, scale_factor=1e-12, scale_threshold=1e-7))
 
         self.add_param(p.floatParameter(name="ECC",
@@ -116,10 +116,16 @@ class PulsarBinary(DelayComponent):
                 method_name = p.lower() + "_func"
                 try:
                     par_method = getattr(self.binary_instance, method_name)
-                    _ = par_method()
-                except:
+                except AttributeError:
                     raise MissingParameter(self.binary_model_name, p + \
                                            " is required for '%s'." %
+                                           self.binary_model_name)
+                try:
+                    _ = par_method()
+                except:
+                    raise MissingParameter(self.binary_model_name, p +
+                                           " is present but somehow "
+                                           "broken for '%s'." %
                                            self.binary_model_name)
 
     # With new parameter class set up, do we need this?

--- a/pint/models/timing_model.py
+++ b/pint/models/timing_model.py
@@ -552,7 +552,7 @@ class TimingModel(object):
 
         for nf in self.basis_funcs:
             result.append(nf(toas)[0])
-        return np.hstack((r for r in result))
+        return np.hstack([r for r in result])
 
 
     def noise_model_basis_weight(self, toas):
@@ -562,7 +562,7 @@ class TimingModel(object):
 
         for nf in self.basis_funcs:
             result.append(nf(toas)[1])
-        return np.hstack((r for r in result))
+        return np.hstack([r for r in result])
 
 
 

--- a/pint/models/timing_model.py
+++ b/pint/models/timing_model.py
@@ -16,12 +16,23 @@ import six
 import inspect
 from pint import dimensionless_cycles
 
-# parameters or lines in parfiles to ignore (for now?), or at
-# least not to complain about
-ignore_params = ['START', 'FINISH', 'CLK', 'UNITS',
+# Parameters or lines in parfiles we don't understand but shouldn't
+# complain about. These are still passed to components so that they
+# can use them if they want to.
+#
+# Other unrecognized parameters produce warnings and possibly indicate
+# errors in the par file.
+#
+# Do people use C in the first column to "comment out" par file entries?
+# That could be supported by simply adding "C" here.
+#
+# What about case (in)sensitivity? Anybody use un-capitalized versions?
+ignore_params = ['START', 'FINISH', 'CLK', 'EPHVER', 'UNITS',
                  'TIMEEPH', 'T2CMETHOD', 'CORRECT_TROPOSPHERE', 'DILATEFREQ',
                  'NTOA', 'CLOCK', 'TRES', 'TZRMJD', 'TZRFRQ', 'TZRSITE',
-                 'NITS', 'IBOOT','BINARY']
+                 'NITS', 'IBOOT','BINARY',
+                 'CHI2R', 'MODE', 'INFO', 'PLANET_SHAPIRO2', 'NE_SW', 'NE_SW2',
+                ]
 ignore_prefix = ['DMXF1_','DMXF2_','DMXEP_'] # DMXEP_ for now.
 
 
@@ -781,6 +792,7 @@ class TimingModel(object):
         param_map = self.get_params_mapping()
         comps = self.components
         pfile = open(filename, 'r')
+        wants_tcb = None
         for l in [pl.strip() for pl in pfile.readlines()]:
             # Skip blank lines
             if not l:
@@ -791,12 +803,20 @@ class TimingModel(object):
 
             k = l.split()
             name = k[0].upper()
-            
-            if name == 'UNITS' and len(k) > 1 and k[1] != 'TDB':
-                log.error("UNITS %s not yet supported by PINT" % k[1])
-                raise Exception("UNITS %s not yet supported by PINT" % k[1])
 
-            
+            if name == 'UNITS':
+                if len(k) > 1 and k[1] == 'TDB':
+                    wants_tcb = False
+                else:
+                    wants_tcb = k[1]
+
+            if name == 'EPHVER':
+                if len(k)>1 and k[1] != '2' and wants_tcb is None:
+                    wants_tcb = l
+                log.warning("EPHVER %s does nothing in PINT" % k[1])
+                #actually people expect EPHVER 5 to work
+                #even though it's supposed to imply TCB which doesn't
+
             if name in checked_param:
                 if name in repeat_param.keys():
                     repeat_param[name] += 1
@@ -815,15 +835,26 @@ class TimingModel(object):
                     parsed = True
 
             if not parsed:
+                p = l.split()[0]
+                if p in ignore_params:
+                    log.debug("Ignoring parfile line '%s'" % (l,))
+                    parsed = True
+            if not parsed:
+                p = l.split()[0]
                 try:
                     prefix,f,v = utils.split_prefixed_name(l.split()[0])
-                    if prefix not in ignore_prefix:
-                        log.warn("Unrecognized parfile line '%s'" % l)
-                except:
-                    if l.split()[0] not in ignore_params:
-                        log.warn("Unrecognized parfile line '%s'" % l)
+                    if prefix in ignore_prefix:
+                        log.debug("Ignoring prefix parfile line '%s'" % (l,))
+                        parsed = True
+                except utils.PrefixError:
+                    pass
+            if not parsed:
+                log.warn("Unrecognized parfile line '%s'" % (l,))
 
             checked_param.append(name)
+        if wants_tcb:
+            log.error("UNITS %s not yet supported by PINT" % k[1])
+            raise ValueError("UNITS %s not yet supported by PINT" % k[1])
         # The "setup" functions contain tests for required parameters or
         # combinations of parameters, etc, that can only be done
         # after the entire parfile is read
@@ -1098,7 +1129,7 @@ class PhaseComponent(Component):
         self.phase_derivs_wrt_delay = []
 
 
-class TimingModelError(Exception):
+class TimingModelError(ValueError):
     """Generic base class for timing model errors."""
     pass
 
@@ -1121,3 +1152,4 @@ class MissingParameter(TimingModelError):
         if self.msg is not None:
             result += "\n  " + self.msg
         return result
+

--- a/pint/models/timing_model.py
+++ b/pint/models/timing_model.py
@@ -134,6 +134,9 @@ class TimingModel(object):
             else:
                 return super().__getattribute__(name)
         except AttributeError:
+            # Note that there is a complex series of fallbacks that can wind up
+            # here - for example if a property inadvertently raises an
+            # AttributeError it looks like it's missing entirely
             errmsg = "'TimingModel' object and its component has no attribute"
             errmsg += " '%s'." % name
             try:
@@ -853,7 +856,6 @@ class TimingModel(object):
 
             checked_param.append(name)
         if wants_tcb:
-            log.error("UNITS %s not yet supported by PINT" % k[1])
             raise ValueError("UNITS %s not yet supported by PINT" % k[1])
         # The "setup" functions contain tests for required parameters or
         # combinations of parameters, etc, that can only be done
@@ -1087,7 +1089,7 @@ class Component(object):
                 return True
             else:
                 return False
-        except:
+        except (AttributeError, KeyError):
             pass
 
         # Compare the componets parameter names with par file parameters

--- a/pint/observatory/special_locations.py
+++ b/pint/observatory/special_locations.py
@@ -166,7 +166,7 @@ class SpacecraftObs(SpecialLocation):
             z = numpy.array([flags['telz'] for flags in grp['flags']])
         except:
             log.error('Missing flag. TOA line should have telx,tely,telz flags for GCRS position in km.')
-            raise Exception('Missing flag. TOA line should have telx,tely,telz flags for GCRS position in km.')
+            raise ValueError('Missing flag. TOA line should have telx,tely,telz flags for GCRS position in km.')
             
         pos = numpy.vstack((x,y,z))
         vdim = (3,) + t.shape
@@ -188,7 +188,7 @@ class SpacecraftObs(SpecialLocation):
             vz = numpy.array([flags['vz'] for flags in grp['flags']])
         except:
             log.error('Missing flag. TOA line should have vx,vy,vz flags for GCRS velocity in km/s.')
-            raise Exception('Missing flag. TOA line should have vx,vy,vz flags for GCRS velocity in km/s.')
+            raise ValueError('Missing flag. TOA line should have vx,vy,vz flags for GCRS velocity in km/s.')
             
         vel_geo = numpy.vstack((vx,vy,vz)) * (u.km/u.s)
         vdim = (3,) + t.shape

--- a/pint/polycos.py
+++ b/pint/polycos.py
@@ -182,7 +182,7 @@ def tempo_polyco_table_reader(filename):
 
         try:
             binaryPhase = data2longdouble(fields[6])
-        except:
+        except ValueError:
             binaryPhase = data2longdouble(0.0)
 
         # Read coefficients
@@ -275,15 +275,10 @@ def tempo_polyco_table_writer(polycoTable, filename = 'polyco.dat'):
         http://tempo.sourceforge.net/ref_man_sections/tz-polyco.txt
     """
     f = open(filename,'w')
-    try:
-        lenTable = len(polycoTable)
-        if lenTable == 0:
-            errorMssg = ("Insufficent polyco data."+
-                         " Please make sure polycoTable has data.")
-            raise AttributeError(errorMssg)
-
-    except:
-        errorMssg = "Insufficent polycoTable. "
+    lenTable = len(polycoTable)
+    if lenTable == 0:
+        errorMssg = ("Insufficent polyco data."+
+                     " Please make sure polycoTable has data.")
         raise AttributeError(errorMssg)
 
     for i in range(lenTable):
@@ -378,13 +373,13 @@ class Polycos(object):
         if (formatName in [f['format'] for f in self.polycoFormat]
             or formatName in registry.get_formats()['Format']):
             errorMssg = 'Format name \''+formatName+ '\' is already exist. '
-            raise Exception(errorMssg)
+            raise ValueError(errorMssg)
 
         pFormat = {'format' : formatName}
 
         if methodMood == 'r':
             if readMethod == None:
-                raise BaseException('Argument readMethod should not be \'None\'.')
+                raise ValueError('Argument readMethod should not be \'None\'.')
 
             pFormat['read_method'] = readMethod
             pFormat['write_method'] = writeMethod
@@ -392,7 +387,7 @@ class Polycos(object):
                                     pFormat['read_method'])
         elif methodMood == 'w':
             if writeMethod == None:
-                raise BaseException('Argument writeMethod should not be \'None\'.')
+                raise ValueError('Argument writeMethod should not be \'None\'.')
 
             pFormat['read_method'] = readMethod
             pFormat['write_method'] = writeMethod
@@ -400,7 +395,7 @@ class Polycos(object):
                                     pFormat['write_method'])
         elif methodMood == 'rw':
             if readMethod == None or writeMethod == None:
-                raise BaseException('Argument readMethod and writeMethod '
+                raise ValueError('Argument readMethod and writeMethod '
                                     'should not be \'None\'.')
 
             pFormat['read_method'] = readMethod
@@ -526,7 +521,8 @@ class Polycos(object):
                                   'obs','obsfreq','entry'),
                                    meta={'name': 'Polyco Data Table'})
             self.polycoTable = pTable
-
+            if len(self.polycoTable)==0:
+                raise ValueError("Zero polycos found for table")
         else:
                 #  Reading from an old polycofile
             pass
@@ -551,20 +547,23 @@ class Polycos(object):
         self.fileName = filename
 
         if format not in [f['format'] for f in self.polycoFormat]:
-            raise Exception('Unknown polyco file format \''+ format +'\'\n'
+            raise ValueError('Unknown polyco file format \''+ format +'\'\n'
                             'Please use function \'self.add_polyco_file_format()\''
                             ' to register the format\n')
         else:
             self.fileFormat = format
 
         self.polycoTable = table.Table.read(filename, format = format)
+        if len(self.polycoTable)==0:
+            raise ValueError("Zero polycos found for table")
+
 
     def write_polyco_file(self,format,filename=None):
         """ Write Polyco table to a file.
         """
 
         if format not in [f['format'] for f in self.polycoFormat]:
-            raise Exception('Unknown polyco file format \''+ format +'\'\n'
+            raise ValueError('Unknown polyco file format \''+ format +'\'\n'
                            'Please use function \'self.add_polyco_file_format()\''
                            ' to register the format\n')
         if filename is not None:
@@ -578,16 +577,8 @@ class Polycos(object):
         if not isinstance(t, (np.ndarray, list)):
             t = np.array([t,])
         # Check if polyco table exist
-        try:
-            lenEntry = len(self.polycoTable)
-            if lenEntry == 0:
-                errorMssg = ("Insufficent polyco data."
-                             "Please read or generate polyco data correctly.")
-                raise AttributeError(errorMssg)
-
-        except:
-            errorMssg = "Insufficent polyco data. Please read or generate polyco data correctly."
-            raise AttributeError(errorMssg)
+        if self.polycoTable is None:
+            raise ValueError("polycoTable not set!")
 
         startIndex = np.searchsorted(self.polycoTable['t_start'], t)
         entryIndex = startIndex-1

--- a/pint/residuals.py
+++ b/pint/residuals.py
@@ -35,8 +35,7 @@ class Residuals(object):
 
             pulse_num = self.toas.get_pulse_numbers()
             if pulse_num is None:
-                log.error('No pulse numbers with TOAs using TRACK -2')
-                raise Exception('No pulse numbers with TOAs using TRACK -2')
+                raise ValueError('No pulse numbers with TOAs using TRACK -2')
 
             pn_act = rs.int
             addPhase = pn_act - (pulse_num + addpn)

--- a/pint/utils.py
+++ b/pint/utils.py
@@ -19,13 +19,6 @@ except AttributeError:
     # fallback for Python 2
     from string import maketrans
 
-# Define prefix parameter pattern
-pp1 = re.compile(r'([a-zA-Z]\d[a-zA-Z]+)(\d+)') # For the prefix like T2EFAC2
-pp2 = re.compile(r'([a-zA-Z]+)(\d+)')  # For the prefix like F12
-pp3 = re.compile(r'([a-zA-Z0-9]+_*)(\d+)')  # For the prefix like DMXR1_3
-
-prefixPattern = [pp1, pp2, pp3]
-
 
 class PosVel(object):
     """Position/Velocity class.
@@ -335,6 +328,17 @@ def str2longdouble(str_data):
     return str2ldarr1(input_str.encode())[0]
 
 
+# Define prefix parameter pattern
+prefixPattern = [
+    re.compile(r'([a-zA-Z]\d[a-zA-Z]+)(\d+)'), # For the prefix like T2EFAC2
+    re.compile(r'([a-zA-Z]+)(\d+)'), # For the prefix like F12
+    re.compile(r'([a-zA-Z0-9]+_*)(\d+)'), # For the prefix like DMXR1_3
+    #re.compile(r'([a-zA-Z]\d[a-zA-Z]+)(\d+)'), # for prefixes like PLANET_SHAPIRO2?
+]
+
+class PrefixError(ValueError):
+    pass
+
 def split_prefixed_name(name):
     """A utility function that splits a prefixed name.
        Parameter
@@ -364,7 +368,7 @@ def split_prefixed_name(name):
         break
 
     if namefield is None:
-        raise ValueError("Unrecognized prefix name pattern'%s'." % name)
+        raise PrefixError("Unrecognized prefix name pattern'%s'." % name)
     indexValue = int(indexPart)
     return prefixPart, indexPart, indexValue
 

--- a/tests/test_B1855.py
+++ b/tests/test_B1855.py
@@ -20,6 +20,8 @@ class TestB1855(unittest.TestCase):
         self.toasB1855 = toa.get_TOAs(self.timB1855, ephem="DE405",
                                       planets=False, include_bipm=False)
         self.modelB1855 = mb.get_model(self.parfileB1855)
+        logging.debug('%s' % self.modelB1855.components)
+        logging.debug('%s' % self.modelB1855.params)
         # tempo result
         self.ltres= np.genfromtxt(self.parfileB1855 + \
                                   '.tempo2_test',skip_header=1, unpack=True)


### PR DESCRIPTION
Reduce the chatter during testing and actual use by ignoring known-unknown par file entries and cleaning up FutureWarnings. 

Ideally one would capture warnings as part of the testing process and show them only on failed tests; one could also write tests to ensure warnings are correctly emitted when, say, typos appear in par files. Unfortunately astropy's log mechanism defeats nosetests' attempts to manage log output and I haven't yet figured out how to make it behave.