### PR TITLE
Fix buggy time conversion code

### DIFF
--- a/docs/structure.rst
+++ b/docs/structure.rst
@@ -77,6 +77,11 @@ We intend that PINT have facilities for managing parameter files that are
 ambiguous by this definition, whether by applying heuristics or by allowing
 users to clarify their intent.
 
+This scheme as it stands has a problem: some parameter files found "in the
+wild" specify equatorial coordinates for the pulsar but ecliptic values for the
+proper motion. These files should certainly use ecliptic coordinates for
+fitting.
+
 Timing files (``.tim``)
 -----------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -193,8 +193,15 @@ deviations of this observatory clock and record them in a file. PINT
 also needs up-to-date versions of these observatory clock correction files
 to produce accurate results.
 
-Even more detail about how PINT handles time scales is available on the
-github wiki_.
+Even more detail about how PINT handles time scales is available on the github
+wiki_.
+
+Specifically, there is a complexity in using MJDs to specify times in the UTC
+time scale, which is the customary way observatories work. PINT attempts to
+handle this correctly by default, but if you see timing anomalies on days with
+leap seconds, this may be the problem. Alternatively, you may not be using
+up-to-date leap-second data files, or the process that generated the MJDs may
+not (this is a particular concern when working with X-ray or gamma-ray data).
 
 .. _International_Earth_Rotation_Service: https://www.iers.org/IERS/EN/Home/home_node.html
 .. _TAI: https://www.bipm.org/en/bipm-services/timescales/tai.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.11.0
-astropy>=2.0
+astropy>=2.0, <4.0
 scipy>=0.18.1
 jplephem>=2.6
 matplotlib>=1.5.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,8 +3,8 @@ pip>=9.0.1
 coverage>=4.3.4
 Sphinx>=1.8.5; python_version < "3.0"
 Sphinx>=2.2; python_version >= "3.0"
-astropy>=2.0; python_version < "3.0"
-astropy>=3.1; python_version >="3.0"
+astropy>=2.0,<4.0; python_version < "3.0"
+astropy>=3.1,<4.0; python_version >="3.0"
 #astropy-helpers>=1.3
 sphinx-rtd-theme>=0.1.9
 coveralls>=1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ package_dir =
 include_package_data = True
 install_requires =
     astropy>=2.0; python_version < "3.0"
-    astropy>=3.2; python_version >= "3.0"
+    astropy>=3.2, <4.0; python_version >= "3.0"
     numpy>=1.11.0
     astropy>=2.0
     scipy>=0.18.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -106,3 +106,10 @@ rst-roles =
     class,
     module,
     func,
