### PR TITLE
Remove numpy import in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,6 @@ import os
 import sys
 import hashlib
 import os.path
-# !! This means setup.py can't even be run without numpy installed!
-import numpy
 
 import versioneer
 


### PR DESCRIPTION
As it stands, it is not possible to run setup.py to find out what PINT's dependencies are unless numpy is already installed. But since Cython was removed, we no longer need to import numpy there.