### PR TITLE
Move parameter validations from setup() to validate()

### DIFF
--- a/src/pint/models/absolute_phase.py
+++ b/src/pint/models/absolute_phase.py
@@ -42,7 +42,7 @@ class AbsPhase(PhaseComponent):
         )
 
     def setup(self):
-        pass
+        super(AbsPhase, self).setup()
 
     def validate(self):
         super(AbsPhase, self).validate()

--- a/src/pint/models/absolute_phase.py
+++ b/src/pint/models/absolute_phase.py
@@ -43,7 +43,7 @@ class AbsPhase(PhaseComponent):
 
     def setup(self):
         pass
-    
+
     def validate(self):
         super(AbsPhase, self).validate()
         # Check input Parameters

--- a/src/pint/models/absolute_phase.py
+++ b/src/pint/models/absolute_phase.py
@@ -42,7 +42,10 @@ class AbsPhase(PhaseComponent):
         )
 
     def setup(self):
-        super(AbsPhase, self).setup()
+        pass
+    
+    def validate(self):
+        super(AbsPhase, self).validate()
         # Check input Parameters
         if self.TZRMJD.value is None:
             raise MissingParameter(

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -45,7 +45,7 @@ class Astrometry(DelayComponent):
         super(Astrometry, self).setup()
 
     def validate(self):
-        pass
+        super(Astrometry, self).validate()
 
     def ssb_to_psb_xyz_ICRS(self, epoch=None):
         """Returns unit vector(s) from SSB to pulsar system barycenter under ICRS.
@@ -451,6 +451,7 @@ class AstrometryEcliptic(Astrometry):
     def validate(self):
         """ Validate Ecliptic coordinate parameter inputs.
         """
+        super(AstrometryEcliptic, self).validate()
         # ELONG/ELAT are required
         for p in ("ELONG", "ELAT"):
             if getattr(self, p).value is None:

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -44,6 +44,9 @@ class Astrometry(DelayComponent):
     def setup(self):
         super(Astrometry, self).setup()
 
+    def validate(self):
+        pass
+
     def ssb_to_psb_xyz_ICRS(self, epoch=None):
         """Returns unit vector(s) from SSB to pulsar system barycenter under ICRS.
 
@@ -210,7 +213,12 @@ class AstrometryEquatorial(Astrometry):
             self.register_deriv_funcs(func, param)
 
     def setup(self):
-        super(AstrometryEquatorial, self).setup()
+        super(AstrometryEquatorial, self).setup() 
+
+    def validate(self):
+        ''' Validate the input parameter.
+        '''
+        super(AstrometryEquatorial, self).validate()
         # RA/DEC are required
         for p in ("RAJ", "DECJ"):
             if getattr(self, p).value is None:
@@ -439,7 +447,11 @@ class AstrometryEcliptic(Astrometry):
 
     def setup(self):
         super(AstrometryEcliptic, self).setup()
-        # RA/DEC are required
+
+    def validate(self):
+        """ Validate Ecliptic coordinate parameter inputs.
+        """
+        # ELONG/ELAT are required
         for p in ("ELONG", "ELAT"):
             if getattr(self, p).value is None:
                 raise MissingParameter("AstrometryEcliptic", p)

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -213,11 +213,11 @@ class AstrometryEquatorial(Astrometry):
             self.register_deriv_funcs(func, param)
 
     def setup(self):
-        super(AstrometryEquatorial, self).setup() 
+        super(AstrometryEquatorial, self).setup()
 
     def validate(self):
-        ''' Validate the input parameter.
-        '''
+        """ Validate the input parameter.
+        """
         super(AstrometryEquatorial, self).validate()
         # RA/DEC are required
         for p in ("RAJ", "DECJ"):

--- a/src/pint/models/binary_bt.py
+++ b/src/pint/models/binary_bt.py
@@ -47,8 +47,11 @@ class BinaryBT(PulsarBinary):
 
     def setup(self):
         super(BinaryBT, self).setup()
-        # If any necessary parameter is missing, raise MissingParameter.
-        # This will probably be updated after ELL1 model is added.
+
+    def validate(self):
+        """ Validate BT model parameters
+        """
+        super(BinaryBT, self).validate()
         for p in ("T0", "A1"):
             if getattr(self, p).value is None:
                 raise MissingParameter("BT", p, "%s is required for BT" % p)

--- a/src/pint/models/binary_dd.py
+++ b/src/pint/models/binary_dd.py
@@ -72,16 +72,19 @@ class BinaryDD(PulsarBinary):
         )
 
     def setup(self):