+
+[isort]
+multi_line_output = 3
+line_length = 88
+skip_glob =
+    src/pint/extern/*
+include_trailing_comma = True

--- a/src/pint/__init__.py
+++ b/src/pint/__init__.py
@@ -1,19 +1,21 @@
 # Top-level PINT __init__.py
+import astropy.constants as c
+import astropy.time as time
+import astropy.units as u
+import numpy as np
+from astropy.units import si
+
+import pint.pulsar_mjd
+from pint.extern._version import get_versions
+
 """
 PINT Is Not TEMPO3!
 """
 
-from .extern._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
 # Define a few important constants
-import astropy.units as u
-from astropy.units import si
-import astropy.constants as c
-import astropy.time as time
-import numpy as np
-from . import utils
 
 # light-second unit
 ls = u.def_unit('ls', c.c * 1.0 * u.s)
@@ -37,7 +39,7 @@ Tsun = (GMsun / c.c**3).to(u.s)
 # Planet system(!) masses in time units
 Tmercury = Tsun / 6023600.
 Tvenus = Tsun / 408523.71
-Tearth = Tsun / 328900.56 # Includes Moon!
+Tearth = Tsun / 328900.56  # Includes Moon!
 Tmars = Tsun / 3098708.
 Tjupiter = Tsun / 1047.3486
 Tsaturn = Tsun / 3497.898
@@ -46,9 +48,9 @@ Tneptune = Tsun / 19412.24
 
 # The Epoch J2000
 J2000 = time.Time('2000-01-01 12:00:00', scale='utc')
-J2000ld = utils.time_to_longdouble(J2000)
+J2000ld = pint.pulsar_mjd.time_to_longdouble(J2000)
 JD_MJD = 2400000.5
 # PINT special units list
-pint_units = {'H:M:S':u.hourangle,'D:M:S':u.deg,'lt-s':ls,'ls':ls,'Tsun':Tsun,
-              'GMsun':GMsun,'MJD':u.day,'pulse phase':u.cycle,
+pint_units = {'H:M:S': u.hourangle, 'D:M:S': u.deg, 'lt-s': ls, 'ls': ls, 'Tsun': Tsun,
+              'GMsun': GMsun, 'MJD': u.day, 'pulse phase': u.cycle,
               'hourangle_second': hourangle_second}

--- a/src/pint/erfautils.py
+++ b/src/pint/erfautils.py
@@ -9,7 +9,7 @@ from astropy.utils.data import (clear_download_cache, download_file,
                                 is_url_in_cache)
 from astropy.utils.iers import IERS_B, IERS_B_URL
 
-from . import utils
+from pint.utils import PosVel
 
 try:
     import astropy.erfa as erfa
@@ -145,7 +145,7 @@ def gcrs_posvel_from_itrf(loc, toas, obsname='obs'):
     vels = np.empty((N, 3), dtype=np.float64)
     poss = np.einsum('ij,ijk->ik', iposs, rc2i)
     vels = np.einsum('ij,ijk->ik', ivels, rc2i)
-    r = utils.PosVel(poss.T * u.m, vels.T * u.m / u.s,
+    r = PosVel(poss.T * u.m, vels.T * u.m / u.s,
                      obj=obsname, origin="earth")
     if unpack:
         return r[0]
@@ -200,7 +200,7 @@ def astropy_gcrs_posvel_from_itrf(loc, toas, obsname=None):
     t = ttoas
 
     pos, vel = loc.get_gcrs_posvel(t)
-    r = utils.PosVel(pos.xyz, vel.xyz, obj=obsname, origin="earth")
+    r = PosVel(pos.xyz, vel.xyz, obj=obsname, origin="earth")
     if unpack:
         return r[0]
     else:

--- a/src/pint/event_toas.py
+++ b/src/pint/event_toas.py
@@ -4,7 +4,7 @@ import numpy as np
 import pint.toa as toa
 from astropy import log
 import astropy.io.fits as pyfits
-from .fits_utils import read_fits_event_mjds_tuples
+from pint.fits_utils import read_fits_event_mjds_tuples
 
 # fits_extension can be a single name or a comma-separated list of allowed
 # extension names.

--- a/src/pint/fits_utils.py
+++ b/src/pint/fits_utils.py
@@ -4,11 +4,8 @@ import astropy.io.fits as pyfits
 import numpy as np
 from astropy import log
 import six
-try:
-    from astropy.erfa import DAYSEC as SECS_PER_DAY
-except ImportError:
-    from astropy._erfa import DAYSEC as SECS_PER_DAY
-from .utils import fortran_float
+from astropy._erfa import DAYSEC as SECS_PER_DAY
+from pint.pulsar_mjd import fortran_float
 
 def read_fits_event_mjds_tuples(event_hdu,timecolumn='TIME'):
     """Read a set of MJDs from a FITS HDU, with proper converstion of times to MJD

--- a/src/pint/ltinterface.py
+++ b/src/pint/ltinterface.py
@@ -9,7 +9,7 @@ import pint.toa as pt
 from pint.phase import Phase
 from pint.residuals import Residuals
 from pint import fitter
-from .utils import has_astropy_unit
+from pint.utils import has_astropy_unit
 import astropy.units as u
 import astropy.constants as ac
 import astropy.coordinates.angles as ang

--- a/src/pint/models/__init__.py
+++ b/src/pint/models/__init__.py
@@ -1,25 +1,24 @@
-# __init__.py for PINT models/ directory
 """Implementations of pulsar timing models."""
 # Import the main timing model classes
-from .timing_model import TimingModel
+from pint.models.timing_model import TimingModel
 
 # Import all standard model components here
-from .astrometry import AstrometryEquatorial, AstrometryEcliptic
-from .binary_bt import BinaryBT
-from .binary_dd import BinaryDD
-from .binary_ell1 import BinaryELL1, BinaryELL1H
-from .binary_ddk import BinaryDDK
-from .dispersion_model import DispersionDM, DispersionDMX
-from .solar_wind_dispersion import SolarWindDispersion
-from .spindown import Spindown
-from .frequency_dependent import FD
-from .absolute_phase import AbsPhase
-from .glitch import Glitch
-from .jump import DelayJump, PhaseJump
-from .solar_system_shapiro import SolarSystemShapiro
-from .noise_model import ScaleToaError, EcorrNoise, PLRedNoise
-from .model_builder import get_model
-from .wave import Wave
+from pint.models.astrometry import AstrometryEquatorial, AstrometryEcliptic
+from pint.models.binary_bt import BinaryBT
+from pint.models.binary_dd import BinaryDD
+from pint.models.binary_ell1 import BinaryELL1, BinaryELL1H
+from pint.models.binary_ddk import BinaryDDK
+from pint.models.dispersion_model import DispersionDM, DispersionDMX
+from pint.models.solar_wind_dispersion import SolarWindDispersion
+from pint.models.spindown import Spindown
+from pint.models.frequency_dependent import FD
+from pint.models.absolute_phase import AbsPhase
+from pint.models.glitch import Glitch
+from pint.models.jump import DelayJump, PhaseJump
+from pint.models.solar_system_shapiro import SolarSystemShapiro
+from pint.models.noise_model import ScaleToaError, EcorrNoise, PLRedNoise
+from pint.models.model_builder import get_model
+from pint.models.wave import Wave
 
 # Define a standard basic model
 StandardTimingModel = TimingModel("StandardTimingModel",

--- a/src/pint/models/absolute_phase.py
+++ b/src/pint/models/absolute_phase.py
@@ -1,12 +1,13 @@
 """Timing model absolute phase (TZRMJD, TZRSITE ...)"""
-from __future__ import absolute_import, print_function, division
-from warnings import warn
-from astropy import log
-from . import parameter as p
-from .timing_model import PhaseComponent, MissingParameter
+from __future__ import absolute_import, division, print_function
+
 import astropy.units as u
+from astropy import log
+
 import pint.toa as toa
-import numpy as np
+from pint.models.parameter import MJDParameter, floatParameter, strParameter
+from pint.models.timing_model import MissingParameter, PhaseComponent
+
 
 class AbsPhase(PhaseComponent):
     """Absolute phase model.
@@ -23,11 +24,11 @@ class AbsPhase(PhaseComponent):
 
     def __init__(self):
         super(AbsPhase, self).__init__()
-        self.add_param(p.MJDParameter(name="TZRMJD",
+        self.add_param(MJDParameter(name="TZRMJD",
                        description="Epoch of the zero phase."))
-        self.add_param(p.strParameter(name="TZRSITE",
+        self.add_param(strParameter(name="TZRSITE",
                        description="Observatory of the zero phase measured."))
-        self.add_param(p.floatParameter(name="TZRFRQ", units=u.MHz,
+        self.add_param(floatParameter(name="TZRFRQ", units=u.MHz,
                        description="The frequency of the zero phase mearsured."))
 
     def setup(self):
@@ -57,13 +58,13 @@ class AbsPhase(PhaseComponent):
         TZR_toa = toa.TOA((self.TZRMJD.quantity.jd1-2400000.5, self.TZRMJD.quantity.jd2), obs=self.TZRSITE.value,
                           freq=self.TZRFRQ.quantity)
         clkc_info = toas.clock_corr_info
-        tz = toa.get_TOAs_list([TZR_toa,], include_bipm=clkc_info['include_bipm'],
+        tz = toa.get_TOAs_list([TZR_toa], include_bipm=clkc_info['include_bipm'],
                                include_gps=clkc_info['include_gps'],
                                ephem=toas.ephem, planets=toas.planets)
         return tz
 
     def make_TZR_toa(self, toas):
-        """ Calculate the TZRMJD if one not given. 
+        """ Calculate the TZRMJD if one not given.
         TZRMJD = first toa after PEPOCH.
         """
         PEPOCH = self.PEPOCH.quantity.value

--- a/src/pint/models/binary_bt.py
+++ b/src/pint/models/binary_bt.py
@@ -5,10 +5,10 @@ See Blandford & Teukolsky 1976, ApJ, 205, 580.
 """
 from __future__ import absolute_import, print_function, division
 from pint import ls,GMsun,Tsun
-from .stand_alone_psr_binaries.BT_model import BTmodel
-from .pulsar_binary import PulsarBinary
-from . import parameter as p
-from .timing_model import TimingModel, MissingParameter
+from pint.models.stand_alone_psr_binaries.BT_model import BTmodel
+from pint.models.pulsar_binary import PulsarBinary
+from pint.models.parameter import floatParameter
+from pint.models.timing_model import TimingModel, MissingParameter
 import astropy.units as u
 
 class BinaryBT(PulsarBinary):
@@ -28,7 +28,7 @@ class BinaryBT(PulsarBinary):
         self.binary_model_name = 'BT'
         self.binary_model_class = BTmodel
 
-        self.add_param(p.floatParameter(name="GAMMA", value=0.0,
+        self.add_param(floatParameter(name="GAMMA", value=0.0,
              units="second",
              description="Time dilation & gravitational redshift"))
         # remove unused parameter.

--- a/src/pint/models/binary_dd.py
+++ b/src/pint/models/binary_dd.py
@@ -1,10 +1,9 @@
-from __future__ import absolute_import, print_function, division
-from pint import ls,GMsun,Tsun
-from .stand_alone_psr_binaries.DD_model import DDmodel
-from .pulsar_binary import PulsarBinary
-from . import parameter as p
-from .timing_model import MissingParameter
-import astropy.units as u
+from __future__ import absolute_import, division, print_function
+
+from pint.models.parameter import floatParameter
+from pint.models.pulsar_binary import PulsarBinary
+from pint.models.stand_alone_psr_binaries.DD_model import DDmodel
+from pint.models.timing_model import MissingParameter
 
 
 class BinaryDD(PulsarBinary):
@@ -25,23 +24,23 @@ class BinaryDD(PulsarBinary):
         super(BinaryDD, self).__init__()
         self.binary_model_name = 'DD'
         self.binary_model_class = DDmodel
-        self.add_param(p.floatParameter(name="A0", value=0.0,
+        self.add_param(floatParameter(name="A0", value=0.0,
              units="s",
              description="DD model aberration parameter A0"))
 
-        self.add_param(p.floatParameter(name="B0", value=0.0,
+        self.add_param(floatParameter(name="B0", value=0.0,
              units="s",
              description="DD model aberration parameter B0",))
 
-        self.add_param(p.floatParameter(name="GAMMA", value=0.0,
+        self.add_param(floatParameter(name="GAMMA", value=0.0,
              units="second",
              description="Time dilation & gravitational redshift"))
 
-        self.add_param(p.floatParameter(name="DR", value=0.0,
+        self.add_param(floatParameter(name="DR", value=0.0,
              units="",
              description="Relativistic deformation of the orbit"))
 
-        self.add_param(p.floatParameter(name="DTH", value=0.0,
+        self.add_param(floatParameter(name="DTH", value=0.0,
              units="",
              description="Relativistic deformation of the orbit",))
 

--- a/src/pint/models/binary_ddk.py
+++ b/src/pint/models/binary_ddk.py
@@ -1,12 +1,12 @@
 """The DDK model - DD with kinematics."""
-from __future__ import absolute_import, print_function, division
-from pint import ls,GMsun,Tsun
-from .stand_alone_psr_binaries.DDK_model import DDKmodel
-from .binary_dd import BinaryDD
-from . import parameter as p
-from .timing_model import MissingParameter
-import astropy.units as u
+from __future__ import absolute_import, division, print_function
+
 from astropy import log
+
+from pint.models.binary_dd import BinaryDD
+from pint.models.parameter import boolParameter, floatParameter
+from pint.models.stand_alone_psr_binaries.DDK_model import DDKmodel
+from pint.models.timing_model import MissingParameter
 
 
 class BinaryDDK(BinaryDD):
@@ -32,19 +32,19 @@ class BinaryDDK(BinaryDD):
         self.binary_model_name = 'DDK'
         self.binary_model_class = DDKmodel
 
-        self.add_param(p.floatParameter(name='KIN', value=0.0, units="deg",
+        self.add_param(floatParameter(name='KIN', value=0.0, units="deg",
                        description="Inclination angle"))
-        self.add_param(p.floatParameter(name='KOM', value=0.0, units="deg",
+        self.add_param(floatParameter(name='KOM', value=0.0, units="deg",
                        description="The longitude of the ascending node"))
-        self.add_param(p.boolParameter(name='K96',
-                       description="Flag for Kopeikin binary model proper motion" + \
+        self.add_param(boolParameter(name='K96',
+                       description="Flag for Kopeikin binary model proper motion"
                        " correction"))
         self.interal_params += ['PMRA_DDK', 'PMDEC_DDK']
 
     @property
     def PMRA_DDK(self):
         params = self.get_params_as_ICRS()
-        par_obj = p.floatParameter(name="PMRA",
+        par_obj = floatParameter(name="PMRA",
             units="mas/year", value=params["PMRA"],
             description="Proper motion in RA")
         return par_obj
@@ -52,7 +52,7 @@ class BinaryDDK(BinaryDD):
     @property
     def PMDEC_DDK(self):
         params = self.get_params_as_ICRS()
-        par_obj = p.floatParameter(name="PMDEC",
+        par_obj = floatParameter(name="PMDEC",
             units="mas/year", value=params["PMDEC"],
             description="Proper motion in DEC")
         return par_obj

--- a/src/pint/models/binary_ell1.py
+++ b/src/pint/models/binary_ell1.py
@@ -1,17 +1,13 @@
-from __future__ import absolute_import, print_function, division
-import numpy as np
-import time
-from pint import ls,GMsun,Tsun
-from pint import utils
-from .stand_alone_psr_binaries.ELL1_model import ELL1model
-from .stand_alone_psr_binaries.ELL1H_model import ELL1Hmodel
-from .pulsar_binary import PulsarBinary
-from . import parameter as p
-from .timing_model import MissingParameter
-import astropy
-from ..utils import time_from_mjd_string, time_to_longdouble
-import astropy.units as u
+from __future__ import absolute_import, division, print_function
+
 from warnings import warn
+
+from pint.models.parameter import MJDParameter, floatParameter
+from pint.models.pulsar_binary import PulsarBinary
+from pint.models.stand_alone_psr_binaries.ELL1_model import ELL1model
+from pint.models.stand_alone_psr_binaries.ELL1H_model import ELL1Hmodel
+from pint.models.timing_model import MissingParameter
+
 
 class BinaryELL1Base(PulsarBinary):
     """PINT wrapper around standalone ELL1 model.
@@ -33,22 +29,22 @@ class BinaryELL1Base(PulsarBinary):
 
     def __init__(self):
         super(BinaryELL1Base, self).__init__()
-        self.add_param(p.MJDParameter(name="TASC",
+        self.add_param(MJDParameter(name="TASC",
                        description="Epoch of ascending node", time_scale='tdb'))
 
-        self.add_param(p.floatParameter(name="EPS1", units="",
+        self.add_param(floatParameter(name="EPS1", units="",
              description="First Laplace-Lagrange parameter, ECC x sin(OM) for ELL1 model",
              long_double = True))
 
-        self.add_param(p.floatParameter(name="EPS2", units="",
+        self.add_param(floatParameter(name="EPS2", units="",
              description="Second Laplace-Lagrange parameter, ECC x cos(OM) for ELL1 model",
              long_double = True))
 
-        self.add_param(p.floatParameter(name="EPS1DOT", units="1e-12/s",
+        self.add_param(floatParameter(name="EPS1DOT", units="1e-12/s",
              description="First derivative of first Laplace-Lagrange parameter",
              long_double = True))
 
-        self.add_param(p.floatParameter(name="EPS2DOT", units="1e-12/s",
+        self.add_param(floatParameter(name="EPS2DOT", units="1e-12/s",
              description="Second derivative of first Laplace-Lagrange parameter",
              long_double = True))
 
@@ -102,18 +98,18 @@ class BinaryELL1H(BinaryELL1Base):
         self.binary_model_name = 'ELL1H'
         self.binary_model_class = ELL1Hmodel
 
-        self.add_param(p.floatParameter(name="H3", units="second",
+        self.add_param(floatParameter(name="H3", units="second",
                   description="Shapiro delay parameter H3 as in Freire and Wex 2010 Eq(20)",
                   long_double = True))
 
-        self.add_param(p.floatParameter(name="H4", units="second",
+        self.add_param(floatParameter(name="H4", units="second",
                   description="Shapiro delay parameter H4 as in Freire and Wex 2010 Eq(21)",
                   long_double = True))
 
-        self.add_param(p.floatParameter(name="STIGMA", units="",
+        self.add_param(floatParameter(name="STIGMA", units="",
                   description="Shapiro delay parameter STIGMA as in Freire and Wex 2010 Eq(12)",
                   long_double = True))
-        self.add_param(p.floatParameter(name="NHARMS", units="", value=3,
+        self.add_param(floatParameter(name="NHARMS", units="", value=3,
                   description="Number of harmonics for ELL1H shapiro delay."))
 
     @property

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -1,15 +1,15 @@
 """A simple model of a base dispersion delay and DMX dispersion."""
-from __future__ import absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function
+
 from warnings import warn
-from . import parameter as p
-from .timing_model import DelayComponent, MissingParameter
+
 import astropy.units as u
-import astropy.constants as const
 import numpy as np
-import pint.utils as ut
-import astropy.time as time
-from ..toa_select import TOASelect
-from ..utils import taylor_horner, split_prefixed_name
+
+from pint.models.parameter import MJDParameter, floatParameter, prefixParameter
+from pint.models.timing_model import DelayComponent, MissingParameter
+from pint.toa_select import TOASelect
+from pint.utils import split_prefixed_name, taylor_horner
 
 # The units on this are not completely correct
 # as we don't really use the "pc cm^3" units on DM.
@@ -62,14 +62,14 @@ class DispersionDM(Dispersion):
     category = 'dispersion_constant'
     def __init__(self):
         super(DispersionDM, self).__init__()
-        self.add_param(p.floatParameter(name="DM", units="pc cm^-3", value=0.0,
+        self.add_param(floatParameter(name="DM", units="pc cm^-3", value=0.0,
                        description="Dispersion measure", long_double=True))
-        self.add_param(p.prefixParameter(name="DM1", value=0.0, units='pc cm^-3/yr^1',
+        self.add_param(prefixParameter(name="DM1", value=0.0, units='pc cm^-3/yr^1',
                        description="First order time derivative of the dispersion measure",
                        unit_template=self.DM_dervative_unit,
                        description_template=self.DM_dervative_description,
                        type_match='float', long_double=True))
-        self.add_param(p.MJDParameter(name="DMEPOCH",
+        self.add_param(MJDParameter(name="DMEPOCH",
                        description="Epoch of DM measurement"))
 
         self.dm_value_funcs += [self.base_dm,]
@@ -180,22 +180,22 @@ class DispersionDMX(Dispersion):
     def __init__(self):
         super(DispersionDMX, self).__init__()
         # DMX is for info output right now
-        self.add_param(p.floatParameter(name="DMX",
+        self.add_param(floatParameter(name="DMX",
                        units="pc cm^-3", value=0.0,
                        description="Dispersion measure"))
-        self.add_param(p.prefixParameter(name='DMX_0001',
+        self.add_param(prefixParameter(name='DMX_0001',
                        units="pc cm^-3", value=0.0,
                        unit_template=lambda x: "pc cm^-3",
                        description='Dispersion measure variation',
                        description_template=lambda x: "Dispersion measure",
                        paramter_type='float'))
-        self.add_param(p.prefixParameter(name='DMXR1_0001',
+        self.add_param(prefixParameter(name='DMXR1_0001',
                        units="MJD",
                        unit_template=lambda x: "MJD",
                        description='Beginning of DMX interval',
                        description_template=lambda x: 'Beginning of DMX interval',
                        parameter_type='MJD', time_scale='utc'))
-        self.add_param(p.prefixParameter(name='DMXR2_0001', units="MJD",
+        self.add_param(prefixParameter(name='DMXR2_0001', units="MJD",
                        unit_template=lambda x: "MJD",
                        description='End of DMX interval',
                        description_template=lambda x: 'End of DMX interval',

--- a/src/pint/models/frequency_dependent.py
+++ b/src/pint/models/frequency_dependent.py
@@ -1,12 +1,14 @@
 """A frequency evolution of pulsar profiles model"""
-from __future__ import absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function
+
 from warnings import warn
-from . import parameter as p
-from .timing_model import DelayComponent, MissingParameter
+
 import astropy.units as u
 import numpy as np
-import pint.utils as ut
-import astropy.time as time
+
+from pint.models.parameter import prefixParameter
+from pint.models.timing_model import DelayComponent, MissingParameter
+
 
 class FD(DelayComponent):
     """A timing model for frequency evolution of pulsar profiles."""
@@ -15,7 +17,7 @@ class FD(DelayComponent):
 
     def __init__(self):
         super(FD, self).__init__()
-        self.add_param(p.prefixParameter(name='FD1', units="second", value=0.0,
+        self.add_param(prefixParameter(name='FD1', units="second", value=0.0,
                        descriptionTplt=lambda x: ("%d term of frequency"
                                                   " dependent  coefficients" % x),
                        unitTplt=lambda x: 'second',

--- a/src/pint/models/glitch.py
+++ b/src/pint/models/glitch.py
@@ -1,21 +1,15 @@
 """Pulsar timing glitches."""
 # glitch.py
 # Defines glitch timing model class
-from __future__ import absolute_import, print_function, division
-import numpy as np
-import astropy.units as u
-try:
-    from astropy.erfa import DAYSEC as SECS_PER_DAY
-except ImportError:
-    from astropy._erfa import DAYSEC as SECS_PER_DAY
-from .parameter import Parameter, MJDParameter, prefixParameter
-from .timing_model import PhaseComponent, MissingParameter
-from ..phase import *
-from ..utils import time_from_mjd_string, str2longdouble, \
-    taylor_horner, split_prefixed_name
+from __future__ import absolute_import, division, print_function
 
-# The maximum number of glitches we allow
-maxglitches = 10  # Have not use this one in the new version.
+import astropy.units as u
+import numpy as np
+
+from pint import dimensionless_cycles
+from pint.models.parameter import prefixParameter
+from pint.models.timing_model import MissingParameter, PhaseComponent
+from pint.utils import split_prefixed_name
 
 
 class Glitch(PhaseComponent):

--- a/src/pint/models/jump.py
+++ b/src/pint/models/jump.py
@@ -1,12 +1,14 @@
 """Phase jumps. """
 # phase_jump.py
 # Defines PhaseJump timing model class
-from __future__ import absolute_import, print_function, division
-import numpy
+from __future__ import absolute_import, division, print_function
+
 import astropy.units as u
-from .timing_model import DelayComponent, PhaseComponent, MissingParameter
-from . import parameter as p
+import numpy
+
 from pint import dimensionless_cycles
+from pint.models.parameter import maskParameter
+from pint.models.timing_model import DelayComponent, MissingParameter, PhaseComponent
 
 
 class DelayJump(DelayComponent):
@@ -23,7 +25,7 @@ class DelayJump(DelayComponent):
     def __init__(self):
         super(DelayJump, self).__init__()
         # TODO: In the future we should have phase jump as well.
-        self.add_param(p.maskParameter(name = 'JUMP', units='second'))
+        self.add_param(maskParameter(name = 'JUMP', units='second'))
         self.delay_funcs_component += [self.jump_delay,]
 
     def setup(self):
@@ -72,7 +74,7 @@ class PhaseJump(PhaseComponent):
     category = 'phase_jump'
     def __init__(self):
         super(PhaseJump, self).__init__()
-        self.add_param(p.maskParameter(name = 'JUMP', units='second'))
+        self.add_param(maskParameter(name = 'JUMP', units='second'))
         self.phase_funcs_component += [self.jump_phase,]
 
     def setup(self):

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -11,7 +11,7 @@ from astropy import log
 
 from pint.utils import split_prefixed_name, interesting_lines, lines_of, PrefixError
 
-from .timing_model import Component, TimingModel, MissingParameter, ignore_prefix
+from pint.models.timing_model import Component, TimingModel, MissingParameter, ignore_prefix
 
 default_models = ["StandardTimingModel",]
 DEFAULT_ORDER = ['astrometry', 'jump_delay', 'solar_system_shapiro',

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -6,8 +6,8 @@ import astropy.units as u
 import numpy as np
 from astropy import log
 
-from . import parameter as p
-from .timing_model import Component
+from pint.models.parameter import maskParameter, floatParameter
+from pint.models.timing_model import Component
 
 
 class NoiseComponent(Component):
@@ -30,23 +30,23 @@ class ScaleToaError(NoiseComponent):
     category = 'scale_toa_error'
     def __init__(self,):
         super(ScaleToaError, self).__init__()
-        self.add_param(p.maskParameter(name ='EFAC', units="",
-                                       aliases=['T2EFAC', 'TNEF'],
-                                       description="A multiplication factor on" \
-                                                   " the measured TOA uncertainties,"))
+        self.add_param(maskParameter(name ='EFAC', units="",
+                                     aliases=['T2EFAC', 'TNEF'],
+                                     description="A multiplication factor on"
+                                                 " the measured TOA uncertainties,"))
 
-        self.add_param(p.maskParameter(name='EQUAD', units="us",\
-                                       aliases=['T2EQUAD'],
-                                       description="An error term added in "
+        self.add_param(maskParameter(name='EQUAD', units="us",
+                                     aliases=['T2EQUAD'],
+                                     description="An error term added in "
                                                   "quadrature to the scaled (by"
                                                   " EFAC) TOA uncertainty."))
 
-        self.add_param(p.maskParameter(name='TNEQ', \
-                                       units=u.LogUnit(physical_unit=u.second),\
-                                       description="An error term added in "
-                                                  "quadrature to the scaled (by"
-                                                  " EFAC) TOA uncertainty in "
-                                                  " the unit of log10(second)."))
+        self.add_param(maskParameter(name='TNEQ',
+                                     units=u.LogUnit(physical_unit=u.second),
+                                     description="An error term added in "
+                                                 "quadrature to the scaled (by"
+                                                 " EFAC) TOA uncertainty in "
+                                                 " the unit of log10(second)."))
         self.covariance_matrix_funcs += [self.sigma_scaled_cov_matrix, ]
         self.scaled_sigma_funcs += [self.scale_sigma, ]
 
@@ -155,11 +155,11 @@ class EcorrNoise(NoiseComponent):
     def __init__(self,):
         super(EcorrNoise, self).__init__()
         self.introduces_correlated_errors = True
-        self.add_param(p.maskParameter(name='ECORR', units="us",\
-                                       aliases=['TNECORR'],
-                                       description="An error term added that"\
-                                                  " correlated all TOAs in an"\
-                                                  " observing epoch."))
+        self.add_param(maskParameter(name='ECORR', units="us",
+                                     aliases=['TNECORR'],
+                                     description="An error term added that"
+                                                 " correlated all TOAs in an"
+                                                 " observing epoch."))
 
 
         self.covariance_matrix_funcs += [self.ecorr_cov_matrix, ]
@@ -241,26 +241,26 @@ class PLRedNoise(NoiseComponent):
     def __init__(self,):
         super(PLRedNoise, self).__init__()
         self.introduces_correlated_errors = True
-        self.add_param(p.floatParameter(name='RNAMP', units="",\
-                                       aliases=[],
-                                       description="Amplitude of powerlaw "\
-                                                "red noise."))
-        self.add_param(p.floatParameter(name='RNIDX', units="",\
-                                       aliases=[],
-                                       description="Spectral index of "\
-                                                "powerlaw red noise."))
+        self.add_param(floatParameter(name='RNAMP', units="",
+                                      aliases=[],
+                                      description="Amplitude of powerlaw "
+                                                  "red noise."))
+        self.add_param(floatParameter(name='RNIDX', units="",
+                                      aliases=[],
+                                      description="Spectral index of "
+                                                  "powerlaw red noise."))
 
-        self.add_param(p.floatParameter(name='TNRedAmp', units="",\
-                                       aliases=[],
-                                       description="Amplitude of powerlaw "\
-                                       "red noise in tempo2 format"))
-        self.add_param(p.floatParameter(name='TNRedGam', units="",\
-                                       aliases=[],
-                                       description="Spectral index of powerlaw "\
-                                       "red noise in tempo2 format"))
-        self.add_param(p.floatParameter(name='TNRedC', units="",\
-                                       aliases=[],
-                                       description="Number of red noise frequencies."))
+        self.add_param(floatParameter(name='TNRedAmp', units="",
+                                      aliases=[],
+                                      description="Amplitude of powerlaw "
+                                      "red noise in tempo2 format"))
+        self.add_param(floatParameter(name='TNRedGam', units="",
+                                      aliases=[],
+                                      description="Spectral index of powerlaw "
+                                      "red noise in tempo2 format"))
+        self.add_param(floatParameter(name='TNRedC', units="",
+                                      aliases=[],
+                                      description="Number of red noise frequencies."))
 
 
         self.covariance_matrix_funcs += [self.pl_rn_cov_matrix, ]

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -498,7 +498,7 @@ class floatParameter(Parameter):
                 raise ValueError("The scale threshold should be given if unit_scale"
                                  " is set to be True.")
         else:
-            if old_unit_scale: # This makes sure the unit_scale if from True to false
+            if old_unit_scale:  # This makes sure the unit_scale if from True to false
                 self.units = self._original_units
 
     def set_quantity_float(self, val):
@@ -529,7 +529,7 @@ class floatParameter(Parameter):
             num_value = setfunc_no_unit(val)
             if self.unit_scale:
                 if np.abs(num_value) > np.abs(self.scale_threshold):
-                    log.info("Parameter %s's unit will be scaled to %s %s" \
+                    log.info("Parameter %s's unit will be scaled to %s %s"
                              % (self.name, str(self.scale_factor), str(self._original_units)))
                     self.units = self.scale_factor * self._original_units
                 else:

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -17,22 +17,30 @@ parameters" and "mask parameters" depending on how they occur in the
 ``.par`` and ``.tim`` files.
 
 """
-from __future__ import absolute_import, print_function, division
-from ..utils import fortran_float, time_from_mjd_string, time_to_mjd_string,\
-    time_to_longdouble, time_from_longdouble, str2longdouble, \
-    longdouble2str, data2longdouble, split_prefixed_name
-import numpy as np
-import astropy.time as time
-from astropy import log
-from pint import pint_units
-from pint import pulsar_mjd
-import astropy.units as u
-import astropy.constants as const
-from astropy.coordinates.angles import Angle
-import re
+from __future__ import absolute_import, division, print_function
+
 import numbers
-from . import priors
-from ..toa_select import TOASelect
+
+import astropy.time as time
+import astropy.units as u
+import numpy as np
+import six
+from astropy import log
+from astropy.coordinates.angles import Angle
+
+from pint import pint_units
+from pint.models import priors
+from pint.toa_select import TOASelect
+from pint.pulsar_mjd import (
+    Time,
+    data2longdouble,
+    fortran_float,
+    str2longdouble,
+    time_from_longdouble,
+    time_to_longdouble,
+    time_to_mjd_string,
+)
+from pint.utils import split_prefixed_name
 
 
 class Parameter(object):
@@ -540,15 +548,11 @@ class floatParameter(Parameter):
 
     def print_quantity_float(self, quan):
         """Quantity as a string (for floating-point values)."""
-        if not self._long_double:
-            result = str(quan.to(self.units).value)
-        else:
-            result = longdouble2str(quan.to(self.units).value)
-            #try:
-            #    result = longdouble2str(quan.to(self.units).value)
-            #except AttributeError:
-            #    result = str(quan)
-        return result
+        v = quan.to(self.units).value
+        if self._long_double:
+            if not isinstance(v, np.longdouble):
+                raise ValueError("Parameter is supposed to contain long double values but contains a float")
+        return str(v)
 
     def get_value_float(self, quan):
         if quan is None:
@@ -749,23 +753,14 @@ class MJDParameter(Parameter):
            Accepted format:
            Astropy time object
            mjd float
-           mjd string
+           mjd string (in pulsar_mjd format)
         """
         if isinstance(val, numbers.Number):
             val = np.longdouble(val)
             result = time_from_longdouble(val, self.time_scale)
-        elif isinstance(val, str):
-            try:
-                result = time_from_mjd_string(val, self.time_scale)
-            except Exception as e:
-                # Would like to chain exceptions so we can keep the original
-                # and add the new message; raise ... from e will do that but
-                # isn't even valid syntax on Python 2
-                msg = ('String "' + val + '" can not be converted to '
-                                 'a time object via time_from_mjd_string.')
-                raise ValueError(msg)
-
-        elif isinstance(val,time.Time):
+        elif isinstance(val, six.string_types):
+            result = Time(val, scale=self.time_scale, format="pulsar_mjd_string")
+        elif isinstance(val, time.Time):
             result = val
         else:
             raise ValueError('MJD parameter can not accept '
@@ -784,7 +779,7 @@ class MJDParameter(Parameter):
         return result
 
     def print_uncertainty(self, uncertainty):
-        return longdouble2str(self.uncertainty_value)
+        return str(self.uncertainty_value)
 
 
 class AngleParameter(Parameter):
@@ -1580,10 +1575,13 @@ class pairParameter(floatParameter):
                 raise ValueError("Don't know how to print this as a pair: %s"
                                  % (quan,))
 
-        if not self._long_double:
-            quan0 = str(quan[0].to(self.units).value)
-            quan1 = str(quan[1].to(self.units).value)
-        else:
-            quan0 = longdouble2str(quan[0].to(self.units).value)
-            quan1 = longdouble2str(quan[1].to(self.units).value)
+        v0 = quan[0].to(self.units).value
+        v1 = quan[1].to(self.units).value
+        if self._long_double:
+            if not isinstance(v0, np.longdouble):
+                raise TypeError("Parameter {} is supposed to contain long doubles but contains a float".format(self))
+            if not isinstance(v1, np.longdouble):
+                raise TypeError("Parameter {} is supposed to contain long doubles but contains a float".format(self))
+        quan0 = str(v0)
+        quan1 = str(v1)
         return quan0 + ' ' + quan1

--- a/src/pint/models/pulsar_binary.py
+++ b/src/pint/models/pulsar_binary.py
@@ -12,10 +12,9 @@ import numpy as np
 from astropy import log
 
 from pint import ls
-
-from . import parameter as p
-from .stand_alone_psr_binaries import binary_orbits as bo
-from .timing_model import DelayComponent, MissingParameter
+from pint.models.parameter import MJDParameter, floatParameter, prefixParameter
+from pint.models.stand_alone_psr_binaries import binary_orbits as bo
+from pint.models.timing_model import DelayComponent, MissingParameter
 
 
 class PulsarBinary(DelayComponent):
@@ -41,44 +40,44 @@ class PulsarBinary(DelayComponent):
         self.binary_model_name = None
         self.barycentric_time = None
         self.binary_model_class = None
-        self.add_param(p.floatParameter(name="PB",
+        self.add_param(floatParameter(name="PB",
             units=u.day,
             description="Orbital period", long_double=True))
-        self.add_param(p.floatParameter(name="PBDOT",
+        self.add_param(floatParameter(name="PBDOT",
             units = u.day/u.day,
             description="Orbital period derivitve respect to time", \
             unit_scale=True, scale_factor=1e-12, scale_threshold=1e-7))
-        self.add_param(p.floatParameter(name="A1",
+        self.add_param(floatParameter(name="A1",
             units=ls,
             description="Projected semi-major axis, a*sin(i)"))
         # NOTE: the DOT here takes the value and times 1e-12, tempo/tempo2 can
         # take both.
-        self.add_param(p.floatParameter(name = "A1DOT", aliases = ['XDOT'],
+        self.add_param(floatParameter(name = "A1DOT", aliases = ['XDOT'],
             units=ls/u.s,
             description="Derivative of projected semi-major axis, da*sin(i)/dt", \
             unit_scale=True, scale_factor=1e-12, scale_threshold=1e-7))
-        self.add_param(p.floatParameter(name="ECC",
+        self.add_param(floatParameter(name="ECC",
             units="",
             aliases = ["E"],
             description="Eccentricity"))
-        self.add_param(p.floatParameter(name="EDOT",
+        self.add_param(floatParameter(name="EDOT",
              units="1/s",
              description="Eccentricity derivitve respect to time", \
              unit_scale=True, scale_factor=1e-12, scale_threshold=1e-7))
-        self.add_param(p.MJDParameter(name="T0",
+        self.add_param(MJDParameter(name="T0",
             description="Epoch of periastron passage", time_scale='tdb'))
-        self.add_param(p.floatParameter(name="OM",
+        self.add_param(floatParameter(name="OM",
             units=u.deg,
             description="Longitude of periastron",long_double=True))
-        self.add_param(p.floatParameter(name="OMDOT",
+        self.add_param(floatParameter(name="OMDOT",
             units="deg/year",
             description="Longitude of periastron", long_double=True))
-        self.add_param(p.floatParameter(name="M2",
+        self.add_param(floatParameter(name="M2",
              units=u.M_sun,
              description="Mass of companian in the unit Sun mass"))
-        self.add_param(p.floatParameter(name="SINI", units="",
+        self.add_param(floatParameter(name="SINI", units="",
              description="Sine of inclination angle"))
-        self.add_param(p.prefixParameter(name="FB0", value=None, units='1/s^1',
+        self.add_param(prefixParameter(name="FB0", value=None, units='1/s^1',
                        description="0th time derivative of frequency of orbit",
                        unit_template=self.FBX_unit, aliases = ['FB'],
                        description_template=self.FBX_description,

--- a/src/pint/models/solar_system_shapiro.py
+++ b/src/pint/models/solar_system_shapiro.py
@@ -1,15 +1,27 @@
 """Solar system Shapiro delay."""
 # solar_system_shapiro.py
 # Add in Shapiro delays due to solar system objects
-from __future__ import absolute_import, print_function, division
-import numpy
-import astropy.units as u
+from __future__ import absolute_import, division, print_function
+
 import astropy.constants as const
+import astropy.units as u
+import numpy
 from astropy import log
-from . import parameter as p
-from .timing_model import DelayComponent
-from .. import Tsun, Tmercury, Tvenus, Tearth, Tmars, \
-        Tjupiter, Tsaturn, Turanus, Tneptune
+
+from pint import (
+    Tearth,
+    Tjupiter,
+    Tmars,
+    Tmercury,
+    Tneptune,
+    Tsaturn,
+    Tsun,
+    Turanus,
+    Tvenus,
+)
+from pint.models.parameter import boolParameter
+from pint.models.timing_model import DelayComponent
+
 
 class SolarSystemShapiro(DelayComponent):
     """Shapiro delay due to light bending near Solar System objects."""
@@ -19,7 +31,7 @@ class SolarSystemShapiro(DelayComponent):
 
     def __init__(self):
         super(SolarSystemShapiro, self).__init__()
-        self.add_param(p.boolParameter(name="PLANET_SHAPIRO",
+        self.add_param(boolParameter(name="PLANET_SHAPIRO",
              value=False, description="Include planetary Shapiro delays (Y/N)"))
         self.delay_funcs_component += [self.solar_system_shapiro_delay,]
 

--- a/src/pint/models/solar_wind_dispersion.py
+++ b/src/pint/models/solar_wind_dispersion.py
@@ -9,9 +9,9 @@ import numpy as np
 
 import pint.utils as ut
 
-from ..toa_select import TOASelect
-from . import parameter as p
-from .dispersion_model import Dispersion, DMconst
+from pint.toa_select import TOASelect
+from pint.models.parameter import floatParameter
+from pint.models.dispersion_model import Dispersion, DMconst
 
 
 class SolarWindDispersion(Dispersion):
@@ -27,10 +27,10 @@ class SolarWindDispersion(Dispersion):
 
     def __init__(self):
         super(SolarWindDispersion, self).__init__()
-        self.add_param(p.floatParameter(name="NE_SW",
+        self.add_param(floatParameter(name="NE_SW",
                        units="cm^-3", value=0.0, aliases=['NE1AU', 'SOLARN0'],
                        description="Solar Wind Parameter"))
-        self.add_param(p.floatParameter(name="SWM",
+        self.add_param(floatParameter(name="SWM",
                        value=0.0, units="",
                        description="Solar Wind Model"))
         self.delay_funcs_component += [self.solar_wind_delay,]

--- a/src/pint/models/stand_alone_psr_binaries/binary_generic.py
+++ b/src/pint/models/stand_alone_psr_binaries/binary_generic.py
@@ -1,19 +1,12 @@
 # This file is a prototype of independent psr binary model class
 from __future__ import absolute_import, print_function, division
 import numpy as np
-import functools
-import collections
 from astropy import log
-import re
-from pint import utils as ut
 import astropy.units as u
 import astropy.constants as c
 from pint import ls, Tsun
-from .binary_orbits import OrbitPB
-try:
-    from astropy.erfa import DAYSEC as SECS_PER_DAY
-except ImportError:
-    from astropy._erfa import DAYSEC as SECS_PER_DAY
+from pint.models.stand_alone_psr_binaries.binary_orbits import OrbitPB
+from astropy._erfa import DAYSEC as SECS_PER_DAY
 SECS_PER_JUL_YEAR = SECS_PER_DAY*365.25
 
 class PSR_BINARY(object):

--- a/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
+++ b/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
@@ -1,5 +1,6 @@
 import re
 import pint.utils as ut
+from pint.utils import taylor_horner, taylor_horner_deriv
 import numpy as np
 import astropy.units as u
 
@@ -135,7 +136,7 @@ class OrbitFBX(orbits):
         while 'FB' + str(ii) in self.orbit_params:
             FBXs.append(getattr(self, 'FB' + str(ii)))
             ii += 1
-        orbits = ut.taylor_horner(self.tt0, FBXs)
+        orbits = taylor_horner(self.tt0, FBXs)
         return orbits.decompose()
 
     def pbprime(self):
@@ -144,7 +145,7 @@ class OrbitFBX(orbits):
         while 'FB' + str(ii) in self.orbit_params:
             FBXs.append(getattr(self, 'FB' + str(ii)))
             ii += 1
-        orbit_freq = ut.taylor_horner_deriv(self.tt0, FBXs, 1)
+        orbit_freq = taylor_horner_deriv(self.tt0, FBXs, 1)
         return 1.0 / orbit_freq
 
     def pbdot_orbit(self):
@@ -153,7 +154,7 @@ class OrbitFBX(orbits):
         while 'FB' + str(ii) in self.orbit_params:
             FBXs.append(getattr(self, 'FB' + str(ii)))
             ii += 1
-        orbit_freq_dot = ut.taylor_horner_deriv(self.tt0, FBXs, 2)
+        orbit_freq_dot = taylor_horner_deriv(self.tt0, FBXs, 2)
         return -(self.pbprime() ** 2) * orbit_freq_dot
 
     def d_orbits_d_par(self, par):
@@ -173,7 +174,7 @@ class OrbitFBX(orbits):
             else:
                 FBXs.append(1.0 * getattr(self, 'FB' + str(ii)).unit)
             ii += 1
-        d_orbits = ut.taylor_horner(self.tt0, FBXs) / par.unit
+        d_orbits = taylor_horner(self.tt0, FBXs) / par.unit
         return d_orbits.decompose()*2*np.pi*u.rad
 
     def d_pbprime_d_FBX(self, FBX):
@@ -186,7 +187,7 @@ class OrbitFBX(orbits):
             else:
                 FBXs.append(1.0 * getattr(self, 'FB' + str(ii)).unit)
             ii += 1
-        d_FB = ut.taylor_horner_deriv(self.tt0, FBXs, 1) / par.unit
+        d_FB = taylor_horner_deriv(self.tt0, FBXs, 1) / par.unit
         return -(self.pbprime() ** 2) * d_FB
 
     def d_pbprime_d_par(self, par):

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -5,10 +5,9 @@ Defines the basic timing model interface classes.
 from __future__ import absolute_import, division, print_function
 
 import abc
-from collections import defaultdict
 import copy
-import functools
 import inspect
+from collections import defaultdict
 
 import astropy.time as time
 import astropy.units as u
@@ -16,13 +15,10 @@ import numpy as np
 import six
 from astropy import log
 
-import pint.utils as utils
-from pint.utils import interesting_lines, lines_of
 from pint import dimensionless_cycles
-from . import parameter as p
-
-from ..phase import Phase
-from .parameter import strParameter
+from pint.models.parameter import strParameter
+from pint.phase import Phase
+from pint.utils import PrefixError, interesting_lines, lines_of, split_prefixed_name
 
 # Parameters or lines in parfiles we don't understand but shouldn't
 # complain about. These are still passed to components so that they
@@ -537,7 +533,7 @@ class TimingModel(object):
                 #if no absolute phase (TZRMJD), add the component to the model and calculate it
                 from pint.models import absolute_phase
                 self.add_component(absolute_phase.AbsPhase())
-                self.make_TZR_toa(toas)#TODO:needs timfile to get all toas, but model doesn't have access to timfile. different place for this? 
+                self.make_TZR_toa(toas)#TODO:needs timfile to get all toas, but model doesn't have access to timfile. different place for this?
             tz_toa = self.get_TZR_toa(toas)
             tz_delay = self.delay(tz_toa)
             tz_phase = Phase(np.zeros(len(toas.table)) , np.zeros(len(toas.table)))
@@ -608,7 +604,7 @@ class TimingModel(object):
                 break
         else:
             log.info('No jump flags to process')
-            return None        
+            return None
         jump_nums = [flag_dict['jump'] if 'jump' in flag_dict.keys() else np.nan for flag_dict in toas.table['flags']]
         if 'PhaseJump' not in self.components:
             log.info("PhaseJump component added")
@@ -907,11 +903,11 @@ class TimingModel(object):
                 continue
 
             try:
-                prefix, f, v = utils.split_prefixed_name(name)
+                prefix, f, v = split_prefixed_name(name)
                 if prefix in ignore_prefix:
                     log.debug("Ignoring prefix parfile line '%s'" % (li,))
                     continue
-            except utils.PrefixError:
+            except PrefixError:
                 pass
 
             stray_lines.append(li)

--- a/src/pint/models/wave.py
+++ b/src/pint/models/wave.py
@@ -1,8 +1,10 @@
-from __future__ import absolute_import, print_function, division
-import numpy as np
+from __future__ import absolute_import, division, print_function
+
 import astropy.units as u
-from .timing_model import DelayComponent, MissingParameter
-from . import parameter as p
+import numpy as np
+
+from pint.models.parameter import MJDParameter, floatParameter, prefixParameter
+from pint.models.timing_model import DelayComponent, MissingParameter
 
 
 class Wave(DelayComponent):
@@ -16,14 +18,14 @@ class Wave(DelayComponent):
     def __init__(self):
         super(Wave, self).__init__()
 
-        self.add_param(p.floatParameter(name="WAVE_OM",
+        self.add_param(floatParameter(name="WAVE_OM",
                        description="Base frequency of wave solution",
                        units='1/d'))
-        self.add_param(p.prefixParameter(name="WAVE1", units='s',
-                                         description="Wave components",
-                                         type_match='pair', long_double=True,
-                                         parameter_type='pair'))
-        self.add_param(p.MJDParameter(name="WAVEEPOCH",
+        self.add_param(prefixParameter(name="WAVE1", units='s',
+                                       description="Wave components",
+                                       type_match='pair', long_double=True,
+                                       parameter_type='pair'))
+        self.add_param(MJDParameter(name="WAVEEPOCH",
                        description="Reference epoch for wave solution",
                        time_scale='tdb'))
         self.delay_funcs_component += [self.wave_delay,]

--- a/src/pint/observatory/clock_file.py
+++ b/src/pint/observatory/clock_file.py
@@ -1,17 +1,19 @@
 # clock_file.py
 
 # Routines for reading various formats of clock file.
-from __future__ import absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function
+
 import os
-import numpy
-import astropy.units as u
-from astropy.time import Time
-from astropy import log
-from astropy.utils.exceptions import AstropyWarning
-from astropy._erfa import ErfaWarning
 import warnings
-from .. import pulsar_mjd
+
+import astropy.units as u
+import numpy
+from astropy import log
+from astropy._erfa import ErfaWarning
+from astropy.time import Time
 from six import add_metaclass
+
+import pint.pulsar_mjd  # noqa
 
 
 class ClockFileMeta(type):
@@ -82,7 +84,7 @@ class ClockFile(object):
                 raise RuntimeError(msg)
 
         # Can't pass Times directly to numpy.interp.  This should be OK:
-        return numpy.interp(t.mjd, self.time.mjd, self.clock.to(u.us))*u.us
+        return numpy.interp(t.mjd, self.time.mjd, self.clock.to(u.us).value)*u.us
 
 
 class Tempo2ClockFile(ClockFile):

--- a/src/pint/observatory/fermi_obs.py
+++ b/src/pint/observatory/fermi_obs.py
@@ -3,13 +3,13 @@ from __future__ import absolute_import, print_function, division
 
 # Special "site" location for Fermi satelite
 
-from . import Observatory
-from .special_locations import SpecialLocation
+from pint.observatory import Observatory
+from pint.observatory.special_locations import SpecialLocation
 import astropy.units as u
 from astropy.coordinates import GCRS, ITRS, EarthLocation, CartesianRepresentation
-from ..utils import PosVel
-from ..fits_utils import read_fits_event_mjds
-from ..solar_system_ephemerides import objPosVel_wrt_SSB
+from pint.utils import PosVel
+from pint.fits_utils import read_fits_event_mjds
+from pint.solar_system_ephemerides import objPosVel_wrt_SSB
 import numpy as np
 from astropy.time import Time
 from astropy.table import Table

--- a/src/pint/observatory/nicer_obs.py
+++ b/src/pint/observatory/nicer_obs.py
@@ -1,18 +1,15 @@
 """NICER as an observatory."""
 from __future__ import absolute_import, print_function, division
 
-from . import Observatory
-from .special_locations import SpecialLocation
+from pint.observatory.special_locations import SpecialLocation
 import astropy.units as u
 from astropy.coordinates import GCRS, ITRS, EarthLocation, CartesianRepresentation
-from ..utils import PosVel
-from ..fits_utils import read_fits_event_mjds
-from ..solar_system_ephemerides import objPosVel_wrt_SSB
+from pint.utils import PosVel
+from pint.fits_utils import read_fits_event_mjds
+from pint.solar_system_ephemerides import objPosVel_wrt_SSB
 import numpy as np
-from astropy.time import Time
 from astropy.table import Table, vstack
 import astropy.io.fits as pyfits
-import six
 from astropy import log
 from scipy.interpolate import InterpolatedUnivariateSpline
 

--- a/src/pint/observatory/nustar_obs.py
+++ b/src/pint/observatory/nustar_obs.py
@@ -3,12 +3,12 @@ from __future__ import absolute_import, print_function, division
 
 # Special "site" location for the NuSTAR satelite
 
-from .special_locations import SpecialLocation
+from pint.observatory.special_locations import SpecialLocation
 import astropy.units as u
 from astropy.coordinates import GCRS, ITRS, CartesianRepresentation
-from ..utils import PosVel
-from ..fits_utils import read_fits_event_mjds
-from ..solar_system_ephemerides import objPosVel_wrt_SSB
+from pint.utils import PosVel
+from pint.fits_utils import read_fits_event_mjds
+from pint.solar_system_ephemerides import objPosVel_wrt_SSB
 import numpy as np
 from astropy.table import Table
 import astropy.io.fits as pyfits

--- a/src/pint/observatory/rxte_obs.py
+++ b/src/pint/observatory/rxte_obs.py
@@ -3,13 +3,13 @@ from __future__ import absolute_import, print_function, division
 
 # Special "site" location for RXTE satellite
 
-from . import Observatory
-from .special_locations import SpecialLocation
+from pint.observatory import Observatory
+from pint.observatory.special_locations import SpecialLocation
 import astropy.units as u
 from astropy.coordinates import GCRS, ITRS, EarthLocation, CartesianRepresentation
-from ..utils import PosVel
-from ..fits_utils import read_fits_event_mjds
-from ..solar_system_ephemerides import objPosVel_wrt_SSB
+from pint.utils import PosVel
+from pint.fits_utils import read_fits_event_mjds
+from pint.solar_system_ephemerides import objPosVel_wrt_SSB
 import numpy as np
 from astropy.time import Time
 from astropy.table import Table
@@ -17,7 +17,7 @@ import astropy.io.fits as pyfits
 import six
 from astropy import log
 from scipy.interpolate import interp1d
-from .nicer_obs import load_FPorbit
+from pint.observatory.nicer_obs import load_FPorbit
 
 class RXTEObs(SpecialLocation):
     """Observatory-derived class for the RXTE photon data.

--- a/src/pint/observatory/special_locations.py
+++ b/src/pint/observatory/special_locations.py
@@ -9,10 +9,10 @@ import numpy
 import astropy.units as u
 from astropy.coordinates import EarthLocation
 from astropy import log
-from ..utils import PosVel
-from ..solar_system_ephemerides import objPosVel_wrt_SSB
-from ..config import datapath
-from .clock_file import ClockFile
+from pint.utils import PosVel
+from pint.solar_system_ephemerides import objPosVel_wrt_SSB
+from pint.config import datapath
+from pint.observatory.clock_file import ClockFile
 
 class SpecialLocation(Observatory):
     """Special locations that are not really observatories.

--- a/src/pint/observatory/topo_obs.py
+++ b/src/pint/observatory/topo_obs.py
@@ -1,20 +1,24 @@
+"""Ground-based fixed observatories."""
 # topo_obs.py
 # Code for dealing with "standard" ground-based observatories.
-from __future__ import absolute_import, print_function, division
-from . import Observatory
-from .clock_file import ClockFile
+from __future__ import absolute_import, division, print_function
+
 import os
-import numpy
-import astropy.units as u
+
 import astropy.constants as c
+import astropy.units as u
+import numpy
 from astropy import log
 from astropy.coordinates import EarthLocation
 from astropy.time import Time
-from ..utils import PosVel, has_astropy_unit
-from ..solar_system_ephemerides import objPosVel_wrt_SSB, get_tdb_tt_ephem_geocenter
-from ..config import datapath
-from ..erfautils import gcrs_posvel_from_itrf, SECS_PER_DAY
+
 from pint import JD_MJD
+from pint.config import datapath
+from pint.erfautils import SECS_PER_DAY, gcrs_posvel_from_itrf
+from pint.observatory import Observatory
+from pint.observatory.clock_file import ClockFile
+from pint.solar_system_ephemerides import get_tdb_tt_ephem_geocenter, objPosVel_wrt_SSB
+from pint.utils import PosVel, has_astropy_unit
 
 
 class TopoObs(Observatory):

--- a/src/pint/polycos.py
+++ b/src/pint/polycos.py
@@ -2,16 +2,11 @@
 # given interval using polynomial expansion. The return will be some necessary
 # information and the polynomial coefficients
 from __future__ import absolute_import, print_function, division
-import functools
 from .phase import Phase
 import numpy as np
 import pint.toa as toa
-import pint.utils as utils
-import astropy.units as u
-import astropy.constants as const
 import astropy.time as at
-from .models.parameter import Parameter
-from .utils import data2longdouble
+from pint.pulsar_mjd import data2longdouble
 import astropy.table as table
 from astropy.io import registry
 MIN_PER_DAY = 60.0*24.0
@@ -162,7 +157,7 @@ def tempo_polyco_table_reader(filename):
         psrname = fields[0].strip()
         date = fields[1].strip()
         utc = fields[2]
-        tmid = utils.str2longdouble(fields[3])
+        tmid = np.longdouble(fields[3])
         dm = float(fields[4])
         doppler = float(fields[5])
         logrms = float(fields[6])
@@ -287,7 +282,7 @@ def tempo_polyco_table_writer(polycoTable, filename = 'polyco.dat'):
         psrname = polycoTable['psr'][i].ljust(10)
         dateDMY = polycoTable['date'][i].ljust(10)
         utcHMS = polycoTable['utc'][i][0:9].ljust(10)
-        tmid_mjd = utils.longdouble2str(entry.tmid.value)+' '
+        tmid_mjd = str(entry.tmid.value)+' '
         dm = str(polycoTable['dm'][i]).ljust(72-52+1)
         dshift = str(polycoTable['doppler'][i]).ljust(79-74+1)
         logrms = str(polycoTable['logrms'][i]).ljust(80-86+1)
@@ -296,7 +291,7 @@ def tempo_polyco_table_writer(polycoTable, filename = 'polyco.dat'):
         # Get the reference phase
         rph = (entry.rphase.int+entry.rphase.frac).value[0]
         # FIXME: sometimes raises error, sometimes loses precision!
-        rphase  = utils.longdouble2str(rph)[0:19].ljust(20)
+        rphase  = str(rph)[0:19].ljust(20)
         f0 = ('%.12lf' % entry.f0).ljust(38-21+1)
         obs = entry.obs.ljust(43-39+1)
         tspan = str(round(entry.mjdspan.to('min').value,4))[0].ljust(49-44+1)

--- a/src/pint/pulsar_mjd.py
+++ b/src/pint/pulsar_mjd.py
@@ -26,19 +26,52 @@ was observing the sky at the moment a leap second was introduced.
 
 .. _leap_smear: https://developers.google.com/time/smear
 """
-from __future__ import absolute_import, division, print_function
 
+import astropy._erfa as erfa
+import astropy.time
+import astropy.units as u
 import numpy as np
+import six
+from astropy._erfa import DJM0
 from astropy.time.formats import TimeFormat
+from astropy.time import Time
 
-from pint.utils import (
-    jds_to_mjds,
-    jds_to_mjds_pulsar,
-    mjds_to_jds,
-    mjds_to_jds_pulsar,
-    mjds_to_str,
-    str_to_mjds,
-)
+try:
+    maketrans = str.maketrans
+except AttributeError:
+    # fallback for Python 2
+    from string import maketrans
+
+# FIXME: can we make this exception raise on install as well as on use?
+if np.finfo(np.longdouble).eps > 2e-19:
+    raise ValueError(
+        "This platform does not support extended precision "
+        "floating-point, and PINT cannot run without this."
+    )
+
+
+__all__ = [
+    "Time",
+    "PulsarMJD",
+    "MJDLong",
+    "PulsarMJDLong",
+    "MJDString",
+    "PulsarMJDString",
+    "fortran_float",
+    "longdouble2str",
+    "str2longdouble",
+    "data2longdouble",
+    "time_from_longdouble",
+    "time_to_longdouble",
+    "time_from_mjd_string",
+    "time_to_mjd_string",
+    "mjds_to_str",
+    "str_to_mjds",
+    "mjds_to_jds",
+    "jds_to_mjds",
+    "mjds_to_jds_pulsar",
+    "jds_to_mjds_pulsar",
+]
 
 
 class PulsarMJD(TimeFormat):
@@ -64,20 +97,96 @@ class PulsarMJD(TimeFormat):
     def value(self):
         if self._scale == "utc":
             mjd1, mjd2 = jds_to_mjds_pulsar(self.jd1, self.jd2)
-            return mjd1 + np.longdouble(mjd2)
+            return mjd1 + mjd2
         else:
             mjd1, mjd2 = jds_to_mjds(self.jd1, self.jd2)
-            return mjd1 + np.longdouble(mjd2)
+            return mjd1 + mjd2
 
 
 class MJDLong(TimeFormat):
-    """Support conversion of MJDs to or from long double.
-
-    On machines with 80-bit floating-point (in particular x86 hardware), this
-    representation gives a quantization error a bit under a nanosecond.
-    """
+    """Support conversion of MJDs to and from extended precision."""
 
     name = "mjd_long"
+
+    def _check_val_type(self, val1, val2):
+        if val1.dtype != np.longdouble:
+            raise ValueError(
+                "mjd_long requires a long double number but got {!r} of type {}".format(
+                    val1, val1.dtype
+                )
+            )
+        if val2 is None:
+            val2 = 0
+        elif val2.dtype != np.longdouble:
+            raise ValueError(
+                "mjd_long requires a long double number but got {!r} of type {}".format(
+                    val2, val2.dtype
+                )
+            )
+        return val1, val2
+
+    def set_jds(self, val1, val2):
+        self._check_scale(self._scale)
+
+        i = np.floor(val1)
+        f = val1 - i
+        i2 = np.floor(val2)
+        f2 = val2 - i2
+
+        self.jd1, self.jd2 = mjds_to_jds((i + i2).astype(float), (f + f2).astype(float))
+
+    @property
+    def value(self):
+        mjd1, mjd2 = jds_to_mjds(self.jd1, self.jd2)
+        return np.longdouble(mjd1) + np.longdouble(mjd2)
+
+
+class PulsarMJDLong(TimeFormat):
+    """Support conversion of pulsar MJDs to and from extended precision."""
+
+    name = "pulsar_mjd_long"
+
+    def _check_val_type(self, val1, val2):
+        if val1.dtype != np.longdouble:
+            raise ValueError(
+                "pulsar_mjd_long requires a long double number but got {!r} of type {}".format(
+                    val1, val1.dtype
+                )
+            )
+        if val2 is None:
+            val2 = 0
+        elif val2.dtype != np.longdouble:
+            raise ValueError(
+                "pulsar_mjd_long requires a long double number but got {!r} of type {}".format(
+                    val2, val2.dtype
+                )
+            )
+        return val1, val2
+
+    def set_jds(self, val1, val2):
+        self._check_scale(self._scale)
+
+        i = np.floor(val1)
+        f = val1 - i
+        i2 = np.floor(val2)
+        f2 = val2 - i2
+
+        i = (i + i2).astype(float)
+        f = (f + f2).astype(float)
+
+        if self._scale == "utc":
+            self.jd1, self.jd2 = mjds_to_jds_pulsar(i, f)
+        else:
+            self.jd1, self.jd2 = mjds_to_jds(i, f)
+
+    @property
+    def value(self):
+        if self._scale == "utc":
+            mjd1, mjd2 = jds_to_mjds_pulsar(self.jd1, self.jd2)
+            return mjd1 + np.longdouble(mjd2)
+        else:
+            mjd1, mjd2 = jds_to_mjds(self.jd1, self.jd2)
+            return np.longdouble(mjd1) + np.longdouble(mjd2)
 
 
 class MJDString(TimeFormat):
@@ -85,19 +194,22 @@ class MJDString(TimeFormat):
 
     name = "mjd_string"
 
-    # FIXME: arrays!
+    def _check_val_type(self, val1, val2):
+        if val1.dtype.kind not in "US":
+            raise ValueError("mjd_string requires a string but got {!r}".format(val1))
+        if val2 is not None:
+            raise ValueError(
+                "mjd_string doesn't accept a val2 but got {!r}".format(val2)
+            )
+        return val1, val2
+
     def set_jds(self, val1, val2):
-        # What do I do with val2?
         self._check_scale(self._scale)
-        self.jd1, self.jd2 = str_to_mjds(val1)
+        self.jd1, self.jd2 = mjds_to_jds(*str_to_mjds(val1))
 
     @property
     def value(self):
-        return mjds_to_str(self.jd1, self.jd2)
-
-
-class PulsarMJDLong(TimeFormat):
-    """Support conversion of pulsar MJDs to or from long double."""
+        return mjds_to_str(*jds_to_mjds(self.jd1, self.jd2))
 
 
 class PulsarMJDString(TimeFormat):
@@ -105,12 +217,418 @@ class PulsarMJDString(TimeFormat):
 
     name = "pulsar_mjd_string"
 
-    # FIXME: arrays!
+    def _check_val_type(self, val1, val2):
+        if val1.dtype.kind not in "US":
+            raise ValueError(
+                "pulsar_mjd_string requires a string but got {!r}".format(val1)
+            )
+        if val2 is not None:
+            raise ValueError(
+                "pulsar_mjd_string doesn't accept a val2 but got {!r}".format(val2)
+            )
+        return val1, val2
+
     def set_jds(self, val1, val2):
-        # What do I do with val2?
         self._check_scale(self._scale)
-        self.jd1, self.jd2 = str_to_mjds(val1)
+        if self._scale == "utc":
+            self.jd1, self.jd2 = mjds_to_jds_pulsar(*str_to_mjds(val1))
+        else:
+            self.jd1, self.jd2 = mjds_to_jds(*str_to_mjds(val1))
 
     @property
     def value(self):
-        return mjds_to_str(self.jd1, self.jd2)
+        if self._scale == "utc":
+            return mjds_to_str(*jds_to_mjds_pulsar(self.jd1, self.jd2))
+        else:
+            return mjds_to_str(*jds_to_mjds(self.jd1, self.jd2))
+
+
+def time_from_mjd_string(s, scale="utc", format="pulsar_mjd"):
+    """Returns an astropy Time object generated from a MJD string input."""
+    if format.lower().startswith("pulsar_mjd"):
+        return astropy.time.Time(val=s, scale=scale, format="pulsar_mjd_string")
+    elif format.lower().startswith("mjd"):
+        return astropy.time.Time(val=s, scale=scale, format="mjd_string")
+    else:
+        raise ValueError(
+            "Format {} is not recognizable as an MJD format".format(format)
+        )
+
+
+def time_from_longdouble(t, scale="utc", format="pulsar_mjd"):
+    t = np.longdouble(t)
+    i = np.float(np.floor(t))
+    f = np.float(t - i)
+    return astropy.time.Time(val=i, val2=f, format=format, scale=scale)
+
+
+def time_to_mjd_string(t):
+    """Print an MJD time with lots of digits.
+
+    astropy does not seem to provide this capability (yet?).
+    """
+    if t.format.startswith("pulsar_mjd"):
+        return t.pulsar_mjd_string
+    else:
+        return t.mjd_string
+
+
+longdouble_mjd_eps = (70000 * u.day * np.finfo(np.longdouble).eps).to(u.ns)
+
+
+def time_to_longdouble(t):
+    """ Return an astropy Time value as MJD in longdouble
+
+    The returned value is accurate to within a nanosecond, while the precision of long
+    double MJDs (near the present) is roughly 0.7 ns.
+
+    """
+    if t.format.startswith("pulsar_mjd"):
+        return t.pulsar_mjd_long
+    else:
+        return t.mjd_long
+
+
+# Precision-aware conversion functions
+
+
+def fortran_float(x):
+    """Convert Fortran-format floating-point strings.
+
+    returns a copy of the input string with all 'D' or 'd' turned
+    into 'e' characters.  Intended for dealing with exponential
+    notation in tempo1-generated parfiles.
+    """
+    try:
+        # First treat it as a string, wih d->e
+        return float(x.translate(maketrans("Dd", "ee")))
+    except AttributeError:
+        # If that didn't work it may already be a numeric type
+        return float(x)
+
+
+def data2longdouble(data):
+    """Return a numpy long double scalar form different type of data
+
+    If a string, permit Fortran-format scientific notation (1.0d2). Otherwise just use
+    np.longdouble to convert. In particular if ``data`` is an array, convert all the
+    elements.
+
+    Parameters
+    ----------
+    data : str, np.array, or number
+
+    Returns
+    -------
+    np.longdouble
+
+    """
+    if type(data) is str:
+        return str2longdouble(data)
+    else:
+        return np.longdouble(data)
+
+
+def longdouble2str(x):
+    """Convert numpy longdouble to string."""
+    return repr(x)
+
+
+def str2longdouble(str_data):
+    """Return a long double from the input string.
+
+    Accepts Fortran-style exponent notation (1.0d2).
+
+    """
+    if not isinstance(str_data, six.string_types):
+        raise TypeError("Need a string: {!r}".format(str_data))
+    return np.longdouble(str_data.translate(maketrans("Dd", "ee")))
+
+
+# Simplified functions: These core functions, if they can be made to work
+# reliably and efficiently, should implement everything else.
+
+
+def safe_kind_conversion(values, dtype):
+    try:
+        from collections.abc import Iterable
+    except ImportError:
+        from collections import Iterable
+    if isinstance(values, Iterable):
+        return np.asarray(values, dtype=dtype)
+    else:
+        return dtype(values)
+
+
+# This can be removed once we only support astropy >=3.1.
+# The str(c) is necessary for python2/numpy -> no unicode literals...
+_new_ihmsfs_dtype = np.dtype([(str(c), np.intc) for c in "hmsf"])
+
+
+def jds_to_mjds(jd1, jd2):
+    return day_frac(jd1 - DJM0, jd2)
+
+
+def mjds_to_jds(mjd1, mjd2):
+    return day_frac(mjd1 + DJM0, mjd2)
+
+
+_digits = 9
+
+
+def jds_to_mjds_pulsar(jd1, jd2):
+    # Do the reverse of the above calculation
+    # Note this will return an incorrect value during
+    # leap seconds, so raise an exception in that
+    # case.
+    y, mo, d, hmsf = erfa.d2dtf("UTC", _digits, jd1, jd2)
+    # For ASTROPY_LT_3_1, convert to the new structured array dtype that
+    # is returned by the new erfa gufuncs.
+    if not hmsf.dtype.names:
+        hmsf = hmsf.view(_new_ihmsfs_dtype)[..., 0]
+    if np.any((hmsf["s"] == 60) & (hmsf["f"] != 0)):
+        # if f is exactly zero, this is probably fine to treat as the end of the day.
+        raise ValueError(
+            "UTC times during a leap second cannot be represented in pulsar_mjd format"
+        )
+    j1, j2 = erfa.cal2jd(y, mo, d)
+    return day_frac(
+        j1 - erfa.DJM0 + j2,
+        hmsf["h"] / 24.0
+        + hmsf["m"] / 1440.0
+        + hmsf["s"] / 86400.0
+        + hmsf["f"] / 86400.0 / 10 ** _digits,
+    )
+
+
+def mjds_to_jds_pulsar(mjd1, mjd2):
+    # To get around leap second issues, first convert to YMD,
+    # then back to astropy/ERFA-convention jd1,jd2 using the
+    # ERFA dtf2d() routine which handles leap seconds.
+    v1, v2 = day_frac(mjd1, mjd2)
+    (y, mo, d, f) = erfa.jd2cal(erfa.DJM0 + v1, v2)
+    # Fractional day to HMS.  Uses 86400-second day always.
+    # Seems like there should be a ERFA routine for this..
+    # There is: erfa.d2tf. Unfortunately it takes a "number of
+    # digits" argument and returns some kind of bogus
+    # fractional-part-as-an-integer thing.
+    # Worse, it fails to provide nanosecond accuracy.
+    # Good idea, though, because using np.remainder is
+    # numerically unstable and gives bogus values now
+    # and then. This is more stable.
+    f *= 24
+    h = safe_kind_conversion(np.floor(f), dtype=int)
+    f -= h
+    f *= 60
+    m = safe_kind_conversion(np.floor(f), dtype=int)
+    f -= m
+    f *= 60
+    s = f
+    return erfa.dtf2d("UTC", y, mo, d, h, m, s)
+
+
+# Please forgive the horrible hacks to make these work cleanly on both arrays
+# and single elements
+
+
+def _str_to_mjds(s):
+    ss = s.lower().strip()
+    if "e" in ss or "d" in ss:
+        ss = ss.translate(maketrans("d", "e"))
+        num, expon = ss.split("e")
+        expon = int(expon)
+        if expon < 0:
+            imjd, fmjd = 0, np.longdouble(ss)
+        else:
+            mjd_s = num.split(".")
+            # If input was given as an integer, add floating "0"
+            if len(mjd_s) == 1:
+                mjd_s.append("0")
+            imjd_s, fmjd_s = mjd_s
+            imjd = np.longdouble(int(imjd_s))
+            fmjd = np.longdouble("0." + fmjd_s)
+            if ss.startswith("-"):
+                fmjd = -fmjd
+            imjd *= 10 ** expon
+            fmjd *= 10 ** expon
+    else:
+        mjd_s = ss.split(".")
+        # If input was given as an integer, add floating "0"
+        if len(mjd_s) == 1:
+            mjd_s.append("0")
+        imjd_s, fmjd_s = mjd_s
+        imjd = int(imjd_s)
+        fmjd = float("0." + fmjd_s)
+        if ss.startswith("-"):
+            fmjd = -fmjd
+    return day_frac(imjd, fmjd)
+
+
+def str_to_mjds(s):
+    if isinstance(s, six.string_types):
+        return _str_to_mjds(s)
+    else:
+        imjd = np.empty_like(s, dtype=int)
+        fmjd = np.empty_like(s, dtype=float)
+        with np.nditer(
+            [s, imjd, fmjd],
+            flags=["refs_ok"],
+            op_flags=[["readonly"], ["writeonly"], ["writeonly"]],
+        ) as it:
+            for si, i, f in it:
+                si = si[()]
+                if not isinstance(si, six.string_types):
+                    raise TypeError("Requires an array of strings")
+                i[...], f[...] = _str_to_mjds(si)
+            return it.operands[1], it.operands[2]
+
+
+def _mjds_to_str(mjd1, mjd2):
+    (imjd, fmjd) = day_frac(mjd1, mjd2)
+    imjd = int(imjd)
+    assert np.fabs(fmjd) < 1.0
+    while fmjd < 0.0:
+        imjd -= 1
+        fmjd += 1.0
+    assert 0 <= fmjd < 1
+    return str(imjd) + "{:.16f}".format(fmjd)[1:]
+    # return str(imjd) + str(1+fmjd)[1:]
+
+
+_v_mjds_to_str = np.vectorize(_mjds_to_str, otypes=[np.dtype("U30")])
+
+
+def mjds_to_str(mjd1, mjd2):
+    r = _v_mjds_to_str(mjd1, mjd2)
+    if r.shape == ():
+        return r[()]
+    else:
+        return r
+
+
+# These routines are from astropy but were broken in < 3.2.2 and <= 2.0.15
+
+
+def day_frac(val1, val2, factor=None, divisor=None):
+    """Return the sum of ``val1`` and ``val2`` as two float64s.
+
+    The returned floats are an integer part and the fractional remainder,
+    with the latter guaranteed to be within -0.5 and 0.5 (inclusive on
+    either side, as the integer is rounded to even).
+
+    The arithmetic is all done with exact floating point operations so no
+    precision is lost to rounding error.  It is assumed the sum is less
+    than about 1e16, otherwise the remainder will be greater than 1.0.
+
+    Parameters
+    ----------
+    val1, val2 : array of float
+        Values to be summed.
+    factor : float, optional
+        If given, multiply the sum by it.
+    divisor : float, optional
+        If given, divide the sum by it.
+
+    Returns
+    -------
+    day, frac : float64
+        Integer and fractional part of val1 + val2.
+    """
+    # Add val1 and val2 exactly, returning the result as two float64s.
+    # The first is the approximate sum (with some floating point error)
+    # and the second is the error of the float64 sum.
+    sum12, err12 = two_sum(val1, val2)
+
+    if factor is not None:
+        sum12, carry = two_product(sum12, factor)
+        carry += err12 * factor
+        sum12, err12 = two_sum(sum12, carry)
+
+    if divisor is not None:
+        q1 = sum12 / divisor
+        p1, p2 = two_product(q1, divisor)
+        d1, d2 = two_sum(sum12, -p1)
+        d2 += err12
+        d2 -= p2
+        q2 = (d1 + d2) / divisor  # 3-part float fine here; nothing can be lost
+        sum12, err12 = two_sum(q1, q2)
+
+    # get integer fraction
+    day = np.round(sum12)
+    extra, frac = two_sum(sum12, -day)
+    frac += extra + err12
+    # Our fraction can now have gotten >0.5 or <-0.5, which means we would
+    # loose one bit of precision. So, correct for that.
+    excess = np.round(frac)
+    day += excess
+    extra, frac = two_sum(sum12, -day)
+    frac += extra + err12
+    return day, frac
+
+
+def two_sum(a, b):
+    """
+    Add ``a`` and ``b`` exactly, returning the result as two float64s.
+    The first is the approximate sum (with some floating point error)
+    and the second is the error of the float64 sum.
+
+    Using the procedure of Shewchuk, 1997,
+    Discrete & Computational Geometry 18(3):305-363
+    http://www.cs.berkeley.edu/~jrs/papers/robustr.pdf
+
+    Returns
+    -------
+    sum, err : float64
+        Approximate sum of a + b and the exact floating point error
+    """
+    x = a + b
+    eb = x - a  # bvirtual in Shewchuk
+    ea = x - eb  # avirtual in Shewchuk
+    eb = b - eb  # broundoff in Shewchuk
+    ea = a - ea  # aroundoff in Shewchuk
+    return x, ea + eb
+
+
+def two_product(a, b):
+    """
+    Multiple ``a`` and ``b`` exactly, returning the result as two float64s.
+    The first is the approximate product (with some floating point error)
+    and the second is the error of the float64 product.
+
+    Uses the procedure of Shewchuk, 1997,
+    Discrete & Computational Geometry 18(3):305-363
+    http://www.cs.berkeley.edu/~jrs/papers/robustr.pdf
+
+    Returns
+    -------
+    prod, err : float64
+        Approximate product a * b and the exact floating point error
+    """
+    x = a * b
+    ah, al = split(a)
+    bh, bl = split(b)
+    y1 = ah * bh
+    y = x - y1
+    y2 = al * bh
+    y -= y2
+    y3 = ah * bl
+    y -= y3
+    y4 = al * bl
+    y = y4 - y
+    return x, y
+
+
+def split(a):
+    """
+    Split float64 in two aligned parts.
+
+    Uses the procedure of Shewchuk, 1997,
+    Discrete & Computational Geometry 18(3):305-363
+    http://www.cs.berkeley.edu/~jrs/papers/robustr.pdf
+
+    """
+    c = 134217729.0 * a  # 2**27+1.
+    abig = c - a
+    ah = c - abig
+    al = a - ah
+    return ah, al

--- a/src/pint/scripts/htest_optimize.py
+++ b/src/pint/scripts/htest_optimize.py
@@ -10,12 +10,9 @@ from pint.fitter import Fitter
 import pint.fermi_toas as fermi
 from pint.eventstats import hmw, hm, sf_hm
 import matplotlib.pyplot as plt
-import astropy.table
 import pint.plot_utils
-import astropy.units as u
-import psr_utils as pu
 import scipy.optimize as op
-import sys, os, copy, fftfit
+import sys, os, copy
 from astropy.coordinates import SkyCoord
 
 
@@ -155,7 +152,7 @@ class emcee_fitter(Fitter):
         """
         mjds = self.toas.table['tdbld'].astype(np.float64)
         phss = self.get_event_phases()
-        plot_utils.phaseogram(mjds, phss, weights=self.weights, bins=bins,
+        pint.plot_utils.phaseogram(mjds, phss, weights=self.weights, bins=bins,
             rotate=rotate, size=size, alpha=alpha, file=file)
 
     def prof_vs_weights(self, nbins=50, use_weights=False):

--- a/src/pint/solar_system_ephemerides.py
+++ b/src/pint/solar_system_ephemerides.py
@@ -7,17 +7,11 @@ from six.moves.urllib.parse import urljoin
 import numpy as np
 import astropy.units as u
 import astropy.coordinates as coor
-from astropy.time import Time
 from astropy import log
 from astropy.utils.data import download_file
-from jplephem.spk import SPK
-try:
-    from astropy.erfa import DAYSEC as SECS_PER_DAY
-except ImportError:
-    from astropy._erfa import DAYSEC as SECS_PER_DAY
 
-from .utils import PosVel
-from .config import datapath
+from pint.utils import PosVel
+from pint.config import datapath
 
 
 ephemeris_mirrors = [

--- a/src/pint/tmtestfuncs.py
+++ b/src/pint/tmtestfuncs.py
@@ -1,7 +1,9 @@
-# Test timing model functions to test out the residuals class
-from __future__ import absolute_import, print_function, division
-from astropy.time import Time
+"""Test timing model functions to test out the residuals class."""
+from __future__ import absolute_import, division, print_function
+
 import numpy
+from astropy.time import Time
+
 
 def F0(toa, model):
 
@@ -11,7 +13,3 @@ def F0(toa, model):
     ph = numpy.array([x.sec*model.F0.value for x in dt])
 
     return ph
-
-
-
-

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -291,7 +291,7 @@ def format_toa_line(toatime, toaerr, freq, obs,
     """
     from .utils import time_to_mjd_string
     if format.upper() in ('TEMPO2', '1'):
-        toa_str = time_to_mjd_string(toatime, prec=16)
+        toa_str = time_to_mjd_string(toatime)
         # In Tempo2 format, freq=0.0 means infinite frequency
         if freq == np.inf*u.MHz:
             freq = 0.0*u.MHz

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1,24 +1,21 @@
 """Miscellaneous potentially-helpful functions."""
 from __future__ import absolute_import, division, print_function
 
+import decimal
 import re
-from contextlib import contextmanager
-from six import StringIO
-import numpy as np
-from scipy.special import factorial
 import string
+from contextlib import contextmanager
+from copy import deepcopy
+from decimal import Decimal
+
+import astropy._erfa as erfa
 import astropy.time
 import astropy.units as u
 import numpy as np
-from astropy.time.utils import day_frac
-
-try:
-    from astropy.erfa import DJM0, d2dtf
-except ImportError:
-    from astropy._erfa import DJM0, d2dtf
-
 from astropy import log
-from copy import deepcopy
+from astropy._erfa import DJM0, d2dtf
+from scipy.special import factorial
+from six import StringIO
 
 try:
     maketrans = str.maketrans
@@ -26,19 +23,173 @@ except AttributeError:
     # fallback for Python 2
     from string import maketrans
 
+# FIXME: can we make this exception raise on install instead of on use?
 if np.finfo(np.longdouble).eps > 2e-19:
-    raise ValueError("This platform does not support extended precision "
-                     "floating-point, and PINT cannot run without this.")
+    raise ValueError(
+        "This platform does not support extended precision "
+        "floating-point, and PINT cannot run without this."
+    )
 
-__all__ = ['PosVel', 'fortran_float', 'time_from_mjd_string',
-           'time_from_longdouble', 'time_to_mjd_string',
-           'time_to_mjd_string_array', 'time_to_longdouble',
-           'numeric_partial', 'numeric_partials',
-           'check_all_partials', 'has_astropy_unit',
-           'str2longdouble',
-           'PrefixError', 'split_prefixed_name', 'data2longdouble',
-           'taylor_horner', 'taylor_horner_deriv', 'is_number', 'open_or_use',
-           'lines_of', 'interesting_lines']
+__all__ = [
+    "PosVel",
+    "fortran_float",
+    "longdouble2str",
+    "str2longdouble",
+    "data2longdouble",
+    "time_from_longdouble",
+    "time_to_longdouble",
+    "time_from_mjd_string",
+    "time_to_mjd_string",
+    "numeric_partial",
+    "numeric_partials",
+    "check_all_partials",
+    "has_astropy_unit",
+    "PrefixError",
+    "split_prefixed_name",
+    "taylor_horner",
+    "taylor_horner_deriv",
+    "open_or_use",
+    "lines_of",
+    "interesting_lines",
+    "mjds_to_str",
+    "str_to_mjds",
+    "mjds_to_jds",
+    "jds_to_mjds",
+    "mjds_to_jds_pulsar",
+    "jds_to_mjds_pulsar",
+]
+
+
+# These routines are from astropy but were broken in < 3.2.2 and <= 2.0.15
+
+
+def day_frac(val1, val2, factor=None, divisor=None):
+    """Return the sum of ``val1`` and ``val2`` as two float64s.
+
+    The returned floats are an integer part and the fractional remainder,
+    with the latter guaranteed to be within -0.5 and 0.5 (inclusive on
+    either side, as the integer is rounded to even).
+
+    The arithmetic is all done with exact floating point operations so no
+    precision is lost to rounding error.  It is assumed the sum is less
+    than about 1e16, otherwise the remainder will be greater than 1.0.
+
+    Parameters
+    ----------
+    val1, val2 : array of float
+        Values to be summed.
+    factor : float, optional
+        If given, multiply the sum by it.
+    divisor : float, optional
+        If given, divide the sum by it.
+
+    Returns
+    -------
+    day, frac : float64
+        Integer and fractional part of val1 + val2.
+    """
+    # Add val1 and val2 exactly, returning the result as two float64s.
+    # The first is the approximate sum (with some floating point error)
+    # and the second is the error of the float64 sum.
+    sum12, err12 = two_sum(val1, val2)
+
+    if factor is not None:
+        sum12, carry = two_product(sum12, factor)
+        carry += err12 * factor
+        sum12, err12 = two_sum(sum12, carry)
+
+    if divisor is not None:
+        q1 = sum12 / divisor
+        p1, p2 = two_product(q1, divisor)
+        d1, d2 = two_sum(sum12, -p1)
+        d2 += err12
+        d2 -= p2
+        q2 = (d1 + d2) / divisor  # 3-part float fine here; nothing can be lost
+        sum12, err12 = two_sum(q1, q2)
+
+    # get integer fraction
+    day = np.round(sum12)
+    extra, frac = two_sum(sum12, -day)
+    frac += extra + err12
+    # Our fraction can now have gotten >0.5 or <-0.5, which means we would
+    # loose one bit of precision. So, correct for that.
+    excess = np.round(frac)
+    day += excess
+    extra, frac = two_sum(sum12, -day)
+    frac += extra + err12
+    return day, frac
+
+
+def two_sum(a, b):
+    """
+    Add ``a`` and ``b`` exactly, returning the result as two float64s.
+    The first is the approximate sum (with some floating point error)
+    and the second is the error of the float64 sum.
+
+    Using the procedure of Shewchuk, 1997,
+    Discrete & Computational Geometry 18(3):305-363
+    http://www.cs.berkeley.edu/~jrs/papers/robustr.pdf
+
+    Returns
+    -------
+    sum, err : float64
+        Approximate sum of a + b and the exact floating point error
+    """
+    x = a + b
+    eb = x - a  # bvirtual in Shewchuk
+    ea = x - eb  # avirtual in Shewchuk
+    eb = b - eb  # broundoff in Shewchuk
+    ea = a - ea  # aroundoff in Shewchuk
+    return x, ea + eb
+
+
+def two_product(a, b):
+    """
+    Multiple ``a`` and ``b`` exactly, returning the result as two float64s.
+    The first is the approximate product (with some floating point error)
+    and the second is the error of the float64 product.
+
+    Uses the procedure of Shewchuk, 1997,
+    Discrete & Computational Geometry 18(3):305-363
+    http://www.cs.berkeley.edu/~jrs/papers/robustr.pdf
+
+    Returns
+    -------
+    prod, err : float64
+        Approximate product a * b and the exact floating point error
+    """
+    x = a * b
+    ah, al = split(a)
+    bh, bl = split(b)
+    y1 = ah * bh
+    y = x - y1
+    y2 = al * bh
+    y -= y2
+    y3 = ah * bl
+    y -= y3
+    y4 = al * bl
+    y = y4 - y
+    return x, y
+
+
+def split(a):
+    """
+    Split float64 in two aligned parts.
+
+    Uses the procedure of Shewchuk, 1997,
+    Discrete & Computational Geometry 18(3):305-363
+    http://www.cs.berkeley.edu/~jrs/papers/robustr.pdf
+
+    """
+    c = 134217729.0 * a  # 2**27+1.
+    abig = c - a
+    ah = c - abig
+    al = a - ah
+    return ah, al
+
+
+# Back to your regularly scheduled PINT
+
 
 class PosVel(object):
     """Position/Velocity class.
@@ -63,18 +214,17 @@ class PosVel(object):
     origin of the vector on the left.
 
     """
+
     def __init__(self, pos, vel, obj=None, origin=None):
         if len(pos) != 3:
-            raise ValueError(
-                "Position vector has length %d instead of 3" % len(pos))
+            raise ValueError("Position vector has length %d instead of 3" % len(pos))
         if isinstance(pos, u.Quantity):
             self.pos = pos
         else:
             self.pos = np.asarray(pos)
 
         if len(vel) != 3:
-            raise ValueError(
-                "Position vector has length %d instead of 3" % len(pos))
+            raise ValueError("Position vector has length %d instead of 3" % len(pos))
         if isinstance(vel, u.Quantity):
             self.vel = vel
         else:
@@ -83,13 +233,12 @@ class PosVel(object):
         if len(self.pos.shape) != len(self.vel.shape):
             # FIXME: could broadcast them, but have to be careful
             raise ValueError(
-                "pos and vel must have the same number of dimensions but are {} and {}"
-                .format(self.pos.shape, self.vel.shape)
+                "pos and vel must have the same number of dimensions but are {} and {}".format(
+                    self.pos.shape, self.vel.shape
+                )
             )
         elif self.pos.shape != self.vel.shape:
-            self.pos, self.vel = np.broadcast_arrays(
-                self.pos, self.vel, subok=True
-            )
+            self.pos, self.vel = np.broadcast_arrays(self.pos, self.vel, subok=True)
 
         if bool(obj is None) != bool(origin is None):
             raise ValueError(
@@ -118,23 +267,34 @@ class PosVel(object):
                 origin = other.origin
                 obj = self.obj
             else:
-                raise ValueError("Attempting to add incompatible vectors: " +
-                                 "%s->%s + %s->%s" % (self.origin, self.obj,
-                                                      other.origin,
-                                                      other.obj))
+                raise ValueError(
+                    "Attempting to add incompatible vectors: "
+                    + "%s->%s + %s->%s"
+                    % (self.origin, self.obj, other.origin, other.obj)
+                )
 
-        return PosVel(self.pos + other.pos, self.vel + other.vel,
-                      obj=obj, origin=origin)
+        return PosVel(
+            self.pos + other.pos, self.vel + other.vel, obj=obj, origin=origin
+        )
 
     def __sub__(self, other):
         return self.__add__(other.__neg__())
 
     def __str__(self):
         if self._has_labels():
-            return ("PosVel(" + str(self.pos)+", "+str(self.vel)
-                    + " " + self.origin + "->" + self.obj + ")")
+            return (
+                "PosVel("
+                + str(self.pos)
+                + ", "
+                + str(self.vel)
+                + " "
+                + self.origin
+                + "->"
+                + self.obj
+                + ")"
+            )
         else:
-            return "PosVel(" + str(self.pos)+", "+str(self.vel) + ")"
+            return "PosVel(" + str(self.pos) + ", " + str(self.vel) + ")"
 
     def __getitem__(self, k):
         """Allow extraction of slices of the contained arrays"""
@@ -144,137 +304,8 @@ class PosVel(object):
         else:
             ix = (colon, k)
         return self.__class__(
-                self.pos[ix],
-                self.vel[ix],
-                obj=self.obj,
-                origin=self.origin)
-
-
-def fortran_float(x):
-    """Convert Fortran-format floating-point strings.
-
-    returns a copy of the input string with all 'D' or 'd' turned
-    into 'e' characters.  Intended for dealing with exponential
-    notation in tempo1-generated parfiles.
-    """
-    try:
-        # First treat it as a string, wih d->e
-        return float(x.translate(maketrans('Dd', 'ee')))
-    except AttributeError:
-        # If that didn't work it may already be a numeric type
-        return float(x)
-
-
-def time_from_mjd_string(s, scale='utc'):
-    """Returns an astropy Time object generated from a MJD string input."""
-    ss = s.lower().strip()
-    if "e" in ss or "d" in ss:
-        ss = ss.translate(maketrans("d", "e"))
-        num, expon = ss.split("e")
-        expon = int(expon)
-        if expon < 0:
-            imjd, fmjd = 0, np.longdouble(ss)
-        else:
-            mjd_s = num.split('.')
-            # If input was given as an integer, add floating "0"
-            if len(mjd_s) == 1:
-                mjd_s.append("0")
-            imjd_s, fmjd_s = mjd_s
-            imjd = np.longdouble(int(imjd_s))
-            fmjd = np.longdouble("0." + fmjd_s)
-            if ss.startswith("-"):
-                fmjd = -fmjd
-            imjd *= 10**expon
-            fmjd *= 10**expon
-    else:
-        mjd_s = ss.split('.')
-        # If input was given as an integer, add floating "0"
-        if len(mjd_s) == 1:
-            mjd_s.append("0")
-        imjd_s, fmjd_s = mjd_s
-        imjd = int(imjd_s)
-        fmjd = float("0." + fmjd_s)
-        if ss.startswith("-"):
-            fmjd = -fmjd
-    return astropy.time.Time(imjd, fmjd, scale=scale, format='pulsar_mjd',
-                             precision=9)
-
-
-def time_from_longdouble(t, scale='utc'):
-    st = longdouble2str(t)
-    return time_from_mjd_string(st, scale)
-
-
-def time_to_mjd_string(t, prec=15):
-    """Print an MJD time with lots of digits (number is 'prec').
-
-    astropy does not seem to provide this capability (yet?).
-    """
-
-    if t.format == 'pulsar_mjd':
-        (imjd, fmjd) = day_frac(t.jd1 - DJM0, t.jd2)
-        imjd = int(imjd)
-        if fmjd < 0.0:
-            imjd -= 1
-        y, mo, d, hmsf = d2dtf('UTC', 9, t.jd1, t.jd2)
-
-        if hmsf[0].size == 1:
-            hmsf = np.array([list(hmsf)])
-        fmjd = (hmsf[..., 0]/24.0 + hmsf[..., 1]/1440.0
-                + hmsf[..., 2]/86400.0 + hmsf[..., 3]/86400.0e9)
-    else:
-        (imjd, fmjd) = day_frac(t.jd1 - DJM0, t.jd2)
-        imjd = int(imjd)
-        assert np.fabs(fmjd) < 2.0
-        while fmjd >= 1.0:
-            imjd += 1
-            fmjd -= 1.0
-        while fmjd < 0.0:
-            imjd -= 1
-            fmjd += 1.0
-
-    fmt = "%." + "%sf" % prec
-    return str(imjd) + (fmt % fmjd)[1:]
-
-
-def time_to_mjd_string_array(t, prec=15):
-    """Print and MJD time array from an astropy time object as array in
-       time.
-    """
-    jd1 = np.array(t.jd1)
-    jd2 = np.array(t.jd2)
-    jd1 = jd1 - DJM0
-    imjd = jd1.astype(int)
-    fjd1 = jd1 - imjd
-    fmjd = jd2 + fjd1
-
-    assert np.fabs(fmjd).max() < 2.0
-    s = []
-    for i, f in zip(imjd, fmjd):
-        if f >= 1.0:
-            i += 1
-            f -= 1.0
-        if f < 0.0:
-            i -= 1
-            f += 1.0
-        fmt = "%." + "%sf" % prec
-        s.append(str(i) + (fmt % f)[1:])
-    return s
-
-
-longdouble_mjd_eps = (70000*u.day*np.finfo(np.longdouble).eps).to(u.ns)
-
-
-def time_to_longdouble(t):
-    """ Return an astropy Time value as MJD in longdouble
-
-    The returned value is accurate to within a nanosecond, while the precision of long
-    double MJDs (near the present) is roughly 0.7 ns.
-
-    """
-    i_djm0 = np.longdouble(np.floor(DJM0))
-    f_djm0 = np.longdouble(DJM0)-i_djm0
-    return (np.longdouble(t.jd1) - i_djm0) + (np.longdouble(t.jd2)-f_djm0)
+            self.pos[ix], self.vel[ix], obj=self.obj, origin=self.origin
+        )
 
 
 def numeric_partial(f, args, ix=0, delta=1e-6):
@@ -287,12 +318,12 @@ def numeric_partial(f, args, ix=0, delta=1e-6):
     """
     # r = np.array(f(*args))
     args2 = list(args)
-    args2[ix] = args[ix]+delta/2.
+    args2[ix] = args[ix] + delta / 2.0
     r2 = np.array(f(*args2))
     args3 = list(args)
-    args3[ix] = args[ix]-delta/2.
+    args3[ix] = args[ix] - delta / 2.0
     r3 = np.array(f(*args3))
-    return (r2-r3)/delta
+    return (r2 - r3) / delta
 
 
 def numeric_partials(f, args, delta=1e-6):
@@ -321,10 +352,10 @@ def check_all_partials(f, args, delta=1e-6, atol=1e-4, rtol=1e-4):
     try:
         np.testing.assert_allclose(jac, njac, atol=atol, rtol=rtol)
     except AssertionError:
-        #print jac
-        #print njac
-        d = np.abs(jac-njac)/(atol+rtol*np.abs(njac))
-        print("fail fraction:", np.sum(d > 1)/float(np.sum(d >= 0)))
+        # print jac
+        # print njac
+        d = np.abs(jac - njac) / (atol + rtol * np.abs(njac))
+        print("fail fraction:", np.sum(d > 1) / float(np.sum(d >= 0)))
         worst_ix = np.unravel_index(np.argmax(d.reshape((-1,))), d.shape)
         print("max fail:", np.amax(d), "at", worst_ix)
         print("jac there:", jac[worst_ix], "njac there:", njac[worst_ix])
@@ -338,32 +369,15 @@ def has_astropy_unit(x):
     associated with them.
 
     """
-    return hasattr(x, 'unit') and isinstance(x.unit, u.core.UnitBase)
-
-
-def longdouble2str(x):
-    """Convert numpy longdouble to string."""
-    return repr(x)
-
-
-def str2longdouble(str_data):
-    """Return a long double from the input string.
-
-    Accepts Fortran-style exponent notation (1.0d2).
-
-    """
-    if not isinstance(str_data, str):
-        raise TypeError("Need a string: {!r}".format(str_data))
-    input_str = str_data.translate(maketrans('Dd', 'ee'))
-    return np.longdouble(input_str.encode())
+    return hasattr(x, "unit") and isinstance(x.unit, u.core.UnitBase)
 
 
 # Define prefix parameter pattern
 prefix_pattern = [
-    re.compile(r'^([a-zA-Z]*\d+[a-zA-Z]+)(\d+)$'),  # For the prefix like T2EFAC2
-    re.compile(r'^([a-zA-Z]+)(\d+)$'),  # For the prefix like F12
-    re.compile(r'^([a-zA-Z0-9]+_)(\d+)$'),  # For the prefix like DMXR1_3
-    #re.compile(r'([a-zA-Z]\d[a-zA-Z]+)(\d+)'),  # for prefixes like PLANET_SHAPIRO2?
+    re.compile(r"^([a-zA-Z]*\d+[a-zA-Z]+)(\d+)$"),  # For the prefix like T2EFAC2
+    re.compile(r"^([a-zA-Z]+)(\d+)$"),  # For the prefix like F12
+    re.compile(r"^([a-zA-Z0-9]+_)(\d+)$"),  # For the prefix like DMXR1_3
+    # re.compile(r'([a-zA-Z]\d[a-zA-Z]+)(\d+)'),  # for prefixes like PLANET_SHAPIRO2?
 ]
 
 
@@ -412,8 +426,8 @@ def split_prefixed_name(name):
         if namefield is None:
             continue
         prefix_part, index_part = namefield.groups()
-        if '_' in name:
-            if '_' in prefix_part:
+        if "_" in name:
+            if "_" in prefix_part:
                 break
             else:
                 continue
@@ -423,28 +437,6 @@ def split_prefixed_name(name):
     if namefield is None:
         raise PrefixError("Unrecognized prefix name pattern '%s'." % name)
     return prefix_part, index_part, int(index_part)
-
-
-def data2longdouble(data):
-    """Return a numpy long double scalar form different type of data
-
-    If a string, permit Fortran-format scientific notation (1.0d2). Otherwise just use
-    np.longdouble to convert. In particular if ``data`` is an array, convert all the
-    elements.
-
-    Parameters
-    ----------
-    data : str, np.array, or number
-
-    Returns
-    -------
-    np.longdouble
-
-    """
-    if type(data) is str:
-        return str2longdouble(data)
-    else:
-        return np.longdouble(data)
 
 
 def taylor_horner(x, coeffs):
@@ -458,8 +450,8 @@ def taylor_horner(x, coeffs):
 
     """
     result = 0.0
-    if hasattr(coeffs[-1], 'unit'):
-        if not hasattr(x, 'unit'):
+    if hasattr(coeffs[-1], "unit"):
+        if not hasattr(x, "unit"):
             x = x * u.Unit("")
         result *= coeffs[-1].unit / x.unit
     fact = float(len(coeffs))
@@ -480,8 +472,8 @@ def taylor_horner_deriv(x, coeffs, deriv_order=1):
 
     """
     result = 0.0
-    if hasattr(coeffs[-1], 'unit'):
-        if not hasattr(x, 'unit'):
+    if hasattr(coeffs[-1], "unit"):
+        if not hasattr(x, "unit"):
             x = x * u.Unit("")
         result *= coeffs[-1].unit / x.unit
     der_coeffs = coeffs[deriv_order::]
@@ -490,28 +482,6 @@ def taylor_horner_deriv(x, coeffs, deriv_order=1):
         result = result * x / fact + coeff
         fact -= 1.0
     return result
-
-
-def is_number(s):
-    """Check if it is a number string.
-
-    Note that this may return False for Fortran-style floating-point
-    numbers (1.0d10).
-
-    """
-    try:
-        float(s)
-        return True
-    except ValueError:
-        pass
-
-    try:
-        import unicodedata
-        unicodedata.numeric(s)
-        return True
-    except (TypeError, ValueError):
-        pass
-    return False
 
 
 @contextmanager
@@ -557,13 +527,14 @@ def interesting_lines(lines, comments=None):
     elif isinstance(comments, tuple):
         cc = comments
     else:
-        cc = comments,
+        cc = (comments,)
     for c in cc:
         cs = c.strip()
         if not cs or not c.startswith(cs):
             raise ValueError(
                 "Unable to deal with comments that start with whitespace, "
-                "but comment string {!r} was requested.".format(c))
+                "but comment string {!r} was requested.".format(c)
+            )
     for ln in lines:
         ln = ln.strip()
         if not ln:
@@ -572,19 +543,20 @@ def interesting_lines(lines, comments=None):
             continue
         yield ln
 
-def show_param_cov_matrix(matrix,params,name='Covaraince Matrix',switchRD=False):
-    '''function to print covariance matrices in a clean and easily readable way
-    
+
+def show_param_cov_matrix(matrix, params, name="Covaraince Matrix", switchRD=False):
+    """function to print covariance matrices in a clean and easily readable way
+
     :param matrix: matrix to be printed, should be square, list of lists
     :param params: name of the parameters in the matrix, list
     :param name: title to be printed above, default Covariance Matrix
     :param switchRD: if True, switch the positions of RA and DEC to match setup of TEMPO cov. matrices
-    
-    :return string to be printed'''
+
+    :return string to be printed"""
     output = StringIO.StringIO()
     matrix = deepcopy(matrix)
     try:
-        RAi = params.index('RAJ')
+        RAi = params.index("RAJ")
     except:
         RAi = None
         switchRD = False
@@ -601,8 +573,8 @@ def show_param_cov_matrix(matrix,params,name='Covaraince Matrix',switchRD=False)
         else:
             params1.append(param)
     if switchRD:
-        #switch RA and DEC so cov matrix matches TEMPO
-        params1[RAi:RAi+2] = [params1[RAi+1],params1[RAi]]
+        # switch RA and DEC so cov matrix matches TEMPO
+        params1[RAi : RAi + 2] = [params1[RAi + 1], params1[RAi]]
         i = 0
         while i < 2:
             RA = deepcopy(matrix[RAi])
@@ -610,31 +582,280 @@ def show_param_cov_matrix(matrix,params,name='Covaraince Matrix',switchRD=False)
             matrix[RAi + 1] = RA
             matrix = matrix.T
             i += 1
-    output.write(name+" switch RD = "+str(switchRD)+"\n")
-    output.write(' ')
+    output.write(name + " switch RD = " + str(switchRD) + "\n")
+    output.write(" ")
     for param in params1:
-        output.write('         '+param)
+        output.write("         " + param)
     i = j = 0
     while i < len(matrix):
-        output.write('\n'+params1[i]+' :: ')
+        output.write("\n" + params1[i] + " :: ")
         while j <= i:
             num = matrix[i][j]
             if num < 0.001 and num > -0.001:
-                output.write('{0: 1.2e}'.format(num)+'   : ')
+                output.write("{0: 1.2e}".format(num) + "   : ")
             else:
-                output.write('  '+'{0: 1.2f}'.format(num)+'   : ')
+                output.write("  " + "{0: 1.2f}".format(num) + "   : ")
             j += 1
         i += 1
         j = 0
-    output.write('\b:\n')
+    output.write("\b:\n")
     contents = output.getvalue()
     output.close()
     return contents
 
 
-if __name__ == "__main__":
-    assert taylor_horner(2.0, [10]) == 10
-    assert taylor_horner(2.0, [10, 3]) == 10 + 3*2.0
-    assert taylor_horner(2.0, [10, 3, 4]) == 10 + 3*2.0 + 4*2.0**2 / 2.0
-    assert taylor_horner(2.0, [10, 3, 4, 12]) == 10 + 3*2.0 + 4*2.0**2 / 2.0 + 12*2.0**3/(3.0*2.0)
+# Precision-aware conversion functions
 
+
+def fortran_float(x):
+    """Convert Fortran-format floating-point strings.
+
+    returns a copy of the input string with all 'D' or 'd' turned
+    into 'e' characters.  Intended for dealing with exponential
+    notation in tempo1-generated parfiles.
+    """
+    try:
+        # First treat it as a string, wih d->e
+        return float(x.translate(maketrans("Dd", "ee")))
+    except AttributeError:
+        # If that didn't work it may already be a numeric type
+        return float(x)
+
+
+def time_from_mjd_string(s, scale="utc", format="pulsar_mjd"):
+    """Returns an astropy Time object generated from a MJD string input."""
+    i, f = str_to_mjds(s)
+    return astropy.time.Time(val=i, val2=f, scale=scale, format=format)
+
+
+def time_from_longdouble(t, scale="utc", format="pulsar_mjd"):
+    t = np.longdouble(t)
+    i = np.floor(t)
+    f = t - i
+    return astropy.time.Time(val=i, val2=f, format=format, scale=scale)
+
+
+def time_to_mjd_string(t):
+    """Print an MJD time with lots of digits.
+
+    astropy does not seem to provide this capability (yet?).
+    """
+    if t.scale == "utc" and t.format == "pulsar_mjd":
+        i, f = jds_to_mjds_pulsar(t.jd1, t.jd2)
+    else:
+        i, f = jds_to_mjds(t.jd1, t.jd2)
+    return mjds_to_str(i, f)
+
+
+longdouble_mjd_eps = (70000 * u.day * np.finfo(np.longdouble).eps).to(u.ns)
+
+
+def time_to_longdouble(t):
+    """ Return an astropy Time value as MJD in longdouble
+
+    The returned value is accurate to within a nanosecond, while the precision of long
+    double MJDs (near the present) is roughly 0.7 ns.
+
+    """
+    if t.scale == "utc" and t.format == "pulsar_mjd":
+        i, f = jds_to_mjds_pulsar(t.jd1, t.jd2)
+    else:
+        i, f = jds_to_mjds(t.jd1, t.jd2)
+    return np.longdouble(i) + np.longdouble(f)
+
+
+def data2longdouble(data):
+    """Return a numpy long double scalar form different type of data
+
+    If a string, permit Fortran-format scientific notation (1.0d2). Otherwise just use
+    np.longdouble to convert. In particular if ``data`` is an array, convert all the
+    elements.
+
+    Parameters
+    ----------
+    data : str, np.array, or number
+
+    Returns
+    -------
+    np.longdouble
+
+    """
+    if type(data) is str:
+        return str2longdouble(data)
+    else:
+        return np.longdouble(data)
+
+
+def longdouble2str(x):
+    """Convert numpy longdouble to string."""
+    return repr(x)
+
+
+def str2longdouble(str_data):
+    """Return a long double from the input string.
+
+    Accepts Fortran-style exponent notation (1.0d2).
+
+    """
+    if not isinstance(str_data, str):
+        raise TypeError("Need a string: {!r}".format(str_data))
+    return np.longdouble(str_data.translate(maketrans("Dd", "ee")))
+
+
+# Simplified functions: These core functions, if they can be made to work
+# reliably and efficiently, should implement everything else.
+
+
+def safe_kind_conversion(values, dtype):
+    try:
+        from collections.abc import Iterable
+    except ImportError:
+        from collections import Iterable
+    if isinstance(values, Iterable):
+        return np.asarray(values, dtype=dtype)
+    else:
+        return dtype(values)
+
+
+# This can be removed once we only support astropy >=3.1.
+# The str(c) is necessary for python2/numpy -> no unicode literals...
+_new_ihmsfs_dtype = np.dtype([(str(c), np.intc) for c in "hmsf"])
+
+
+def jds_to_mjds(jd1, jd2):
+    return day_frac(jd1 - DJM0, jd2)
+
+
+def mjds_to_jds(mjd1, mjd2):
+    return day_frac(mjd1 + DJM0, mjd2)
+
+
+_digits = 9
+
+
+def jds_to_mjds_pulsar(jd1, jd2):
+    # Do the reverse of the above calculation
+    # Note this will return an incorrect value during
+    # leap seconds, so raise an exception in that
+    # case.
+    y, mo, d, hmsf = erfa.d2dtf("UTC", _digits, jd1, jd2)
+    # For ASTROPY_LT_3_1, convert to the new structured array dtype that
+    # is returned by the new erfa gufuncs.
+    if not hmsf.dtype.names:
+        hmsf = hmsf.view(_new_ihmsfs_dtype)[..., 0]
+    if np.any(hmsf["s"] == 60):
+        raise ValueError(
+            "UTC times during a leap second cannot be represented in pulsar_mjd format"
+        )
+    j1, j2 = erfa.cal2jd(y, mo, d)
+    return day_frac(
+        j1 - erfa.DJM0 + j2,
+        hmsf["h"] / 24.0
+        + hmsf["m"] / 1440.0
+        + hmsf["s"] / 86400.0
+        + hmsf["f"] / 86400.0 / 10 ** _digits,
+    )
+
+
+def mjds_to_jds_pulsar(mjd1, mjd2):
+    # To get around leap second issues, first convert to YMD,
+    # then back to astropy/ERFA-convention jd1,jd2 using the
+    # ERFA dtf2d() routine which handles leap seconds.
+    v1, v2 = day_frac(mjd1, mjd2)
+    (y, mo, d, f) = erfa.jd2cal(erfa.DJM0 + v1, v2)
+    # Fractional day to HMS.  Uses 86400-second day always.
+    # Seems like there should be a ERFA routine for this..
+    # There is: erfa.d2tf. Unfortunately it takes a "number of
+    # digits" argument and returns some kind of bogus
+    # fractional-part-as-an-integer thing.
+    # Worse, it fails to provide nanosecond accuracy.
+    # Good idea, though, because using np.remainder is
+    # numerically unstable and gives bogus values now
+    # and then. This is more stable.
+    f *= 24
+    h = safe_kind_conversion(np.floor(f), dtype=int)
+    f -= h
+    f *= 60
+    m = safe_kind_conversion(np.floor(f), dtype=int)
+    f -= m
+    f *= 60
+    s = f
+    return erfa.dtf2d("UTC", y, mo, d, h, m, s)
+
+
+# Please forgive the horrible hacks to make these work cleanly on both arrays
+# and single elements
+
+
+def _str_to_mjds(s):
+    ss = s.lower().strip()
+    if "e" in ss or "d" in ss:
+        ss = ss.translate(maketrans("d", "e"))
+        num, expon = ss.split("e")
+        expon = int(expon)
+        if expon < 0:
+            imjd, fmjd = 0, np.longdouble(ss)
+        else:
+            mjd_s = num.split(".")
+            # If input was given as an integer, add floating "0"
+            if len(mjd_s) == 1:
+                mjd_s.append("0")
+            imjd_s, fmjd_s = mjd_s
+            imjd = np.longdouble(int(imjd_s))
+            fmjd = np.longdouble("0." + fmjd_s)
+            if ss.startswith("-"):
+                fmjd = -fmjd
+            imjd *= 10 ** expon
+            fmjd *= 10 ** expon
+    else:
+        mjd_s = ss.split(".")
+        # If input was given as an integer, add floating "0"
+        if len(mjd_s) == 1:
+            mjd_s.append("0")
+        imjd_s, fmjd_s = mjd_s
+        imjd = int(imjd_s)
+        fmjd = float("0." + fmjd_s)
+        if ss.startswith("-"):
+            fmjd = -fmjd
+    return day_frac(imjd, fmjd)
+
+
+def str_to_mjds(s):
+    if isinstance(s, str):
+        return _str_to_mjds(s)
+    else:
+        imjd = np.empty_like(s, dtype=int)
+        fmjd = np.empty_like(s, dtype=float)
+        with np.nditer(
+            [s, imjd, fmjd],
+            flags=["refs_ok"],
+            op_flags=[["readonly"], ["writeonly"], ["writeonly"]],
+        ) as it:
+            for si, i, f in it:
+                si = si[()]
+                if not isinstance(si, str):
+                    raise TypeError("Requires an array of strings")
+                i[...], f[...] = _str_to_mjds(si)
+            return it.operands[1], it.operands[2]
+
+
+def _mjds_to_str(mjd1, mjd2):
+    (imjd, fmjd) = day_frac(mjd1, mjd2)
+    imjd = int(imjd)
+    assert np.fabs(fmjd) < 1.0
+    while fmjd < 0.0:
+        imjd -= 1
+        fmjd += 1.0
+    assert 0 <= fmjd < 1
+    return str(imjd) + "{:.16f}".format(fmjd)[1:]
+
+
+_v_mjds_to_str = np.vectorize(_mjds_to_str, otypes=[np.object])
+
+
+def mjds_to_str(mjd1, mjd2):
+    r = _v_mjds_to_str(mjd1, mjd2)
+    if r.shape == ():
+        return r[()]
+    else:
+        return r

--- a/tests/test_d_phase_d_toa.py
+++ b/tests/test_d_phase_d_toa.py
@@ -1,31 +1,42 @@
-from pint.polycos import Polycos
-from pint.models import model_builder as mb
-import pint.toa as toa
+import os
+import unittest
+
 import numpy as np
-import pint.utils as ut
-import os, unittest
-from pinttestdata import testdir, datadir
+from astropy._erfa import DJM0
+
+import pint.toa as toa
+from pint.models import model_builder as mb
+from pint.polycos import Polycos
+from pinttestdata import datadir, testdir
 
 
 class TestD_phase_d_toa(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         os.chdir(datadir)
-        self.parfileB1855 = 'B1855+09_polycos.par'
-        self.timB1855 = 'B1855_polyco.tim'
-        self.toasB1855 = toa.get_TOAs(self.timB1855, ephem="DE405",
-                                      planets=False, include_bipm=False)
+        self.parfileB1855 = "B1855+09_polycos.par"
+        self.timB1855 = "B1855_polyco.tim"
+        self.toasB1855 = toa.get_TOAs(
+            self.timB1855, ephem="DE405", planets=False, include_bipm=False
+        )
         self.modelB1855 = mb.get_model(self.parfileB1855)
         # Read tempo style polycos.
         self.plc = Polycos()
-        self.plc.read_polyco_file('B1855_polyco.dat', 'tempo')
+        self.plc.read_polyco_file("B1855_polyco.dat", "tempo")
+
     def TestD_phase_d_toa(self):
         pint_d_phase_d_toa = self.modelB1855.d_phase_d_toa(self.toasB1855)
-        mjd = np.array([np.longdouble(t.jd1 - ut.DJM0)+np.longdouble(t.jd2)
-                        for t in self.toasB1855.table['mjd']])
+        mjd = np.array(
+            [
+                np.longdouble(t.jd1 - DJM0) + np.longdouble(t.jd2)
+                for t in self.toasB1855.table["mjd"]
+            ]
+        )
         tempo_d_phase_d_toa = self.plc.eval_spin_freq(mjd)
         diff = pint_d_phase_d_toa.value - tempo_d_phase_d_toa
-        relative_diff = diff/tempo_d_phase_d_toa
-        assert np.all(relative_diff < 1e-8), 'd_phae_d_toa test filed.'
-if __name__ == '__main__':
+        relative_diff = diff / tempo_d_phase_d_toa
+        assert np.all(relative_diff < 1e-8), "d_phae_d_toa test filed."
+
+
+if __name__ == "__main__":
     pass

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,11 +1,11 @@
 from pint.models import parameter as p
 from pint.models import model_builder as mb
 from pint import pint_units
-from pint.utils import str2longdouble
 from astropy.coordinates.angles import Angle
 import astropy.time as time
 import astropy.units as u
-import numpy, os, unittest
+import numpy as np
+import os, unittest
 
 from pinttestdata import testdir, datadir
 
@@ -48,68 +48,68 @@ class TestParameters(unittest.TestCase):
         self.assertEqual(test_m.F2.frozen, True)
         self.assertEqual(test_m.F3.frozen, True)
         self.assertTrue(
-                numpy.isclose(test_m.F3.value, 0.0))
+                np.isclose(test_m.F3.value, 0.0))
         self.assertTrue(
-                numpy.isclose(test_m.F3.uncertainty_value, 0.0))
+                np.isclose(test_m.F3.uncertainty_value, 0.0))
         self.assertEqual(test_m.F4.frozen, True)
         self.assertTrue(
-                numpy.isclose(test_m.F4.value, 0.0))
+                np.isclose(test_m.F4.value, 0.0))
         self.assertTrue(
-                numpy.isclose(test_m.F4.uncertainty_value, 0.001))
+                np.isclose(test_m.F4.uncertainty_value, 0.001))
         self.assertEqual(test_m.F5.frozen, True)
         self.assertTrue(
-                numpy.isclose(test_m.F5.value, 0.0))
+                np.isclose(test_m.F5.value, 0.0))
         self.assertTrue(
-                numpy.isclose(test_m.F5.uncertainty_value, 0.001))
+                np.isclose(test_m.F5.uncertainty_value, 0.001))
         self.assertEqual(test_m.F6.frozen, False)
         self.assertTrue(
-                numpy.isclose(test_m.F6.value, 0.0))
+                np.isclose(test_m.F6.value, 0.0))
         self.assertTrue(
-                numpy.isclose(test_m.F6.uncertainty_value, 0.001))
+                np.isclose(test_m.F6.uncertainty_value, 0.001))
         self.assertEqual(test_m.F7.frozen, True)
         self.assertTrue(
-                numpy.isclose(test_m.F7.value, 0.0))
+                np.isclose(test_m.F7.value, 0.0))
         self.assertTrue(
-                numpy.isclose(test_m.F7.uncertainty_value, 3.0))
+                np.isclose(test_m.F7.uncertainty_value, 3.0))
         self.assertEqual(test_m.F8.frozen, True)
         self.assertTrue(
-                numpy.isclose(test_m.F8.value, 0.0))
+                np.isclose(test_m.F8.value, 0.0))
         self.assertTrue(
-                numpy.isclose(test_m.F8.uncertainty_value, 10))
+                np.isclose(test_m.F8.uncertainty_value, 10))
         self.assertEqual(test_m.JUMP1.frozen, True)
         self.assertEqual(test_m.JUMP1.key, 'MJD')
         self.assertTrue(
-                numpy.isclose(test_m.JUMP1.key_value[0], 52742.0, atol=1e-10))
+                np.isclose(test_m.JUMP1.key_value[0], 52742.0, atol=1e-10))
         self.assertTrue(
-                numpy.isclose(test_m.JUMP1.key_value[1], 52745.0, atol=1e-10))
+                np.isclose(test_m.JUMP1.key_value[1], 52745.0, atol=1e-10))
         self.assertTrue(
-                numpy.isclose(test_m.JUMP1.value, 0.2))
+                np.isclose(test_m.JUMP1.value, 0.2))
 
         self.assertEqual(test_m.JUMP2.frozen, True)
         self.assertTrue(
-                numpy.isclose(test_m.JUMP2.value, 0.1))
+                np.isclose(test_m.JUMP2.value, 0.1))
         self.assertTrue(
-                numpy.isclose(test_m.JUMP2.uncertainty_value, 0.0))
+                np.isclose(test_m.JUMP2.uncertainty_value, 0.0))
         self.assertTrue(
-                numpy.isclose(test_m.JUMP7.value, 0.1))
+                np.isclose(test_m.JUMP7.value, 0.1))
         self.assertTrue(
-                numpy.isclose(test_m.JUMP7.uncertainty_value, 10.5))
+                np.isclose(test_m.JUMP7.uncertainty_value, 10.5))
         self.assertTrue(
-                numpy.isclose(test_m.JUMP6.value, 0.1))
+                np.isclose(test_m.JUMP6.value, 0.1))
         self.assertTrue(
-                numpy.isclose(test_m.JUMP6.uncertainty_value, 10.0))
+                np.isclose(test_m.JUMP6.uncertainty_value, 10.0))
         self.assertEqual(test_m.JUMP12.key, '-testflag')
         self.assertEqual(test_m.JUMP12.frozen, False)
         self.assertEqual(test_m.JUMP12.key_value[0], 'flagvalue')
         self.assertTrue(
-                numpy.isclose(test_m.JUMP12.value, 0.1))
+                np.isclose(test_m.JUMP12.value, 0.1))
         self.assertTrue(
-                numpy.isclose(test_m.JUMP12.uncertainty_value, 2.0))
+                np.isclose(test_m.JUMP12.uncertainty_value, 2.0))
         self.assertTrue(
-                numpy.isclose(test_m.RAJ.uncertainty_value, 476.94611148516092061223))
+                np.isclose(test_m.RAJ.uncertainty_value, 476.94611148516092061223))
 
         self.assertTrue(
-                numpy.isclose(test_m.DECJ.uncertainty_value, 190996312986311097848351.00000000000000000000))
+                np.isclose(test_m.DECJ.uncertainty_value, 190996312986311097848351.00000000000000000000))
         self.assertTrue(test_m.RAJ.uncertainty.unit, pint_units['hourangle_second'])
         self.assertTrue(test_m.RAJ.uncertainty.unit, u.arcsecond)
     def test_RAJ(self):
@@ -132,11 +132,11 @@ class TestParameters(unittest.TestCase):
     def test_F0(self):
         """Check whether the value and units of F0 parameter are ok"""
         units = u.Hz
-        value = str2longdouble('186.49408156698235146')
+        value = np.longdouble('186.49408156698235146')
 
         self.assertEqual(self.m.F0.units, units)
         self.assertTrue(
-                numpy.isclose(self.m.F0.value, value, atol=1e-19))
+                np.isclose(self.m.F0.value, value, atol=1e-19))
         self.assertEqual(self.m.F0.value, value)
 
     def test_F0_uncertainty(self):
@@ -144,11 +144,11 @@ class TestParameters(unittest.TestCase):
         units = self.m.F0.units
         # Test stored uncertainty value
         self.assertTrue(
-                numpy.isclose(self.m.F0.uncertainty.to(units).value,
+                np.isclose(self.m.F0.uncertainty.to(units).value,
                 uncertainty, atol=1e-20))
         # Test parameter.uncertainty_value returned value
         self.assertTrue(
-                numpy.isclose(self.m.F0.uncertainty_value, uncertainty,
+                np.isclose(self.m.F0.uncertainty_value, uncertainty,
                 atol=1e-20))
 
 
@@ -167,15 +167,15 @@ class TestParameters(unittest.TestCase):
         # Set it to 186.49 Hz: the 'standard' value
         self.m.F0.quantity = value * units
         self.assertTrue(
-                numpy.isclose(self.m.F0.value, value, atol=1e-13))
+                np.isclose(self.m.F0.value, value, atol=1e-13))
 
         # Now change the units
         self.m.F0.units = str_unit_new
         self.assertTrue(
-                numpy.isclose(self.m.F0.value, value_new, atol=1e-13))
+                np.isclose(self.m.F0.value, value_new, atol=1e-13))
 
         self.assertTrue(
-                numpy.isclose(self.m.F0.uncertainty_value, uncertainty_value_new,
+                np.isclose(self.m.F0.uncertainty_value, uncertainty_value_new,
                               atol=1e-13))
         # Change the units back, and then set them implicitly
         # The value will be associate with the new units
@@ -183,18 +183,18 @@ class TestParameters(unittest.TestCase):
         self.m.F0.quantity = value_new * units_new
         self.m.F0.uncertainty = uncertainty_value_new * units_new
         self.assertTrue(
-                numpy.isclose(self.m.F0.value, value, atol=1e-13))
+                np.isclose(self.m.F0.value, value, atol=1e-13))
         self.assertTrue(
-                numpy.isclose(self.m.F0.uncertainty_value, uncertainty_value,
+                np.isclose(self.m.F0.uncertainty_value, uncertainty_value,
                               atol=1e-20))
         # Check the ratio, using the old units as a reference
         ratio = self.m.F0.quantity / (value * units)
         ratio_uncertainty = self.m.F0.uncertainty / (uncertainty_value * units)
         self.assertTrue(
-                numpy.isclose(ratio.decompose(u.si.bases), 1.0, atol=1e-13))
+                np.isclose(ratio.decompose(u.si.bases), 1.0, atol=1e-13))
 
         self.assertTrue(
-                numpy.isclose(ratio_uncertainty.decompose(u.si.bases), 1.0,
+                np.isclose(ratio_uncertainty.decompose(u.si.bases), 1.0,
                               atol=1e-20))
 
     def set_units_fail(self):
@@ -223,7 +223,7 @@ class TestParameters(unittest.TestCase):
         self.m.T0.value = 50044.3322
         # I don't understand why this is failing...  something about float128
         # Does not fail for me (both lines)  -- RvH 02/22/2015
-        self.assertTrue(numpy.isclose(self.m.T0.value, 50044.3322))
+        self.assertTrue(np.isclose(self.m.T0.value, 50044.3322))
         self.assertEqual(self.m.T0.value, 50044.3322)
 
     def set_num_to_none(self):

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -1,52 +1,159 @@
+from __future__ import absolute_import, division, print_function
+
+import decimal
 import re
 import sys
+from datetime import datetime
+from decimal import Decimal
+from itertools import product
 
+import astropy._erfa as erfa
 import astropy.units as u
 import numpy as np
 import pytest
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
-from hypothesis import example, given, settings
-from hypothesis.strategies import floats, integers, just, one_of
+from hypothesis import assume, example, given, settings
+from hypothesis.strategies import (
+    booleans,
+    composite,
+    floats,
+    integers,
+    one_of,
+    sampled_from,
+)
 from numpy.testing import assert_array_equal
 
 import pint.pulsar_mjd
 from pint.utils import (
     PosVel,
     data2longdouble,
+    day_frac,
+    jds_to_mjds,
+    jds_to_mjds_pulsar,
     longdouble2str,
+    mjds_to_jds,
+    mjds_to_jds_pulsar,
+    mjds_to_str,
+    safe_kind_conversion,
     str2longdouble,
+    str_to_mjds,
+    time_from_longdouble,
     time_from_mjd_string,
     time_to_longdouble,
     time_to_mjd_string,
+    two_sum,
 )
 
 time_eps = (np.finfo(float).eps * u.day).to(u.ns)
 
 
-@given(
-    one_of(integers(40000, 60000), integers(-3000000, 3000000), just(0)),
-    floats(-2, 2, allow_nan=False),
+leap_sec_mjds = set(
+    [
+        41499,
+        41683,
+        42048,
+        42413,
+        42778,
+        43144,
+        43509,
+        43874,
+        44239,
+        44786,
+        45151,
+        45516,
+        46247,
+        47161,
+        47892,
+        48257,
+        48804,
+        49169,
+        49534,
+        50083,
+        50630,
+        51179,
+        53736,
+        54832,
+        56109,
+        57204,
+        57754,
+    ]
 )
-def test_str_roundtrip_is_exact(i, f):
+leap_sec_days = set([d - 1 for d in leap_sec_mjds])
+near_leap_sec_days = list(
+    sorted([d - 1 for d in leap_sec_days] + [d + 1 for d in leap_sec_days])
+)
+
+
+@composite
+def possible_leap_sec_days(draw):
+    y = draw(integers(2017, 2050))
+    s = draw(booleans())
+    if s:
+        m = Time(datetime(y, 6, 30, 0, 0, 0), scale="tai").mjd
+    else:
+        m = Time(datetime(y, 12, 31, 0, 0, 0), scale="tai").mjd
+    return int(np.round(m))
+
+
+@composite
+def leap_sec_day_mjd(draw):
+    i = draw(sampled_from(sorted(leap_sec_days)))
+    f = draw(floats(0, 1, allow_nan=False))
+    return (i, f)
+
+
+@composite
+def normal_mjd(draw):
+    i = draw(
+        one_of(
+            integers(40000, 70000),
+            sampled_from(near_leap_sec_days),
+            possible_leap_sec_days(),
+        )
+    )
+    assume(i not in leap_sec_days)
+    f = draw(floats(0, 1, allow_nan=False))
+    return (i, f)
+
+
+@composite
+def reasonable_mjd(draw):
+    return draw(one_of(normal_mjd(), leap_sec_day_mjd()))
+
+
+@composite
+def unreasonable_mjd(draw):
+    i = draw(integers(-3000000, 3000000))
+    f = draw(floats(-2, 2, allow_nan=False))
+    return (i, f)
+
+
+@composite
+def any_mjd(draw):
+    return draw(one_of(normal_mjd(), leap_sec_day_mjd(), unreasonable_mjd()))
+
+
+# longdouble2str, str2longdouble
+
+
+@given(any_mjd())
+def test_str_roundtrip_is_exact(i_f):
+    i, f = i_f
     ld = np.longdouble(i) + np.longdouble(f)
     assert ld == np.longdouble(str(ld))
 
 
-@given(
-    one_of(integers(40000, 60000), integers(-3000000, 3000000), just(0)),
-    floats(-2, 2, allow_nan=False),
-)
-def test_longdouble_str_roundtrip_is_exact(i, f):
+@given(any_mjd())
+def test_longdouble_str_roundtrip_is_exact(i_f):
+    i, f = i_f
     ld = np.longdouble(i) + np.longdouble(f)
     assert ld == str2longdouble(longdouble2str(ld))
 
 
-@given(
-    one_of(integers(40000, 60000), integers(-3000000, 3000000), just(0)),
-    one_of(floats(-2, 2, allow_nan=False), integers(-2, 2), just(0)),
-)
-def test_longdouble2str_same_as_str_and_repr(i, f):
+@given(any_mjd())
+def test_longdouble2str_same_as_str_and_repr(i_f):
+    i, f = i_f
     ld = np.longdouble(i) + np.longdouble(f)
     assert longdouble2str(ld) == str(ld)
     assert longdouble2str(ld) == repr(ld)
@@ -96,6 +203,9 @@ def test_data2longdouble_accepts_types(d, ld):
     assert data2longdouble(d) == ld
 
 
+# data2longdouble
+
+
 @pytest.mark.parametrize(
     "a",
     [
@@ -110,97 +220,240 @@ def test_data2longdouble_converts_arrays(a):
     assert_array_equal(data2longdouble(a), np.asarray(a, dtype=np.longdouble))
 
 
-@given(one_of(integers(40000, 70000)), floats(-2.0, 2.0, allow_nan=False))
-@example(i=65536, f=3.552713678800502e-15)
-@example(format="pulsar_mjd", i=43143, f=9.313492199680697e-10)
-@example(format="pulsar_mjd", i=40000, f=-4.440892098500627e-16)
-@example(format="mjd", i=40000, f=-4.440892098500627e-16)
+# astropy.time.Time construction (?!)
+
+
+@given(reasonable_mjd())
+@example(i_f=(65536, 3.552713678800502e-15))
+@example(i_f=(43143, 9.313492199680697e-10))
+@example(i_f=(40000, -4.440892098500627e-16))
+@example(i_f=(40000, -4.440892098500627e-16))
+@example(scale="tdb", i_f=(65536, 3.637978807091714e-12))
+@pytest.mark.parametrize("scale", ["tai", "tt", "tdb"])
+def test_time_construction_jds_exact(scale, i_f):
+    i, f = i_f
+    jd1, jd2 = day_frac(i + erfa.DJM0, f)
+    t = Time(val=jd1, val2=jd2, format="jd", scale=scale)
+    jd1_t, jd2_t = day_frac(t.jd1, t.jd2)
+    assert (jd1, jd2) == (jd1_t, jd2_t)
+
+
+@pytest.mark.xfail(reason="astropy bug #9327; fixed in 3.2.2")
+@given(reasonable_mjd())
+@example(i_f=(40000, -4.440892098500627e-16))
+@example(i_f=(43143, 9.313492199680697e-10))
+@example(i_f=(65536, 3.637978807091714e-12))
+# @example(i_f=(65536, 3.552713678800502e-15))
+def test_time_construction_mjds_preserved(i_f):
+    i, f = i_f
+    t = Time(val=i, val2=f, format="mjd", scale="tai")
+    jd1, jd2 = day_frac(i + erfa.DJM0, f)
+    jd1_t, jd2_t = day_frac(t.jd1, t.jd2)
+    assert (abs((jd1 - jd1_t) + (jd2 - jd2_t)) * u.day).to(u.ns) < 1 * u.ns
+
+
+@pytest.mark.xfail(reason="astropy bug #9327; fixed in 3.2.2")
+@given(reasonable_mjd())
+@example(i_f=(40000, -4.440892098500627e-16))
+@example(i_f=(43143, 9.313492199680697e-10))
+@example(i_f=(65536, 3.637978807091714e-12))
+@pytest.mark.parametrize("scale", ["tai", "tt", "tdb"])
+def test_time_construction_mjd_versus_jd(scale, i_f):
+    i, f = i_f
+    jd1, jd2 = day_frac(i + erfa.DJM0, f)
+    t = Time(val=jd1, val2=jd2, format="jd", scale=scale)
+    t2 = Time(val=i, val2=f, format="mjd", scale=scale)
+    assert abs(t - t2).to(u.ns) < 1 * u.ns
+
+
+# time_to_longdouble, time_from_longdouble
+
+
+@given(reasonable_mjd())
+@example(i_f=(43143, 9.313492199680697e-10))
+@example(i_f=(40000, -4.440892098500627e-16))
+@example(i_f=(65536, 3.637978807091714e-12))
+@pytest.mark.parametrize("scale", ["tai", "tt", "tdb"])
+def test_time_to_longdouble_via_jd(scale, i_f):
+    i, f = i_f
+    jd1, jd2 = day_frac(i + erfa.DJM0, f)
+    t = Time(val=jd1, val2=jd2, format="jd", scale=scale)
+    ld = np.longdouble(i) + np.longdouble(f)
+    assert (abs(time_to_longdouble(t) - ld) * u.day).to(u.ns) < 1 * u.ns
+
+
+@pytest.mark.xfail(reason="astropy bug #9327; fixed in 3.2.2")
+@given(reasonable_mjd())
+@example(i_f=(43143, 9.313492199680697e-10))
+@example(i_f=(40000, -4.440892098500627e-16))
+@example(i_f=(65536, 3.637978807091714e-12))
+@pytest.mark.parametrize("scale", ["tai", "tt", "tdb"])
+def test_time_to_longdouble(scale, i_f):
+    i, f = i_f
+    t = Time(val=i, val2=f, format="mjd", scale=scale)
+    ld = np.longdouble(i) + np.longdouble(f)
+    assert (abs(time_to_longdouble(t) - ld) * u.day).to(u.ns) < 1 * u.ns
+
+
+@pytest.mark.xfail(reason="astropy bug #9327; fixed in 3.2.2")
+@given(reasonable_mjd())
+@example(format="pulsar_mjd", i_f=(43143, 9.313492199680697e-10))
+@example(format="pulsar_mjd", i_f=(40000, -4.440892098500627e-16))
+@example(i_f=(65536, 3.637978807091714e-12))
+@example(format="mjd", i_f=(40000, -4.440892098500627e-16))
 @pytest.mark.parametrize("format", ["mjd", "pulsar_mjd"])
-def test_time_to_longdouble(format, i, f):
-    t = Time(val=i, val2=f, format=format, scale="tai")
+def test_time_to_longdouble_utc(format, scale, i_f):
+    i, f = i_f
+    t = Time(val=i, val2=f, format=format, scale="utc")
     ld = np.longdouble(i) + np.longdouble(f)
     assert_quantity_allclose(
         time_to_longdouble(t) * u.day, ld * u.day, rtol=0, atol=1.0 * u.ns
     )
 
 
-@pytest.mark.xfail(reason="What on Earth? A day? Is this a failure of pulsar_mjd?")
-@given(integers(40000, 70000), floats(-2.0, 2.0, allow_nan=False))
-@example(i=65536, f=3.552713678800502e-15)
-@example(format="pulsar_mjd", i=43143, f=9.313492199680697e-10)
-@example(format="pulsar_mjd", i=40000, f=-4.440892098500627e-16)
-@example(format="mjd", i=40000, f=-4.440892098500627e-16)
-@settings(max_examples=5000)
-@pytest.mark.parametrize("format", ["mjd", pytest.param("pulsar_mjd")])
-def test_time_to_mjd_string_precision(format, i, f):
-    t = Time(val=i, val2=f, format=format, scale="tai")
+@given(reasonable_mjd())
+@example(i_f=(65536, 3.552713678800502e-15))
+@example(i_f=(43143, 9.313492199680697e-10))
+@example(i_f=(40000, -4.440892098500627e-16))
+@example(i_f=(40000, -4.440892098500627e-16))
+@pytest.mark.parametrize("scale", ["tai", "tt", "tdb"])
+def test_time_from_longdouble(scale, i_f):
+    i, f = i_f
+    t = Time(val=i, val2=f, format="mjd", scale=scale)
     ld = np.longdouble(i) + np.longdouble(f)
-    assert_quantity_allclose(
-        np.longdouble(time_to_mjd_string(t)) * u.day,
-        ld * u.day,
-        rtol=0,
-        atol=2.0 * u.ns,
+    assert (
+        abs(time_from_longdouble(ld, format="mjd", scale=scale) - t).to(u.ns) < 1 * u.ns
     )
 
 
-@pytest.mark.xfail(reason="What on Earth? A day? Is this a failure of pulsar_mjd?")
-@given(integers(40000, 70000), floats(-2.0, 2.0, allow_nan=False))
-@example(i=65536, f=3.552713678800502e-15)
-@example(format="pulsar_mjd", i=43143, f=9.313492199680697e-10)
-@example(format="pulsar_mjd", i=50081, f=1.0000000016292463)
-@example(format="pulsar_mjd", i=40000, f=-4.440892098500627e-16)
-@example(format="mjd", i=40000, f=-4.440892098500627e-16)
-@example(format='pulsar_mjd', i=40000, f=-4.440892098500627e-16)
+@given(reasonable_mjd())
+@example(format="pulsar_mjd", i_f=(40000, 0.7333333333333333))
+@example(format="mjd", i_f=(40000, 0.7333333333333333))
+# @example(format="mjd", i_f=(41498, 0.9999999999999982))
+# @example(format="pulsar_mjd", i_f=(41498, 0.9999999999999982))
 @pytest.mark.parametrize("format", ["mjd", "pulsar_mjd"])
-def test_time_to_longdouble_close_to_time_to_mjd_string(format, i, f):
-    t = Time(val=i, val2=f, format=format, scale="tai")
-    assert_quantity_allclose(
-        np.longdouble(time_to_mjd_string(t)) * u.day,
-        time_to_longdouble(t) * u.day,
-        rtol=0,
-        atol=3.0 * u.ns,
+def test_time_from_longdouble_utc(format, i_f):
+    i, f = i_f
+    assume(
+        not (format == "pulsar_mjd" and i in leap_sec_days and (1 - f) * 86400 < 1e-9)
+    )
+    t = Time(val=i, val2=f, format=format, scale="utc")
+    ld = np.longdouble(i) + np.longdouble(f)
+    assert (
+        abs(time_from_longdouble(ld, format=format, scale="utc") - t).to(u.ns)
+        < 1 * u.ns
     )
 
 
-@given(integers(40000, 70000), floats(-2.0, 2.0, allow_nan=False))
-@example(i=65536, f=3.552713678800502e-15)
-def test_time_to_longdouble_no_longer_than_time_to_mjd_string(i, f):
+# time_to_mjd_string, time_from_mjd_string
+
+
+@given(reasonable_mjd())
+@example(i_f=(65536, 3.552713678800502e-15))
+@example(format="pulsar_mjd", i_f=(43143, 9.313492199680697e-10))
+@example(format="pulsar_mjd", i_f=(40000, -4.440892098500627e-16))
+@example(format="mjd", i_f=(40000, -4.440892098500627e-16))
+@example(format="pulsar_mjd", i_f=(40001, -4.440892098500627e-16))
+@example(format="pulsar_mjd", i_f=(50081, 1.0000000016292463))
+@pytest.mark.parametrize(
+    "format",
+    [
+        "mjd",
+        pytest.param(
+            "pulsar_mjd",
+            marks=pytest.mark.xfail(reason="astropy bug #9327; fixed in 3.2.2"),
+        ),
+    ],
+)
+def test_time_to_longdouble_close_to_time_to_mjd_string(format, i_f):
+    i, f = i_f
+    t = Time(val=i, val2=f, format=format, scale="utc")
+    assert (
+        abs(np.longdouble(time_to_mjd_string(t)) - time_to_longdouble(t)) * u.day
+    ).to(u.ns) < 1 * u.ns
+
+
+@given(reasonable_mjd())
+@example(i_f=(65536, 3.552713678800502e-15))
+def test_time_to_longdouble_no_longer_than_time_to_mjd_string(i_f):
+    i, f = i_f
     t = Time(val=i, val2=f, format="mjd", scale="tai")
     assert len(time_to_mjd_string(t)) >= len(str(time_to_longdouble(t)))
 
 
-@pytest.mark.xfail(reason="What on Earth? A day? Is this a failure of pulsar_mjd?")
-@given(integers(40000, 70000), floats(-2.0, 2.0, allow_nan=False))
-@example(i=65536, f=3.552713678800502e-15)
-@example(i=40000, f=-8.881784197001254e-16)
-@example(i=40000, f=-4.440892098500627e-16)
-def test_time_to_mjd_string_format_dependence(i, f):
-    t = Time(val=i, val2=f, format="mjd", scale="tai")
-    t2 = Time(val=i, val2=f, format="pulsar_mjd", scale="tai")
-    assert_quantity_allclose(
-        np.longdouble(time_to_mjd_string(t)) * u.day,
-        np.longdouble(time_to_mjd_string(t2)) * u.day,
-        rtol=0,
-        atol=1.0 * u.ns,
+@given(reasonable_mjd())
+@example(i_f=(65536, 3.552713678800502e-15))
+@example(format="pulsar_mjd", i_f=(43143, 9.313492199680697e-10))
+@example(format="pulsar_mjd", i_f=(40000, -4.440892098500627e-16))
+@example(format="mjd", i_f=(40000, -4.440892098500627e-16))
+@example(format="pulsar_mjd", i_f=(40001, -4.440892098500627e-16))
+@pytest.mark.parametrize(
+    "format",
+    [
+        "mjd",
+        pytest.param(
+            "pulsar_mjd",
+            marks=pytest.mark.xfail(reason="astropy bug #9327; fixed in 3.2.2"),
+        ),
+    ],
+)
+def test_time_to_mjd_string_versus_longdouble(format, i_f):
+    i, f = i_f
+    m = i + np.longdouble(f)
+    t = Time(val=i, val2=f, format=format, scale="utc")
+    assert (abs(np.longdouble(time_to_mjd_string(t)) - m) * u.day).to(u.ns) < 1 * u.ns
+
+
+@given(reasonable_mjd())
+def test_time_from_mjd_string_versus_longdouble_tai(i_f):
+    i, f = i_f
+    m = np.longdouble(i) + np.longdouble(f)
+    s = str(m)
+    assert (
+        abs(
+            time_from_mjd_string(s, scale="tai") - time_from_longdouble(s, scale="tai")
+        ).to(u.ns)
+        < 1 * u.ns
     )
 
 
-@given(integers(40000, 70000), floats(-2.0, 2.0, allow_nan=False))
-@example(i=40000, f=-8.881784197001254e-16)
-@example(i=69666, f=-1.4552476513551895)
-def test_pulsar_mjd_never_differs_too_much_from_mjd(i, f):
+@given(reasonable_mjd())
+@pytest.mark.parametrize("format", ["mjd", "pulsar_mjd"])
+def test_time_from_mjd_string_versus_longdouble_utc(format, i_f):
+    i, f = i_f
+    m = np.longdouble(i) + np.longdouble(f)
+    s = str(m)
+    assert (
+        abs(
+            time_from_mjd_string(s, scale="utc", format=format)
+            - time_from_longdouble(s, scale="utc", format=format)
+        ).to(u.ns)
+        < 1 * u.ns
+    )
+
+
+# pulsar_mjd
+
+
+@given(reasonable_mjd())
+@example(i_f=(40000, -8.881784197001254e-16))
+@example(i_f=(69666, -1.4552476513551895))
+def test_pulsar_mjd_never_differs_too_much_from_mjd_tai(i_f):
+    i, f = i_f
     t = Time(val=i, val2=f, format="mjd", scale="tai")
     t2 = Time(val=i, val2=f, format="pulsar_mjd", scale="tai")
     assert abs(t2 - t) <= 1 * u.ns
 
 
-@given(integers(40000, 70000), floats(-2.0, 2.0, allow_nan=False))
-@example(i=40000, f=-8.881784197001254e-16)
-@example(i=43510, f=-1.0000000000000002)
-def test_pulsar_mjd_never_differs_too_much_from_mjd_utc(i, f):
+@given(reasonable_mjd())
+@example(i_f=(40000, -8.881784197001254e-16))
+@example(i_f=(43510, -1.0000000000000002))
+@example(i_f=(41498, 0.7333333333333333))
+def test_pulsar_mjd_never_differs_too_much_from_mjd_utc(i_f):
+    i, f = i_f
     t = Time(val=i, val2=f, format="mjd", scale="utc")
     t2 = Time(val=i, val2=f, format="pulsar_mjd", scale="utc")
-    assert abs(t2 - t).to(u.s) <= 1 * u.s
+    assert abs(t2 - t).to(u.s) < (1 + 1e-10) * u.s
 
 
 def test_posvel_respects_longdouble():
@@ -213,34 +466,51 @@ def test_posvel_respects_longdouble():
     assert_array_equal(pv.vel, vel)
 
 
-@pytest.mark.xfail
-@given(
-    one_of(integers(40000, 60000), integers(-1000000, 3000000), just(0)),
-    floats(-2, 2, allow_nan=False),
-)
-@example(i=-1, f=0.9)
-@example(i=0, f=-0.00010000000000021106)
-@example(i=40000, f=1.2434497875801756e-14)
-@example(i=524288, f=1.1567635738174434e-11)
-def test_time_from_mjd_string_accuracy_vs_longdouble(i, f):
+@given(reasonable_mjd())
+@example(i_f=(40000, 1.2434497875801756e-14))
+@example(i_f=(43875, -1.000000000000002))
+@example(i_f=(48803, 1.0769154457079824e-09))
+@example(i_f=(48803, 1.0000079160299438e-06))
+@pytest.mark.parametrize("format", ["pulsar_mjd", "mjd"])
+def test_time_from_mjd_string_accuracy_vs_longdouble(format, i_f):
+    i, f = i_f
     mjd = np.longdouble(i) + np.longdouble(f)
+    assume(
+        not (format == "pulsar_mjd" and i in leap_sec_days and (1 - f) * 86400 < 1e-9)
+    )
     s = str(mjd)
-    t = Time(val=i, val2=f, format="mjd", scale="utc")
-    assert abs(time_from_mjd_string(s) - t).to(u.us) < 1 * u.us
+    t = Time(val=i, val2=f, format=format, scale="utc")
+    assert (
+        abs(time_from_mjd_string(s, format=format, scale="utc") - t).to(u.us) < 1 * u.us
+    )
     if 40000 <= i <= 60000:
-        assert abs(time_from_mjd_string(s) - t).to(u.us) < 1 * u.ns
+        assert (
+            abs(time_from_mjd_string(s, format=format, scale="utc") - t).to(u.us)
+            < 1 * u.ns
+        )
 
 
-@given(
-    one_of(integers(40000, 60000), integers(-3000000, 3000000), just(0)),
-    floats(-2, 2, allow_nan=False),
-)
-def test_time_from_mjd_string_roundtrip_very_close(i, f):
+@pytest.mark.parametrize("format", ["pulsar_mjd", "mjd"])
+def test_time_from_mjd_string_roundtrip_very_close(format):
     i = 50000
     f = np.finfo(float).eps
-    t = Time(val=i, val2=f, format="pulsar_mjd", scale="utc")
+    t = Time(val=i, val2=f, format=format, scale="utc")
     s = time_to_mjd_string(t)
     assert abs(time_from_mjd_string(s) - t).to(u.ns) <= 4 * time_eps
+
+
+@given(reasonable_mjd())
+@pytest.mark.parametrize("format", ["pulsar_mjd", "mjd"])
+def test_time_from_mjd_string_roundtrip(format, i_f):
+    i, f = i_f
+    assume(
+        not (format == "pulsar_mjd" and i in leap_sec_days and (1 - f) * 86400 < 1e-9)
+    )
+    t = Time(val=i, val2=f, format=format, scale="utc")
+    assert (
+        abs(t - time_from_mjd_string(time_to_mjd_string(t), format=format)).to(u.ns)
+        < 1 * u.ns
+    )
 
 
 def test_astropy_time_epsilon():
@@ -251,24 +521,299 @@ def test_astropy_time_epsilon():
     assert t1 - t2 <= 1.1 * np.finfo(float).eps * u.day
 
 
-@given(
-    one_of(integers(40000, 60000), integers(-1000000, 3000000), just(0)),
-    floats(-2, 2, allow_nan=False),
+@pytest.mark.xfail(
+    reason="ERFA doesn't like outrageous times and I haven't implemented an "
+    "array-capable fallback"
 )
-@example(i=-1, f=0.9)
-@example(i=0, f=-0.00010000000000021106)
-@example(i=40000, f=1.2434497875801756e-14)
-@example(i=524288, f=1.1567635738174434e-11)
-def test_make_pulsar_mjd_ancient(i, f):
+@given(any_mjd())
+@example(i_f=(-2431739, -4.440892098500627e-16))
+def test_make_pulsar_mjd_ancient(i_f):
+    i, f = i_f
     Time(val=i, val2=f, format="pulsar_mjd", scale="utc")
 
 
-@given(
-    one_of(integers(40000, 60000), integers(-1000000, 3000000), just(0)),
-    floats(-2, 2, allow_nan=False),
-)
-@example(i=-1, f=0.9)
-@example(i=0, f=-0.00010000000000021106)
-@example(i=40000, f=1.2434497875801756e-14)
-def test_make_mjd_ancient(i, f):
+@given(any_mjd())
+@example(i_f=(-2431739, -4.440892098500627e-16))
+@example(i_f=(-1, 0.9))
+@example(i_f=(0, -0.00010000000000021106))
+@example(i_f=(40000, 1.2434497875801756e-14))
+@example(i_f=(524288, 1.1567635738174434e-11))
+@example(i_f=(43875, -1.000000000000002))
+@example(i_f=(48803, 1.0769154457079824e-09))
+@example(i_f=(48803, 1.0000079160299438e-06))
+def test_make_mjd_ancient(i_f):
+    i, f = i_f
     Time(val=i, val2=f, format="mjd", scale="utc")
+
+
+@given(normal_mjd())
+@example(i_f=(41316, 3.338154197507493e-10))
+@example(i_f=(40000, 0.7333333333333333))
+def test_pulsar_mjd_equals_mjd_on_non_leap_second_days(i_f):
+    i, f = i_f
+    t1 = Time(val=i, val2=f, format="mjd", scale="utc")
+    t2 = Time(val=i, val2=f, format="pulsar_mjd", scale="utc")
+    assert abs(t1 - t2).to(u.ns) < 5 * time_eps
+
+
+@given(leap_sec_day_mjd())
+@example(i_f=(41498, 0.7333333333333333))
+def test_pulsar_mjd_equals_mjd_on_leap_second_days(i_f):
+    i, f = i_f
+    assume(f != 1)
+    assume(f != 0)
+    t1 = Time(val=i, val2=f * 86400 / 86401, format="mjd", scale="utc")
+    # t1 = Time(val=i, val2=f * 86400 / 86401, format="mjd", scale="utc")
+    t2 = Time(val=i, val2=f, format="pulsar_mjd", scale="utc")
+    assert abs(t1 - t2).to(u.ns) < 4 * time_eps
+
+
+@given(leap_sec_day_mjd())
+@example(i_f=(41498, 0.7333333333333333))
+def test_pulsar_mjd_close_to_mjd_on_leap_second_days(i_f):
+    i, f = i_f
+    assume(f != 1)
+    assume(f != 0)
+    t1 = Time(val=i, val2=f, format="mjd", scale="utc")
+    t2 = Time(val=i, val2=f, format="pulsar_mjd", scale="utc")
+    assert abs(t1 - t2).to(u.s) < 1.0 * u.s
+    # assert abs(t1 - t2).to(u.ns) < 4 * time_eps
+
+
+@given(leap_sec_day_mjd())
+def test_pulsar_mjd_proceeds_at_normal_rate_on_leap_second_days(i_f):
+    i, f = i_f
+    assume(0.2 < f < 1)
+    t1 = Time(val=i, val2=0, format="pulsar_mjd", scale="utc")
+    t2 = Time(val=i, val2=f, format="pulsar_mjd", scale="utc")
+    assert abs((t2 - t1).to(u.day) / (f * u.day) - 1) < 1e-9
+
+
+@given(leap_sec_day_mjd())
+def test_mjd_proceeds_slower_on_leap_second_days(i_f):
+    i, f = i_f
+    assume(0.2 < f < 1)
+    t1 = Time(val=i, val2=0, format="mjd", scale="utc")
+    t2 = Time(val=i, val2=f, format="mjd", scale="utc")
+    assert abs((t2 - t1).to(u.s) / (f * 86401 * u.s) - 1) < 1e-9
+
+
+def test_pulsar_mjd_likes_arrays():
+    i = np.arange(50000, 50010)
+    f = np.zeros(len(i))
+    Time(val=i, val2=f, format="mjd", scale="utc")
+    Time(val=i, val2=f, format="pulsar_mjd", scale="utc")
+
+
+# Checking with raw ERFA
+
+
+@given(leap_sec_day_mjd())
+@example(i_f=(41498, 0.5000057870370372))
+def test_erfa_conversion_on_leap_sec_days(i_f):
+    _test_erfa_conversion(leap=True, i_f=i_f)
+
+
+@given(normal_mjd())
+@example(i_f=(41497, 0.5000000000000001))
+@example(i_f=(41316, 9.280065826899888e-09))
+@example(i_f=(40000, 0.7333333333333333))
+@example(i_f=(41497, 0.7333333333333333))
+@example(i_f=(41316, 9.280065826899888e-09))
+def test_erfa_conversion_normal(i_f):
+    _test_erfa_conversion(leap=False, i_f=i_f)
+
+
+def _test_erfa_conversion(leap, i_f):
+    i_i, f_i = i_f
+    assume(0 <= f_i < 1)
+    if leap:
+        assume(i_i in leap_sec_days)
+    else:
+        assume(i_i not in leap_sec_days)
+    jd1_in, jd2_in = day_frac(erfa.DJM0 + i_i, f_i)
+    y, mo, d, f = erfa.jd2cal(jd1_in, jd2_in)
+    assert 0 < y < 3000
+    assert 0 < mo <= 12
+    assert 0 <= d < 32
+    assert 0 <= f < 1
+
+    jd1_temp, jd2_temp = erfa.cal2jd(y, mo, d)
+    jd1_temp, jd2_temp = day_frac(jd1_temp, jd2_temp)  # improve numerics
+    jd1_temp, jd2_temp = day_frac(jd1_temp, jd2_temp + f)
+    jd_change = abs((jd1_temp - jd1_in) + (jd2_temp - jd2_in)) * u.day
+    assert jd_change.to(u.ns) < 1 * u.ns
+
+    ft = 24 * f
+    h = safe_kind_conversion(np.floor(ft), dtype=int)
+    ft -= h
+    ft *= 60
+    m = safe_kind_conversion(np.floor(ft), dtype=int)
+    ft -= m
+    ft *= 60
+    s = ft
+    assert 0 <= h < 24
+    assert 0 <= m < 60
+    assert 0 <= s < 60
+
+    jd1, jd2 = erfa.dtf2d("UTC", y, mo, d, h, m, s)
+    y2, mo2, d2, f2 = erfa.jd2cal(jd1, jd2)
+    # assert (y, mo, d) == (y2, mo2, d2)
+    # assert (abs(f2-f)*u.day).to(u.s) < 1*u.ns
+
+    assert jd1 == np.floor(jd1) + 0.5
+    assert 0 <= jd2 < 1
+    jd1, jd2 = day_frac(jd1, jd2)
+    jd_change = abs((jd1 - jd1_in) + (jd2 - jd2_in)) * u.day
+    if leap:
+        assert jd_change.to(u.s) < 1 * u.s
+    else:
+        assert jd_change.to(u.ns) < 2 * u.ns
+        # assert jd_change.to(u.ns) < 1 * u.ns
+    return
+
+    i_o, f_o = day_frac(jd1 - erfa.DJM0, jd2)
+
+    mjd_change = abs((i_o - i_i) + (f_o - f_i)) * u.day
+    if leap:
+        assert mjd_change.to(u.s) < 1 * u.s
+    else:
+        assert mjd_change.to(u.ns) < 1 * u.ns
+
+
+# Try to nail down ERFA behaviour
+
+_new_ihmsfs_dtype = np.dtype([(str(c), np.intc) for c in "hmsf"])
+
+
+def d2tf_nice(ndp, days):
+    sgn, hmsf = erfa.d2tf(ndp, days)
+    if sgn == b"+":
+        sgn = "+"
+    elif sgn == b"-":
+        sgn = "-"
+    else:
+        raise ValueError("Mysterious sign found: {!r}".format(sgn))
+    if not hmsf.dtype.names:
+        hmsf = hmsf.view(_new_ihmsfs_dtype)
+    h = hmsf["h"]
+    m = hmsf["m"]
+    s = hmsf["s"] + hmsf["f"] / 10.0 ** ndp
+
+    return sgn, h, m, s
+
+
+def tf2d_nice(sgn, h, m, s):
+    return erfa.tf2d(sgn, h, m, s)
+
+
+@given(floats(-2, 2, allow_nan=False))
+@example(ndp=10, f=1.3322676295501882e-15)
+@example(ndp=11, f=4.440892098500627e-16)
+@example(ndp=12, f=4.440892098500627e-16)
+@pytest.mark.parametrize(
+    "ndp, k",
+    [
+        (8, 1),
+        (9, 1),
+        pytest.param(10, 100, marks=pytest.mark.xfail(reason="ERFA limitations")),
+        pytest.param(11, 1000, marks=pytest.mark.xfail(reason="ERFA limitations")),
+        pytest.param(12, 10000, marks=pytest.mark.xfail(reason="ERFA limitations")),
+    ],
+)
+def test_d2tf_tf2d_roundtrip(ndp, k, f):
+    assert abs(tf2d_nice(*d2tf_nice(ndp, f)) - f) * 86400 < k * 10 ** (-ndp)
+
+
+# New functions
+
+
+@pytest.fixture
+def dec():
+    with decimal.localcontext(decimal.Context(prec=40)):
+        yield
+
+
+def decimalify(i, f):
+    return Decimal(i) + Decimal(f)
+
+
+def assert_closer_than_ns(i_f, i_f_2, amt):
+    d = decimalify(*i_f) * 86400 * 10 ** 9
+    d_2 = decimalify(*i_f_2) * 86400 * 10 ** 9
+    assert abs(d_2 - d) < amt
+
+
+@given(reasonable_mjd())
+def test_mjd_jd_round_trip(dec, i_f):
+    assert_closer_than_ns(jds_to_mjds(*mjds_to_jds(*i_f)), i_f, 1)
+
+
+@given(reasonable_mjd())
+def test_mjd_jd_pulsar_round_trip(dec, i_f):
+    i, f = i_f
+    assume(not (i in leap_sec_days and (1 - f) * 86400 < 1e-9))
+    jds = mjds_to_jds_pulsar(*i_f)
+    assert_closer_than_ns(jds_to_mjds_pulsar(*jds), i_f, 1)
+
+
+@pytest.mark.xfail(
+    reason="Round-trip roundoff error winds up in a leap second; probably fine"
+)
+@given(leap_sec_day_mjd())
+@example(i_f=(41498, 0.9999999999999982))
+def test_mjd_jd_pulsar_round_trip_leap_sec_day_edge(dec, i_f):
+    jds = mjds_to_jds_pulsar(*i_f)
+    assert_closer_than_ns(jds_to_mjds_pulsar(*jds), i_f, 1)
+
+
+def test_mjds_to_jds_pulsar_ok_near_leap_second():
+    """
+    Since we've never had a negative leap second, there are no pulsar_mjd
+    times that don't correspond to any real moment. Check we got this the
+    right way around.
+    """
+    i = 41498
+    f = 86400.5 / 86401
+    mjds_to_jds_pulsar(i, f)
+
+
+def test_jds_to_mjds_pulsar_raises_during_leap_second():
+    i = 41498
+    f = 86400.5 / 86401
+    jd1, jd2 = mjds_to_jds(i, f)
+    with pytest.raises(ValueError):
+        jds_to_mjds_pulsar(jd1, jd2)
+
+
+@given(reasonable_mjd())
+@example(i_f=(41498, 0.9999999999999982))
+@example(i_f=(40000, 1.2434497875801756e-14))
+@example(i_f=(43875, -1.000000000000002))
+@example(i_f=(48803, 1.0769154457079824e-09))
+@example(i_f=(48803, 1.0000079160299438e-06))
+def test_str_to_mjds(dec, i_f):
+    i, f = i_f
+    assert_closer_than_ns(str_to_mjds(str(decimalify(i, f))), i_f, 1)
+
+
+@given(reasonable_mjd())
+@example(i_f=(41498, 0.9999999999999982))
+def test_mjds_to_str(dec, i_f):
+    i, f = i_f
+    s = mjds_to_str(i, f)
+    d = Decimal(s) * 86400 * 10 ** 9
+    d2 = decimalify(i, f) * 86400 * 10 ** 9
+    assert abs(d2 - d) < 1
+
+
+@given(reasonable_mjd())
+@example(i_f=(65536, 3.637978807091714e-12))
+def test_day_frac(i_f):
+    assert_closer_than_ns(day_frac(*i_f), i_f, 1)
+
+
+@given(reasonable_mjd())
+@example(i_f=(65536, 3.637978807091714e-12))
+def test_two_sum(i_f):
+    assert_closer_than_ns(two_sum(*i_f), i_f, 1)

--- a/tests/test_times.py
+++ b/tests/test_times.py
@@ -1,13 +1,13 @@
-from pint import toa, utils, erfautils
+from pint import toa, erfautils
 from pint.observatory import Observatory
 import math, shlex, subprocess, numpy
 import astropy.constants as const
 import astropy.units as u
 from pint.utils import PosVel
+from pint.pulsar_mjd import Time
 from astropy import log
-import os
 
-from pinttestdata import testdir, datadir
+from pinttestdata import datadir
 
 def test_times_against_tempo2():
     log.setLevel('ERROR')
@@ -47,14 +47,14 @@ def test_times_against_tempo2():
               tp0, tp1, tp2, tv0, tv1, tv2, Ttt = \
               (float(x) for x in line.split())
 
-        t2_epv = utils.PosVel(numpy.asarray([ep0, ep1, ep2]) * ls,
+        t2_epv = PosVel(numpy.asarray([ep0, ep1, ep2]) * ls,
                               numpy.asarray([ev0, ev1, ev2]) * ls/u.s)
-        t2_opv = utils.PosVel(numpy.asarray([tp0, tp1, tp2]) * ls,
+        t2_opv = PosVel(numpy.asarray([tp0, tp1, tp2]) * ls,
                               numpy.asarray([tv0, tv1, tv2]) * ls/u.s)
 
         t2_ssb2obs = t2_epv + t2_opv
-        # print utils.time_toq_mjd_string(TOA.mjd.tt), line.split()[-1]
-        tempo_tt = utils.time_from_mjd_string(line.split()[-1], scale='tt')
+        # print time_to_mjd_string(TOA.mjd.tt), line.split()[-1]
+        tempo_tt = Time(line.split()[-1], format='mjd_string', scale='tt')
         # Ensure that the clock corrections are accurate to better than 0.1 ns
         assert(math.fabs((oclk*u.s + gps_utc*u.s - TOA['flags']["clkcorr"]).to(u.ns).value) < 0.1)
 
@@ -64,7 +64,7 @@ def test_times_against_tempo2():
         pint_opv = erfautils.gcrs_posvel_from_itrf(
                 Observatory.get(TOA['obs']).earth_location_itrf(),
                 TOA, obsname=TOA['obs'])
-        pint_opv = utils.PosVel(pint_opv.pos, pint_opv.vel)
+        pint_opv = PosVel(pint_opv.pos, pint_opv.vel)
         #print " obs  T2:", t2_opv.pos.to(u.m).value, t2_opv.vel.to(u.m/u.s)
         #print " obs PINT:", pint_opv.pos.to(u.m), pint_opv.vel.to(u.m/u.s)
         dopv = pint_opv - t2_opv


### PR DESCRIPTION
Update: essentially all precision problems intrinsic to PINT are under control at the nanosecond level or better, as far as I know and hypothesis can find. The remaining xfail tests are almost all pointing out upstream problems, whether due to astropy bugs or ERFA limitations. The astropy bugs are fixed in the current 3.2.2 release and should be fixed in the final 2.0.16 release which will appear in a few months. (2.0.15 was meant to be the final if-theres-a-bug-tough-luck python2 release but in light of the bug revealed here and other worries the mainainers decided to delay stopping bug fixes.)

The patch also dramatically simplifies the precision-conversion functions in pint.utils by providing new astropy.time.Time formats mjd_string and pulsar_mjd_string that read and write full-precision strings, as well as mjd_long and pulsar_mjd_long that write but do not read long doubles (reading long doubles is prevented by a frustrating limitation of astropy, under discussion for removal in astropy 4). Conversion of existing code to replace time_to_* and time_from_* with the new formats has not been carried out yet.

Was:

We have a number of severe time conversion problems, producing errors of, in some cases, 60s or a day. Others may just be off by a microsecond. I am fixing them where I can but there are a number I have not tracked down yet. This PR tracks those with xfail statements; use
```
pytest --runxfail -v tests/test_precision.py
```
to see the damage.

Most but not all of the problems center around days with leap seconds, and some of the problems appear to originate from within our pulsar_mjd implementation (possibly but I hope not from within ERFA). 