### PR TITLE
Export PulsarMJD and PulsarEcliptic at top level

### DIFF
--- a/src/pint/__init__.py
+++ b/src/pint/__init__.py
@@ -4,10 +4,11 @@ import astropy.constants as c
 import astropy.time as time
 import astropy.units as u
 import numpy as np
-from astropy.units import si
-
 import pint.pulsar_mjd
+from astropy.units import si
 from pint.extern._version import get_versions
+from pint.pulsar_ecliptic import PulsarEcliptic
+from pint.pulsar_mjd import PulsarMJD
 
 __all__ = [
     "__version__",

--- a/src/pint/__init__.py
+++ b/src/pint/__init__.py
@@ -31,6 +31,8 @@ __all__ = [
     "J2000ld",
     "JD_MJD",
     "pint_units",
+    "PulsarEcliptic",
+    "PulsarMJD",
 ]
 
 __version__ = get_versions()["version"]


### PR DESCRIPTION
This adds `PulsarMJD` and `PulsarEcliptic` to `__init__.py`, so that they can be imported in a simpler way. You can now do
```
from pint import PulsarMJD, PulsarEcliptic
```
rather than
```
from pint.pulsar_mjd import PulsarMJD
from pint.pulsar_ecliptic import PulsarEcliptic
```