### PR TITLE
Remove u.cycle units from phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project, at least loosely, adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Changed units of Phase to be u.dimensionless_unscaled instead of u.cycle, which was confusing
 ### Added
 - Added pmtot() convenience function
 - Added dmxstats() utility function

--- a/docs/examples/build_model_from_scratch.md
+++ b/docs/examples/build_model_from_scratch.md
@@ -271,7 +271,7 @@ The prefix type of parameters have to use `prefixParameter` class from `pint.mod
 ```python
 # Add prefix parameters
 dmx_0003 = p.prefixParameter(
-    parameter_type="float", name="DMX_0003", value=None, unit=u.pc / u.cm ** 3
+    parameter_type="float", name="DMX_0003", value=None, units=u.pc / u.cm ** 3
 )
 
 tm.components["DispersionDMX"].add_param(dmx_0003, setup=True)
@@ -290,10 +290,10 @@ However only adding DMX_0003 is not enough, since one DMX parameter also need a 
 
 ```python
 dmxr1_0003 = p.prefixParameter(
-    parameter_type="mjd", name="DMXR1_0003", value=None, unit=u.day
+    parameter_type="mjd", name="DMXR1_0003", value=None, units=u.day
 )  # DMXR1 is a type of MJD parameter internally.
 dmxr2_0003 = p.prefixParameter(
-    parameter_type="mjd", name="DMXR2_0003", value=None, unit=u.day
+    parameter_type="mjd", name="DMXR2_0003", value=None, units=u.day
 )  # DMXR1 is a type of MJD parameter internally.
 
 tm.components["DispersionDMX"].add_param(dmxr1_0003, setup=True)

--- a/src/pint/__init__.py
+++ b/src/pint/__init__.py
@@ -18,7 +18,6 @@ __all__ = [
     "ls",
     "dmu",
     "light_second_equivalency",
-    "dimensionless_cycles",
     "hourangle_second",
     "pulsar_mjd",
     "GMsun",
@@ -51,7 +50,6 @@ dmu = u.def_unit("dmu", u.pc * u.cm ** -3)
 
 # define equivalency for astropy units
 light_second_equivalency = [(ls, si.second, lambda x: x, lambda x: x)]
-dimensionless_cycles = [(u.cycle, None)]
 # hourangle_second unit
 hourangle_second = u.def_unit("hourangle_second", u.hourangle / np.longdouble(3600.0))
 
@@ -85,7 +83,7 @@ pint_units = {
     "Tsun": Tsun,
     "GMsun": GMsun,
     "MJD": u.day,
-    "pulse phase": u.cycle,
+    "pulse phase": u.dimensionless_unscaled,
     "hourangle_second": hourangle_second,
 }
 

--- a/src/pint/mcmc_fitter.py
+++ b/src/pint/mcmc_fitter.py
@@ -291,7 +291,6 @@ class MCMCFitter(Fitter):
         """
         phases = self.model.phase(self.toas)[1]
         # ensure all positive
-        phases = phases.to(u.cycle).value
         return np.where(phases < 0.0, phases + 1.0, phases)
 
     def lnposterior(self, theta):
@@ -642,7 +641,6 @@ class CompositeMCMCFitter(MCMCFitter):
             print("Showing all %d phases" % len(phases))
         else:
             phases = self.model.phase(self.toas_list[index])[1]
-        phases = phases.to(u.cycle).value
         return np.where(phases < 0.0, phases + 1.0, phases)
 
     def get_template_vals(self, phases, index):

--- a/src/pint/models/ifunc.py
+++ b/src/pint/models/ifunc.py
@@ -132,5 +132,5 @@ class IFunc(PhaseComponent):
         else:
             raise ValueError("Interpolation type %d not supported.".format(itype))
 
-        phase = (times * u.s) * self.F0.quantity * u.cycle
+        phase = ((times * u.s) * self.F0.quantity).to(u.dimensionless_unscaled)
         return phase

--- a/src/pint/models/jump.py
+++ b/src/pint/models/jump.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, print_function
 import astropy.units as u
 import numpy
 
-from pint import dimensionless_cycles
 from pint.models.parameter import maskParameter
 from pint.models.timing_model import DelayComponent, MissingParameter, PhaseComponent
 
@@ -120,8 +119,7 @@ class PhaseJump(PhaseComponent):
         d_phase_d_j = numpy.zeros(len(tbl))
         mask = jpar.select_toa_mask(toas)
         d_phase_d_j[mask] = self.F0.value
-        with u.set_enabled_equivalencies(dimensionless_cycles):
-            return (d_phase_d_j * self.F0.units).to(u.cycle / u.second)
+        return (d_phase_d_j * self.F0.units).to(1 / u.second)
 
     def print_par(self):
         result = ""

--- a/src/pint/models/spindown.py
+++ b/src/pint/models/spindown.py
@@ -7,7 +7,6 @@ import astropy.units as u
 import numpy
 
 import pint.toa as toa
-from pint import dimensionless_cycles
 from pint.models.parameter import MJDParameter, floatParameter, prefixParameter
 from pint.models.timing_model import MissingParameter, PhaseComponent
 from pint.pulsar_mjd import Time
@@ -127,10 +126,9 @@ class Spindown(PhaseComponent):
         """
         dt = self.get_dt(toas, delay)
         # Add the [0.0] because that is the constant phase term
-        fterms = [0.0 * u.cycle] + self.get_spin_terms()
-        with u.set_enabled_equivalencies(dimensionless_cycles):
-            phs = taylor_horner(dt.to(u.second), fterms)
-            return phs.to(u.cycle)
+        fterms = [0.0 * u.dimensionless_unscaled] + self.get_spin_terms()
+        phs = taylor_horner(dt.to(u.second), fterms)
+        return phs.to(u.dimensionless_unscaled)
 
     def change_pepoch(self, new_epoch, toas=None, delay=None):
         """Move PEPOCH to a new time and change the related paramters.
@@ -197,13 +195,11 @@ class Spindown(PhaseComponent):
         fterms = [ft * numpy.longdouble(0.0) / unit for ft in fterms]
         fterms[order] += numpy.longdouble(1.0)
         dt = self.get_dt(toas, delay)
-        with u.set_enabled_equivalencies(dimensionless_cycles):
-            d_pphs_d_f = taylor_horner(dt.to(u.second), fterms)
-            return d_pphs_d_f.to(u.cycle / unit)
+        d_pphs_d_f = taylor_horner(dt.to(u.second), fterms)
+        return d_pphs_d_f.to(1 / unit)
 
     def d_spindown_phase_d_delay(self, toas, delay):
         dt = self.get_dt(toas, delay)
         fterms = [0.0] + self.get_spin_terms()
-        with u.set_enabled_equivalencies(dimensionless_cycles):
-            d_pphs_d_delay = taylor_horner_deriv(dt.to(u.second), fterms)
-            return -d_pphs_d_delay.to(u.cycle / u.second)
+        d_pphs_d_delay = taylor_horner_deriv(dt.to(u.second), fterms)
+        return -d_pphs_d_delay.to(1 / u.second)

--- a/src/pint/models/wave.py
+++ b/src/pint/models/wave.py
@@ -111,5 +111,5 @@ class Wave(PhaseComponent):
             times += wave_a * np.sin(wave_phase)
             times += wave_b * np.cos(wave_phase)
 
-        phase = (times) * self.F0.quantity * u.cycle
+        phase = ((times) * self.F0.quantity).to(u.dimensionless_unscaled)
         return phase

--- a/src/pint/phase.py
+++ b/src/pint/phase.py
@@ -1,11 +1,3 @@
-# phase.py
-# Simple class representing pulse phase as integer and fractional
-# parts.
-# SUGGESTION(@paulray): How about adding some documentation here
-# describing why the fractional part is reduced to [-0.5,0.5] instead of [0,1].
-# I think I understand it, but it would be good to have it stated.
-# Also, probably one of the comparisons below should be <= or >=, so the
-# range is [-0.5,0.5) or (-0.5,0.5].
 from __future__ import absolute_import, division, print_function
 
 from collections import namedtuple
@@ -13,50 +5,72 @@ from collections import namedtuple
 import astropy.units as u
 import numpy
 
-from pint import dimensionless_cycles
-
 
 class Phase(namedtuple("Phase", "int frac")):
     """
-    Phase class array version
+    Class representing pulse phase as integer (.int) and fractional (.frac) parts.
+
+    The phase values are dimensionless Quantitys (u.dimensionless_unscaled == u.Unit("") == Unit(dimensionless))
 
     Ensures that the fractional part stays in [-0.5, 0.5)
+
+    SUGGESTION(@paulray): How about adding some documentation here
+    describing why the fractional part is reduced to [-0.5,0.5) instead of [0,1).
+
     """
 
     __slots__ = ()
 
     def __new__(cls, arg1, arg2=None):
-        # Assume inputs are numerical, could add an extra
-        # case to parse strings as input.
-        # if it is not a list, convert to a list
+        """Create new Phase object
+
+        Constructs a Phase object. 
+        Can be initialized with arrays or a scalar Quantity.
+        Can take inputs as plain numerical types, or dimensionaless Quantitys
+        Accepts either floating point argument (arg1) or pair of arguments with integer (arg1) and fractional (arg2) parts separate
+        Scalars are converted to length 1 arrays so `Phase.int` and `Phase.frac` are always arrays
+
+        Parameters
+        ----------
+        arg1 : array or dimensionless Quantity
+        arg2 : array or dimensionless Quantity 
+
+        Returns
+        -------
+        Phase : pulse phase object with arrays of dimensionless Quantitys as the int and frac parts
+        """
         if not hasattr(arg1, "unit"):
-            arg1 = arg1 * u.cycle
+            arg1 = u.Quantity(arg1)
+        else:
+            # This will raise an exception if the argument has any unit not convertable to Unit(dimensionless)
+            arg1 = arg1.to(u.dimensionless_unscaled)
+        #  If arg is scalar, convert to an array of length 1
         if arg1.shape == ():
             arg1 = arg1.reshape((1,))
-        with u.set_enabled_equivalencies(dimensionless_cycles):
-            arg1 = arg1.to(u.Unit(""))
-            # Since modf does not like dimensioned quantity
-            if arg2 is None:
-                ff, ii = numpy.modf(arg1)
+        if arg2 is None:
+            ff, ii = numpy.modf(arg1)
+        else:
+            if not hasattr(arg2, "unit"):
+                arg2 = u.Quantity(arg2)
             else:
-                if not hasattr(arg2, "unit"):
-                    arg2 = arg2 * u.cycle
-                if arg2.shape == ():
-                    arg2 = arg2.reshape((1,))
-                arg2 = arg2.to(u.Unit(""))
-                arg1S = numpy.modf(arg1)
-                arg2S = numpy.modf(arg2)
-                ii = arg1S[1] + arg2S[1]
-                ff = arg2S[0]
-            index = numpy.where(ff < -0.5)
-            ff[index] += 1.0
-            ii[index] -= 1
-            # The next line is >= so that the range is the interval [-0.5,0.5)
-            # Otherwise, the same phase could be represented 0,0.5 or 1,-0.5
-            index = numpy.where(ff >= 0.5)
-            ff[index] -= 1.0
-            ii[index] += 1
-            return super(Phase, cls).__new__(cls, ii.to(u.cycle), ff.to(u.cycle))
+                arg2 = arg2.to(u.dimensionless_unscaled)
+            if arg2.shape == ():
+                arg2 = arg2.reshape((1,))
+            arg1S = numpy.modf(arg1)
+            arg2S = numpy.modf(arg2)
+            # Prior code assumed that fractional part of arg1 was 0 if arg2 was present
+            # @paulray removed that assumption here
+            ff = arg1S[0] + arg2S[0]
+            ii = arg1S[1] + arg2S[1]
+        index = ff < -0.5
+        ff[index] += 1.0
+        ii[index] -= 1
+        # The next line is >= so that the range is the interval [-0.5,0.5)
+        # Otherwise, the same phase could be represented 0,0.5 or 1,-0.5
+        index = ff >= 0.5
+        ff[index] -= 1.0
+        ii[index] += 1
+        return super(Phase, cls).__new__(cls, ii, ff)
 
     def __neg__(self):
         # TODO: add type check for __neg__ and __add__
@@ -64,10 +78,8 @@ class Phase(namedtuple("Phase", "int frac")):
 
     def __add__(self, other):
         ff = self.frac + other.frac
-        with u.set_enabled_equivalencies(dimensionless_cycles):
-            ii = numpy.modf(ff.to(u.Unit("")))[1]
-            ii = ii.to(u.cycle)
-            return Phase(self.int + other.int + ii, ff - ii)
+        ii = numpy.modf(ff)[1]
+        return Phase(self.int + other.int + ii, ff - ii)
 
     def __sub__(self, other):
         return self.__add__(other.__neg__())

--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -168,7 +168,7 @@ class Pulsar(object):
 
         phase = np.modf(tpb)[0]
         phase[phase < 0] += 1
-        return phase * u.cycle
+        return phase
 
     def dayofyear(self):
         """

--- a/src/pint/polycos.py
+++ b/src/pint/polycos.py
@@ -615,9 +615,7 @@ class Polycos(object):
                 dt = (nodes * u.day - tmid).to("min")  # Use constant
                 rdcPhase = ph - refPhase
                 rdcPhase = (
-                    rdcPhase.int
-                    - (dt.value * model.F0.value * 60.0) * u.cycle
-                    + rdcPhase.frac
+                    rdcPhase.int - (dt.value * model.F0.value * 60.0) + rdcPhase.frac
                 )
                 dtd = dt.value.astype(float)  # Truncate to double
                 rdcPhased = rdcPhase.astype(float)
@@ -791,8 +789,8 @@ class Polycos(object):
             phaseInt += (absp.int,)
             phaseFrac += (absp.frac,)
             # Maybe add sort function here, since the time has been masked.
-        phaseInt = np.hstack(phaseInt).value * u.cycle
-        phaseFrac = np.hstack(phaseFrac).value * u.cycle
+        phaseInt = np.hstack(phaseInt).value
+        phaseFrac = np.hstack(phaseFrac).value
         absPhase = Phase(phaseInt, phaseFrac)
 
         return absPhase

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -5,7 +5,6 @@ import numpy as np
 from scipy.linalg import LinAlgError
 from astropy import log
 
-from pint import dimensionless_cycles
 from pint.phase import Phase
 from pint.utils import weighted_mean
 
@@ -130,8 +129,7 @@ class Residuals(object):
         """Return timing model residuals in time (seconds)."""
         if self.phase_resids is None:
             self.phase_resids = self.calc_phase_resids(weighted_mean=weighted_mean)
-        with u.set_enabled_equivalencies(dimensionless_cycles):
-            return (self.phase_resids.to(u.Unit("")) / self.get_PSR_freq()).to(u.s)
+        return (self.phase_resids / self.get_PSR_freq()).to(u.s)
 
     def get_PSR_freq(self, modelF0=True):
         if modelF0:

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -279,7 +279,6 @@ class emcee_fitter(Fitter):
         """
         phss = self.model.phase(self.toas)[1]
         # ensure all postive
-        phss = phss.to(u.cycle).value
         return np.where(phss < 0.0, phss + 1.0, phss)
 
     def lnprior(self, theta):

--- a/src/pint/scripts/event_optimize_multiple.py
+++ b/src/pint/scripts/event_optimize_multiple.py
@@ -322,7 +322,7 @@ def main(argv=None):
                 gtemplate = cPickle.load(file(tname))
             except:
                 phases = (modelin.phase(ts)[1]).astype(np.float64)
-                phases[phases < 0] += 1 * u.cycle
+                phases[phases < 0] += 1 * u.dimensionless_unscaled
                 gtemplate = lctemplate.get_gauss2()
                 lcf = lcfitters.LCFitter(gtemplate, phases, weights=wlist[i])
                 lcf.fit(unbinned=False)
@@ -332,7 +332,7 @@ def main(argv=None):
                     protocol=2,
                 )
             phases = (modelin.phase(ts)[1]).astype(np.float64)
-            phases[phases < 0] += 1 * u.cycle
+            phases[phases < 0] += 1 * u.dimensionless_unscaled
             lcf = lcfitters.LCFitter(
                 gtemplate, phases.value, weights=wlist[i], binned_bins=200
             )

--- a/src/pint/scripts/fermiphase.py
+++ b/src/pint/scripts/fermiphase.py
@@ -117,7 +117,6 @@ def main(argv=None):
     # Compute model phase for each TOA
     iphss, phss = modelin.phase(ts, abs_phase=True)
     # ensure all postive
-    phss = phss.to(u.cycle).value
     phases = np.where(phss < 0.0, phss + 1.0, phss)
     mjds = ts.get_mjds()
     weights = np.array([w["weight"] for w in ts.table["flags"]])

--- a/src/pint/scripts/photonphase.py
+++ b/src/pint/scripts/photonphase.py
@@ -213,7 +213,6 @@ def main(argv=None):
     # Compute model phase for each TOA
     iphss, phss = modelin.phase(ts, abs_phase=True)
     # ensure all postive
-    phss = phss.to(u.cycle).value
     negmask = phss < 0.0
     phases = np.where(negmask, phss + 1.0, phss)
     h = float(hm(phases))
@@ -251,7 +250,7 @@ def main(argv=None):
             data_to_add["PULSE_PHASE"] = [phases, "D"]
 
         if args.absphase:
-            data_to_add["ABS_PHASE"] = [iphss - negmask * u.cycle, "K"]
+            data_to_add["ABS_PHASE"] = [iphss - negmask, "K"]
 
         if args.barytime:
             bats = modelin.get_barycentric_toas(ts)

--- a/src/pint/scripts/pintempo.py
+++ b/src/pint/scripts/pintempo.py
@@ -55,10 +55,11 @@ def main(argv=None):
     f = pint.fitter.WLSFitter(t, m)
     f.fit_toas()
 
-    # Print some basic params
-    print("Best fit has reduced chi^2 of", f.resids.chi2_reduced)
-    print("RMS in phase is", f.resids.phase_resids.std())
-    print("RMS in time is", f.resids.time_resids.std().to(u.us))
+    # Print fit summary
+    print(
+        "============================================================================"
+    )
+    f.print_summary()
 
     if args.plot:
         import matplotlib.pyplot as plt

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -749,7 +749,7 @@ class TOAs(object):
                     self.get_freqs(),
                     self.get_obss(),
                     self.get_flags(),
-                    np.zeros(len(mjds)) * u.cycle,
+                    np.zeros(len(mjds)),
                     self.get_groups(),
                 ],
                 names=(
@@ -854,7 +854,7 @@ class TOAs(object):
         # TODO: use a masked array?  Only some pulse numbers may be known
         if hasattr(self, "toas"):
             try:
-                return np.array([t.flags["pn"] for t in self.toas]) * u.cycle
+                return np.array([t.flags["pn"] for t in self.toas])
             except KeyError:
                 log.warning("Not all TOAs have pulse numbers, using none")
                 return None
@@ -864,7 +864,7 @@ class TOAs(object):
                     raise ValueError(
                         "Pulse number cannot be both a column and a TOA flag"
                     )
-                return np.array(flags["pn"] for flags in self.table["flags"]) * u.cycle
+                return np.array(flags["pn"] for flags in self.table["flags"])
             elif "pulse_number" in self.table.colnames:
                 return self.table["pulse_number"]
             else:
@@ -1021,7 +1021,7 @@ class TOAs(object):
         try:
             pns = [flags["pn"] for flags in self.table["flags"]]
             self.table["pulse_number"] = pns
-            self.table["pulse_number"].unit = u.cycle
+            self.table["pulse_number"].unit = u.dimensionless_unscaled
 
             # Remove pn from dictionary to prevent redundancies
             for flags in self.table["flags"]:
@@ -1047,7 +1047,7 @@ class TOAs(object):
         # paulr: I think pulse numbers should be computed with abs_phase=True!
         phases = model.phase(self, abs_phase=True)
         self.table["pulse_number"] = phases.int
-        self.table["pulse_number"].unit = u.cycle
+        self.table["pulse_number"].unit = u.dimensionless_unscaled
 
     def adjust_TOAs(self, delta):
         """Apply a time delta to TOAs

--- a/tests/test_pintempo.py
+++ b/tests/test_pintempo.py
@@ -19,12 +19,11 @@ def test_result():
     pintempo.main(cmd.split())
     lines = sys.stdout.getvalue()
     v = 999.0
+    # This line is in the output:
+    # Prefit residuals 1090.580262221985 us, Postfit residuals 21.182038051610704 us
     for l in lines.split("\n"):
-        if l.startswith("RMS in time is"):
-            v = float(l.split()[4])
-    # Check that RMS is less than 34 microseconds
-    from astropy import log
-
-    log.warning("%f" % v)
-    assert v < 34.0
+        if l.startswith("Prefit residuals"):
+            v = float(l.split()[6])
+    # Check that RMS is less than 30 microseconds
+    assert v < 30.0
     sys.stdout = saved_stdout


### PR DESCRIPTION
OK this was easier than I expected, at least so far.
I change Phases to be u.dimensionless_unscaled (which is a synonym for u.Units("") and Quantity(x)), so Phases are still Quantities, they just are dimensionless.  I think this is the right choice rather than trying to make them bare np.arrays.

I removed all the `u.cycle` references and many dimensionless_cycle equivalencies. In nearly all cases, this was a *simplification* of the code, which gives me confidence that this is the right way to go. 

All the tests pass, but this will need review and people to test it with their downstream code.