### PR TITLE
fix for random_models to work in Python3

### DIFF
--- a/src/pint/random_models.py
+++ b/src/pint/random_models.py
@@ -53,7 +53,7 @@ def random_models(
     # scale by fac
     log.debug("errors", np.sqrt(np.diag(cor_matrix)))
     log.debug("mean vector", mean_vector)
-    mean_vector *= fac
+    mean_vector = np.array(list(mean_vector)) * fac
     cov_matrix = ((cor_matrix * fac).T * fac).T
 
     toa_mjds = fitter.toas.get_mjds()


### PR DESCRIPTION
small fix that lets random_models (and therefore pintk) work in Python3. The issue was dictionary .values() is no longer accepted as an array that a scalar can be multiplied by. Replaced with conversion to list and then numpy array.