-        """Check out parameters setup.
+        """setup.
         """
         super(BinaryDD, self).setup()
+
+    def validate(self):
+        super(BinaryDD, self).validate()
         self.check_required_params(["T0", "A1"])
         # If any *DOT is set, we need T0
         for p in ("PBDOT", "OMDOT", "EDOT", "A1DOT"):
             if getattr(self, p).value is None:
                 getattr(self, p).set("0")
                 getattr(self, p).frozen = True
-
+            # TODO This steps seems duplicated. 
             if getattr(self, p).value is not None:
                 if self.T0.value is None:
                     raise MissingParameter("DD", "T0", "T0 is required if *DOT is set")

--- a/src/pint/models/binary_dd.py
+++ b/src/pint/models/binary_dd.py
@@ -77,6 +77,8 @@ class BinaryDD(PulsarBinary):
         super(BinaryDD, self).setup()
 
     def validate(self):
+        """ Validate the input parameters.
+        """
         super(BinaryDD, self).validate()
         self.check_required_params(["T0", "A1"])
         # If any *DOT is set, we need T0

--- a/src/pint/models/binary_dd.py
+++ b/src/pint/models/binary_dd.py
@@ -84,7 +84,7 @@ class BinaryDD(PulsarBinary):
             if getattr(self, p).value is None:
                 getattr(self, p).set("0")
                 getattr(self, p).frozen = True
-            # TODO This steps seems duplicated. 
+            # TODO This steps seems duplicated.
             if getattr(self, p).value is not None:
                 if self.T0.value is None:
                     raise MissingParameter("DD", "T0", "T0 is required if *DOT is set")

--- a/src/pint/models/binary_ddk.py
+++ b/src/pint/models/binary_ddk.py
@@ -85,6 +85,10 @@ class BinaryDDK(BinaryDD):
             "Using ICRS equatorial coordinate. The parameter KOM is"
             " measured respect to equatorial North."
         )
+    def validate(self):
+        """ Validate parameters
+        """
+        super(BinaryDDK, self).validate()
         if "PMRA" not in self._parent.params or "PMDEC" not in self._parent.params:
             # Check ecliptic coordinates proper motion.
             if (

--- a/src/pint/models/binary_ddk.py
+++ b/src/pint/models/binary_ddk.py
@@ -85,6 +85,7 @@ class BinaryDDK(BinaryDD):
             "Using ICRS equatorial coordinate. The parameter KOM is"
             " measured respect to equatorial North."
         )
+
     def validate(self):
         """ Validate parameters
         """

--- a/src/pint/models/binary_ell1.py
+++ b/src/pint/models/binary_ell1.py
@@ -108,9 +108,10 @@ class BinaryELL1(BinaryELL1Base):
 
     def setup(self):
         super(BinaryELL1, self).setup()
-    
+
     def validate(self):
         super(BinaryELL1, self).validate()
+
 
 class BinaryELL1H(BinaryELL1Base):
     """Modified ELL1 to with H3 parameter.
@@ -180,7 +181,7 @@ class BinaryELL1H(BinaryELL1Base):
         """
         super(BinaryELL1H, self).validate()
         if self.H3.quantity is None:
-            raise MissingParameter('ELL1H', 'H3', "'H3' is required for ELL1H model")
+            raise MissingParameter("ELL1H", "H3", "'H3' is required for ELL1H model")
         if self.SINI.quantity is not None:
             warn("'SINI' will not be used in ELL1H model. ")
         if self.M2.quantity is not None:

--- a/src/pint/models/binary_ell1.py
+++ b/src/pint/models/binary_ell1.py
@@ -74,9 +74,11 @@ class BinaryELL1Base(PulsarBinary):
         self.warn_default_params = []
 
     def setup(self):
-        """Check out parameters setup.
-        """
         super(BinaryELL1Base, self).setup()
+
+    def validate(self):
+        """ Validate parameters
+        """
         for p in ["EPS1", "EPS2"]:
             if getattr(self, p).value is None:
                 raise MissingParameter("ELL1", p, p + " is required for ELL1 model.")
@@ -106,7 +108,9 @@ class BinaryELL1(BinaryELL1Base):
 
     def setup(self):
         super(BinaryELL1, self).setup()
-
+    
+    def validate(self):
+        super(BinaryELL1, self).validate()
 
 class BinaryELL1H(BinaryELL1Base):
     """Modified ELL1 to with H3 parameter.
@@ -167,11 +171,16 @@ class BinaryELL1H(BinaryELL1Base):
         return self.binary_instance.ds_func_list
 
     def setup(self):
-        """Check out parameters setup.
+        """ Parameter setup.
         """
         super(BinaryELL1H, self).setup()
+
+    def validate(self):
+        """ Parameter validate
+        """
+        super(BinaryELL1H, self).validate()
         if self.H3.quantity is None:
-            raise MissingParameter("'H3' is required for ELL1H model")
+            raise MissingParameter('ELL1H', 'H3', "'H3' is required for ELL1H model")
         if self.SINI.quantity is not None:
             warn("'SINI' will not be used in ELL1H model. ")
         if self.M2.quantity is not None:

--- a/src/pint/models/binary_ell1.py
+++ b/src/pint/models/binary_ell1.py
@@ -79,6 +79,8 @@ class BinaryELL1Base(PulsarBinary):
     def validate(self):
         """ Validate parameters
         """
+        super(BinaryELL1Base, self).validate()
+
         for p in ["EPS1", "EPS2"]:
             if getattr(self, p).value is None:
                 raise MissingParameter("ELL1", p, p + " is required for ELL1 model.")
@@ -177,7 +179,7 @@ class BinaryELL1H(BinaryELL1Base):
         super(BinaryELL1H, self).setup()
 
     def validate(self):
-        """ Parameter validate
+        """ Parameter validation.
         """
         super(BinaryELL1H, self).validate()
         if self.H3.quantity is None:

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -100,7 +100,7 @@ class DispersionDM(Dispersion):
 
         for dm_name in base_dms:
             self.register_deriv_funcs(self.d_delay_d_DMs, dm_name)
-    
+
     def validate(self):
         """ Validate the DM parameters input.
         """
@@ -111,7 +111,7 @@ class DispersionDM(Dispersion):
                     "Dispersion",
                     "DMEPOCH",
                     "DMEPOCH is required if DM1 or higher are set",
-                )    
+                )
 
     def DM_dervative_unit(self, n):
         return "pc cm^-3/yr^%d" % n if n else "pc cm^-3"

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -95,6 +95,15 @@ class DispersionDM(Dispersion):
 
     def setup(self):
         super(Dispersion, self).setup()
