### PR TITLE
Updates travis/tox to test at minimum supported versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,15 @@ tests/datafile/fermitest.png
 tests/datafile/photontest.fits
 tests/datafile/photontest.png
 tests/datafile/test_parfile_write.par
+tests/datafile/J0030+0451_chains.png
+tests/datafile/J0030+0451_post.par
+tests/datafile/J0030+0451_post.png
+tests/datafile/J0030+0451_pre.png
+tests/datafile/J0030+0451_prof_post.txt
+tests/datafile/J0030+0451_prof_pre.txt
+tests/datafile/J0030+0451_results.txt
+tests/datafile/J0030+0451_samples.pickle
+tests/datafile/J0030+0451_triangle.png
 fermitest.fits
 fermitest.png
 photontest.fits

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ de-403-masses.tpc
 
 .idea
 .cache
+.vscode
 
 # Test output/intermediate files
 tests/datafile/fake_testzima.tim

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 
 language: python
 
+compiler: gcc
+
+os: linux
+
 matrix:
     fast_finish: true
     include:
@@ -26,7 +30,7 @@ matrix:
           services: []
           after_success: []
           before_script: git fetch --unshallow
-        - name: "Test oldest dependencies"
+        - name: "Test oldest Python3 dependencies"
           python: 
             - "3.7"
           sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,14 @@ matrix:
           install: travis_retry pip install tox-travis
           script: 
             - tox -e oldestdeps
+        - name: "Test oldest Python2 dependencies"
+          python: 
+            - "2.7"
+          sudo: false
+          language: python
+          install: travis_retry pip install tox-travis
+          script: 
+            - tox -e oldestdeps2
         - python: "2.7"
         - python: "3.5"
         - python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,14 @@ matrix:
           after_success: []
           before_script: git fetch --unshallow
         - name: "Test oldest Python3 dependencies"
-          python: 
-            - "3.7"
+          python: "3.7"
           sudo: false
           language: python
           install: travis_retry pip install tox-travis
           script: 
             - tox -e oldestdeps
         - name: "Test oldest Python2 dependencies"
-          python: 
-            - "2.7"
+          python: "2.7"
           sudo: false
           language: python
           install: travis_retry pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,15 @@ matrix:
           install: travis_retry pip install tox-travis
           script: 
             - tox -e oldestdeps
-        - name: "Test oldest Python2 dependencies"
+#        - name: "Test oldest Python2 dependencies"
+#          python: "2.7"
+#          sudo: false
+#          language: python
+#          install: travis_retry pip install tox-travis
+#          script: 
+#            - tox -e oldestdeps2
+        - name: "Test under Python 2.7"
           python: "2.7"
-          sudo: false
-          language: python
-          install: travis_retry pip install tox-travis
-          script: 
-            - tox -e oldestdeps2
-        - python: "2.7"
         - python: "3.5"
         - python: "3.6"
         - python: "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,14 @@ matrix:
           services: []
           after_success: []
           before_script: git fetch --unshallow
+        - name: "Test oldest dependencies"
+          python: 
+            - "3.7"
+          sudo: false
+          language: python
+          install: travis_retry pip install tox-travis
+          script: 
+            - tox -e oldestdeps
         - python: "2.7"
         - python: "3.5"
         - python: "3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-numpy>=1.11.0
-astropy>=2.0
+numpy>=1.15.0
+astropy>=2.0; python_version < "3.0"
+astropy>=3.2; python_version >="3.0"
 scipy>=0.18.1
 jplephem>=2.6
 matplotlib>=1.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.15.0
-astropy>=2.0; python_version < "3.0"
+astropy>=2.0.15; python_version < "3.0"
 astropy>=3.2; python_version >="3.0"
 scipy>=0.18.1
 jplephem>=2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.15.0
+numpy>=1.16.0
 astropy>=2.0.15; python_version < "3.0"
 astropy>=3.2; python_version >="3.0"
 scipy>=0.18.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ pip>=9.0.1
 coverage>=4.3.4
 Sphinx>=1.8.5; python_version < "3.0"
 Sphinx>=2.2; python_version >= "3.0"
-astropy>=2.0; python_version < "3.0"
+astropy>=2.0.15; python_version < "3.0"
 astropy>=3.2; python_version >="3.0"
 #astropy-helpers>=1.3
 sphinx-rtd-theme>=0.1.9

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,6 +3,8 @@ pip>=9.0.1
 coverage>=4.3.4
 Sphinx>=1.8.5; python_version < "3.0"
 Sphinx>=2.2; python_version >= "3.0"
+astropy>=2.0.15; python_version < "3.0"
+astropy>=3.2; python_version >="3.0"
 #astropy-helpers>=1.3
 sphinx-rtd-theme>=0.1.9
 coveralls>=1.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,8 +3,6 @@ pip>=9.0.1
 coverage>=4.3.4
 Sphinx>=1.8.5; python_version < "3.0"
 Sphinx>=2.2; python_version >= "3.0"
