### PR TITLE
Clean up erfautils' use of IERS tables

### DIFF
--- a/pint/erfautils.py
+++ b/pint/erfautils.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, division
 from . import utils
 import numpy as np
+from astropy import log
 import astropy.units as u
 try:
     import astropy.erfa as erfa
@@ -8,21 +9,27 @@ except ImportError:
     import astropy._erfa as erfa
 import astropy.table as table
 from astropy.time import Time
+
+from astropy.utils.iers import IERS_B, IERS_B_URL
+from astropy.utils.data import download_file, clear_download_cache, is_url_in_cache
+
+def get_iers_b_up_to_date(mjd):
+    """Update the IERS B table to include MJD if necessary
+
+    """
+    if Time.now().mjd <= mjd:
+        raise ValueError("IERS B data requested for future MJD {}".format(mjd))
+    might_be_old = is_url_in_cache(IERS_B_URL)
+    iers_b = IERS_B.open(download_file(IERS_B_URL, cache=True))
+    if might_be_old and iers_b[-1]['MJD'].to(u.d).value < mjd:
+        # Try wiping the download and re-downloading
+        clear_download_cache(IERS_B_URL)
+        iers_b = IERS_B.open(download_file(IERS_B_URL, cache=True))
+    if iers_b[-1]['MJD'].to(u.d).value < mjd:
+        raise ValueError("IERS B data not yet available for MJD {}".format(mjd))
+    return iers_b
+
 SECS_PER_DAY = erfa.DAYSEC
-
-from astropy.utils.iers import IERS_A, IERS_A_URL, IERS_B, IERS_B_URL, IERS
-from astropy.utils.data import download_file
-
-iers_tab = None
-def _download_IERS():
-    global IERS, iers_tab
-    #FIXME: downloading a changing file with cache
-    # iers_a_file = download_file(IERS_A_URL, cache=True)
-    iers_b_file = download_file(IERS_B_URL, cache=True)
-    # iers_a = IERS_A.open(iers_a_file)
-    iers_b = IERS_B.open(iers_b_file)
-    IERS.iers_table = iers_b
-    iers_tab = IERS.iers_table
 
 # Earth rotation rate in radians per UT1 second
 #
@@ -58,33 +65,36 @@ def gcrs_posvel_from_itrf(loc, toas, obsname='obs'):
     # then put it into a list
     if type(toas) == table.row.Row:
         ttoas = Time([toas['mjd']])
-        N = 1
     elif type(toas) == table.table.Table:
-        N = len(toas)
         ttoas = toas['mjd']
-    else:
+    elif isinstance(toas,Time):
         if toas.isscalar:
             ttoas = Time([toas])
         else:
             ttoas = toas
-        N = len(ttoas)
+    else:
+        if np.isscalar(toas):
+            ttoas = Time([toas],format="mjd")
+        else:
+            ttoas = toas
+    N = len(ttoas)
 
     # Get various times from the TOAs as arrays
     tts = np.asarray([(t.jd1, t.jd2) for t in ttoas.tt]).T
     ut1s = np.asarray([(t.jd1, t.jd2) for t in ttoas.ut1]).T
     mjds = np.asarray(ttoas.mjd)
 
+    iers_b = get_iers_b_up_to_date(mjds.max())
+
     # Get x, y coords of Celestial Intermediate Pole and CIO locator s
     X, Y, S = erfa.xys00a(*tts)
 
-    if iers_tab is None:
-        _download_IERS()
     # Get dX and dY from IERS A in arcsec and convert to radians
     #dX = np.interp(mjds, iers_tab['MJD'], iers_tab['dX_2000A_B']) * asec2rad
     #dY = np.interp(mjds, iers_tab['MJD'], iers_tab['dY_2000A_B']) * asec2rad
     # Get dX and dY from IERS B in arcsec and convert to radians
-    dX = np.interp(mjds, iers_tab['MJD'], iers_tab['dX_2000A']) * asec2rad
-    dY = np.interp(mjds, iers_tab['MJD'], iers_tab['dY_2000A']) * asec2rad
+    dX = np.interp(mjds, iers_b['MJD'], iers_b['dX_2000A']) * asec2rad
+    dY = np.interp(mjds, iers_b['MJD'], iers_b['dY_2000A']) * asec2rad
 
     # Get GCRS to CIRS matrices
     rc2i = erfa.c2ixys(X+dX, Y+dY, S)
@@ -96,8 +106,8 @@ def gcrs_posvel_from_itrf(loc, toas, obsname='obs'):
     #xp = np.interp(mjds, iers_tab['MJD'], iers_tab['PM_X_B']) * asec2rad
     #yp = np.interp(mjds, iers_tab['MJD'], iers_tab['PM_Y_B']) * asec2rad
     # Get X and Y from IERS B in arcsec and convert to radians
-    xp = np.interp(mjds, iers_tab['MJD'], iers_tab['PM_x']) * asec2rad
-    yp = np.interp(mjds, iers_tab['MJD'], iers_tab['PM_y']) * asec2rad
+    xp = np.interp(mjds, iers_b['MJD'], iers_b['PM_x']) * asec2rad
+    yp = np.interp(mjds, iers_b['MJD'], iers_b['PM_y']) * asec2rad
 
     # Get the polar motion matrices
     rpm = erfa.pom00(xp, yp, sp)
@@ -126,7 +136,39 @@ def gcrs_posvel_from_itrf(loc, toas, obsname='obs'):
 
 
 # This seems to be never used!  It also has no docstring!
-# def astropy_gcrs_posvel_from_itrf(loc, toas, obsname='obs'):
-#     t = Time(toas['tdbld'], scale='tdb', format='mjd')
-#     pos, vel = loc.get_gcrs_posvel(t)
-#     return utils.PosVel(pos, vel, obj=obsname, origin="earth")
+# Astropy uses IERS A data, which differs from IERS B data.
+def astropy_gcrs_posvel_from_itrf(loc, toas, obsname='obs'):
+    """Return a list of PosVel instances for the observatory at the TOA times.
+
+    Observatory location should be given in the loc argument as an astropy
+    EarthLocation object. This location will be in the ITRF frame (i.e.
+    co-rotating with the Earth).
+
+    The optional obsname argument will be used as label in the returned
+    PosVel instance.
+
+    This routine returns a list of PosVel instances, containing the
+    positions (m) and velocities (m / s) at the times of the toas and
+    referenced to the Earth-centered Inertial (ECI, aka GCRS) coordinates.
+    This routine is basically SOFA's pvtob() [Position and velocity of
+    a terrestrial observing station] with an extra rotation from c2ixys()
+    [Form the celestial to intermediate-frame-of-date matrix given the CIP
+    X,Y and the CIO locator s].
+    """
+    if isinstance(toas, table.row.Row):
+        t = Time([toas['mjd']])
+    elif isinstance(toas, table.table.Table):
+        # FIXME: is this guaranteed to be a Time?
+        t = toas['mjd']
+    elif isinstance(toas,Time):
+        t = toas
+    elif np.isscalar(toas):
+        log.warning("Scalar time has unspecified scale, using default (UTC?)")
+        t = Time([toas], format="mjd")
+    else:
+        log.warning("Array time has unspecified scale, using default (UTC?)")
+        t = Time(toas, format="mjd")
+
+    #t = Time(toas['tdbld'], scale='tdb', format='mjd')
+    pos, vel = loc.get_gcrs_posvel(t)
+    return utils.PosVel(pos.xyz, vel.xyz, obj=obsname, origin="earth")

--- a/pint/utils.py
+++ b/pint/utils.py
@@ -93,6 +93,13 @@ class PosVel(object):
                     + " " + self.origin + "->" + self.obj)
         else:
             return str(self.pos)+", "+str(self.vel)