+        base_dms = list(self.get_prefix_mapping_component("DM").values())
+        base_dms += ["DM"]
+
+        for dm_name in base_dms:
+            self.register_deriv_funcs(self.d_delay_d_DMs, dm_name)
+    
+    def validate(self):
+        """ Validate the DM parameters input.
+        """
         # If DM1 is set, we need DMEPOCH
         if self.DM1.value != 0.0:
             if self.DMEPOCH.value is None:
@@ -102,12 +111,7 @@ class DispersionDM(Dispersion):
                     "Dispersion",
                     "DMEPOCH",
                     "DMEPOCH is required if DM1 or higher are set",
-                )
-        base_dms = list(self.get_prefix_mapping_component("DM").values())
-        base_dms += ["DM"]
-
-        for dm_name in base_dms:
-            self.register_deriv_funcs(self.d_delay_d_DMs, dm_name)
+                )    
 
     def DM_dervative_unit(self, n):
         return "pc cm^-3/yr^%d" % n if n else "pc cm^-3"
@@ -281,6 +285,14 @@ class DispersionDMX(Dispersion):
     def setup(self):
         super(DispersionDMX, self).setup()
         # Get DMX mapping.
+        # Register the DMX derivatives
+        for prefix_par in self.get_params_of_type("prefixParameter"):
+            if prefix_par.startswith("DMX_"):
+                self.register_deriv_funcs(self.d_delay_d_DMX, prefix_par)
+
+    def validate(self):
+        """ Validate the DMX parameters. 
+        """
         DMX_mapping = self.get_prefix_mapping_component("DMX_")
         DMXR1_mapping = self.get_prefix_mapping_component("DMXR1_")
         DMXR2_mapping = self.get_prefix_mapping_component("DMXR2_")
@@ -295,10 +307,6 @@ class DispersionDMX(Dispersion):
             errorMsg += "equals to Number of DMXR2_ parameters. "
             errorMsg += "Please check your prefixed parameters."
             raise AttributeError(errorMsg)
-        # create d_delay_d_dmx functions
-        for prefix_par in self.get_params_of_type("prefixParameter"):
-            if prefix_par.startswith("DMX_"):
-                self.register_deriv_funcs(self.d_delay_d_DMX, prefix_par)
 
     def dmx_dm(self, toas):
         condition = {}

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -104,6 +104,7 @@ class DispersionDM(Dispersion):
     def validate(self):
         """ Validate the DM parameters input.
         """
+        super(Dispersion, self).validate()
         # If DM1 is set, we need DMEPOCH
         if self.DM1.value != 0.0:
             if self.DMEPOCH.value is None:
@@ -291,8 +292,9 @@ class DispersionDMX(Dispersion):
                 self.register_deriv_funcs(self.d_delay_d_DMX, prefix_par)
 
     def validate(self):
-        """ Validate the DMX parameters. 
+        """ Validate the DMX parameters.
         """
+        super(DispersionDMX, self).validate()
         DMX_mapping = self.get_prefix_mapping_component("DMX_")
         DMXR1_mapping = self.get_prefix_mapping_component("DMXR1_")
         DMXR2_mapping = self.get_prefix_mapping_component("DMXR2_")

--- a/src/pint/models/frequency_dependent.py
+++ b/src/pint/models/frequency_dependent.py
@@ -43,7 +43,7 @@ class FD(DelayComponent):
             self.register_deriv_funcs(self.d_delay_FD_d_FDX, val)
 
     def validate(self):
-        FD_terms = list(self.FD_mapping.keys())
+        super(FD, self).validate()
         FD_terms.sort()
         FD_in_order = list(range(1, max(FD_terms) + 1))
         if not FD_terms == FD_in_order:

--- a/src/pint/models/frequency_dependent.py
+++ b/src/pint/models/frequency_dependent.py
@@ -36,17 +36,20 @@ class FD(DelayComponent):
     def setup(self):
         super(FD, self).setup()
         # Check if FD terms are in order.
-        FD_mapping = self.get_prefix_mapping_component("FD")
-        FD_terms = list(FD_mapping.keys())
+        self.FD_mapping = self.get_prefix_mapping_component("FD")
+        self.num_FD_terms = len(self.FD_mapping)
+        # set up derivative functions
+        for val in self.FD_mapping.values():
+            self.register_deriv_funcs(self.d_delay_FD_d_FDX, val)        
+
+
+    def validate(self):
+        FD_terms = list(self.FD_mapping.keys())
         FD_terms.sort()
         FD_in_order = list(range(1, max(FD_terms) + 1))
         if not FD_terms == FD_in_order:
             diff = list(set(FD_in_order) - set(FD_terms))
             raise MissingParameter("FD", "FD%d" % diff[0])
-        self.num_FD_terms = len(FD_terms)
-        # set up derivative functions
-        for ii, val in FD_mapping.items():
-            self.register_deriv_funcs(self.d_delay_FD_d_FDX, val)
 
     def FD_delay(self, toas, acc_delay=None):
         """Calculate frequency dependent delay.

--- a/src/pint/models/frequency_dependent.py
+++ b/src/pint/models/frequency_dependent.py
@@ -36,14 +36,15 @@ class FD(DelayComponent):
     def setup(self):
         super(FD, self).setup()
         # Check if FD terms are in order.
-        self.FD_mapping = self.get_prefix_mapping_component("FD")
-        self.num_FD_terms = len(self.FD_mapping)
+        FD_mapping = self.get_prefix_mapping_component("FD")
+        self.num_FD_terms = len(FD_mapping)
         # set up derivative functions
