### PR TITLE
WIP: __all__ hygiene

### DIFF
--- a/docs/coding-style.rst
+++ b/docs/coding-style.rst
@@ -6,7 +6,7 @@ PINT coding style
    - Code should follow PEP8_. This constrains whitespace,
      formatting, and naming.
    - Code should follow the black_ style.
-   - Use the standard formats for imports.
+   - Use the standard formats for imports:
 
       - The only abbreviated imports are ``import numpy as np``,
         ``import astropy.units as u``, and
@@ -18,20 +18,34 @@ PINT coding style
         is long, use ``from pint.utils import interesting_lines``
       - Sort imports with isort_.
       - Remove all unused imports.
+      - Do not abbreviate any other imports.
 
-   - Raise an exception if the code cannot continue and produce
-     correct results.
-   - Use :mod:`~astropy.log` to signal conditions the user should
-     know about but that do not prevent the code from producing
-     correct results.
-   - Use keyword argument names when calling a function with more
-     than two or three arguments.
+   - Modules should list all public functions, classes, and constants
+     in ``__all__``. You can use the order of ``__all__`` to specify
+     the order that things appear in the documentation.
    - Every public function or class should have a docstring. It
      should be in the correct format (numpy guidelines_).
-   - Use :class:`~astropy.units.Quantity` for things with physical units.
+   - Do not abbreviate public names (for example, use "Residuals"
+     not "resids"). If *aboslutely* necessary, make certain that there
+     is One True Abbreviation and that it is used everywhere.
+   - Raise an exception if the code cannot continue and produce
+     correct results.
+   - Use :mod:`~astropy.logger` to signal conditions the user should
+     know about but that do not prevent the code from producing
+     correct results. Be conservative; normal operation should
+     generate no warnings or else users will ignore them (think
+     LaTeX warnings).
+   - Use keyword argument names when calling a function with more
+     than two or three arguments.
+   - Use :class:`~astropy.units.Quantity` for things with physical
+     units.
+   - If you need a :class:`~astropy.time.Time` object use
+     ``from pint.pulsar_mjd import Time``; this ensures that you have
+     available the ``pulsar_mjd`` time format.
    - PINT should work with python 2.7, 3.5, 3.6, 3.7, and later. There
      is no need to maintain compatibility with older versions, so use
-     approprate modern constructs like sets and iterators.
+     approprate modern constructs like sets, iterators, and the string
+     ``.format()`` method.
    - Use six_ to manage python 2/3 compatibility problems.
 
 .. _PEP8: https://www.python.org/dev/peps/pep-0008/

--- a/docs/editing-documentation.rst
+++ b/docs/editing-documentation.rst
@@ -54,7 +54,7 @@ In a ``.rst`` file:
      a line ``.. _`label`:``
    - To refer to a class, module, or function in text, use
      ``:class:`~astropy.module.ClassName```, ``:mod:`~astropy.module```,
-     or ``:fun:`~astropy.module.function```.
+     or ``:func:`~astropy.module.function```.
    - To get ``typewriter font`` for text, use double back-ticks. Single back-ticks
      are for Sphinx special objects like links and class names and things.
    - To get *emphasis*, use asterisks.
@@ -90,7 +90,7 @@ still the indended one and not `something else`_.
 .. _Sphinx: http://www.sphinx-doc.org/en/master/
 .. _reStructuredText: http://docutils.sourceforge.net/rst.html
 .. _readthedocs: https://readthedocs.org/
-.. _here: https://readthedocs.org/
+.. _here: https://nanograv-pint.readthedocs.io/en/latest/
 .. _`docstring guidelines`: https://numpydoc.readthedocs.io/en/latest/format.html
 .. _napoleon: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/
 .. _`something else`: https://placekitten.com/

--- a/docs/examples/PINT_walkthrough.md
+++ b/docs/examples/PINT_walkthrough.md
@@ -193,7 +193,7 @@ The fitter is *completely* separate from the model and the TOA code.  So you can
 ```python
 import pint.fitter as fit
 
-f = fit.WlsFitter(t, m)
+f = fit.WLSFitter(t, m)
 f.fit_toas()
 ```
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,6 +97,11 @@ extend-ignore = E203,
 #    D400,D401,D402,D403,D412,D413
 #    RST201,RST202,RST203,RST210,RST212,RST299
 #    RST301,RST304,RST306
