### PR TITLE
Add print_summary to fitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,9 @@ tests/datafile/J0030+0451_prof_pre.txt
 tests/datafile/J0030+0451_results.txt
 tests/datafile/J0030+0451_samples.pickle
 tests/datafile/J0030+0451_triangle.png
+tests/datafile/testbary.tim
+tests/datafile/testtopo.tim
+tests/datafile/testtopot1.tim
 fermitest.fits
 fermitest.png
 photontest.fits

--- a/docs/examples/fit_NGC6440E.py
+++ b/docs/examples/fit_NGC6440E.py
@@ -52,7 +52,10 @@ plt.show()
 # Now do the fit
 print("Fitting.")
 f = pint.fitter.WLSFitter(t, m)
+# f = pint.fitter.PowellFitter(t, m)
 f.fit_toas()
+# f = pint.fitter.GLSFitter(t, m)
+# f.fit_toas(full_cov=True)
 
 # Print some basic params
 print("Best fit has reduced chi^2 of", f.resids.chi2_reduced)
@@ -62,8 +65,7 @@ print("RMS in time is", f.resids.time_resids.std().to(u.us))
 # Show the parameter correlation matrix
 corm = f.get_correlation_matrix(pretty_print=True)
 
-print("Best model is:")
-print(f.model.as_parfile())
+f.print_summary()
 
 plt.errorbar(
     xt.value,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ jplephem>=2.6
 matplotlib>=1.5.3
 emcee>=3.0
 corner>=2.0.1
+uncertainties
 pathlib2; python_version < "3.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     jplephem>=2.6
     matplotlib>=1.5.3
     emcee>=3.0
+    uncertainties
     corner>=2.0.1
     enum34; python_version < "3.0"
 setup_requires=

--- a/src/pint/config.py
+++ b/src/pint/config.py
@@ -5,6 +5,12 @@ import os
 
 from .extern import appdirs
 
+# Hack to support FileNotFoundError in Python 2
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 # Values for appdirs calls
 _app = "pint"
 _auth = "pint"

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -8,8 +8,18 @@ import numpy as np
 import scipy.linalg as sl
 import scipy.optimize as opt
 from astropy import log
+import astropy.constants as const
+import pint.utils
+from pint.models.pulsar_binary import PulsarBinary
+from pint import Tsun
 
 from pint.residuals import Residuals
+from pint.models.parameter import (
+    AngleParameter,
+    prefixParameter,
+    strParameter,
+    floatParameter,
+)
 
 __all__ = ["Fitter", "PowellFitter", "GLSFitter", "WLSFitter"]
 
@@ -135,6 +145,225 @@ class Fitter(object):
     def fit_toas(self, maxiter=None):
         raise NotImplementedError
 
+    def get_summary(self):
+        """Return a short ASCII summary of the Fitter results."""
+
+        # Need to check that fit has been done first!
+        if not hasattr(self, "covariance_matrix"):
+            log.warning(
+                "fit_toas() has not been run, so pre-fit and post-fit will be the same!"
+            )
+
+        from uncertainties import ufloat
+        import uncertainties.umath as um
+
+        # First, print fit quality metrics
+        s = "Fitted model using {} method with {} free parameters to {} TOAs\n".format(
+            self.method, len(self.get_fitparams()), self.toas.ntoas
+        )
+        s += "Prefit residuals {}, Postfit residuals {}\n".format(
+            self.resids_init.rms_weighted(), self.resids.rms_weighted()
+        )
+        s += "Chisq = {:.3f} for {} d.o.f. for reduced Chisq of {:.3f}\n".format(
+            self.resids.chi2, self.resids.dof, self.resids.chi2_reduced
+        )
+        s += "\n"
+
+        # Next, print the model parameters
+        s += "{:<14s} {:^20s} {:^28s} {}\n".format("PAR", "Prefit", "Postfit", "Units")
+        s += "{:<14s} {:>20s} {:>28s} {}\n".format(
+            "=" * 14, "=" * 20, "=" * 28, "=" * 5
+        )
+        for pn in self.get_allparams().keys():
+            prefitpar = getattr(self.model_init, pn)
+            par = getattr(self.model, pn)
+            if par.value is not None:
+                if isinstance(par, strParameter):
+                    s += "{:14s} {:>20s} {:28s} {}\n".format(
+                        pn, prefitpar.value, "", par.units
+                    )
+                elif isinstance(par, AngleParameter):
+                    # Add special handling here to put uncertainty into arcsec
+                    if par.frozen:
+                        s += "{:14s} {:>20s} {:>28s} {} \n".format(
+                            pn, str(prefitpar.quantity), "", par.units
+                        )
+                    else:
+                        s += "{:14s} {:>20s}  {:>16s} +/- {:.2g} \n".format(
+                            pn,
+                            str(prefitpar.quantity),
+                            str(par.quantity),
+                            par.uncertainty.to(u.arcsec),
+                        )
+
+                else:
+                    # Assume a numerical parameter
+                    if par.frozen:
+                        s += "{:14s} {:20g} {:28s} {} \n".format(
+                            pn, prefitpar.value, "", par.units
+                        )
+                    else:
+                        # s += "{:14s} {:20g} {:20g} {:20.2g} {} \n".format(
+                        #     pn,
+                        #     prefitpar.value,
+                        #     par.value,
+                        #     par.uncertainty.value,
+                        #     par.units,
+                        # )
+                        s += "{:14s} {:20g} {:28SP} {} \n".format(
+                            pn,
+                            prefitpar.value,
+                            ufloat(par.value, par.uncertainty.value),
+                            par.units,
+                        )
+        # Now print some useful derived parameters
+        s += "\nDerived Parameters:\n"
+        if hasattr(self.model, "F0"):
+            F0 = self.model.F0.quantity
+            if not self.model.F0.frozen:
+                p, perr = pint.utils.pferrs(F0, self.model.F0.uncertainty)
+                s += "Period = {} +/- {}\n".format(p.to(u.s), perr.to(u.s))
+            else:
+                s += "Period = {}\n".format((1.0 / F0).to(u.s))
+        if hasattr(self.model, "F1"):
+            F1 = self.model.F1.quantity
+            if not any([self.model.F1.frozen, self.model.F0.frozen]):
+                p, perr, pd, pderr = pint.utils.pferrs(
+                    F0, self.model.F0.uncertainty, F1, self.model.F1.uncertainty
+                )
+                s += "Pdot = {} +/- {}\n".format(
+                    pd.to(u.dimensionless_unscaled), pderr.to(u.dimensionless_unscaled)
+                )
+                brakingindex = 3
+                s += "Characteristic age = {:.4g} (braking index = {})\n".format(
+                    pint.utils.pulsar_age(F0, F1, n=brakingindex), brakingindex
+                )
+                s += "Surface magnetic field = {:.3g}\n".format(
+                    pint.utils.pulsar_B(F0, F1)
+                )
+                s += "Magnetic field at light cylinder = {:.4g}\n".format(
+                    pint.utils.pulsar_B_lightcyl(F0, F1)
+                )
+                I_NS = I = 1.0e45 * u.g * u.cm ** 2
+                s += "Spindown Edot = {:.4g} (I={})\n".format(
+                    pint.utils.pulsar_edot(F0, F1, I=I_NS), I_NS
+                )
+
+        if hasattr(self.model, "PX"):
+            if not self.model.PX.frozen:
+                s += "\n"
+                px = ufloat(
+                    self.model.PX.quantity.to(u.arcsec).value,
+                    self.model.PX.uncertainty.to(u.arcsec).value,
+                )
+                s += "Parallax distance = {:.3uP} pc\n".format(1.0 / px)
+
+        # Now binary system derived parameters
+        binary = None
+        for x in self.model.components:
+            if x.startswith("Binary"):
+                binary = x
+        if binary is not None:
+            s += "\n"
+            s += "Binary model {}\n".format(binary)
+
+            if binary.startswith("BinaryELL1"):
+                if not any(
+                    [
+                        self.model.EPS1.frozen,
+                        self.model.EPS2.frozen,
+                        self.model.TASC.frozen,
+                        self.model.PB.frozen,
+                    ]
+                ):
+                    eps1 = ufloat(
+                        self.model.EPS1.quantity.value,
+                        self.model.EPS1.uncertainty.value,
+                    )
+                    eps2 = ufloat(
+                        self.model.EPS1.quantity.value,
+                        self.model.EPS1.uncertainty.value,
+                    )
+                    tasc = ufloat(
+                        # This is a time in MJD
+                        self.model.TASC.quantity.mjd,
+                        self.model.TASC.uncertainty.to(u.d).value,
+                    )
+                    pb = ufloat(
+                        self.model.PB.quantity.to(u.d).value,
+                        self.model.PB.uncertainty.to(u.d).value,
+                    )
+                    s += "Conversion from ELL1 parameters:\n"
+                    ecc = um.sqrt(eps1 ** 2 + eps2 ** 2)
+                    s += "ECC = {:P}\n".format(ecc)
+                    om = um.atan2(eps1, eps2) * 180.0 / np.pi
+                    if om < 0.0:
+                        om += 360.0
+                    s += "OM  = {:P}\n".format(om)
+                    t0 = tasc + pb / (360.0 * om)
+                    s += "T0  = {:SP}\n".format(t0)
+
+                    s += pint.utils.ELL1_check(
+                        self.model.A1.quantity,
+                        ecc.nominal_value,
+                        self.resids.rms_weighted(),
+                        self.toas.ntoas,
+                        outstring=True,
+                    )
+                    s += "\n"
+
+                # Masses and inclination
+                if not any([self.model.PB.frozen, self.model.A1.frozen]):
+                    pbs = ufloat(
+                        self.model.PB.quantity.to(u.s).value,
+                        self.model.PB.uncertainty.to(u.s).value,
+                    )
+                    a1 = ufloat(
+                        self.model.A1.quantity.to(pint.ls).value,
+                        self.model.A1.uncertainty.to(pint.ls).value,
+                    )
+                    fm = 4.0 * np.pi ** 2 * a1 ** 3 / (4.925490947e-6 * pbs ** 2)
+                    s += "Mass function = {:SP} Msun\n".format(fm)
+                    mcmed = pint.utils.companion_mass(
+                        self.model.PB.quantity,
+                        self.model.A1.quantity,
+                        inc=60.0 * u.deg,
+                        mpsr=1.4 * u.solMass,
+                    )
+                    mcmin = pint.utils.companion_mass(
+                        self.model.PB.quantity,
+                        self.model.A1.quantity,
+                        inc=90.0 * u.deg,
+                        mpsr=1.4 * u.solMass,
+                    )
+                    s += "Companion mass min, median (assuming Mpsr = 1.4 Msun) = {:.4f}, {:.4f} Msun\n".format(
+                        mcmin, mcmed
+                    )
+
+                if hasattr(self.model, "SINI"):
+                    if not self.model.SINI.frozen:
+                        si = ufloat(
+                            self.model.SINI.quantity.value,
+                            self.model.SINI.uncertainty.value,
+                        )
+                        s += "From SINI in model:\n"
+                        s += "    cos(i) = {:SP}\n".format(um.sqrt(1 - si ** 2))
+                        s += "    i = {:SP} deg\n".format(um.asin(si) * 180.0 / np.pi)
+
+                    psrmass = pint.utils.pulsar_mass(
+                        self.model.PB.quantity,
+                        self.model.A1.quantity,
+                        self.model.M2.quantity,
+                        np.arcsin(self.model.SINI.quantity),
+                    )
+                    s += "Pulsar mass (Shapiro Delay) = {}".format(psrmass)
+
+        return s
+
+    def print_summary(self):
+        """Write a summary of the TOAs to stdout."""
+        print(self.get_summary())
+
     def get_covariance_matrix(self, with_phase=False, pretty_print=False, prec=3):
         """Show the parameter covariance matrix post-fit.
         If with_phase, then show and return the phase column as well.
@@ -158,8 +387,8 @@ class Fitter(object):
                 print(line)
                 for ii, fp1 in enumerate(fps):
                     line = "{0:^{width}}".format(fp1, width=maxlen)
-                    for jj, (fp2, ln) in enumerate(zip(fps, lens)):
-                        line += "{0:^{width}.{prec}g}".format(
+                    for jj, (fp2, ln) in enumerate(zip(fps[: ii + 1], lens[: ii + 1])):
+                        line += "{0: {width}.{prec}e}".format(
                             cm[ii, jj], width=ln, prec=prec
                         )
                     print(line)
@@ -236,7 +465,7 @@ class WLSFitter(Fitter):
        required.
     """
 
-    def __init__(self, toas=None, model=None):
+    def __init__(self, toas, model):
         super(WLSFitter, self).__init__(toas=toas, model=model)
         self.method = "weighted_least_square"
 
@@ -334,7 +563,8 @@ class GLSFitter(Fitter):
         """Run a Generalized least-squared fitting method
 
         If maxiter is less than one, no fitting is done, just the
-        chi-squared computation.
+        chi-squared computation. In this case, you must provide the residuals
+        argument.
 
         If maxiter is one or more, so fitting is actually done, the
         chi-squared value returned is only approximately the chi-squared

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import collections
 import copy

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -7,6 +7,7 @@ from astropy import log
 
 from pint import dimensionless_cycles
 from pint.phase import Phase
+from pint.utils import weighted_mean
 
 __all__ = ["Residuals"]
 
@@ -45,6 +46,17 @@ class Residuals(object):
             self._chi2 = self.calc_chi2()
         assert self._chi2 is not None
         return self._chi2
+
+    def rms_weighted(self):
+        """Compute weighted RMS of the residals in time."""
+        if np.any(self.toas.get_errors() == 0):
+            raise ValueError(
+                "Some TOA errors are zero - cannot calculate weighted RMS of residuals"
+            )
+        w = 1.0 / (self.toas.get_errors().to(u.s) ** 2)
+
+        wmean, werr, wsdev = weighted_mean(self.time_resids, w, sdev=True)
+        return wsdev.to(u.us)
 
     def calc_phase_resids(self, weighted_mean=True, set_pulse_nums=False):
         """Return timing model residuals in pulse phase."""

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -506,8 +506,8 @@ def dmxparse(fitter, save=False):
         DMX_Errs.append(
             getattr(fitter.model, "DMX_{:04d}".format(ii)).uncertainty_value
         )
-        dmxr1 = getattr(fitter.model, "DMX_{:04d}".format(ii)).value
-        dmxr2 = getattr(fitter.model, "DMX_{:04d}".format(ii)).value
+        dmxr1 = getattr(fitter.model, "DMXR1_{:04d}".format(ii)).value
+        dmxr2 = getattr(fitter.model, "DMXR2_{:04d}".format(ii)).value
         DMX_R1.append(dmxr1)
         DMX_R2.append(dmxr2)
         DMX_center_MJD.append((dmxr1 + dmxr2) / 2)

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -4,12 +4,14 @@ from __future__ import absolute_import, division, print_function
 import re
 from contextlib import contextmanager
 from copy import deepcopy
-
 import astropy.units as u
 from astropy import log
+import astropy.constants as const
 import numpy as np
 import six
-from six import StringIO
+import scipy.optimize.zeros as zeros
+
+from io import StringIO
 
 __all__ = [
     "PosVel",
@@ -26,6 +28,18 @@ __all__ = [
     "interesting_lines",
     "show_param_cov_matrix",
     "dmxparse",
+    "p_to_f",
+    "pferrs",
+    "weighted_mean",
+    "ELL1_check",
+    "mass_funct",
+    "mass_funct2",
+    "pulsar_mass",
+    "companion_mass",
+    "pulsar_age",
+    "pulsar_edot",
+    "pulsar_B",
+    "pulsar_B_lightcyl",
 ]
 
 
@@ -378,7 +392,7 @@ def interesting_lines(lines, comments=None):
         yield ln
 
 
-def show_param_cov_matrix(matrix, params, name="Covaraince Matrix", switchRD=False):
+def show_param_cov_matrix(matrix, params, name="Covariance Matrix", switchRD=False):
     """function to print covariance matrices in a clean and easily readable way
 
     :param matrix: matrix to be printed, should be square, list of lists
@@ -387,7 +401,7 @@ def show_param_cov_matrix(matrix, params, name="Covaraince Matrix", switchRD=Fal
     :param switchRD: if True, switch the positions of RA and DEC to match setup of TEMPO cov. matrices
 
     :return string to be printed"""
-    output = StringIO.StringIO()
+    output = StringIO()
     matrix = deepcopy(matrix)
     try:
         RAi = params.index("RAJ")
@@ -570,3 +584,292 @@ def dmxparse(fitter, save=False):
     dmx["avg_dm_err"] = DMX_mean_err
 
     return dmx
+
+
+def weighted_mean(arrin, weights_in, inputmean=None, calcerr=False, sdev=False):
+    """Compute weighted mean of input values
+
+    Calculate the weighted mean, error, and optionally standard deviation of
+    an input array.  By default error is calculated assuming the weights are
+    1/err^2, but if you send calcerr=True this assumption is dropped and the
+    error is determined from the weighted scatter.
+
+    Parameters
+    ----------
+    arrin : array
+    Array containing the numbers whose weighted mean is desired.      
+    weights: array
+    A set of weights for each element in array. For measurements with 
+    uncertainties, these should be 1/sigma^2.
+    inputmean: float, optional
+        An input mean value, around which the mean is calculated.
+    calcerr : bool, optional
+        Calculate the weighted error.  By default the error is calculated as
+        1/sqrt( weights.sum() ).  If calcerr=True it is calculated as 
+        sqrt((w**2 * (arr-mean)**2).sum() )/weights.sum().
+    sdev : bool, optional
+        If True, also return the weighted standard deviation as a third
+        element in the tuple. Defaults to False.
+
+    Returns
+    -------
+    wmean, werr: tuple
+    A tuple of the weighted mean and error. If sdev=True the
+    tuple will also contain sdev: wmean,werr,wsdev
+
+    Notes
+    -----
+    Converted from IDL: 2006-10-23. Erin Sheldon, NYU
+    Copied from PRESTO to PINT : 2020-04-18
+
+   """
+    arr = arrin
+    weights = weights_in
+    wtot = weights.sum()
+    # user has input a mean value
+    if inputmean is None:
+        wmean = (weights * arr).sum() / wtot
+    else:
+        wmean = float(inputmean)
+    # how should error be calculated?
+    if calcerr:
+        werr2 = (weights ** 2 * (arr - wmean) ** 2).sum()
+        werr = np.sqrt(werr2) / wtot
+    else:
+        werr = 1.0 / np.sqrt(wtot)
+    # should output include the weighted standard deviation?
+    if sdev:
+        wvar = (weights * (arr - wmean) ** 2).sum() / wtot
+        wsdev = np.sqrt(wvar)
+        return wmean, werr, wsdev
+    else:
+        return wmean, werr
+
+
+def p_to_f(p, pd, pdd=None):
+    """Converts P, Pdot to F, Fdot (or vice versa)
+
+    Convert period, period derivative and period second
+    derivative to the equivalent frequency counterparts.
+    Will also convert from f to p.
+    """
+    f = 1.0 / p
+    fd = -pd / (p * p)
+    if pdd is None:
+        return [f, fd]
+    else:
+        if pdd == 0.0:
+            fdd = 0.0
+        else:
+            fdd = 2.0 * pd * pd / (p ** 3.0) - pdd / (p * p)
+        return [f, fd, fdd]
+
+
+def pferrs(porf, porferr, pdorfd=None, pdorfderr=None):
+    """Convert P, Pdot to F, Fdot with uncertainties.
+
+    Calculate the period or frequency errors and
+    the pdot or fdot errors from the opposite one.
+    """
+    if pdorfd is None:
+        return [1.0 / porf, porferr / porf ** 2.0]
+    else:
+        forperr = porferr / porf ** 2.0
+        fdorpderr = np.sqrt(
+            (4.0 * pdorfd ** 2.0 * porferr ** 2.0) / porf ** 6.0
+            + pdorfderr ** 2.0 / porf ** 4.0
+        )
+        [forp, fdorpd] = p_to_f(porf, pdorfd)
+        return [forp, forperr, fdorpd, fdorpderr]
+
+
+def pulsar_age(f, fdot, n=3, fo=1e99 * u.Hz):
+    """Compute pulsar characteristic age
+
+    Return the age of a pulsar given the spin frequency
+    and frequency derivative.  By default, the characteristic age
+    is returned (assuming a braking index 'n'=3 and an initial
+    spin frequency fo >> f).  But 'n' and 'fo' can be set.
+    """
+    return (-f / ((n - 1.0) * fdot) * (1.0 - (f / fo) ** (n - 1.0))).to(u.yr)
+
+
+def pulsar_edot(f, fdot, I=1.0e45 * u.g * u.cm ** 2):
+    """Compute pulsar spindown energy loss rate
+
+    Return the pulsar Edot (in erg/s) given the spin frequency and
+    frequency derivative. The NS moment of inertia is assumed to be
+    I = 1.0e45 g cm^2 by default.
+    """
+    return (-4.0 * np.pi ** 2 * I * f * fdot).to(u.erg / u.s)
+
+
+def pulsar_B(f, fdot):
+    """Compute pulsar surface magnetic field
+    
+    Return the estimated pulsar surface magnetic field strength
+    given the spin frequency and frequency derivative.
+    """
+    # This is a hack to use the traditional formula by stripping the units.
+    # It would be nice to improve this to a  proper formula with units
+    return 3.2e19 * u.G * np.sqrt(-fdot.to(u.Hz / u.s).value / f.to(u.Hz).value ** 3.0)
+
+
+def pulsar_B_lightcyl(f, fdot):
+    """Compute pulsar magnetic field at the light cylinder
+    
+    Return the estimated pulsar magnetic field strength at the
+    light cylinder given the spin frequency and
+    frequency derivative.
+    """
+    p, pd = p_to_f(f, fdot)
+    # This is a hack to use the traditional formula by stripping the units.
+    # It would be nice to improve this to a  proper formula with units
+    return (
+        2.9e8
+        * u.G
+        * p.to(u.s).value ** (-5.0 / 2.0)
+        * np.sqrt(pd.to(u.dimensionless_unscaled).value)
+    )
+
+
+def mass_funct(pb, x):
+    """Compute binary mass function from period and semi-major axis
+
+    Parameters
+    ----------
+    pb : Quantity
+        Binary period
+    x : Quantity in `pint.ls`
+        Semi-major axis, A1SINI, in units of ls
+
+    Returns
+    -------
+    f_m : Quantity
+        Mass function in solar masses
+    """
+    fm = 4.0 * np.pi ** 2 * x ** 3 / (const.G * pb ** 2)
+    return fm.to(u.solMass)
+
+
+def mass_funct2(mp, mc, i):
+    """Compute binary mass function from masses and inclination
+
+    Parameters
+    ----------
+    mp : Quantity
+        Pulsar mass, typically in u.solMass
+    mc : Quantity
+        Companion mass, typically in u.solMass
+    i : Angle
+        Inclination angle, in u.deg or u.rad
+
+    Notes
+    -----
+    Inclination is such that edge on is `i = 90*u.deg`
+    An 'average' orbit has cos(i) = 0.5, or `i = 60*u.deg`
+    """
+    return (mc * np.sin(i)) ** 3.0 / (mc + mp) ** 2.0
+
+
+def pulsar_mass(pb, x, mc, inc):
+    """Compute pulsar mass from orbit and Shapiro delay parameters
+
+    Return the pulsar mass (in solar mass units) for a binary.
+    Finds the value using a bisection technique.
+ 
+    Parameters
+    ----------
+    pb : Quantity
+        Binary orbital period
+    x : Quantity
+        Projected semi-major axis (aka ASINI) in `pint.ls`
+    mc : Quantity
+        Companion mass in u.solMass
+    inc : Angle
+        Inclination angle, in u.deg or u.rad
+    """
+    massfunct = mass_funct(pb, x)
+
+    # Do some unit manipulation here so that scipy bisect doesn't see the units
+    def localmf(mp, mc=mc, mf=massfunct, i=inc):
+        return (mass_funct2(mp * u.solMass, mc, i) - mf).value
+
+    return zeros.bisect(localmf, 0.0, 1000.0)
+
+
+def companion_mass(pb, x, inc=60.0 * u.deg, mpsr=1.4 * u.solMass):
+    """Commpute the companion mass from the orbital parameters
+
+    Compute companion mass for a binary system from orbital mechanics,
+    not Shapiro delay.
+
+    Parameters
+    ----------
+    pb : Quantity
+        Binary orbital period
+    x : Quantity
+        Projected semi-major axis (aka ASINI) in `pint.ls`
+    inc : Angle, optional
+        Inclination angle, in u.deg or u.rad. Default is 60 deg.
+    mpsr : Quantity, optional
+        Pulsar mass in u.solMass. Default is 1.4 Msun
+    """
+    massfunct = mass_funct(pb, x)
+
+    # Do some unit manipulation here so that scipy bisect doesn't see the units
+    def localmf(mc, mp=mpsr, mf=massfunct, i=inc):
+        return (mass_funct2(mp, mc * u.solMass, i) - mf).value
+
+    return zeros.bisect(localmf, 0.001, 1000.1)
+
+
+def ELL1_check(A1, E, TRES, NTOA, outstring=True):
+    """Check for validity of assumptions in ELL1 binary model
+
+    Checks whether the assumptions that allow ELL1 to be safely used are 
+    satisfied. To work properly, we should have:
+            asini/c * ecc**2 << timing precision / sqrt(# TOAs)
+            or A1 * E**2 << TRES / sqrt(NTOA)
+
+    Parameters
+    ----------
+    A1 : Quantity
+        Projected semi-major axis (aka ASINI) in `pint.ls`
+    E : Quantity (dimensionless)
+        Eccentricity
+    TRES : Quantity
+        RMS TOA uncertainty
+    NTOA : int
+        Number of TOAs in the fit
+    outstring : bool, optional
+
+    Returns
+    -------
+    bool or str
+        Returns True if ELL1 is safe to use, otherwise False.
+        If outstring is True then returns a string summary instead.
+
+    """
+    lhs = A1 / const.c * E ** 2.0
+    rhs = TRES / np.sqrt(NTOA)
+    if outstring:
+        s = "Checking applicability of ELL1 model -- \n"
+        s += "    Condition is asini/c * ecc**2 << timing precision / sqrt(# TOAs) to use ELL1\n"
+        s += "    asini/c * ecc**2    = {:.3g} \n".format(lhs.to(u.us))
+        s += "    TRES / sqrt(# TOAs) = {:.3g} \n".format(rhs.to(u.us))
+    if lhs * 50.0 < rhs:
+        if outstring:
+            s += "    Should be fine.\n"
+            return s
+        return True
+    elif lhs * 5.0 < rhs:
+        if outstring:
+            s += "    Should be OK, but not optimal.\n"
+            return s
+        return True
+    else:
+        if outstring:
+            s += "    *** WARNING*** Should probably use BT or DD instead!\n"
+            return s
+        return False

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -457,29 +457,35 @@ def dmxparse(fitter, save=False):
 
     Based off dmxparse by P. Demorest (https://github.com/nanograv/tempo/tree/master/util/dmxparse)
 
-    Inputs:
-    :param fitter: PINT fitter used to get timing residuals, must have already run GLS fit
-    :param save: boolean; if True saves output to text file in the format of the TEMPO version.
-    If not output save file is desired, save = False (which is the default)
-    Output file name is dmxparse.out
+    Parameters
+    ----------
+    fitter
+        PINT fitter used to get timing residuals, must have already run GLS fit
+    save : bool
+        if True saves output to text file in the format of the TEMPO version.
+        If not output save file is desired, save = False (which is the default)
+        Output file name is dmxparse.out
     
-    Returns a dictionary with the following entries:
+    Returns
+    -------
+    dictionary
 
-        dmxs        mean-subtraced dmx values
+        dmxs : mean-subtraced dmx values
 
-        dmx_verrs   dmx variance errors
+        dmx_verrs : dmx variance errors
 
-        dmxeps      center mjds of the dmx bins
+        dmxeps : center mjds of the dmx bins
 
-        r1s         lower mjd bounds on the dmx bins
+        r1s : lower mjd bounds on the dmx bins
 
-        r2s         upper mjd bounds on the dmx bins
+        r2s : upper mjd bounds on the dmx bins
 
-        bins        dmx bins
+        bins : dmx bins
 
-        mean_dmx    mean dmx value
+        mean_dmx : mean dmx value
 
-        avg_dm_err  uncertainty in average dmx
+        avg_dm_err : uncertainty in average dmx
+
     """
     # We get the DMX values, errors, and mjds (same as in getting the DMX values for DMX v. time)
     # Get number of DMX epochs
@@ -829,8 +835,8 @@ def ELL1_check(A1, E, TRES, NTOA, outstring=True):
 
     Checks whether the assumptions that allow ELL1 to be safely used are 
     satisfied. To work properly, we should have:
-            asini/c * ecc**2 << timing precision / sqrt(# TOAs)
-            or A1 * E**2 << TRES / sqrt(NTOA)
+    asini/c * ecc**2 << timing precision / sqrt(# TOAs)
+    or A1 * E**2 << TRES / sqrt(NTOA)
 
     Parameters
     ----------

--- a/tests/test_fitter.py
+++ b/tests/test_fitter.py
@@ -52,6 +52,11 @@ def test_fitter():
     print("chi^2 is %0.2f after 4-param fit" % f.resids.chi2)
     p2 = plt.errorbar(xt, f.resids.time_resids.value, yerr.value, fmt="go")
 
+    # Make sure the summary printing works
+    f.print_summary()
+
+    # Try a few utils
+
     # Now perturb F1 and fit only that. This doesn't work, though tempo2 easily fits
     # it.
     f.model.F1.value = 1.1 * f.model.F1.value

--- a/tests/test_solar_system_body.py
+++ b/tests/test_solar_system_body.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import unittest
+import pytest
 
 import astropy.time as time
 import numpy as np
@@ -26,6 +27,11 @@ class TestSolarSystemDynamic(unittest.TestCase):
         cls.tdb_time = time.Time(mjd, scale="tdb", format="mjd")
         cls.ephem = ["de405", "de421", "de434", "de430", "de436"]
         cls.planets = ["jupiter", "saturn", "venus", "uranus"]
+
+    def test_datapath(self):
+        # Check that datapath of a non-existent file raises FileNotFoundError exception.
+        with pytest.raises(FileNotFoundError):
+            d = datapath("foobar")
 
     # Here we only test if any errors happens.
     def test_earth(self):

--- a/tests/test_solar_system_body.py
+++ b/tests/test_solar_system_body.py
@@ -13,6 +13,12 @@ from pint.config import datapath
 from pint.solar_system_ephemerides import objPosVel, objPosVel_wrt_SSB
 from pinttestdata import datadir
 
+# Hack to support FileNotFoundError in Python 2
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 
 class TestSolarSystemDynamic(unittest.TestCase):
     @classmethod

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -588,6 +588,10 @@ def test_dmxparse():
     dmx = dmxparse(f, save=False)
 
 
+# Remove this xfail once our minimum numpy can bump up to 1.17, but this requires excluding Python 2
+@pytest.mark.xfail(
+    reason="numpy 1.16.* does not support isclose with units, fixed in 1.17"
+)
 def test_psr_utils():
 
     from pint.utils import (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 from itertools import product
 from tempfile import NamedTemporaryFile
 
+import pint
 import astropy.units as u
 import numpy as np
 import pytest
@@ -585,3 +586,51 @@ def test_dmxparse():
     f = fitter.GLSFitter(toas=t, model=m)
     f.fit_toas()
     dmx = dmxparse(f, save=False)
+
+
+def test_psr_utils():
+
+    from pint.utils import (
+        mass_funct,
+        mass_funct2,
+        pulsar_mass,
+        companion_mass,
+        pulsar_age,
+        pulsar_edot,
+        pulsar_B,
+        pulsar_B_lightcyl,
+    )
+
+    pb = 1.0 * u.d
+    x = 2.0 * pint.ls
+
+    # Mass function
+    assert np.isclose(mass_funct(pb, x), 0.008589595519643776 * u.solMass)
+
+    # Mass function, second form
+    assert np.isclose(
+        mass_funct2(1.4 * u.solMass, 0.2 * u.solMass, 60.0 * u.deg),
+        0.0020297470401197783 * u.solMass,
+    )
+
+    # Characteristic age
+    assert np.isclose(
+        pulsar_age(0.033 * u.Hz, -2.0e-15 * u.Hz / u.s), 261426.72446573884 * u.yr
+    )
+
+    # Edot
+    assert np.isclose(
+        pulsar_edot(0.033 * u.Hz, -2.0e-15 * u.Hz / u.s),
+        2.6055755618875905e30 * u.erg / u.s,
+    )
+
+    # B
+    assert np.isclose(
+        pulsar_B(0.033 * u.Hz, -2.0e-15 * u.Hz / u.s), 238722891596281.66 * u.G
+    )
+
+    # B_lc
+    assert np.isclose(
+        pulsar_B_lightcyl(0.033 * u.Hz, -2.0e-15 * u.Hz / u.s),
+        0.07774704753236616 * u.G,
+    )


### PR DESCRIPTION
After loading TOAs you can do `ts.print_summary()` which is quite handy in a notebook.  After I did a fit in PINT in a notebook I wanted a nice way to see a summary of the fit. This PR adds `ftr.print_summary()` which does just that. It also adds a bunch of utilities that are translated from presto.psr_utils to support Quantities.

This also adds a rms_weighted() method to compute weighted RMS residuals, which is usually what you want instead of std().

Plus a few other test and documentation fixes.

Introduces a dependency on the uncertainties package, which makes very nice pretty printed parameter values with uncertainties. Too bad it doesn't support Quantity yet.  