-        for val in self.FD_mapping.values():
+        for val in FD_mapping.values():
             self.register_deriv_funcs(self.d_delay_FD_d_FDX, val)
 
     def validate(self):
         super(FD, self).validate()
+        FD_terms = list(self.get_prefix_mapping_component("FD").keys())
         FD_terms.sort()
         FD_in_order = list(range(1, max(FD_terms) + 1))
         if not FD_terms == FD_in_order:

--- a/src/pint/models/frequency_dependent.py
+++ b/src/pint/models/frequency_dependent.py
@@ -40,8 +40,7 @@ class FD(DelayComponent):
         self.num_FD_terms = len(self.FD_mapping)
         # set up derivative functions
         for val in self.FD_mapping.values():
-            self.register_deriv_funcs(self.d_delay_FD_d_FDX, val)        
-
+            self.register_deriv_funcs(self.d_delay_FD_d_FDX, val)
 
     def validate(self):
         FD_terms = list(self.FD_mapping.keys())

--- a/src/pint/models/glitch.py
+++ b/src/pint/models/glitch.py
@@ -126,7 +126,7 @@ class Glitch(PhaseComponent):
             if not hasattr(self, "GLEP_%d" % idx):
                 msg = "Glicth Epoch is needed for Glicth %d." % idx
                 raise MissingParameter("Glitch", "GLEP_%d" % idx, msg)
-       
+
         # Check the Decay Term.
         glf0dparams = [x for x in self.params if x.startswith("GLF0D_")]
         for glf0dnm in glf0dparams:

--- a/src/pint/models/glitch.py
+++ b/src/pint/models/glitch.py
@@ -110,9 +110,6 @@ class Glitch(PhaseComponent):
             if x in y
         ]
         for idx in set(self.glitch_indices):
-            if not hasattr(self, "GLEP_%d" % idx):
-                msg = "Glicth Epoch is needed for Glicth %d." % idx
-                raise MissingParameter("Glitch", "GLEP_%d" % idx, msg)
             for param in self.glitch_prop:
                 if not hasattr(self, param + "%d" % idx):
                     param0 = getattr(self, param + "1")
@@ -122,6 +119,14 @@ class Glitch(PhaseComponent):
                     getattr(self, "d_phase_d_" + param[0:-1]), param + "%d" % idx
                 )
 
+    def validate(self):
+        """ Validate parameters input.
+        """
+        for idx in set(self.glitch_indices):
+            if not hasattr(self, "GLEP_%d" % idx):
+                msg = "Glicth Epoch is needed for Glicth %d." % idx
+                raise MissingParameter("Glitch", "GLEP_%d" % idx, msg)
+       
         # Check the Decay Term.
         glf0dparams = [x for x in self.params if x.startswith("GLF0D_")]
         for glf0dnm in glf0dparams:

--- a/src/pint/models/glitch.py
+++ b/src/pint/models/glitch.py
@@ -122,6 +122,7 @@ class Glitch(PhaseComponent):
     def validate(self):
         """ Validate parameters input.
         """
+        super(Glitch, self).validate()
         for idx in set(self.glitch_indices):
             if not hasattr(self, "GLEP_%d" % idx):
                 msg = "Glicth Epoch is needed for Glicth %d." % idx

--- a/src/pint/models/ifunc.py
+++ b/src/pint/models/ifunc.py
@@ -70,7 +70,7 @@ class IFunc(PhaseComponent):
         self.num_terms = len(self.terms)
 
     def validate(self):
-        self.setup()
+        super(IFunc, self).validate()
         if self.SIFUNC.quantity is None:
             raise MissingParameter(
                 "IFunc", "SIFUNC", "SIFUNC is required if IFUNC entries are present."

--- a/src/pint/models/ifunc.py
+++ b/src/pint/models/ifunc.py
@@ -63,10 +63,10 @@ class IFunc(PhaseComponent):
             )
         )
         self.phase_funcs_component += [self.ifunc_phase]
-    
+
     def setup(self):
         super(IFunc, self).setup()
-        self.terms = list(self.get_prefix_mapping_component("IFUNC").keys())        
+        self.terms = list(self.get_prefix_mapping_component("IFUNC").keys())
         self.num_terms = len(self.terms)
 
     def validate(self):

--- a/src/pint/models/ifunc.py
+++ b/src/pint/models/ifunc.py
@@ -63,9 +63,14 @@ class IFunc(PhaseComponent):
             )
         )
         self.phase_funcs_component += [self.ifunc_phase]
-
+    
     def setup(self):
         super(IFunc, self).setup()