+# Ugh people want to break these rules
+    N802  # Function names should be lowercase
+    N803  # argument name should be lowercase
+    N806  # variable should be lowercase
+
 statistics = True
 exclude =
     docs/conf.py

--- a/src/pint/__init__.py
+++ b/src/pint/__init__.py
@@ -1,4 +1,5 @@
-# Top-level PINT __init__.py
+"""PINT Is Not TEMPO3!"""
+
 import astropy.constants as c
 import astropy.time as time
 import astropy.units as u
@@ -8,12 +9,30 @@ from astropy.units import si
 import pint.pulsar_mjd
 from pint.extern._version import get_versions
 
-"""
-PINT Is Not TEMPO3!
-"""
+__all__ = [
+    "__version__",
+    "ls",
+    "dmu",
+    "light_second_equivalency",
+    "dimensionless_cycles",
+    "hourangle_second",
+    "GMsun",
+    "Tsun",
+    "Tmercury",
+    "Tvenus",
+    "Tearth",
+    "Tmars",
+    "Tjupiter",
+    "Tsaturn",
+    "Turanus",
+    "Tneptune",
+    "J2000",
+    "J2000ld",
+    "JD_MJD",
+    "pint_units",
+]
 
 __version__ = get_versions()["version"]
-del get_versions
 
 # Define a few important constants
 

--- a/src/pint/erfautils.py
+++ b/src/pint/erfautils.py
@@ -11,6 +11,12 @@ from astropy.utils.iers import IERS_B, IERS_B_URL
 from pint.pulsar_mjd import Time
 from pint.utils import PosVel
 
