### PR TITLE
Allow change_pepoch() with no TOA argument

### DIFF
--- a/src/pint/models/spindown.py
+++ b/src/pint/models/spindown.py
@@ -146,8 +146,6 @@ class Spindown(PhaseComponent):
             new_epoch = Time(new_epoch, scale="tdb", precision=9)
         else:
             new_epoch = Time(new_epoch, scale="tdb", format="mjd", precision=9)
-        # make new_epoch a toa for delay calculation.
-        new_epoch_toa = toa.get_TOAs_list([toa.TOA(new_epoch)], ephem=toas.ephem)
 
         if self.PEPOCH.value is None:
             if toas is None or delay is None:

--- a/tests/test_change_epoch.py
+++ b/tests/test_change_epoch.py
@@ -1,0 +1,14 @@
+import pint
+from pint import models
+from astropy.time import Time
+import astropy.units as u
+from pinttestdata import datadir
+import os.path
+
+def test_change_pepoch():
+    model = models.get_model(os.path.join(datadir, 'J1713+0747_NANOGrav_11yv0.gls.par'))
+    t0 = Time(56000, scale='tdb', format='mjd')
+    epoch_diff = (t0.mjd_long - model.PEPOCH.quantity.mjd_long)*u.day
+    F0_at_t0 = model.F0.quantity + model.F1.quantity*epoch_diff.to(u.s)
+    model.change_pepoch(t0)
+    assert model.F0.quantity == F0_at_t0

--- a/tests/test_change_epoch.py
+++ b/tests/test_change_epoch.py
@@ -1,14 +1,17 @@
-import pint
-from pint import models
-from astropy.time import Time
-import astropy.units as u
-from pinttestdata import datadir
 import os.path
 
+import astropy.units as u
+from astropy.time import Time
+
+import pint
+from pint import models
+from pinttestdata import datadir
+
+
 def test_change_pepoch():
-    model = models.get_model(os.path.join(datadir, 'J1713+0747_NANOGrav_11yv0.gls.par'))
-    t0 = Time(56000, scale='tdb', format='mjd')
-    epoch_diff = (t0.mjd_long - model.PEPOCH.quantity.mjd_long)*u.day
-    F0_at_t0 = model.F0.quantity + model.F1.quantity*epoch_diff.to(u.s)
+    model = models.get_model(os.path.join(datadir, "J1713+0747_NANOGrav_11yv0.gls.par"))
+    t0 = Time(56000, scale="tdb", format="mjd")
+    epoch_diff = (t0.mjd_long - model.PEPOCH.quantity.mjd_long) * u.day
+    F0_at_t0 = model.F0.quantity + model.F1.quantity * epoch_diff.to(u.s)
     model.change_pepoch(t0)
     assert model.F0.quantity == F0_at_t0


### PR DESCRIPTION
Removes an unnecessary use of the `toa` argument to `models.Spindown.change_pepoch()` that prevented it from being used on a model object without associated TOAs (#491). Also adds a unit test for the `change_pepoch()` function.

The new unit test checks for equality between two `Quantity` objects, which is maybe too strict (it may fail if the order of floating-point operations changes), but it passes as is.