### PR TITLE
Test against Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
         - python: "3.5"
         - python: "3.6"
         - python: "3.7"
+        - python: "3.8"
         - name: "tox"
           sudo: false
           language: python


### PR DESCRIPTION
Python 3.8 is now the default for new conda environments and we should probably be testing against it. I've run the tests in a local Python 3.8 environment, and they pass, but with more warnings than under 3.7.