+__all__ = [
+    "get_iers_b_up_to_date",
+    "gcrs_posvel_from_itrf",
+    "astropy_gcrs_posvel_from_itrf",
+]
+
 
 def get_iers_b_up_to_date(mjd):
     """Update the IERS B table to include MJD if necessary

--- a/src/pint/event_toas.py
+++ b/src/pint/event_toas.py
@@ -8,6 +8,15 @@ from astropy import log
 import pint.toa as toa
 from pint.fits_utils import read_fits_event_mjds_tuples
 
+__all__ = [
+    "load_fits_TOAs",
+    "load_event_TOAs",
+    "load_NuSTAR_TOAs",
+    "load_NICER_TOAs",
+    "load_RXTE_TOAs",
+    "load_XMM_TOAs",
+]
+
 # fits_extension can be a single name or a comma-separated list of allowed
 # extension names.
 # For weight we use the same conventions used for Fermi: None, a valid FITS

--- a/src/pint/eventstats.py
+++ b/src/pint/eventstats.py
@@ -6,6 +6,27 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
+__all__ = [
+    "sig2sigma",
+    "sigma2sig",
+    "sigma_trials",
+    "z2m",
+    "z2mw",
+    "cosm",
+    "sf_z2m",
+    "best_m",
+    "em_four",
+    "em_lc",
+    "hm",
+    "hmw",
+    "sf_hm",
+    "h2sig",
+    "sf_h20_dj1989",
+    "sf_h20_dj2010",
+    "sig2h20",
+    "sf_stackedh",
+]
+
 TWOPI = np.pi * 2
 
 

--- a/src/pint/fermi_toas.py
+++ b/src/pint/fermi_toas.py
@@ -1,20 +1,16 @@
 """Work with Fermi TOAs."""
 from __future__ import absolute_import, division, print_function
 
-import os
-import sys
-
 import astropy.units as u
 import numpy as np
-import six
 from astropy import log
-from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.coordinates import SkyCoord
 
-import pint.models
-import pint.residuals
 import pint.toa as toa
-from pint.fits_utils import read_fits_event_mjds, read_fits_event_mjds_tuples
+from pint.fits_utils import read_fits_event_mjds_tuples
 from pint.observatory import get_observatory
+
+__all__ = ["load_Fermi_TOAs"]
 
 
 def calc_lat_weights(energies, angseps, logeref=4.1, logesig=0.5):

--- a/src/pint/fits_utils.py
+++ b/src/pint/fits_utils.py
@@ -1,13 +1,14 @@
 """FITS handling functions"""
 from __future__ import absolute_import, division, print_function
 
-import astropy.io.fits as pyfits
 import numpy as np
 import six
 from astropy import log
 from astropy._erfa import DAYSEC as SECS_PER_DAY
 
 from pint.pulsar_mjd import fortran_float
+
+__all__ = ["read_fits_event_mjds", "read_fits_event_mjds_tuples"]
 
 
 def read_fits_event_mjds_tuples(event_hdu, timecolumn="TIME"):

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1,16 +1,16 @@
 from __future__ import absolute_import, division, print_function
 
-import abc
 import collections
 import copy
-import numbers
 
 import astropy.units as u
 import numpy as np
 import scipy.linalg as sl
 import scipy.optimize as opt
 
-from .residuals import Residuals
+from pint.residuals import Residuals
+
+__all__ = ["Fitter", "PowellFitter", "GLSFitter", "WLSFitter"]
 
 
 class Fitter(object):
@@ -152,14 +152,14 @@ class PowellFitter(Fitter):
         self.minimize_func(np.atleast_1d(self.fitresult.x), *list(fitp.keys()))
 
 
-class WlsFitter(Fitter):
+class WLSFitter(Fitter):
     """
        A class for weighted least square fitting method. The design matrix is
        required.
     """
 
     def __init__(self, toas=None, model=None):
-        super(WlsFitter, self).__init__(toas=toas, model=model)
+        super(WLSFitter, self).__init__(toas=toas, model=model)
         self.method = "weighted_least_square"
 
     def fit_toas(self, maxiter=1, threshold=False):
@@ -242,14 +242,14 @@ class WlsFitter(Fitter):
         return chi2
 
 
-class GlsFitter(Fitter):
+class GLSFitter(Fitter):
     """
        A class for weighted least square fitting method. The design matrix is
        required.
     """
 
     def __init__(self, toas=None, model=None, residuals=None):
-        super(GlsFitter, self).__init__(toas=toas, model=model, residuals=residuals)
+        super(GLSFitter, self).__init__(toas=toas, model=model, residuals=residuals)
         self.method = "generalized_least_square"
 
     def fit_toas(self, maxiter=1, threshold=False, full_cov=False):

--- a/src/pint/ltinterface.py
+++ b/src/pint/ltinterface.py
@@ -4,30 +4,22 @@ An interface for pint compatible to the interface of libstempo
 from __future__ import absolute_import, division, print_function
 
 import collections
-import copy
 import time
+from collections import OrderedDict
 
 import astropy.constants as ac
 import astropy.coordinates.angles as ang
 import astropy.units as u
-
-# import matplotlib
-# matplotlib.use('TKAgg')
-import matplotlib.pyplot as plt
 import numpy as np
 from astropy import log
 
 import pint.models as pm
 import pint.toa as pt
 from pint import fitter
-from pint.phase import Phase
-from pint.residuals import Residuals
 from pint.utils import has_astropy_unit
+from pint.residuals import Residuals
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
+__all__ = ["PINTPar", "PINTPulsar"]
 
 # Make sure we have the minuteangle and secondangle units
 u.minuteangle = u.def_unit("minuteangle", u.hourangle / 60)
@@ -89,7 +81,7 @@ map_units = {
 }
 
 
-class pintpar(object):
+class PINTPar(object):
     """
     Similar to the parameter class defined in libstempo, this class gives a nice
     interface to the timing model parameters
@@ -151,7 +143,7 @@ class pintpar(object):
         self._set = value
 
 
-class pintpulsar(object):
+class PINTPulsar(object):
     """
     Pulsar object class with an interface similar to tempopulsar of libstempo
     """
@@ -228,7 +220,7 @@ class pintpulsar(object):
         """Process the timing model parameters, libstempo style"""
         self.pardict = OrderedDict()
         for par in self.model.params:
