### PR TITLE
Make obliquity a QuantityAttribute

### DIFF
--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -459,7 +459,7 @@ class AstrometryEcliptic(Astrometry):
         the position at the given epoch.
         """
         try:
-            PulsarEcliptic.obliquity = OBL[self.ECL.value]
+            obliquity = OBL[self.ECL.value]
         except KeyError:
             raise ValueError(
                 "No obliquity " + str(self.ECL.value) + " provided. "
@@ -476,6 +476,7 @@ class AstrometryEcliptic(Astrometry):
             broadcast = numpy.ones_like(epoch)
 
         pos_ecl = PulsarEcliptic(
+            obliquity=obliquity,
             lon=self.ELONG.quantity + dELONG,
             lat=self.ELAT.quantity + dELAT,
             pm_lon_coslat=self.PMELONG.quantity * broadcast,
@@ -495,7 +496,7 @@ class AstrometryEcliptic(Astrometry):
         rd = dict()
         # From the earth_ra dec to earth_elong and elat
         try:
-            PulsarEcliptic.obliquity = OBL[self.ECL.value]
+            obliquity = OBL[self.ECL.value]
         except KeyError:
             raise ValueError(
                 "No obliquity " + self.ECL.value + " provided. "
@@ -504,7 +505,7 @@ class AstrometryEcliptic(Astrometry):
 
         rd = self.get_d_delay_quantities(toas)
         coords_icrs = coords.ICRS(ra=rd["earth_ra"], dec=rd["earth_dec"])
-        coords_elpt = coords_icrs.transform_to(PulsarEcliptic)
+        coords_elpt = coords_icrs.transform_to(PulsarEcliptic(obliquity=obliquity))
         rd["earth_elong"] = coords_elpt.lon
         rd["earth_elat"] = coords_elpt.lat
 

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -423,8 +423,8 @@ class AstrometryEcliptic(Astrometry):
         self.add_param(
             strParameter(
                 name="ECL",
-                value="IERS2003",
-                description="Obliquity angle value secetion",
+                value="IERS2010",
+                description="Obliquity of the ecliptic (reference)",
             )
         )
 

--- a/src/pint/pulsar_ecliptic.py
+++ b/src/pint/pulsar_ecliptic.py
@@ -52,7 +52,7 @@ class PulsarEcliptic(coord.BaseCoordinateFrame):
     default_differential = coord.SphericalCosLatDifferential
     obliquity = QuantityAttribute(default=OBL["DEFAULT"], unit=u.arcsec)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, ecl=None, **kwargs):
         # Allow using 'pm_lat' and 'pm_lon_coslat' keywords under astropy 2.
         # This matches the behavior of the built-in frames in astropy 2,
         # and the behavior of custom frames in astropy 3+.
@@ -67,6 +67,15 @@ class PulsarEcliptic(coord.BaseCoordinateFrame):
                 del kwargs["pm_lat"]
             except KeyError:
                 pass
+
+        if ecl is not None:
+            try:
+                kwargs["obliquity"] = OBL[ecl]
+            except KeyError:
+                raise ValueError(
+                    "No obliquity " + ecl + " provided. "
+                    "Check your pint/datafile/ecliptic.dat file."
+                )
 
         super(PulsarEcliptic, self).__init__(*args, **kwargs)
 

--- a/src/pint/pulsar_ecliptic.py
+++ b/src/pint/pulsar_ecliptic.py
@@ -50,7 +50,7 @@ class PulsarEcliptic(coord.BaseCoordinateFrame):
     default_representation = coord.SphericalRepresentation
     # NOTE: The feature below needs astropy verison 2.0. Disable it right now
     default_differential = coord.SphericalCosLatDifferential
-    obliquity = QuantityAttribute(default=OBL["DEFAULT"])
+    obliquity = QuantityAttribute(default=OBL["DEFAULT"], unit=u.arcsec)
 
     def __init__(self, *args, **kwargs):
         # Allow using 'pm_lat' and 'pm_lon_coslat' keywords under astropy 2.

--- a/src/pint/pulsar_ecliptic.py
+++ b/src/pint/pulsar_ecliptic.py
@@ -52,7 +52,7 @@ class PulsarEcliptic(coord.BaseCoordinateFrame):
     default_differential = coord.SphericalCosLatDifferential
     obliquity = QuantityAttribute(default=OBL["DEFAULT"], unit=u.arcsec)
 
-    def __init__(self, *args, ecl=None, **kwargs):
+    def __init__(self, *args, **kwargs):
         # Allow using 'pm_lat' and 'pm_lon_coslat' keywords under astropy 2.
         # This matches the behavior of the built-in frames in astropy 2,
         # and the behavior of custom frames in astropy 3+.
@@ -68,14 +68,15 @@ class PulsarEcliptic(coord.BaseCoordinateFrame):
             except KeyError:
                 pass
 
-        if ecl is not None:
+        if "ecl" in kwargs:
             try:
-                kwargs["obliquity"] = OBL[ecl]
+                kwargs["obliquity"] = OBL[kwargs["ecl"]]
             except KeyError:
                 raise ValueError(
-                    "No obliquity " + ecl + " provided. "
+                    "No obliquity " + kwargs["ecl"] + " provided. "
                     "Check your pint/datafile/ecliptic.dat file."
                 )
+            del kwargs["ecl"]
 
         super(PulsarEcliptic, self).__init__(*args, **kwargs)
 

--- a/src/pint/pulsar_ecliptic.py
+++ b/src/pint/pulsar_ecliptic.py
@@ -4,7 +4,7 @@ import sys
 
 import astropy.coordinates as coord
 import astropy.units as u
-from astropy.coordinates import frame_transform_graph
+from astropy.coordinates import QuantityAttribute, frame_transform_graph
 from astropy.coordinates.matrix_utilities import rotation_matrix
 
 from pint.config import datapath
@@ -50,7 +50,7 @@ class PulsarEcliptic(coord.BaseCoordinateFrame):
     default_representation = coord.SphericalRepresentation
     # NOTE: The feature below needs astropy verison 2.0. Disable it right now
     default_differential = coord.SphericalCosLatDifferential
-    obliquity = OBL["DEFAULT"]
+    obliquity = QuantityAttribute(default=OBL["DEFAULT"])
 
     def __init__(self, *args, **kwargs):
         # Allow using 'pm_lat' and 'pm_lon_coslat' keywords under astropy 2.

--- a/tests/datafile/J1600-3053_test.par
+++ b/tests/datafile/J1600-3053_test.par
@@ -21,4 +21,3 @@ A1DOT           -0.0040E-12               1   6.000e-16
 PMELONG         0.46                      1   1.000e-02
 PMELAT          -7.16                     1   6.000e-02
 UNITS           TDB
-ECL             IERS2010


### PR DESCRIPTION
This addresses #610. Rather than make the `PulsarEcliptic.obliquity` a normal instance attribute, it makes it a `QuantityAttribute`, thereby using the same mechanism as Astropy's built-in coordinate frames like `BarycentricTrueEcliptic` (https://docs.astropy.org/en/stable/coordinates/frames.html#defining-frame-attributes). This means that printing a `PulsarEcliptic` object now shows the corresponding obliquity:
```
<PulsarEcliptic Coordinate (obliquity=84381.4059 arcsec): (lon, lat) in deg
    (244.34767784, -10.07183903)
 (pm_lon_coslat, pm_lat) in mas / yr
    (0.46, -7.16)>
```
It also means that it's easy to transform to and between `PulsarEcliptic` frames with different obliquities. `coords.transform_to(PulsarEcliptic)` uses the default obliquity value, and you can also transform to a `PulsarEcliptic` frame with a different obliquity value if you want by doing things like `coords.transform_to(PulsarEcliptic(obliquity=84381.406*u.arcsec))`. To make this more convenient, I added an optional parameter `ecl` to the `PulsarEcliptic` constructor, so you can also do things like `coords.transform_to(PulsarEcliptic(ecl="DE403"))`.

I've also changed the default `ECL` in `astrometry.py` to `IERS2010` to match the global default set in `ecliptic.dat`. This means that models based on par files with out `ECL` set (which is most of them that I've seen) will now use the IERS2010 value rather than IERS2003. This will affect comparisons with Tempo2.