+        self.terms = list(self.get_prefix_mapping_component("IFUNC").keys())        
+        self.num_terms = len(self.terms)
+
+    def validate(self):
+        self.setup()
         if self.SIFUNC.quantity is None:
             raise MissingParameter(
                 "IFunc", "SIFUNC", "SIFUNC is required if IFUNC entries are present."
@@ -78,13 +83,10 @@ class IFunc(PhaseComponent):
         # this is copied from the wave model, but I don't think this check
         # is strictly necessary.  An ephemeris could remain perfectly valid
         # if some IFUNC terms were "missing".  (The same is true for WAVE.)
-        terms = list(self.get_prefix_mapping_component("IFUNC").keys())
-        terms.sort()
-        for i, term in enumerate(terms):
+        self.terms.sort()
+        for i, term in enumerate(self.terms):
             if (i + 1) != term:
                 raise MissingParameter("IFunc", "IFUNC%d" % (i + 1))
-
-        self.num_terms = len(terms)
 
     def print_par(self,):
         result = self.SIFUNC.as_parfile_line()

--- a/src/pint/models/jump.py
+++ b/src/pint/models/jump.py
@@ -37,10 +37,10 @@ class DelayJump(DelayComponent):
                 self.jumps.append(mask_par)
         for j in self.jumps:
             self.register_deriv_funcs(self.d_delay_d_jump, j)
-    
+
     def validate(self):
-        pass 
-    
+        pass
+
     def jump_delay(self, toas, acc_delay=None):
         """This method returns the jump delays for each toas section collected by
         jump parameters. The delay value is determined by jump parameter value
@@ -95,7 +95,7 @@ class PhaseJump(PhaseComponent):
             if j in self.deriv_funcs.keys():
                 del self.deriv_funcs[j]
             self.register_deriv_funcs(self.d_phase_d_jump, j)
-    
+
     def validate(self):
         pass
 

--- a/src/pint/models/jump.py
+++ b/src/pint/models/jump.py
@@ -37,7 +37,10 @@ class DelayJump(DelayComponent):
                 self.jumps.append(mask_par)
         for j in self.jumps:
             self.register_deriv_funcs(self.d_delay_d_jump, j)
-
+    
+    def validate(self):
+        pass 
+    
     def jump_delay(self, toas, acc_delay=None):
         """This method returns the jump delays for each toas section collected by
         jump parameters. The delay value is determined by jump parameter value
@@ -92,6 +95,9 @@ class PhaseJump(PhaseComponent):
             if j in self.deriv_funcs.keys():
                 del self.deriv_funcs[j]
             self.register_deriv_funcs(self.d_phase_d_jump, j)
+    
+    def validate(self):
+        pass
 
     def jump_phase(self, toas, delay):
         """This method returns the jump phase for each toas section collected by

--- a/src/pint/models/jump.py
+++ b/src/pint/models/jump.py
@@ -39,7 +39,7 @@ class DelayJump(DelayComponent):
             self.register_deriv_funcs(self.d_delay_d_jump, j)
 
     def validate(self):
-        pass
+        super(DelayJump, self).validate()
 
     def jump_delay(self, toas, acc_delay=None):
         """This method returns the jump delays for each toas section collected by
@@ -97,7 +97,7 @@ class PhaseJump(PhaseComponent):
             self.register_deriv_funcs(self.d_phase_d_jump, j)
 
     def validate(self):
-        pass
+        super(PhaseJump, self).validate()
 
     def jump_phase(self, toas, delay):
         """This method returns the jump phase for each toas section collected by

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -122,7 +122,7 @@ class ScaleToaError(NoiseComponent):
             if pp.startswith("EQUAD"):
                 par = getattr(self, pp)
                 self.EQUADs[pp] = (par.key, par.key_value)
-        
+
     def validate(self):
         # check duplicate
         for el in ["EFACs", "EQUADs"]:

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -122,6 +122,8 @@ class ScaleToaError(NoiseComponent):
             if pp.startswith("EQUAD"):
                 par = getattr(self, pp)
                 self.EQUADs[pp] = (par.key, par.key_value)
+        
+    def validate(self):
         # check duplicate
         for el in ["EFACs", "EQUADs"]:
             l = list(getattr(self, el).values())

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -17,7 +17,7 @@ class NoiseComponent(Component):
         self.scaled_sigma_funcs = []
         self.basis_funcs = []
 
-    def validate(self, ):
+    def validate(self,):
         super(NoiseComponent, self).validate()
 
 

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -17,6 +17,9 @@ class NoiseComponent(Component):
         self.scaled_sigma_funcs = []
         self.basis_funcs = []
 
+    def validate(self, ):
+        super(NoiseComponent, self).validate()
+
 
 class ScaleToaError(NoiseComponent):
     """Correct reported template fitting uncertainties.
@@ -124,6 +127,7 @@ class ScaleToaError(NoiseComponent):
                 self.EQUADs[pp] = (par.key, par.key_value)
 
     def validate(self):
+        super(ScaleToaError, self).validate()
         # check duplicate
         for el in ["EFACs", "EQUADs"]:
             l = list(getattr(self, el).values())
@@ -208,6 +212,15 @@ class EcorrNoise(NoiseComponent):
                 self.ECORRs[mask_par] = (par.key, par.key_value)
             else:
                 continue
+
+        # check duplicate
+        for el in ["ECORRs"]:
+            l = list(getattr(self, el).values())
+            if [x for x in l if l.count(x) > 1] != []:
+                raise ValueError("'%s' have duplicated keys and key values." % el)
+
+    def validate(self):
+        super(EcorrNoise, self).validate()
 
         # check duplicate
         for el in ["ECORRs"]:
@@ -322,6 +335,9 @@ class PLRedNoise(NoiseComponent):
 
     def setup(self):
         super(PLRedNoise, self).setup()
+
+    def validate(self):
+        super(PLRedNoise, self).validate()
 
     def get_pl_vals(self):
         nf = int(self.TNRedC.value) if self.TNRedC.value is not None else 30

--- a/src/pint/models/pulsar_binary.py
+++ b/src/pint/models/pulsar_binary.py
@@ -160,7 +160,7 @@ class PulsarBinary(DelayComponent):
             )
 
     def validate(self):
-        pass
+        super(PulsarBinary, self).validate()
 
     def check_required_params(self, required_params):
         # seach for all the possible to get the parameters.

--- a/src/pint/models/pulsar_binary.py
+++ b/src/pint/models/pulsar_binary.py
@@ -147,20 +147,20 @@ class PulsarBinary(DelayComponent):
         # Setup the model isinstance
         self.binary_instance = self.binary_model_class()
         # Setup the FBX orbits if FB is set.
