### PR TITLE
Save covariance and correlation matrices in fitter classes

### DIFF
--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -222,10 +222,10 @@ class WLSFitter(Fitter):
             sigma_var = (Sigma / fac).T / fac
             errors = np.sqrt(np.diag(sigma_var))
             sigma_cov = (sigma_var / errors).T / errors
-            # correlation matrix = variances in diagonal, used for gaussian random models
-            self.correlation_matrix = sigma_var
-            # covariance matrix = 1s in diagonal, use for comparison to tempo/tempo2 cov matrix
-            self.covariance_matrix = sigma_cov
+            # covariance matrix = variances in diagonal, used for gaussian random models
+            self.covariance_matrix = sigma_var
+            # correlation matrix = 1s in diagonal, use for comparison to tempo/tempo2 cov matrix
+            self.correlation_matrix = sigma_cov
             self.fac = fac
             self.errors = errors
 

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -367,6 +367,9 @@ class GLSFitter(Fitter):
             # compute absolute estimates, normalized errors, covariance matrix
             dpars = xhat / norm
             errs = np.sqrt(np.diag(xvar)) / norm
+            covmat = (xvar / norm).T / norm
+            self.covariance_matrix = covmat
+            self.correlation_matrix = (covmat / errs).T / errs
 
             for ii, pn in enumerate(fitp.keys()):
                 uind = params.index(pn)  # Index of designmatrix

--- a/src/pint/random_models.py
+++ b/src/pint/random_models.py
@@ -45,16 +45,16 @@ def random_models(
     params = fitter.get_fitparams_num()
     mean_vector = params.values()
     # remove the first column and row (absolute phase)
-    cor_matrix = (((fitter.correlation_matrix[1:]).T)[1:]).T
+    cov_matrix = (((fitter.covariance_matrix[1:]).T)[1:]).T
     fac = fitter.fac[1:]
     f_rand = deepcopy(fitter)
     mrand = f_rand.model
 
     # scale by fac
-    log.debug("errors", np.sqrt(np.diag(cor_matrix)))
+    log.debug("errors", np.sqrt(np.diag(cov_matrix)))
     log.debug("mean vector", mean_vector)
     mean_vector = np.array(list(mean_vector)) * fac
-    cov_matrix = ((cor_matrix * fac).T * fac).T
+    cov_matrix = ((cov_matrix * fac).T * fac).T
 
     toa_mjds = fitter.toas.get_mjds()
     minMJD, maxMJD = toa_mjds.min(), toa_mjds.max()


### PR DESCRIPTION
This makes parameter covariance and correlation matrices accessible as the `covariance_matrix` and `correlation_matrix` attributes, respectively, of `WLSFitter` and `GLSFitter` instances, once the fit has been run. For `WLSFitter`, this functionality already existed, but the matrices were labelled incorrectly (#625). For `GLSFitter`, the matrices were computed inside the fitting function but not accessible from outside (#542). 