-            self.pardict[par] = pintpar(getattr(self.model, par), par)
+            self.pardict[par] = PINTPar(getattr(self.model, par), par)
 
     def loadtimfile(self, timfile):
         """
@@ -330,7 +322,7 @@ class pintpulsar(object):
 
         log.info("Computing residuals...")
         t0 = time.time()
-        self.resids_us = resids(self.t, self.model).time_resids.to(u.us)
+        self.resids_us = Residuals(self.t, self.model).time_resids.to(u.us)
         time_phase = time.time() - t0
         log.info("Computed phases and residuals in %.3f sec" % time_phase)
 

--- a/src/pint/mcmc_fitter.py
+++ b/src/pint/mcmc_fitter.py
@@ -3,19 +3,23 @@ import copy
 import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
-import scipy.linalg as sl
-import scipy.optimize as opt
 from astropy import log
 from astropy.table import vstack
 from scipy.stats import norm, uniform
 
 import pint.plot_utils as plot_utils
-import pint.toa
+from pint.eventstats import hm, hmw
 from pint.fitter import Fitter
 from pint.models.priors import Prior
+from pint.residuals import Residuals
 from pint.templates.lctemplate import LCTemplate
 
-from .residuals import Residuals
+__all__ = [
+    "MCMCFitter",
+    "MCMCFitterAnalyticTemplate",
+    "MCMCFitterBinnedTemplate",
+    "CompositeMCMCFitter",
+]
 
 
 def concat_toas(toas):
@@ -169,7 +173,7 @@ class MCMCFitter(Fitter):
         self.n_fit_params = len(self.fitvals)
 
         template = kwargs.get("template", None)
-        if not template is None:
+        if template is not None:
             self.set_template(template)
         else:
             self.template = None
@@ -370,9 +374,7 @@ class MCMCFitter(Fitter):
     def phaseogram(
         self, weights=None, bins=100, rotate=0.0, size=5, alpha=0.25, plotfile=None
     ):
-        """
-        Make a nice 2-panel phaseogram for the current model
-        """
+        """Make a nice 2-panel phaseogram for the current model"""
         mjds = self.toas.table["tdbld"].quantity
         phss = self.get_event_phases()
         plot_utils.phaseogram(

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -17,6 +17,8 @@ from pint.models.timing_model import (
 )
 from pint.utils import PrefixError, interesting_lines, lines_of, split_prefixed_name
 
+__all__ = ["get_model", "get_model_new"]
+
 default_models = ["StandardTimingModel"]
 DEFAULT_ORDER = [
     "astrometry",

--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -450,7 +450,7 @@ class Pulsar(object):
         if self.fitter == Fitters.POWELL:
             fitter = pint.fitter.PowellFitter(self.selected_toas, self.prefit_model)
         elif self.fitter == Fitters.WLS:
-            fitter = pint.fitter.WlsFitter(self.selected_toas, self.prefit_model)
+            fitter = pint.fitter.WLSFitter(self.selected_toas, self.prefit_model)
         elif self.fitter == Fitters.GLS:
             fitter = pint.fitter.GLSFitter(self.selected_toas, self.prefit_model)
         chi2 = self.prefit_resids.chi2

--- a/src/pint/plot_utils.py
+++ b/src/pint/plot_utils.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import, division, print_function
 import matplotlib.pyplot as plt
 import numpy as np
 
+__all__ = ["phaseogram", "phaseogram_binned"]
+
 
 def phaseogram(
     mjds,
@@ -18,13 +20,11 @@ def phaseogram(
     maxphs=2.0,
     plotfile=None,
 ):
-    """
-    Make a nice 2-panel phaseogram
-    """
+    """Make a nice 2-panel phaseogram"""
     years = (mjds.value - 51544.0) / 365.25 + 2000.0
     phss = phases + rotate
     phss[phss > 1.0] -= 1.0
-    fig = plt.figure(figsize=(width, 8))
+    plt.figure(figsize=(width, 8))
     ax1 = plt.subplot2grid((3, 1), (0, 0))
     ax2 = plt.subplot2grid((3, 1), (1, 0), rowspan=2)
     wgts = None if weights is None else np.concatenate((weights, weights))
@@ -91,7 +91,7 @@ def phaseogram_binned(
     years = (mjds.value - 51544.0) / 365.25 + 2000.0
     phss = phases + rotate
     phss[phss >= 1.0] -= 1.0
-    fig = plt.figure(figsize=(width, 8))
+    plt.figure(figsize=(width, 8))
     ax1 = plt.subplot2grid((3, 1), (0, 0))
     ax2 = plt.subplot2grid((3, 1), (1, 0), rowspan=2)
     wgts = None if weights is None else np.concatenate((weights, weights))

--- a/src/pint/pulsar_ecliptic.py
+++ b/src/pint/pulsar_ecliptic.py
@@ -1,27 +1,22 @@
 from __future__ import absolute_import, division, print_function
 
-import os
-
 import astropy.coordinates as coord
 import astropy.units as u
-import numpy as np
-from astropy.coordinates import DynamicMatrixTransform, frame_transform_graph
+from astropy.coordinates import frame_transform_graph
 from astropy.coordinates.matrix_utilities import rotation_matrix
 
-from .config import datapath
+from pint.config import datapath
+from pint.utils import interesting_lines, lines_of
+
+__all__ = ["OBL", "PulsarEcliptic"]
 
 
 # Load obliquity data
 # Assume the data file is in the ./datafile directory
 def load_obliquity_file(filename):
     obliquity_data = {}
-    for l in open(filename).readlines():
-        l = l.strip()
+    for l in interesting_lines(lines_of(filename), comments="#"):
         if l.startswith("Obliquity of the ecliptic"):
-            continue
-        if l.startswith("#"):
-            continue
-        if l == "":
             continue
         line = l.split()
         obliquity_data[line[0]] = float(line[1]) * u.arcsecond

--- a/src/pint/random_models.py
+++ b/src/pint/random_models.py
@@ -52,13 +52,13 @@ def random_models(
     spanMJDs = maxMJD - minMJD
     # ledge and redge _multiplier control how far the fake toas extend
     # in either direction of the selected points
-    x = toa.make_toas(
+    x = toa.make_fake_toas(
         minMJD - spanMJDs * ledge_multiplier,
         maxMJD + spanMJDs * redge_multiplier,
         npoints,
         mrand,
     )
-    x2 = toa.make_toas(minMJD, maxMJD, npoints, mrand)
+    x2 = toa.make_fake_toas(minMJD, maxMJD, npoints, mrand)
 
     rss = []
     for i in range(iter):

--- a/src/pint/random_models.py
+++ b/src/pint/random_models.py
@@ -1,15 +1,15 @@
+"""Generate random models distributed like the results of a fit"""
 from collections import OrderedDict
 from copy import deepcopy
 
-import matplotlib.pyplot as plt
 import numpy as np
 from astropy import log
 
-import pint.fitter as fitter
 import pint.toa as toa
 from pint.phase import Phase
 
-log.setLevel("INFO")
+__all__ = ["random_models"]
+# log.setLevel("INFO")
 
 
 def random_models(
@@ -22,16 +22,25 @@ def random_models(
     edge_multipliers determine how far beyond the selected toas the random models are plotted.
     This uses an approximate method based on the cov matrix, it doesn't use MCMC.
 
-    :param fitter: fitter object with model and toas to vary from
-    :param rs_mean: average phase residual for toas in fitter object, used to plot random models
-    :param ledge_multiplier: how far the lines will plot to the left in multiples of the fit toas span, default 4
-    :param redge_multiplier: how far the lines will plot to the right in multiples of the fit toas span, default 4
-    :param iter: how many random models will be computed, default 1
-    :param npoints: how many fake toas will be reated for the random lines, default 100
+    Parameters
+    ----------
+    fitter
+        fitter object with model and toas to vary from
+    rs_mean
+        average phase residual for toas in fitter object, used to plot random models
+    ledge_multiplier
+        how far the lines will plot to the left in multiples of the fit toas span, default 4
+    redge_multiplier
+        how far the lines will plot to the right in multiples of the fit toas span, default 4
+    iter
+        how many random models will be computed, default 1
+    npoints
+        how many fake toas will be reated for the random lines, default 100
 
-    :return TOAs object containing the evenly spaced fake toas to plot the random lines with
-    :return list of residual objects for the random models (one residual object each)
-
+    Returns
+    -------
+        TOAs object containing the evenly spaced fake toas to plot the random lines with
+        list of residual objects for the random models (one residual object each)
     """
     params = fitter.get_fitparams_num()
     mean_vector = params.values()