+        # TODO this should use a smarter way to set up orbit.
         FBX_mapping = self.get_prefix_mapping_component("FB")
         FBXs = {}
         for fbn in FBX_mapping.values():
             FBXs[fbn] = getattr(self, fbn).quantity
         if None not in FBXs.values():
             for fb_name, fb_value in FBXs.items():
-                if fb_value is None:
-                    raise MissingParameter(
-                        self.binary_model_name, fb_name + " is required for FB orbits."
-                    )
                 self.binary_instance.add_binary_params(fb_name, fb_value)
             self.binary_instance.orbits_cls = bo.OrbitFBX(
                 self.binary_instance, list(FBXs.keys())
             )
+
+    def validate(self):
+        pass
 
     def check_required_params(self, required_params):
         # seach for all the possible to get the parameters.

--- a/src/pint/models/solar_system_shapiro.py
+++ b/src/pint/models/solar_system_shapiro.py
@@ -43,6 +43,9 @@ class SolarSystemShapiro(DelayComponent):
     def setup(self):
         super(SolarSystemShapiro, self).setup()
 
+    def validate(self):
+        super(SolarSystemShapiro, self).validate()
+
     # Put masses in a convenient dictionary
     _ss_mass_sec = {
         "sun": Tsun.value,

--- a/src/pint/models/solar_wind_dispersion.py
+++ b/src/pint/models/solar_wind_dispersion.py
@@ -48,7 +48,7 @@ class SolarWindDispersion(Dispersion):
         self.register_deriv_funcs(self.d_delay_d_ne_sw, "NE_SW")
 
     def validate(self):
-        pass
+        super(SolarWindDispersion, self).validate()
 
     def solar_wind_delay(self, toas, acc_delay=None):
         """Return the solar wind dispersion delay for a set of frequencies

--- a/src/pint/models/solar_wind_dispersion.py
+++ b/src/pint/models/solar_wind_dispersion.py
@@ -46,6 +46,9 @@ class SolarWindDispersion(Dispersion):
     def setup(self):
         super(SolarWindDispersion, self).setup()
         self.register_deriv_funcs(self.d_delay_d_ne_sw, "NE_SW")
+    
+    def validate(self):
+        pass
 
     def solar_wind_delay(self, toas, acc_delay=None):
         """Return the solar wind dispersion delay for a set of frequencies

--- a/src/pint/models/solar_wind_dispersion.py
+++ b/src/pint/models/solar_wind_dispersion.py
@@ -46,7 +46,7 @@ class SolarWindDispersion(Dispersion):
     def setup(self):
         super(SolarWindDispersion, self).setup()
         self.register_deriv_funcs(self.d_delay_d_ne_sw, "NE_SW")
-    
+
     def validate(self):
         pass
 

--- a/src/pint/models/spindown.py
+++ b/src/pint/models/spindown.py
@@ -56,29 +56,31 @@ class Spindown(PhaseComponent):
 
     def setup(self):
         super(Spindown, self).setup()
+        self.F_terms = list(self.get_prefix_mapping_component("F").keys())
+        self.num_spin_terms = len(self.F_terms) + 1
+        # Add derivative functions
+        for fp in list(self.get_prefix_mapping_component("F").values()) + ["F0"]:
+            self.register_deriv_funcs(self.d_phase_d_F, fp)
+
+    def validate(self):
+        super(Spindown, self).validate()
         # Check for required params
         for p in ("F0",):
             if getattr(self, p).value is None:
                 raise MissingParameter("Spindown", p)
-
         # Check continuity
         F_terms = list(self.get_prefix_mapping_component("F").keys())
-        F_terms.sort()
-        F_in_order = list(range(1, max(F_terms) + 1))
-        if not F_terms == F_in_order:
-            diff = list(set(F_in_order) - set(F_terms))
+        self.F_terms.sort()
+        F_in_order = list(range(1, max(self.F_terms) + 1))
+        if not self.F_terms == F_in_order:
+            diff = list(set(F_in_order) - set(self.F_terms))
             raise MissingParameter("Spindown", "F%d" % diff[0])
-
-        # If F1 is set, we need PEPOCH
+         # If F1 is set, we need PEPOCH
         if self.F1.value != 0.0:
             if self.PEPOCH.value is None:
                 raise MissingParameter(
                     "Spindown", "PEPOCH", "PEPOCH is required if F1 or higher are set"
                 )
-        self.num_spin_terms = len(F_terms) + 1
-        # Add derivative functions
-        for fp in list(self.get_prefix_mapping_component("F").values()) + ["F0"]:
-            self.register_deriv_funcs(self.d_phase_d_F, fp)
 
     def F_description(self, n):
         """Template function for description"""

--- a/src/pint/models/spindown.py
+++ b/src/pint/models/spindown.py
@@ -56,7 +56,6 @@ class Spindown(PhaseComponent):
 
     def setup(self):
         super(Spindown, self).setup()
-        self.F_terms = list(self.get_prefix_mapping_component("F").keys())
         self.num_spin_terms = len(self.F_terms) + 1
         # Add derivative functions
         for fp in list(self.get_prefix_mapping_component("F").values()) + ["F0"]:
@@ -69,11 +68,10 @@ class Spindown(PhaseComponent):
             if getattr(self, p).value is None:
                 raise MissingParameter("Spindown", p)
         # Check continuity
-        F_terms = list(self.get_prefix_mapping_component("F").keys())
-        self.F_terms.sort()
+        sort_F_terms = sorted(self.F_terms)
         F_in_order = list(range(1, max(self.F_terms) + 1))
-        if not self.F_terms == F_in_order:
-            diff = list(set(F_in_order) - set(self.F_terms))
+        if not sort_F_terms == F_in_order:
+            diff = list(set(F_in_order) - set(sort_F_terms))
             raise MissingParameter("Spindown", "F%d" % diff[0])
         # If F1 is set, we need PEPOCH
         if self.F1.value != 0.0:
@@ -81,6 +79,10 @@ class Spindown(PhaseComponent):
                 raise MissingParameter(
                     "Spindown", "PEPOCH", "PEPOCH is required if F1 or higher are set"
                 )
+
+    @property
+    def F_terms(self):
+        return list(self.get_prefix_mapping_component("F").keys())
 
     def F_description(self, n):
         """Template function for description"""

--- a/src/pint/models/spindown.py
+++ b/src/pint/models/spindown.py
@@ -75,7 +75,7 @@ class Spindown(PhaseComponent):
         if not self.F_terms == F_in_order:
             diff = list(set(F_in_order) - set(self.F_terms))
             raise MissingParameter("Spindown", "F%d" % diff[0])
-         # If F1 is set, we need PEPOCH
+        # If F1 is set, we need PEPOCH
         if self.F1.value != 0.0:
             if self.PEPOCH.value is None:
                 raise MissingParameter(

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1006,7 +1006,7 @@ class TimingModel(object):
                     "didn't find parameter {}".format(name, param)
                 )
             log.info("Final object: {}".format(repr(self)))
-        
+
         self.setup()
         # The "validate" functions contain tests for required parameters or
         # combinations of parameters, etc, that can only be done
@@ -1103,7 +1103,7 @@ class Component(object):
     def setup(self):
         """Finalize construction loaded values."""
         pass
-    
+
     def validate(self):
         """ Validate loaded values."""
         pass

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -146,6 +146,15 @@ class TimingModel(object):
         for cp in self.components.values():
             cp.setup()
 
+    def validate(self):
+        """ Validate component setup. 
+            The checks includes:
+            - Required parameters
+            - Parameter values
+        """
+        for cp in self.components.values():
+            cp.validate()
+
     # def __str__(self):
     #    result = ""
     #    comps = self.components
@@ -914,7 +923,7 @@ class TimingModel(object):
             M[:, mask] /= F0.value
         return M, params, units, scale_by_F0
 
-    def read_parfile(self, file):
+    def read_parfile(self, file, validate=True):
         """Read values from the specified parfile into the model parameters.
 
         Parameters
@@ -997,11 +1006,13 @@ class TimingModel(object):
                     "didn't find parameter {}".format(name, param)
                 )
             log.info("Final object: {}".format(repr(self)))
-
-        # The "setup" functions contain tests for required parameters or
+        
+        self.setup()
+        # The "validate" functions contain tests for required parameters or
         # combinations of parameters, etc, that can only be done
         # after the entire parfile is read
-        self.setup()
+        if validate:
+            self.validate()
 
     def as_parfile(
         self,
@@ -1090,7 +1101,11 @@ class Component(object):
         )
 
     def setup(self):
-        """Finalize construction and validate loaded values."""
+        """Finalize construction loaded values."""
+        pass
+    
+    def validate(self):
+        """ Validate loaded values."""
         pass
 
     @property

--- a/src/pint/models/wave.py
+++ b/src/pint/models/wave.py
@@ -53,20 +53,6 @@ class Wave(PhaseComponent):
 
     def setup(self):
         super(Wave, self).setup()
-        if self.WAVEEPOCH.quantity is None:
-            if self.PEPOCH.quantity is None:
-                raise MissingParameter(
-                    "Wave",
-                    "WAVEEPOCH",
-                    "WAVEEPOCH or PEPOCH are required if " "WAVE_OM is set.",
-                )
-            else:
-                self.WAVEEPOCH = self.PEPOCH
-        if (not hasattr(self, "F0")) or (self.F0.quantity is None):
-            raise MissingParameter(
-                "Wave", "F0", "F0 is required if WAVE entries are present."
-            )
-
         self.wave_terms = list(self.get_prefix_mapping_component("WAVE").keys())
         self.num_wave_terms = len(self.wave_terms)
 

--- a/src/pint/models/wave.py
+++ b/src/pint/models/wave.py
@@ -82,7 +82,7 @@ class Wave(PhaseComponent):
                 )
             else:
                 self.WAVEEPOCH = self.PEPOCH
-         
+
         if (not hasattr(self, "F0")) or (self.F0.quantity is None):
             raise MissingParameter(
                 "Wave", "F0", "F0 is required if WAVE entries are present."

--- a/src/pint/models/wave.py
+++ b/src/pint/models/wave.py
@@ -67,14 +67,31 @@ class Wave(PhaseComponent):
                 "Wave", "F0", "F0 is required if WAVE entries are present."
             )
 
-        wave_terms = list(self.get_prefix_mapping_component("WAVE").keys())
-        wave_terms.sort()
-        wave_in_order = list(range(1, max(wave_terms) + 1))
-        if not wave_terms == wave_in_order:
-            diff = list(set(wave_in_order) - set(wave_terms))
-            raise MissingParameter("Wave", "WAVE%d" % diff[0])
+        self.wave_terms = list(self.get_prefix_mapping_component("WAVE").keys())
+        self.num_wave_terms = len(self.wave_terms)
 
-        self.num_wave_terms = len(wave_terms)
+    def validate(self):
+        super(Wave, self).validate()
+        self.setup()
+        if self.WAVEEPOCH.quantity is None:
+            if self.PEPOCH.quantity is None:
+                raise MissingParameter(
+                    "Wave",
+                    "WAVEEPOCH",
+                    "WAVEEPOCH or PEPOCH are required if " "WAVE_OM is set.",
+                )
+            else:
+                self.WAVEEPOCH = self.PEPOCH
+         
+        if (not hasattr(self, "F0")) or (self.F0.quantity is None):
+            raise MissingParameter(
+                "Wave", "F0", "F0 is required if WAVE entries are present."
+            )
+        self.wave_terms.sort()
+        wave_in_order = list(range(1, max(self.wave_terms) + 1))
+        if not self.wave_terms == wave_in_order:
+            diff = list(set(wave_in_order) - set(self.wave_terms))
+            raise MissingParameter("Wave", "WAVE%d" % diff[0])
 
     def print_par(self,):
         result = ""

--- a/tests/test_model_manual.py
+++ b/tests/test_model_manual.py
@@ -147,19 +147,21 @@ def test_get_model_roundtrip(tmp_dir, parfile):
     # for p in m_old.get_params_mapping():
     #    assert getattr(m_old, p).quantity == getattr(m_roundtrip, p).quantity
 
-def test_simple_manual():
-    tm = TimingModel(name='test_manual', components=[AstrometryEquatorial(),
-                                                     Spindown()])
-    tm.setup()
-    assert 'F0' in tm.phase_deriv_funcs.keys()
-    assert 'F1' in tm.phase_deriv_funcs.keys()
-    assert 'RAJ' in tm.delay_deriv_funcs.keys()
-    assert 'DECJ' in tm.delay_deriv_funcs.keys()
 
-    with pytest.raises(MissingParameter): # No RA and DEC input
+def test_simple_manual():
+    tm = TimingModel(
+        name="test_manual", components=[AstrometryEquatorial(), Spindown()]
+    )
+    tm.setup()
+    assert "F0" in tm.phase_deriv_funcs.keys()
+    assert "F1" in tm.phase_deriv_funcs.keys()
+    assert "RAJ" in tm.delay_deriv_funcs.keys()
+    assert "DECJ" in tm.delay_deriv_funcs.keys()
+
+    with pytest.raises(MissingParameter):  # No RA and DEC input
         tm.validate()
 
-    tm.RAJ.value = '19:59:48'
-    tm.DECJ.value = '20:48:36'
+    tm.RAJ.value = "19:59:48"
+    tm.DECJ.value = "20:48:36"
     tm.F0.value = 622.122030511927 * u.Hz
-    tm.validate() # This should work.
+    tm.validate()  # This should work.

--- a/tests/test_model_manual.py
+++ b/tests/test_model_manual.py
@@ -2,7 +2,7 @@
 
 from glob import glob
 from os.path import basename, join
-
+from collections import defaultdict
 import pytest
 
 import astropy.units as u
@@ -10,7 +10,7 @@ from pint.models.astrometry import AstrometryEquatorial
 from pint.models.dispersion_model import DispersionDM, DispersionDMX
 from pint.models.spindown import Spindown
 from pint.models.model_builder import UnknownBinaryModel, get_model, get_model_new
-from pint.models.timing_model import MissingParameter, TimingModel
+from pint.models.timing_model import MissingParameter, TimingModel, Component
 from pinttestdata import datadir
 
 
@@ -165,3 +165,14 @@ def test_simple_manual():
     tm.DECJ.value = "20:48:36"
     tm.F0.value = 622.122030511927 * u.Hz
     tm.validate()  # This should work.
+
+def test_add_all_components():
+    # models_by_category = defaultdict(list)
+    # for k, c_type in Component.component_types.items():
+    #     print(k, c_type)
+    #     models_by_category[c_type.category].append(c_type)
+    comps = [x() for x in Component.component_types.values()]
+    tm = TimingModel(
+        name="test_manual", components=comps)
+    tm.setup() # This should not have any parameter check.
+    assert len(tm.components) == len(comps)

--- a/tests/test_model_manual.py
+++ b/tests/test_model_manual.py
@@ -166,13 +166,13 @@ def test_simple_manual():
     tm.F0.value = 622.122030511927 * u.Hz
     tm.validate()  # This should work.
 
+
 def test_add_all_components():
     # models_by_category = defaultdict(list)
     # for k, c_type in Component.component_types.items():
     #     print(k, c_type)
     #     models_by_category[c_type.category].append(c_type)
     comps = [x() for x in Component.component_types.values()]
-    tm = TimingModel(
-        name="test_manual", components=comps)
-    tm.setup() # This should not have any parameter check.
+    tm = TimingModel(name="test_manual", components=comps)
+    tm.setup()  # This should not have any parameter check.
     assert len(tm.components) == len(comps)


### PR DESCRIPTION
This PR moves the parameter validation from setup() to validate(). This will allow us to set up the timing model first (e.g., register derivatives), without error raise and then validate the parameters. 
One can do
``` 
tm = TimingModel('name',  [Astrometry(), Spindown()])
tm.setup() # setup the derivatives. In old method, this would fail since 'RA' and 'Dec' are not set.
tm.RA.value = '19:59:48'
tm.DEC.value = '20:48:36'
tm.F0.value = 1.6 * u.ms  
tm.validate() # Check parameters.
```
Or
```
tm = get_model('pulsar.par', validate=False)
tm.add_component(Jump())
tm.setup() # This would fail in the old setup()
tm.JUMP1.value = 0.3
tm.validate()
```