-astropy>=2.0.15; python_version < "3.0"
-astropy>=3.2; python_version >="3.0"
 #astropy-helpers>=1.3
 sphinx-rtd-theme>=0.1.9
 coveralls>=1.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 attrs>=19.2
 pip>=9.0.1
-setuptools
+setuptools>=41.0
 coverage>=4.3.4
 Sphinx>=1.8.5; python_version < "3.0"
 Sphinx>=2.2; python_version >= "3.0"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,6 @@
 attrs>=19.2
 pip>=9.0.1
+setuptools
 coverage>=4.3.4
 Sphinx>=1.8.5; python_version < "3.0"
 Sphinx>=2.2; python_version >= "3.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ include_package_data = True
 install_requires =
     astropy>=2.0.15; python_version < "3.0"
     astropy>=3.2; python_version >= "3.0"
-    numpy>=1.15.0
+    numpy>=1.16.0
     scipy>=0.18.1
     jplephem>=2.6
     matplotlib>=1.5.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ include_package_data = True
 install_requires =
     astropy>=2.0; python_version < "3.0"
     astropy>=3.2; python_version >= "3.0"
-    numpy>=1.11.0
+    numpy>=1.15.0
     scipy>=0.18.1
     jplephem>=2.6
     matplotlib>=1.5.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ package_dir =
     = src
 include_package_data = True
 install_requires =
-    astropy>=2.0; python_version < "3.0"
+    astropy>=2.0.15; python_version < "3.0"
     astropy>=3.2; python_version >= "3.0"
     numpy>=1.15.0
     scipy>=0.18.1

--- a/tox.ini
+++ b/tox.ini
@@ -33,11 +33,10 @@ depends =
 
 [testenv:oldestdeps]
 description =
-    Run tests with minimum versions of astropy, numpy, scipy
-
+    Run tests with minimum supported versions of astropy, numpy
 deps =
-    numpy==1.11.*
-    astropy==2.0.*
+    numpy==1.15.*
+    astropy==3.2.*
 
 [testenv:report]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -33,10 +33,20 @@ depends =
 
 [testenv:oldestdeps]
 description =
-    Run tests with minimum supported versions of astropy, numpy
+    Run tests on Python 3 with minimum supported versions of astropy, numpy
 deps =
     numpy==1.15.*
     astropy==3.2.*
+    pytest
+    coverage
+    hypothesis
+
+[testenv:oldestdeps2]
+description =
+    Run tests on Python 2 with minimum supported versions of astropy, numpy
+deps =
+    numpy==1.15.*
+    astropy==2.0.15
     pytest
     coverage
     hypothesis

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ deps =
     astropy==2.0.15
     pytest
     wheel
-    setuptools
+    setuptools>=41.0
     coverage
     hypothesis
     pathlib2 ; python_version < "3.0"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = clean, py27, py37, py36, py35, oldestdeps, notebooks, docs, report
+envlist = clean, py27, py37, py36, py35, oldestdeps, oldestdeps2, notebooks, docs, report
 skip_missing_interpreters = True
 
 [tool:pytest]
@@ -35,7 +35,7 @@ depends =
 description =
     Run tests on Python 3 with minimum supported versions of astropy, numpy
 deps =
-    numpy==1.15.*
+    numpy==1.16.*
     astropy==3.2.*
     pytest
     coverage
@@ -45,7 +45,7 @@ deps =
 description =
     Run tests on Python 2 with minimum supported versions of astropy, numpy
 deps =
-    numpy==1.15.*
+    numpy==1.16.*
     astropy==2.0.15
     pytest
     coverage

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,10 @@ description =
 deps =
     numpy==1.15.*
     astropy==3.2.*
+    pytest
+    coverage
+    hypothesis
+    pathlib2 ; python_version < "3.0"
 
 [testenv:report]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,8 @@ deps =
     numpy==1.16.*
     astropy==2.0.15
     pytest
+    wheel
+    setuptools
     coverage
     hypothesis
     pathlib2 ; python_version < "3.0"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = clean, py27, py37, py36, py35, notebooks, docs, report
+envlist = clean, py27, py37, py36, py35, oldestdeps, notebooks, docs, report
 skip_missing_interpreters = True
 
 [tool:pytest]
@@ -18,6 +18,7 @@ addopts =
 passenv =
     HOME
     DISPLAY
+    
 deps =
     pytest
     coverage
@@ -29,6 +30,14 @@ depends =
     {py27,py35,py36,py37}: clean
     report: py27,py35,py36,py37
     docs: notebooks
+
+[testenv:oldestdeps]
+description =
+    Run tests with minimum versions of astropy, numpy, scipy
+
+deps =
+    numpy==1.11.*
+    astropy==2.0.*
 
 [testenv:report]
 skip_install = true


### PR DESCRIPTION
This updates our travis/tox testing to run tests on the minimum supported versions of numpy and astropy to ensure that new features don't break support for the older versions.
In order to make this work, I had to bump up the minimum version for numpy to 1.15.*

Fixes #632 and #584 