@@ -42,8 +51,8 @@ def random_models(
     mrand = f_rand.model
 
     # scale by fac
-    log.info("errors", np.sqrt(np.diag(cor_matrix)))
-    log.info("mean vector", mean_vector)
+    log.debug("errors", np.sqrt(np.diag(cor_matrix)))
+    log.debug("mean vector", mean_vector)
     mean_vector *= fac
     cov_matrix = ((cor_matrix * fac).T * fac).T
 

--- a/src/pint/sampler.py
+++ b/src/pint/sampler.py
@@ -1,10 +1,11 @@
-import corner
 import emcee
 import numpy as np
 
+__all__ = ["MCMCSampler", "EmceeSampler"]
+
 
 class MCMCSampler(object):
-    """ Base class for samplers used in MCMC fitting
+    """Base class for samplers used in MCMC fitting
 
     The sampling method should be implemented in the run_mcmc() method.
 

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -28,6 +28,7 @@ from pint.models.priors import (
 )
 from pint.observatory.fermi_obs import FermiObs
 
+__all__ = ["read_gaussfitfile", "marginalize_over_phase", "main"]
 # log.setLevel('DEBUG')
 # np.seterr(all='raise')
 
@@ -182,13 +183,12 @@ def marginalize_over_phase(
     lophs=0.0,
     hiphs=1.0,
 ):
-    """
-    def marginalize_over_phase(phases, template, weights=None, resolution=1.0/1024,
-        minimize=True, fftfit=False, showplot=False, lophs=0.0, hiphs=1.0):
-            a pulse profile comprised of combined photon phases.  A maximum
-            likelood technique is used.  The shift and the max log likehood
-            are returned.  You probably want to use "minimize" rathre than
-            "fftfit" unless you are only sampling very close to your known min.
+    """Find the best fit pulse profile
+
+    a pulse profile comprised of combined photon phases.  A maximum
+    likelood technique is used.  The shift and the max log likehood
+    are returned.  You probably want to use "minimize" rathre than
+    "fftfit" unless you are only sampling very close to your known min.
     """
     ltemp = len(template)
     xtemp = np.arange(ltemp) * 1.0 / ltemp

--- a/src/pint/scripts/event_optimize_MCMCFitter.py
+++ b/src/pint/scripts/event_optimize_MCMCFitter.py
@@ -2,36 +2,24 @@
 from __future__ import absolute_import, division, print_function
 
 import argparse
-import copy
 import os
 import sys
 
-import astropy.table
-import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.optimize as op
 from astropy import log
 from astropy.coordinates import SkyCoord
-from scipy.stats import norm, uniform
 
-import fftfit
 import pint.fermi_toas as fermi
 import pint.models
-import pint.plot_utils as plot_utils
 import pint.toa as toa
-from pint.eventstats import hm, hmw
-from pint.mcmc_fitter import MCMCFitter, MCMCFitterBinnedTemplate
-from pint.models.priors import (
-    GaussianBoundedRV,
-    Prior,
-    UniformBoundedRV,
-    UniformUnboundedRV,
-)
+from pint.mcmc_fitter import MCMCFitterBinnedTemplate
 from pint.observatory.fermi_obs import FermiObs
 from pint.sampler import EmceeSampler
 from pint.scripts.event_optimize import marginalize_over_phase, read_gaussfitfile
 
+__all__ = ["main"]
 # log.setLevel('DEBUG')
 # np.seterr(all='raise')
 

--- a/src/pint/scripts/event_optimize_multiple.py
+++ b/src/pint/scripts/event_optimize_multiple.py
@@ -2,38 +2,25 @@
 from __future__ import absolute_import, division, print_function
 
 import argparse
-import copy
-import os
 import sys
 
-import astropy.table
 import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
-import scipy.optimize as op
 from astropy import log
 from astropy.coordinates import SkyCoord
-from scipy.stats import norm, uniform
 
-import fftfit
 import pint.fermi_toas as fermi
 import pint.models
-import pint.plot_utils as plot_utils
 import pint.toa as toa
-from pint.eventstats import hm, hmw
 from pint.mcmc_fitter import CompositeMCMCFitter
-from pint.models.priors import (
-    GaussianBoundedRV,
-    Prior,
-    UniformBoundedRV,
-    UniformUnboundedRV,
-)
 from pint.observatory.fermi_obs import FermiObs
 from pint.sampler import EmceeSampler
-from pint.scripts.event_optimize import marginalize_over_phase, read_gaussfitfile
+from pint.scripts.event_optimize import read_gaussfitfile
 
+__all__ = ["main"]
 # log.setLevel('DEBUG')
-log.setLevel("INFO")
+# log.setLevel("INFO")
 # np.seterr(all='raise')
 
 # initialization values
@@ -47,7 +34,7 @@ def get_toas(evtfile, flags, tcoords=None, minweight=0, minMJD=0, maxMJD=100000)
         usepickle = False
         if "usepickle" in flags:
             usepickle = flags["usepickle"]
-        ts = toa.get_TOAs(evtfile, usepickle=False)
+        ts = toa.get_TOAs(evtfile, usepickle=usepickle)
         # Prune out of range MJDs
         mask = np.logical_or(
             ts.get_mjds() < minMJD * u.day, ts.get_mjds() > maxMJD * u.day
@@ -161,7 +148,7 @@ def lnlikelihood_prob(ftr, theta, index):
 
 
 def lnlikelihood_resid(ftr, theta, index):
-    return -resids(toas=ftr.toas_list[index], model=ftr.model).chi2.value
+    return -Residuals(toas=ftr.toas_list[index], model=ftr.model).chi2.value
 
 
 def main(argv=None):

--- a/src/pint/scripts/fermiphase.py
+++ b/src/pint/scripts/fermiphase.py
@@ -18,6 +18,8 @@ from pint.observatory.fermi_obs import FermiObs
 from pint.plot_utils import phaseogram
 from pint.pulsar_mjd import Time
 
+__all__ = ["main"]
+
 # log.setLevel('DEBUG')
 
 

--- a/src/pint/scripts/htest_optimize.py
+++ b/src/pint/scripts/htest_optimize.py
@@ -4,7 +4,6 @@
 # It will not be installed by setup.py and not tested by nosetests.
 from __future__ import absolute_import, division, print_function
 
-import copy
 import os
 import sys
 
@@ -19,6 +18,8 @@ import pint.plot_utils
 import pint.toa as toa
 from pint.eventstats import hm, hmw, sf_hm
 from pint.fitter import Fitter
+
+__all__ = ["main"]
 
 # Params you might want to edit
 nwalkers = 200
@@ -423,7 +424,7 @@ def main(argv=None):
         fig = corner.corner(samples, labels=ftr.fitkeys, bins=50)
         fig.savefig(ftr.model.PSR.value + "_triangle.png")
         plt.close()
-    except:
+    except ImportError:
         pass
 
     # Make a phaseogram with the 50th percentile values

--- a/src/pint/scripts/photonphase.py
+++ b/src/pint/scripts/photonphase.py
@@ -24,6 +24,8 @@ from pint.observatory.rxte_obs import RXTEObs
 from pint.plot_utils import phaseogram_binned
 from pint.pulsar_mjd import Time
 
+__all__ = ["main"]
+
 
 def main(argv=None):
     import argparse

--- a/src/pint/scripts/pintbary.py
+++ b/src/pint/scripts/pintbary.py
@@ -12,7 +12,9 @@ import pint.models
 import pint.toa as toa
 from pint.pulsar_mjd import Time
 
-log.setLevel("INFO")
+__all__ = ["main"]
+
+# log.setLevel("INFO")
 
 
 def main(argv=None):

--- a/src/pint/scripts/pintempo.py
+++ b/src/pint/scripts/pintempo.py
@@ -11,17 +11,16 @@ This is currently just a stub and should be added to and expanded, as desired.
 from __future__ import absolute_import, division, print_function
 
 import argparse
-import os
 import sys
 
 import astropy.units as u
-import numpy as np
 from astropy import log
 
 import pint.fitter
 import pint.models
 import pint.residuals
-import pint.toa as toa
+
+__all__ = ["main"]
 
 
 def main(argv=None):
@@ -53,7 +52,7 @@ def main(argv=None):
     prefit_resids = pint.residuals.Residuals(t, m).time_resids
 
     log.info("Fitting...")
-    f = pint.fitter.WlsFitter(t, m)
+    f = pint.fitter.WLSFitter(t, m)
     f.fit_toas()
 
     # Print some basic params

--- a/src/pint/scripts/pintk.py
+++ b/src/pint/scripts/pintk.py
@@ -19,7 +19,9 @@ from pint.pintk.plk import PlkWidget, helpstring
 from pint.pintk.pulsar import Pulsar
 from pint.pintk.timedit import TimWidget
 
-log.setLevel("WARNING")
+__all__ = ["main"]
+
+# log.setLevel("WARNING")
 
 
 class PINTk(object):

--- a/src/pint/scripts/zima.py
+++ b/src/pint/scripts/zima.py
@@ -14,7 +14,9 @@ import pint.models
 import pint.toa as toa
 from pint.observatory import get_observatory
 
-log.setLevel("INFO")
+__all__ = ["main"]
+
+# log.setLevel("INFO")
 
 
 def get_freq_array(base_freq_values, ntoas):

--- a/src/pint/solar_system_ephemerides.py
+++ b/src/pint/solar_system_ephemerides.py
@@ -13,6 +13,8 @@ from six.moves.urllib.parse import urljoin
 from pint.config import datapath
 from pint.utils import PosVel
 
+__all__ = ["objPosVel_wrt_SSB", "get_tdb_tt_ephem_geocenter"]
+
 ephemeris_mirrors = [
     # NOTE the JPL ftp site is disabled for our automatic builds. Instead,
     # we duplicated the JPL ftp site on the nanograv server.

--- a/src/pint/tmtestfuncs.py
+++ b/src/pint/tmtestfuncs.py
@@ -5,6 +5,8 @@ import numpy as np
 
 from pint.pulsar_mjd import Time
 
+__all__ = ["F0"]
+
 
 def F0(toa, model):
 

--- a/src/pint/toa_select.py
+++ b/src/pint/toa_select.py
@@ -2,9 +2,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-import copy
-
 import numpy as np
+
+__all__ = ["TOASelect"]
 
 
 class TOASelect(object):

--- a/tests/test_ell1h.py
+++ b/tests/test_ell1h.py
@@ -91,7 +91,7 @@ class TestELL1H(unittest.TestCase):
 
     def test_J0613_H4(self):
         log = logging.getLogger("TestJ0613.fit_tests")
-        f = ff.GlsFitter(self.toasJ0613, self.modelJ0613)
+        f = ff.GLSFitter(self.toasJ0613, self.modelJ0613)
         f.fit_toas()
         f.set_fitparams("H3", "H4")
         for pn, p in (f.get_fitparams()).items():
@@ -105,7 +105,7 @@ class TestELL1H(unittest.TestCase):
 
     def test_J0613_STIG(self):
         log = logging.getLogger("TestJ0613.fit_tests_stig")
-        f = ff.GlsFitter(self.toasJ0613, self.modelJ0613_STIG)
+        f = ff.GLSFitter(self.toasJ0613, self.modelJ0613_STIG)
         f.fit_toas()
         f.set_fitparams("H3", "STIGMA")
         for pn, p in (f.get_fitparams()).items():

--- a/tests/test_fitter.py
+++ b/tests/test_fitter.py
@@ -29,7 +29,7 @@ def test_fitter():
         planet_ephems = False
     t.compute_posvels(planets=planet_ephems)
 
-    f = fitter.WlsFitter(toas=t, model=m)
+    f = fitter.WLSFitter(toas=t, model=m)
 
     # Print initial chi2
     print("chi^2 is initially %0.2f" % f.resids.chi2)

--- a/tests/test_gls_fitter.py
+++ b/tests/test_gls_fitter.py
@@ -8,11 +8,11 @@ import numpy as np
 
 import pint.models.model_builder as mb
 from pint import toa
-from pint.fitter import GlsFitter
+from pint.fitter import GLSFitter
 from pinttestdata import datadir
 
 
-class TestGls(unittest.TestCase):
+class TestGLS(unittest.TestCase):
     """Compare delays from the dd model with tempo and PINT"""
 
     @classmethod
@@ -22,7 +22,7 @@ class TestGls(unittest.TestCase):
         cls.tim = "B1855+09_NANOGrav_9yv1.tim"
         cls.m = mb.get_model(cls.par)
         cls.t = toa.get_TOAs(cls.tim, ephem="DE436")
-        cls.f = GlsFitter(cls.t, cls.m)
+        cls.f = GLSFitter(cls.t, cls.m)
         # get tempo2 parameter dict
         with open("B1855+09_tempo2_gls_pars.json", "r") as fp:
             cls.t2d = json.load(fp)

--- a/tests/test_wls_fitter.py
+++ b/tests/test_wls_fitter.py
@@ -4,7 +4,7 @@ import unittest
 
 from pint.models.model_builder import get_model
 from pint import toa
-from pint.fitter import WlsFitter
+from pint.fitter import WLSFitter
 from pinttestdata import datadir
 
 
@@ -18,7 +18,7 @@ class Testwls(unittest.TestCase):
         cls.tim = "B1855+09_NANOGrav_dfg+12.tim"
         cls.m = get_model(cls.par)
         cls.t = toa.get_TOAs(cls.tim, ephem="DE405")
-        cls.f = WlsFitter(cls.t, cls.m)
+        cls.f = WLSFitter(cls.t, cls.m)
         # set perturb parameter step
         cls.per_param = {
             "A1": 1e-05,


### PR DESCRIPTION
Clean up files so that they use __all__ to export only the names that they actually mean to be public; this also means trimming functions from their public interfaces that are barely used and easily replaced.