+    def __getitem__(self, k):
+        """Allow extraction of slices of the contained arrays"""
+        return self.__class__(
+                self.pos[:,k],
+                self.vel[:,k],
+                obj=self.obj,
+                origin=self.origin)
 
 def fortran_float(x):
     """Convert Fortran-format floating-point strings.

--- a/tests/test_erfautils.py
+++ b/tests/test_erfautils.py
@@ -3,58 +3,126 @@ import unittest
 
 from nose.tools import raises
 import numpy as np
+from numpy.testing import assert_equal, assert_allclose
 from astropy import log
 import astropy.table as table
 from astropy.time import Time
 import astropy.units as u
-from astropy.utils.iers import IERS_Auto, IERS_B
+from astropy.utils.iers import IERS_Auto, IERS_B, IERS_B_URL, IERS_B_FILE
+from astropy.utils.data import download_file
 
 from pint.observatory import Observatory
 from pint import toa, utils, erfautils
 from pinttestdata import testdir, datadir
 
+class TestERFAUtils(unittest.TestCase):
+    def test_simpler_erfa_import(self):
+        import astropy._erfa as erfa
 
-def test_simpler_erfa_import():
-    import astropy._erfa as erfa
+    @unittest.expectedFailure
+    def test_compare_erfautils_astropy(self):
+        o = "Arecibo"
+        loc = Observatory.get(o).earth_location_itrf()
+        mjds = np.linspace(50000,58000,512)
+        t = Time(mjds, scale="tdb", format="mjd")
+        posvel = erfautils.gcrs_posvel_from_itrf(loc, t, obsname=o)
+        astropy_posvel = erfautils.astropy_gcrs_posvel_from_itrf(
+            loc, t, obsname=o)
+        dopv = astropy_posvel - posvel
+        dpos = np.sqrt((dopv.pos**2).sum(axis=0))
+        dvel = np.sqrt((dopv.vel**2).sum(axis=0))
+        assert len(dpos)==len(mjds)
+        # This is just above the level of observed difference
+        assert dpos.max()<0.05*u.m, "position difference of %s" % dpos.max().to(u.m)
+        # This level is what is permitted as a velocity difference from tempo2 in test_times.py
+        assert dvel.max()<0.02*u.mm/u.s, "velocity difference of %s" % dvel.max().to(u.mm/u.s)
 
-@unittest.skip
-def test_compare_erfautils_astropy():
-    o = "Arecibo"
-    loc = Observatory.get(o).earth_location_itrf()
-    mjds = np.linspace(50000,58000,512)
-    t = Time(mjds, scale="tdb", format="mjd")
-    posvel = erfautils.gcrs_posvel_from_itrf(loc, t, obsname=o)
-    astropy_posvel = erfautils.astropy_gcrs_posvel_from_itrf(
-        loc, t, obsname=o)
-    dopv = astropy_posvel - posvel
-    dpos = np.sqrt((dopv.pos**2).sum(axis=0))
-    dvel = np.sqrt((dopv.vel**2).sum(axis=0))
-    assert len(dpos)==len(mjds)
-    # This is just above the level of observed difference
-    assert dpos.max()<0.05*u.m, "position difference of %s" % dpos.max().to(u.m)
-    # This level is what is permitted as a velocity difference from tempo2 in test_times.py
-    assert dvel.max()<0.02*u.mm/u.s, "velocity difference of %s" % dvel.max().to(u.mm/u.s)
+    def test_iers_discrepancies(self):
+        iers_auto = IERS_Auto.open()
+        iers_b = IERS_B.open()
+        for mjd in [56000,56500,57000]:
+            t = Time(mjd, scale="tdb", format="mjd")
+            b_x, b_y = iers_b.pm_xy(t)
+            a_x, a_y = iers_auto.pm_xy(t)
+            assert abs(a_x-b_x)<1*u.marcsec
+            assert abs(a_y-b_y)<1*u.marcsec
 
-def test_iers_discrepancies():
-    iers_auto = IERS_Auto.open()
-    iers_b = IERS_B.open()
-    for mjd in [56000,56500,57000]:
-        t = Time(mjd, scale="tdb", format="mjd")
-        b_x, b_y = iers_b.pm_xy(t)
-        a_x, a_y = iers_auto.pm_xy(t)
-        assert abs(a_x-b_x)<1*u.marcsec
-        assert abs(a_y-b_y)<1*u.marcsec
+    def test_scalar(self):
+        o = "Arecibo"
+        loc = Observatory.get(o).earth_location_itrf()
+        t = Time(56000, scale="tdb", format="mjd")
+        posvel = erfautils.gcrs_posvel_from_itrf(loc, t, obsname=o)
+        assert posvel.pos.shape == (3,)
 
-def test_scalar():
-    o = "Arecibo"
-    loc = Observatory.get(o).earth_location_itrf()
-    t = Time(56000, scale="tdb", format="mjd")
-    posvel = erfautils.gcrs_posvel_from_itrf(loc, t, obsname=o)
-    assert posvel.pos.shape == (3,)
+    @raises(ValueError)
+    def test_matrix(self):
+        o = "Arecibo"
+        loc = Observatory.get(o).earth_location_itrf()
+        t = Time(56000*np.ones((4,5)), scale="tdb", format="mjd")
+        posvel = erfautils.gcrs_posvel_from_itrf(loc, t, obsname=o)
 
-@raises(ValueError)
-def test_matrix():
-    o = "Arecibo"
-    loc = Observatory.get(o).earth_location_itrf()
-    t = Time(56000*np.ones((4,5)), scale="tdb", format="mjd")
-    posvel = erfautils.gcrs_posvel_from_itrf(loc, t, obsname=o)
+    @unittest.expectedFailure # Not true in current astropy; wish we had knownfail!
+    def test_IERS_B_all_in_IERS_Auto(self):
+        B = IERS_B.open(download_file(IERS_B_URL, cache=True))
+        mjd = B['MJD'].to(u.day).value
+        A = IERS_Auto.open()
+        A.pm_xy(mjd) # ensure that data is available for this date
+        i_A = np.searchsorted(A['MJD'].to(u.day).value, mjd)
+        assert_equal(A['dX_2000A_B'][i_A], B['dX_2000A'])
+
+    @unittest.expectedFailure # Disagreement in current astropy
+    def test_IERS_B_agree_with_IERS_Auto(self):
+        A = IERS_Auto.open()
+        B = IERS_B.open(download_file(IERS_B_URL, cache=True))
+        mjd = B['MJD'].to(u.day).value
+        A.pm_xy(mjd) # ensure that data is available for this date
+
+        # Let's get rid of some trouble values and see if they agree on a restricted subset
+        # IERS Auto ends with a bunch of 1e20 values meant as sentinels (?)
+        ok_A = abs(A['dX_2000A_B']) < 1e6*u.marcsec
+        # For some reason IERS B starts with zeros up to MJD 45700? IERS Auto doesn't match this
+        #ok_A &= A['MJD'] > 45700*u.d
+        # Maybe the old values are bogus?
+        ok_A &= A['MJD'] > 50000*u.d
+
+        mjds_A = A['MJD'][ok_A].to(u.day).value
+        i_B = np.searchsorted(B['MJD'].to(u.day).value, mjds_A)
+        assert_equal(A['MJD'][ok_A], B['MJD'][i_B], "MJDs don't make sense")
+        assert_allclose(
+                A['dX_2000A_B'][ok_A].to(u.marcsec).value,
+                B['dX_2000A'][i_B].to(u.marcsec).value,
+                atol=1e-5, rtol=1e-3,
+                err_msg="Inserted IERS B values don't match current IERS B values")
+
+    def test_astropy_IERS_B_vs_downloaded(self):
+        P = IERS_B.open(IERS_B_FILE)
+        B = IERS_B.open(download_file(IERS_B_URL, cache=True))
+        assert B['MJD'][-1]>P['MJD'][-1]
+
+    @unittest.expectedFailure # Disagreement in current astropy (!)
+    def test_IERS_B_builtin_agree_with_IERS_Auto(self):
+        A = IERS_Auto.open()
+        B = IERS_B.open(IERS_B_FILE)
+        mjd = B['MJD'].to(u.day).value
+        A.pm_xy(mjd) # ensure that data is available for these dates
+
+        # We're going to look up the OK auto values in the B table
+        ok_A = A['MJD'] < B['MJD'][-1]
+        # Let's get rid of some trouble values and see if they agree on a restricted subset
+        # IERS Auto ends with a bunch of 1e20 values meant as sentinels (?)
+        ok_A &= abs(A['dX_2000A_B']) < 1e6*u.marcsec
+        # For some reason IERS B starts with zeros up to MJD 45700? IERS Auto doesn't match this
+        ok_A &= A['MJD'] > 45700*u.d
+        # Maybe the old values are bogus?
+        ok_A &= A['MJD'] > 50000*u.d
+
+        mjds_A = A['MJD'][ok_A].to(u.day).value
+        i_B = np.searchsorted(B['MJD'].to(u.day).value, mjds_A)
+
+        assert np.all(np.diff(i_B)==1), "Valid region not contiguous"
+        assert_equal(A['MJD'][ok_A], B['MJD'][i_B], "MJDs don't make sense")
+        assert_allclose(
+                A['dX_2000A_B'][ok_A].to(u.marcsec).value,
+                B['dX_2000A'][i_B].to(u.marcsec).value,
+                atol=1e-5, rtol=1e-3,
+                err_msg="Inserted IERS B values don't match IERS_B_FILE values")

--- a/tests/test_erfautils.py
+++ b/tests/test_erfautils.py
@@ -1,0 +1,152 @@
+from __future__ import absolute_import, print_function, division
+
+import numpy as np
+import astropy.units as u
+try:
+    import astropy.erfa as erfa
+except ImportError:
+    import astropy._erfa as erfa
+import astropy.table as table
+from astropy.time import Time
+
+from pint.observatory import Observatory
+from pint import toa, utils, erfautils
+from pinttestdata import testdir, datadir
+
+# This is the old erfautils module, that uses IERS data files directly
+# The implementation was moved here so we can remove it and use astropy
+# functions, checking them against this
+
+SECS_PER_DAY = erfa.DAYSEC
+
+from astropy.utils.iers import IERS_A, IERS_A_URL, IERS_B, IERS_B_URL, IERS
+from astropy.utils.data import download_file
+# iers_a_file = download_file(IERS_A_URL, cache=True)
+iers_b_file = download_file(IERS_B_URL, cache=True)
+# iers_a = IERS_A.open(iers_a_file)
+iers_b = IERS_B.open(iers_b_file)
+IERS.iers_table = iers_b
+iers_tab = IERS.iers_table
+
+# Earth rotation rate in radians per UT1 second
+#
+# This is from Capitaine, Guinot, McCarthy, 2000 and is
+# in IAU Resolution B1.8 on the Earth Rotation Angle (ERA)
+# and the relation of it to UT1.  The number 1.00273781191135448
+# below is a defining constant.  See here:
+# http://iau-c31.nict.go.jp/pdf/2009_IAUGA_JD6/JD06_capitaine_wallace.pdf
+OM = 1.00273781191135448 * 2.0 * np.pi / SECS_PER_DAY
+
+# arcsec to radians
+asec2rad = 4.84813681109536e-06
+
+def gcrs_posvel_from_itrf(loc, toas, obsname='obs'):
+    """Return a list of PosVel instances for the observatory at the TOA times.
+
+    Observatory location should be given in the loc argument as an astropy
+    EarthLocation object. This location will be in the ITRF frame (i.e.
+    co-rotating with the Earth).
+
+    The optional obsname argument will be used as label in the returned
+    PosVel instance.
+
+    This routine returns a list of PosVel instances, containing the
+    positions (m) and velocities (m / s) at the times of the toas and
+    referenced to the Earth-centered Inertial (ECI, aka GCRS) coordinates.
+    This routine is basically SOFA's pvtob() [Position and velocity of
+    a terrestrial observing station] with an extra rotation from c2ixys()
+    [Form the celestial to intermediate-frame-of-date matrix given the CIP
+    X,Y and the CIO locator s].
+    """
+    # If the input is a single TOA (i.e. a row from the table),
+    # then put it into a list
+    if type(toas) == table.row.Row:
+        ttoas = Time([toas['mjd']])
+        N = 1
+    elif type(toas) == table.table.Table:
+        N = len(toas)
+        ttoas = toas['mjd']
+    else:
+        if toas.isscalar:
+            ttoas = Time([toas])
+        else:
+            ttoas = toas
+        N = len(ttoas)
+
+    # Get various times from the TOAs as arrays
+    tts = np.asarray([(t.jd1, t.jd2) for t in ttoas.tt]).T
+    ut1s = np.asarray([(t.jd1, t.jd2) for t in ttoas.ut1]).T
+    mjds = np.asarray(ttoas.mjd)
+
+    # Get x, y coords of Celestial Intermediate Pole and CIO locator s
+    X, Y, S = erfa.xys00a(*tts)
+
+    # Get dX and dY from IERS A in arcsec and convert to radians
+    #dX = np.interp(mjds, iers_tab['MJD'], iers_tab['dX_2000A_B']) * asec2rad
+    #dY = np.interp(mjds, iers_tab['MJD'], iers_tab['dY_2000A_B']) * asec2rad
+    # Get dX and dY from IERS B in arcsec and convert to radians
+    dX = np.interp(mjds, iers_tab['MJD'], iers_tab['dX_2000A']) * asec2rad
+    dY = np.interp(mjds, iers_tab['MJD'], iers_tab['dY_2000A']) * asec2rad
+
+    # Get GCRS to CIRS matrices
+    rc2i = erfa.c2ixys(X+dX, Y+dY, S)
+
+    # Gets the TIO locator s'
+    sp = erfa.sp00(*tts)
+
+    # Get X and Y from IERS A in arcsec and convert to radians
+    #xp = np.interp(mjds, iers_tab['MJD'], iers_tab['PM_X_B']) * asec2rad
+    #yp = np.interp(mjds, iers_tab['MJD'], iers_tab['PM_Y_B']) * asec2rad
+    # Get X and Y from IERS B in arcsec and convert to radians
+    xp = np.interp(mjds, iers_tab['MJD'], iers_tab['PM_x']) * asec2rad
+    yp = np.interp(mjds, iers_tab['MJD'], iers_tab['PM_y']) * asec2rad
+
+    # Get the polar motion matrices
+    rpm = erfa.pom00(xp, yp, sp)
+
+    # Observatory geocentric coords in m
+    xyzm = np.array([a.to(u.m).value for a in loc.geocentric])
+    x, y, z = np.dot(xyzm, rpm).T
+
+    # Functions of Earth Rotation Angle
+    theta = erfa.era00(*ut1s)
+    s, c = np.sin(theta), np.cos(theta)
+    sx, cx = s * x, c * x
+    sy, cy = s * y, c * y
+
+    # Initial positions and velocities
+    iposs = np.asarray([cx - sy, sx + cy, z]).T
+    ivels = np.asarray([OM * (-sx - cy), OM * (cx - sy), \
+                        np.zeros_like(x)]).T
+    # There is probably a way to do this with np.einsum or something...
+    # and here it is .
+    poss = np.empty((N, 3), dtype=np.float64)
+    vels = np.empty((N, 3), dtype=np.float64)
+    poss = np.einsum('ij,ijk->ik', iposs, rc2i)
+    vels = np.einsum('ij,ijk->ik', ivels, rc2i)
+    return utils.PosVel(poss.T * u.m, vels.T * u.m / u.s, obj=obsname, origin="earth")
+
+
+# This seems to be never used!  It also has no docstring!
+# def astropy_gcrs_posvel_from_itrf(loc, toas, obsname='obs'):
+#     t = Time(toas['tdbld'], scale='tdb', format='mjd')
+#     pos, vel = loc.get_gcrs_posvel(t)
+#     return utils.PosVel(pos, vel, obj=obsname, origin="earth")
+
+def test_erfautils_compare_to_direct_implementation():
+    ts = toa.get_TOAs(datadir + "/testtimes.tim",
+                      include_bipm=False, usepickle=False)
+
+    # is this for loop really needed?
+    for TOA in ts.table:
+        local_posvel = gcrs_posvel_from_itrf(
+            Observatory.get(TOA['obs']).earth_location_itrf(),
+            TOA, obsname=TOA['obs'])
+        posvel = erfautils.gcrs_posvel_from_itrf(
+            Observatory.get(TOA['obs']).earth_location_itrf(),
+            TOA, obsname=TOA['obs'])
+        dopv = local_posvel - posvel
+        dpos = np.sqrt(np.dot(dopv.pos.to(u.m)[:,0], dopv.pos.to(u.m)[:,0]))
+        dvel = np.sqrt(np.dot(dopv.vel.to(u.mm/u.s)[:,0], dopv.vel.to(u.mm/u.s)[:,0]))
+        assert dpos<2, "position difference in meters"
+        assert dvel<0.02, "velocity difference in mm/s"

--- a/tests/test_erfautils.py
+++ b/tests/test_erfautils.py
@@ -21,7 +21,7 @@ def test_simpler_erfa_import():
 def test_compare_erfautils_astropy():
     o = "Arecibo"
     loc = Observatory.get(o).earth_location_itrf()
-    mjds = np.linspace(56000,58000,256)
+    mjds = np.linspace(50000,58000,512)
     t = Time(mjds, scale="tdb", format="mjd")
     posvel = erfautils.gcrs_posvel_from_itrf(loc, t, obsname=o)
     astropy_posvel = erfautils.astropy_gcrs_posvel_from_itrf(
@@ -30,7 +30,9 @@ def test_compare_erfautils_astropy():
     dpos = np.sqrt((dopv.pos**2).sum(axis=0))
     dvel = np.sqrt((dopv.vel**2).sum(axis=0))
     assert len(dpos)==len(mjds)
-    assert dpos.max()<2*u.m, "position difference of %s" % dpos.max().to(u.m/u.s)
+    # This is just above the level of observed difference
+    assert dpos.max()<0.05*u.m, "position difference of %s" % dpos.max().to(u.m)
+    # This level is what is permitted as a velocity difference from tempo2 in test_times.py
     assert dvel.max()<0.02*u.mm/u.s, "velocity difference of %s" % dvel.max().to(u.mm/u.s)
 
 def test_iers_discrepancies():

--- a/tests/test_erfautils.py
+++ b/tests/test_erfautils.py
@@ -1,166 +1,58 @@
 from __future__ import absolute_import, print_function, division
+import unittest
 
+from nose.tools import raises
 import numpy as np
 from astropy import log
-try:
-    import astropy.erfa as erfa
-except ImportError:
-    import astropy._erfa as erfa
 import astropy.table as table
 from astropy.time import Time
 import astropy.units as u
+from astropy.utils.iers import IERS_Auto, IERS_B
 
 from pint.observatory import Observatory
 from pint import toa, utils, erfautils
 from pinttestdata import testdir, datadir
 
-# This is the old erfautils module, that uses IERS data files directly
-# The implementation was moved here so we can remove it and use astropy
-# functions, checking them against this
 
-SECS_PER_DAY = erfa.DAYSEC
+def test_simpler_erfa_import():
+    import astropy._erfa as erfa
 
-from astropy.utils.iers import IERS_A, IERS_A_URL, IERS_B, IERS_B_URL, IERS, IERS_Auto
-from astropy.utils.data import download_file
-# iers_a_file = download_file(IERS_A_URL, cache=True)
-#iers_b_file = download_file(IERS_B_URL, cache=True)
-# iers_a = IERS_A.open(iers_a_file)
-#iers_b = IERS_B.open(iers_b_file)
-#IERS.iers_table = iers_b
-#iers_tab = IERS.iers_table
-iers_tab = IERS_Auto.open()
-iers_b_tab = IERS_B.open()
-
-# Earth rotation rate in radians per UT1 second
-#
-# This is from Capitaine, Guinot, McCarthy, 2000 and is
-# in IAU Resolution B1.8 on the Earth Rotation Angle (ERA)
-# and the relation of it to UT1.  The number 1.00273781191135448
-# below is a defining constant.  See here:
-# http://iau-c31.nict.go.jp/pdf/2009_IAUGA_JD6/JD06_capitaine_wallace.pdf
-OM = 1.00273781191135448 * 2.0 * np.pi / SECS_PER_DAY
-
-# arcsec to radians
-asec2rad = 4.84813681109536e-06
-
-def gcrs_posvel_from_itrf(loc, toas, obsname='obs'):
-    """Return a list of PosVel instances for the observatory at the TOA times.
-
-    Observatory location should be given in the loc argument as an astropy
-    EarthLocation object. This location will be in the ITRF frame (i.e.
-    co-rotating with the Earth).
-
-    The optional obsname argument will be used as label in the returned
-    PosVel instance.
-
-    This routine returns a list of PosVel instances, containing the
-    positions (m) and velocities (m / s) at the times of the toas and
-    referenced to the Earth-centered Inertial (ECI, aka GCRS) coordinates.
-    This routine is basically SOFA's pvtob() [Position and velocity of
-    a terrestrial observing station] with an extra rotation from c2ixys()
-    [Form the celestial to intermediate-frame-of-date matrix given the CIP
-    X,Y and the CIO locator s].
-    """
-    # If the input is a single TOA (i.e. a row from the table),
-    # then put it into a list
-    if type(toas) == table.row.Row:
-        ttoas = Time([toas['mjd']])
-    elif type(toas) == table.table.Table:
-        ttoas = toas['mjd']
-    elif isinstance(toas,Time):
-        if toas.isscalar:
-            ttoas = Time([toas])
-        else:
-            ttoas = toas
-    else:
-        if np.isscalar(toas):
-            ttoas = Time([toas],format="mjd")
-        else:
-            ttoas = toas
-    N = len(ttoas)
-
-    # Get various times from the TOAs as arrays
-    tts = np.asarray([(t.jd1, t.jd2) for t in ttoas.tt]).T
-    ut1s = np.asarray([(t.jd1, t.jd2) for t in ttoas.ut1]).T
-    mjds = np.asarray(ttoas.mjd)
-
-    # Get x, y coords of Celestial Intermediate Pole and CIO locator s
-    X, Y, S = erfa.xys00a(*tts)
-
-    # Get dX and dY from IERS A in arcsec and convert to radians
-    #dX = np.interp(mjds, iers_tab['MJD'], iers_tab['dX_2000A_B']) * asec2rad
-    #dY = np.interp(mjds, iers_tab['MJD'], iers_tab['dY_2000A_B']) * asec2rad
-    # Get dX and dY from IERS B in arcsec and convert to radians
-    dX = np.interp(mjds, iers_tab['MJD'], iers_tab['dX_2000A_B'],
-            left=np.nan, right=np.nan) * asec2rad
-    dY = np.interp(mjds, iers_tab['MJD'], iers_tab['dY_2000A_B'],
-            left=np.nan, right=np.nan) * asec2rad
-    dX_B = np.interp(mjds, iers_b_tab['MJD'], iers_b_tab['dX_2000A'],
-            left=np.nan, right=np.nan) * asec2rad
-    dY_B = np.interp(mjds, iers_b_tab['MJD'], iers_b_tab['dY_2000A'],
-            left=np.nan, right=np.nan) * asec2rad
-    assert (dX, dY) == (dX_B,dY_B)
-
-    # Get GCRS to CIRS matrices
-    rc2i = erfa.c2ixys(X+dX, Y+dY, S)
-
-    # Gets the TIO locator s'
-    sp = erfa.sp00(*tts)
-
-    # Get X and Y from IERS A in arcsec and convert to radians
-    #xp = np.interp(mjds, iers_tab['MJD'], iers_tab['PM_X_B']) * asec2rad
-    #yp = np.interp(mjds, iers_tab['MJD'], iers_tab['PM_Y_B']) * asec2rad
-    # Get X and Y from IERS B in arcsec and convert to radians
-    xp = np.interp(mjds, iers_tab['MJD'], iers_tab['PM_X_B'],
-            left=np.nan, right=np.nan) * asec2rad
-    yp = np.interp(mjds, iers_tab['MJD'], iers_tab['PM_Y_B'],
-            left=np.nan, right=np.nan) * asec2rad
-
-    # Get the polar motion matrices
-    rpm = erfa.pom00(xp, yp, sp)
-
-    # Observatory geocentric coords in m
-    xyzm = np.array([a.to(u.m).value for a in loc.geocentric])
-    x, y, z = np.dot(xyzm, rpm).T
-
-    # Functions of Earth Rotation Angle
-    theta = erfa.era00(*ut1s)
-    s, c = np.sin(theta), np.cos(theta)
-    sx, cx = s * x, c * x
-    sy, cy = s * y, c * y
-
-    # Initial positions and velocities
-    iposs = np.asarray([cx - sy, sx + cy, z]).T
-    ivels = np.asarray([OM * (-sx - cy), OM * (cx - sy), \
-                        np.zeros_like(x)]).T
-    # There is probably a way to do this with np.einsum or something...
-    # and here it is .
-    poss = np.empty((N, 3), dtype=np.float64)
-    vels = np.empty((N, 3), dtype=np.float64)
-    poss = np.einsum('ij,ijk->ik', iposs, rc2i)
-    vels = np.einsum('ij,ijk->ik', ivels, rc2i)
-    return utils.PosVel(poss.T * u.m, vels.T * u.m / u.s, obj=obsname, origin="earth")
-
-
-def test_erfautils_compare_to_direct_implementation():
+@unittest.skip
+def test_compare_erfautils_astropy():
     o = "Arecibo"
     loc = Observatory.get(o).earth_location_itrf()
-    # is this for loop really needed?
-    for mjd in [56000.,56500.,57000.]:
-        t = Time(mjd, scale="tdb", format="mjd")
-        local_posvel = gcrs_posvel_from_itrf(
-            loc, t, obsname=o)
-        posvel = erfautils.gcrs_posvel_from_itrf(
-            loc, t, obsname=o)
-        dopv = local_posvel - posvel
-        dpos = np.sqrt(np.dot(dopv.pos.to(u.m)[:,0], dopv.pos.to(u.m)[:,0]))
-        dvel = np.sqrt(np.dot(dopv.vel.to(u.mm/u.s)[:,0], dopv.vel.to(u.mm/u.s)[:,0]))
-        assert dpos<2, "position difference in meters"
-        assert dvel<0.02, "velocity difference in mm/s"
+    mjds = np.linspace(56000,58000,256)
+    t = Time(mjds, scale="tdb", format="mjd")
+    posvel = erfautils.gcrs_posvel_from_itrf(loc, t, obsname=o)
+    astropy_posvel = erfautils.astropy_gcrs_posvel_from_itrf(
+        loc, t, obsname=o)
+    dopv = astropy_posvel - posvel
+    dpos = np.sqrt((dopv.pos**2).sum(axis=0))
+    dvel = np.sqrt((dopv.vel**2).sum(axis=0))
+    assert len(dpos)==len(mjds)
+    assert dpos.max()<2*u.m, "position difference of %s" % dpos.max().to(u.m/u.s)
+    assert dvel.max()<0.02*u.mm/u.s, "velocity difference of %s" % dvel.max().to(u.mm/u.s)
 
 def test_iers_discrepancies():
     iers_auto = IERS_Auto.open()
     iers_b = IERS_B.open()
     for mjd in [56000,56500,57000]:
         t = Time(mjd, scale="tdb", format="mjd")
-        assert iers_b.pm_xy(t) == iers_auto.pm_xy(t)
+        b_x, b_y = iers_b.pm_xy(t)
+        a_x, a_y = iers_auto.pm_xy(t)
+        assert abs(a_x-b_x)<1*u.marcsec
+        assert abs(a_y-b_y)<1*u.marcsec
+
+def test_scalar():
+    o = "Arecibo"
+    loc = Observatory.get(o).earth_location_itrf()
+    t = Time(56000, scale="tdb", format="mjd")
+    posvel = erfautils.gcrs_posvel_from_itrf(loc, t, obsname=o)
+    assert posvel.pos.shape == (3,)
+
+@raises(ValueError)
+def test_matrix():
+    o = "Arecibo"
+    loc = Observatory.get(o).earth_location_itrf()
+    t = Time(56000*np.ones((4,5)), scale="tdb", format="mjd")
+    posvel = erfautils.gcrs_posvel_from_itrf(loc, t, obsname=o)

--- a/tests/test_erfautils.py
+++ b/tests/test_erfautils.py
@@ -18,7 +18,9 @@ from pinttestdata import testdir, datadir
 def test_simpler_erfa_import():
     import astropy._erfa as erfa
 
-@pytest.mark.xfail(reason="astropy doesn't include up-to-date IERS B")
+@pytest.mark.xfail(reason="astropy doesn't include up-to-date IERS B - "
+                          "if this starts passing we can ditch the "
+                          "implementation in erfautils")
 def test_compare_erfautils_astropy():
     o = "Arecibo"
     loc = Observatory.get(o).earth_location_itrf()
@@ -54,11 +56,14 @@ def test_scalar():
     assert posvel.pos.shape == (3,)
 
 def test_matrix():
+    """Confirm higher-dimensional arrays raise an exception"""
     with pytest.raises(ValueError):
         o = "Arecibo"
         loc = Observatory.get(o).earth_location_itrf()
         t = Time(56000*np.ones((4,5)), scale="tdb", format="mjd")
         posvel = erfautils.gcrs_posvel_from_itrf(loc, t, obsname=o)
+
+# The below explore why astropy might disagree with PINT internal code
 
 @pytest.mark.xfail(reason="astropy doesn't include up-to-date IERS B")
 def test_IERS_B_all_in_IERS_Auto():

--- a/tests/test_erfautils.py
+++ b/tests/test_erfautils.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, print_function, division
 import unittest
 
-from nose.tools import raises
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 from astropy import log
@@ -10,210 +9,207 @@ from astropy.time import Time
 import astropy.units as u
 from astropy.utils.iers import IERS_Auto, IERS_B, IERS_B_URL, IERS_B_FILE
 from astropy.utils.data import download_file
-#import pytest
+import pytest
 
 from pint.observatory import Observatory
 from pint import toa, utils, erfautils
 from pinttestdata import testdir, datadir
 
-class TestERFAUtils(unittest.TestCase):
-    def test_simpler_erfa_import(self):
-        import astropy._erfa as erfa
+def test_simpler_erfa_import():
+    import astropy._erfa as erfa
 
-    @unittest.expectedFailure
-    def test_compare_erfautils_astropy(self):
-        o = "Arecibo"
-        loc = Observatory.get(o).earth_location_itrf()
-        mjds = np.linspace(50000,58000,512)
-        t = Time(mjds, scale="tdb", format="mjd")
-        posvel = erfautils.gcrs_posvel_from_itrf(loc, t, obsname=o)
-        astropy_posvel = erfautils.astropy_gcrs_posvel_from_itrf(
-            loc, t, obsname=o)
-        dopv = astropy_posvel - posvel
-        dpos = np.sqrt((dopv.pos**2).sum(axis=0))
-        dvel = np.sqrt((dopv.vel**2).sum(axis=0))
-        assert len(dpos)==len(mjds)
-        # This is just above the level of observed difference
-        assert dpos.max()<0.05*u.m, "position difference of %s" % dpos.max().to(u.m)
-        # This level is what is permitted as a velocity difference from tempo2 in test_times.py
-        assert dvel.max()<0.02*u.mm/u.s, "velocity difference of %s" % dvel.max().to(u.mm/u.s)
+@pytest.mark.xfail(reason="astropy doesn't include up-to-date IERS B")
+def test_compare_erfautils_astropy():
+    o = "Arecibo"
+    loc = Observatory.get(o).earth_location_itrf()
+    mjds = np.linspace(50000,58000,512)
+    t = Time(mjds, scale="tdb", format="mjd")
+    posvel = erfautils.gcrs_posvel_from_itrf(loc, t, obsname=o)
+    astropy_posvel = erfautils.astropy_gcrs_posvel_from_itrf(
+        loc, t, obsname=o)
+    dopv = astropy_posvel - posvel
+    dpos = np.sqrt((dopv.pos**2).sum(axis=0))
+    dvel = np.sqrt((dopv.vel**2).sum(axis=0))
+    assert len(dpos)==len(mjds)
+    # This is just above the level of observed difference
+    assert dpos.max()<0.05*u.m, "position difference of %s" % dpos.max().to(u.m)
+    # This level is what is permitted as a velocity difference from tempo2 in test_times.py
+    assert dvel.max()<0.02*u.mm/u.s, "velocity difference of %s" % dvel.max().to(u.mm/u.s)
 
-    def test_iers_discrepancies(self):
-        iers_auto = IERS_Auto.open()
-        iers_b = IERS_B.open()
-        for mjd in [56000,56500,57000]:
-            t = Time(mjd, scale="tdb", format="mjd")
-            b_x, b_y = iers_b.pm_xy(t)
-            a_x, a_y = iers_auto.pm_xy(t)
-            assert abs(a_x-b_x)<1*u.marcsec
-            assert abs(a_y-b_y)<1*u.marcsec
+def test_iers_discrepancies():
+    iers_auto = IERS_Auto.open()
+    iers_b = IERS_B.open()
+    for mjd in [56000,56500,57000]:
+        t = Time(mjd, scale="tdb", format="mjd")
+        b_x, b_y = iers_b.pm_xy(t)
+        a_x, a_y = iers_auto.pm_xy(t)
+        assert abs(a_x-b_x)<1*u.marcsec
+        assert abs(a_y-b_y)<1*u.marcsec
 
-    def test_scalar(self):
-        o = "Arecibo"
-        loc = Observatory.get(o).earth_location_itrf()
-        t = Time(56000, scale="tdb", format="mjd")
-        posvel = erfautils.gcrs_posvel_from_itrf(loc, t, obsname=o)
-        assert posvel.pos.shape == (3,)
+def test_scalar():
+    o = "Arecibo"
+    loc = Observatory.get(o).earth_location_itrf()
+    t = Time(56000, scale="tdb", format="mjd")
+    posvel = erfautils.gcrs_posvel_from_itrf(loc, t, obsname=o)
+    assert posvel.pos.shape == (3,)
 
-    @raises(ValueError)
-    def test_matrix(self):
+def test_matrix():
+    with pytest.raises(ValueError):
         o = "Arecibo"
         loc = Observatory.get(o).earth_location_itrf()
         t = Time(56000*np.ones((4,5)), scale="tdb", format="mjd")
         posvel = erfautils.gcrs_posvel_from_itrf(loc, t, obsname=o)
 
-    @unittest.expectedFailure # Not true in current astropy
-    def test_IERS_B_all_in_IERS_Auto(self):
-        B = IERS_B.open(download_file(IERS_B_URL, cache=True))
-        mjd = B['MJD'].to(u.day).value
-        A = IERS_Auto.open()
-        A.pm_xy(mjd) # ensure that data is available for this date
-        i_A = np.searchsorted(A['MJD'].to(u.day).value, mjd)
-        assert_equal(A['dX_2000A_B'][i_A], B['dX_2000A'])
+@pytest.mark.xfail(reason="astropy doesn't include up-to-date IERS B")
+def test_IERS_B_all_in_IERS_Auto():
+    B = IERS_B.open(download_file(IERS_B_URL, cache=True))
+    mjd = B['MJD'].to(u.day).value
+    A = IERS_Auto.open()
+    A.pm_xy(mjd) # ensure that data is available for this date
+    i_A = np.searchsorted(A['MJD'].to(u.day).value, mjd)
+    assert_equal(A['dX_2000A_B'][i_A], B['dX_2000A'])
 
-    @unittest.expectedFailure # IERS B changes old values :(.
-    def test_IERS_B_agree_with_IERS_Auto_dX(self):
-        A = IERS_Auto.open()
-        B = IERS_B.open(download_file(IERS_B_URL, cache=True))
-        mjd = B['MJD'].to(u.day).value
-        A.pm_xy(mjd) # ensure that data is available for this date
+@pytest.mark.xfail(reason="IERS changes old values in new versions of the B table")
+def test_IERS_B_agree_with_IERS_Auto_dX():
+    A = IERS_Auto.open()
+    B = IERS_B.open(download_file(IERS_B_URL, cache=True))
+    mjd = B['MJD'].to(u.day).value
+    A.pm_xy(mjd) # ensure that data is available for this date
 
-        # Let's get rid of some trouble values and see if they agree on a restricted subset
-        # IERS Auto ends with a bunch of 1e20 values meant as sentinels (?)
-        ok_A = abs(A['dX_2000A_B']) < 1e6*u.marcsec
-        # For some reason IERS B starts with zeros up to MJD 45700? IERS Auto doesn't match this
-        #ok_A &= A['MJD'] > 45700*u.d
-        # Maybe the old values are bogus?
-        ok_A &= A['MJD'] > 50000*u.d
+    # Let's get rid of some trouble values and see if they agree on a restricted subset
+    # IERS Auto ends with a bunch of 1e20 values meant as sentinels (?)
+    ok_A = abs(A['dX_2000A_B']) < 1e6*u.marcsec
+    # For some reason IERS B starts with zeros up to MJD 45700? IERS Auto doesn't match this
+    #ok_A &= A['MJD'] > 45700*u.d
+    # Maybe the old values are bogus?
+    ok_A &= A['MJD'] > 50000*u.d
 
-        mjds_A = A['MJD'][ok_A].to(u.day).value
-        i_B = np.searchsorted(B['MJD'].to(u.day).value, mjds_A)
-        assert np.all(np.diff(i_B)==1), "Valid region not contiguous"
-        assert_equal(A['MJD'][ok_A], B['MJD'][i_B], "MJDs don't make sense")
-        for tag in ["dX_2000A", "dY_2000A"]:
-            assert_allclose(
-                    A[tag+'_B'][ok_A].to(u.marcsec).value,
-                    B[tag][i_B].to(u.marcsec).value,
-                    atol=1e-5, rtol=1e-3,
-                    err_msg="IERS A-derived IERS B {} values don't match current IERS B values".format(tag))
-
-    @unittest.expectedFailure # IERS B changes old values :(.
-    def test_IERS_B_agree_with_IERS_Auto(self):
-        A = IERS_Auto.open()
-        B = IERS_B.open(download_file(IERS_B_URL, cache=True))
-        mjd = B['MJD'].to(u.day).value
-        A.pm_xy(mjd) # ensure that data is available for this date
-
-        # Let's get rid of some trouble values and see if they agree on a restricted subset
-        # IERS Auto ends with a bunch of 1e20 values meant as sentinels (?)
-        ok_A = abs(A['PM_X_B']) < 1e6*u.marcsec
-        # Maybe the old values are bogus?
-        ok_A &= A['MJD'] > 50000*u.d
-
-        mjds_A = A['MJD'][ok_A].to(u.day).value
-        i_B = np.searchsorted(B['MJD'].to(u.day).value, mjds_A)
-        assert np.all(np.diff(i_B)==1), "Valid region not contiguous"
-        assert_equal(A['MJD'][ok_A], B['MJD'][i_B], "MJDs don't make sense")
-        for atag, btag, unit in [('UT1_UTC_B', 'UT1_UTC', u.s), # s, six decimal places
-                                 ('PM_X_B', 'PM_x', u.arcsec),
-                                 ('PM_Y_B', 'PM_y', u.arcsec)]:
-            assert_allclose(
-                    A[atag][ok_A].to(unit).value,
-                    B[btag][i_B].to(unit).value,
-                    atol=1e-5, rtol=1e-5, # should be "close enough"
-                    err_msg="Inserted IERS B {} values don't match IERS_B_URL {} values".format(atag,btag))
-
-    def test_astropy_IERS_B_vs_downloaded(self):
-        P = IERS_B.open(IERS_B_FILE)
-        B = IERS_B.open(download_file(IERS_B_URL, cache=True))
-        assert B['MJD'][-1]>P['MJD'][-1]
-
-    @unittest.expectedFailure # Disagreement in current astropy (!)
-    def test_IERS_B_builtin_agree_with_IERS_Auto_dX(self):
-        A = IERS_Auto.open()
-        B = IERS_B.open(IERS_B_FILE)
-        mjd = B['MJD'].to(u.day).value
-        A.pm_xy(mjd) # ensure that data is available for these dates
-
-        # We're going to look up the OK auto values in the B table
-        ok_A = A['MJD'] < B['MJD'][-1]
-        # Let's get rid of some trouble values and see if they agree on a restricted subset
-        # IERS Auto ends with a bunch of 1e20 values meant as sentinels (?)
-        ok_A &= abs(A['dX_2000A_B']) < 1e6*u.marcsec
-        # For some reason IERS B starts with zeros up to MJD 45700? IERS Auto doesn't match this
-        ok_A &= A['MJD'] > 45700*u.d
-        # Maybe the old values are bogus?
-        ok_A &= A['MJD'] > 50000*u.d
-
-        mjds_A = A['MJD'][ok_A].to(u.day).value
-        i_B = np.searchsorted(B['MJD'].to(u.day).value, mjds_A)
-
-        assert np.all(np.diff(i_B)==1), "Valid region not contiguous"
-        assert_equal(A['MJD'][ok_A], B['MJD'][i_B], "MJDs don't make sense")
+    mjds_A = A['MJD'][ok_A].to(u.day).value
+    i_B = np.searchsorted(B['MJD'].to(u.day).value, mjds_A)
+    assert np.all(np.diff(i_B)==1), "Valid region not contiguous"
+    assert_equal(A['MJD'][ok_A], B['MJD'][i_B], "MJDs don't make sense")
+    for tag in ["dX_2000A", "dY_2000A"]:
         assert_allclose(
-                A['dX_2000A_B'][ok_A].to(u.marcsec).value,
-                B['dX_2000A'][i_B].to(u.marcsec).value,
+                A[tag+'_B'][ok_A].to(u.marcsec).value,
+                B[tag][i_B].to(u.marcsec).value,
                 atol=1e-5, rtol=1e-3,
-                err_msg="IERS B values included in IERS A (dX_2000A) don't match IERS_B_FILE values")
+                err_msg="IERS A-derived IERS B {} values don't match current IERS B values".format(tag))
 
-    def test_IERS_B_builtin_agree_with_IERS_Auto(self):
-        """The UT1-UTC, PM_X, and PM_Y values are correctly copied"""
-        A = IERS_Auto.open()
-        B = IERS_B.open(IERS_B_FILE)
-        mjd = B['MJD'].to(u.day).value
-        A.pm_xy(mjd) # ensure that data is available for these dates
+@pytest.mark.xfail(reason="IERS changes old values in new versions of the B table")
+def test_IERS_B_agree_with_IERS_Auto():
+    A = IERS_Auto.open()
+    B = IERS_B.open(download_file(IERS_B_URL, cache=True))
+    mjd = B['MJD'].to(u.day).value
+    A.pm_xy(mjd) # ensure that data is available for this date
 
-        # We're going to look up the OK auto values in the B table
-        ok_A = A['MJD'] < B['MJD'][-1]
-        # Let's get rid of some trouble values and see if they agree on a restricted subset
-        # IERS Auto ends with a bunch of 1e20 values meant as sentinels (?)
-        ok_A &= abs(A['PM_X_B']) < 1e6*u.marcsec
-        # For some reason IERS B starts with zeros up to MJD 45700? IERS Auto doesn't match this
-        ok_A &= A['MJD'] > 45700*u.d
-        # Maybe the old values are bogus?
-        ok_A &= A['MJD'] > 50000*u.d
+    # Let's get rid of some trouble values and see if they agree on a restricted subset
+    # IERS Auto ends with a bunch of 1e20 values meant as sentinels (?)
+    ok_A = abs(A['PM_X_B']) < 1e6*u.marcsec
+    # Maybe the old values are bogus?
+    ok_A &= A['MJD'] > 50000*u.d
 
-        mjds_A = A['MJD'][ok_A].to(u.day).value
-        i_B = np.searchsorted(B['MJD'].to(u.day).value, mjds_A)
+    mjds_A = A['MJD'][ok_A].to(u.day).value
+    i_B = np.searchsorted(B['MJD'].to(u.day).value, mjds_A)
+    assert np.all(np.diff(i_B)==1), "Valid region not contiguous"
+    assert_equal(A['MJD'][ok_A], B['MJD'][i_B], "MJDs don't make sense")
+    for atag, btag, unit in [('UT1_UTC_B', 'UT1_UTC', u.s), # s, six decimal places
+                             ('PM_X_B', 'PM_x', u.arcsec),
+                             ('PM_Y_B', 'PM_y', u.arcsec)]:
+        assert_allclose(
+                A[atag][ok_A].to(unit).value,
+                B[btag][i_B].to(unit).value,
+                atol=1e-5, rtol=1e-5, # should be "close enough"
+                err_msg="Inserted IERS B {} values don't match IERS_B_URL {} values".format(atag,btag))
 
-        assert np.all(np.diff(i_B)==1), "Valid region not contiguous"
-        assert_equal(A['MJD'][ok_A], B['MJD'][i_B], "MJDs don't make sense")
-        for atag, btag, unit in [('UT1_UTC_B', 'UT1_UTC', u.s),
-                                 ('PM_X_B', 'PM_x', u.arcsec),
-                                 ('PM_Y_B', 'PM_y', u.arcsec)]:
-            assert_allclose(
-                    A[atag][ok_A].to(unit).value,
-                    B[btag][i_B].to(unit).value,
-                    atol=1e-5, rtol=1e-5, # should be exactly equal
-                    err_msg="Inserted IERS B {} values don't match IERS_B_FILE {} values".format(atag,btag))
+def test_astropy_IERS_B_vs_downloaded():
+    P = IERS_B.open(IERS_B_FILE)
+    B = IERS_B.open(download_file(IERS_B_URL, cache=True))
+    assert B['MJD'][-1]>P['MJD'][-1]
 
-    copy_columns = [
-        ("UT1_UTC", "UT1_UTC_B"),
-        ("PM_x", "PM_X_B"),
-        ("PM_y", "PM_Y_B"),
-        ("dX_2000A", "dX_2000A_B"),
-        ("dY_2000A", "dY_2000A_B"),
-    ]
-    #@pytest.mark.parametrize("b_name,a_name", copy_columns)
-    @unittest.expectedFailure
-    def test_IERS_B_parameters_loaded_into_IERS_Auto(self):
-        for (b_name, a_name) in self.copy_columns:
-            A = IERS_Auto.open()
-            A[a_name]
-            B = IERS_B.open(IERS_B_FILE)
+@pytest.mark.xfail(reason="disagreement in current astropy")
+def test_IERS_B_builtin_agree_with_IERS_Auto_dX():
+    A = IERS_Auto.open()
+    B = IERS_B.open(IERS_B_FILE)
+    mjd = B['MJD'].to(u.day).value
+    A.pm_xy(mjd) # ensure that data is available for these dates
 
-            ok_A = A["MJD"] < B["MJD"][-1]
+    # We're going to look up the OK auto values in the B table
+    ok_A = A['MJD'] < B['MJD'][-1]
+    # Let's get rid of some trouble values and see if they agree on a restricted subset
+    # IERS Auto ends with a bunch of 1e20 values meant as sentinels (?)
+    ok_A &= abs(A['dX_2000A_B']) < 1e6*u.marcsec
+    # For some reason IERS B starts with zeros up to MJD 45700? IERS Auto doesn't match this
+    ok_A &= A['MJD'] > 45700*u.d
+    # Maybe the old values are bogus?
+    ok_A &= A['MJD'] > 50000*u.d
 
-            mjds_A = A["MJD"][ok_A].to(u.day).value
-            i_B = np.searchsorted(B["MJD"].to(u.day).value, mjds_A)
+    mjds_A = A['MJD'][ok_A].to(u.day).value
+    i_B = np.searchsorted(B['MJD'].to(u.day).value, mjds_A)
 
-            assert_equal(np.diff(i_B), 1, err_msg="Valid region not contiguous")
-            assert_equal(A["MJD"][ok_A], B["MJD"][i_B], err_msg="MJDs don't make sense")
-            assert_equal(
-                A[a_name][ok_A],
-                B[b_name][i_B],
-                err_msg="IERS B parameter {} not copied over IERS A parameter {}".format(
-                    b_name, a_name
-                ),
-            )
+    assert np.all(np.diff(i_B)==1), "Valid region not contiguous"
+    assert_equal(A['MJD'][ok_A], B['MJD'][i_B], "MJDs don't make sense")
+    assert_allclose(
+            A['dX_2000A_B'][ok_A].to(u.marcsec).value,
+            B['dX_2000A'][i_B].to(u.marcsec).value,
+            atol=1e-5, rtol=1e-3,
+            err_msg="IERS B values included in IERS A (dX_2000A) don't match IERS_B_FILE values")
+
+def test_IERS_B_builtin_agree_with_IERS_Auto():
+    """The UT1-UTC, PM_X, and PM_Y values are correctly copied"""
+    A = IERS_Auto.open()
+    B = IERS_B.open(IERS_B_FILE)
+    mjd = B['MJD'].to(u.day).value
+    A.pm_xy(mjd) # ensure that data is available for these dates
+
+    # We're going to look up the OK auto values in the B table
+    ok_A = A['MJD'] < B['MJD'][-1]
+    # Let's get rid of some trouble values and see if they agree on a restricted subset
+    # IERS Auto ends with a bunch of 1e20 values meant as sentinels (?)
+    ok_A &= abs(A['PM_X_B']) < 1e6*u.marcsec
+    # For some reason IERS B starts with zeros up to MJD 45700? IERS Auto doesn't match this
+    ok_A &= A['MJD'] > 45700*u.d
+    # Maybe the old values are bogus?
+    ok_A &= A['MJD'] > 50000*u.d
+
+    mjds_A = A['MJD'][ok_A].to(u.day).value
+    i_B = np.searchsorted(B['MJD'].to(u.day).value, mjds_A)
+
+    assert np.all(np.diff(i_B)==1), "Valid region not contiguous"
+    assert_equal(A['MJD'][ok_A], B['MJD'][i_B], "MJDs don't make sense")
+    for atag, btag, unit in [('UT1_UTC_B', 'UT1_UTC', u.s),
+                             ('PM_X_B', 'PM_x', u.arcsec),
+                             ('PM_Y_B', 'PM_y', u.arcsec)]:
+        assert_allclose(
+                A[atag][ok_A].to(unit).value,
+                B[btag][i_B].to(unit).value,
+                atol=1e-5, rtol=1e-5, # should be exactly equal
+                err_msg="Inserted IERS B {} values don't match IERS_B_FILE {} values".format(atag,btag))
+
+copy_columns = [
+    ("UT1_UTC", "UT1_UTC_B"),
+    ("PM_x", "PM_X_B"),
+    ("PM_y", "PM_Y_B"),
+    pytest.param("dX_2000A", "dX_2000A_B", marks=pytest.mark.xfail(reason="Bug in astropy")),
+    pytest.param("dY_2000A", "dY_2000A_B", marks=pytest.mark.xfail(reason="Bug in astropy")),
+]
+@pytest.mark.parametrize("b_name,a_name", copy_columns)
+def test_IERS_B_parameters_loaded_into_IERS_Auto(b_name, a_name):
+    A = IERS_Auto.open()
+    A[a_name]
+    B = IERS_B.open(IERS_B_FILE)
+
+    ok_A = A["MJD"] < B["MJD"][-1]
+
+    mjds_A = A["MJD"][ok_A].to(u.day).value
+    i_B = np.searchsorted(B["MJD"].to(u.day).value, mjds_A)
+
+    assert_equal(np.diff(i_B), 1, err_msg="Valid region not contiguous")
+    assert_equal(A["MJD"][ok_A], B["MJD"][i_B], err_msg="MJDs don't make sense")
+    assert_equal(
+        A[a_name][ok_A],
+        B[b_name][i_B],
+        err_msg="IERS B parameter {} not copied over IERS A parameter {}".format(
+            b_name, a_name
+        ),
+    )
 

--- a/tests/test_times.py
+++ b/tests/test_times.py
@@ -64,7 +64,7 @@ def test_times_against_tempo2():
         pint_opv = erfautils.gcrs_posvel_from_itrf(
                 Observatory.get(TOA['obs']).earth_location_itrf(),
                 TOA, obsname=TOA['obs'])
-        pint_opv = utils.PosVel(pint_opv.pos.T[0], pint_opv.vel.T[0])
+        pint_opv = utils.PosVel(pint_opv.pos, pint_opv.vel)
         #print " obs  T2:", t2_opv.pos.to(u.m).value, t2_opv.vel.to(u.m/u.s)
         #print " obs PINT:", pint_opv.pos.to(u.m), pint_opv.vel.to(u.m/u.s)
         dopv = pint_opv - t2_opv

--- a/tests/test_times.py
+++ b/tests/test_times.py
@@ -9,7 +9,7 @@ import os
 
 from pinttestdata import testdir, datadir
 
-def test_times():
+def test_times_against_tempo2():
     log.setLevel('ERROR')
     # for nice output info, set the following instead
     #log.setLevel('INFO')


### PR DESCRIPTION
Previously erfautils did not update its IERS B table after the first use, leaving it to grow potentially months old, and silently extrapolating from the last download if necessary. Now it re-downloads it when out of date - that is, when erfautils encounters a time past the end of the table it has.

Added test cases to, among other things, compare with astropy's built-in position/velocity calculation, which uses IERS A. 

Closes #469 
Relevant to #383 
Conflicts with PR #502 in that it supersedes the handling of the IERS B table
