### PR TITLE
Fix units on DMEPOCH, POSEPOCH and some other updates

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,24 +6,40 @@ Development of PINT is partially supported by the NANOGrav_ pulsar timing array 
 
 .. _NANOGrav: http://nanograv.org/
 
+If you use PINT for your work, please cite the PINT paper and the ASCL entry_ .
+
+.. _entry: http://ascl.net/1902.007
+
 Development Leads
 -----------------
 
-In alphabetical order:
+As listed in the PINT paper:
 
-* Anne Archibald
-* Matteo Bachetti
-* Paul Demorest
-* Justin A. Ellis
 * Luo Jing
-* Rick Jenet
 * Scott Ransom
+* Paul Demorest
 * Paul Ray
-* Chris Sheehy
-* Michele Vallisneri
+* Anne Archibald
+* Matthew Kerr
+* Ross Jennings
+* Matteo Bachetti
 * Rutger van Haasteren
+* Jonathan Colen
+* Camryn Phillips
+* Kevin Stovall
+* Michael Lam
+* Rick Jenet
 
 Other contributors
 ------------------
 
-None yet. Why not be the first?
+* Bastian Beischer
+* Chris Deil
+* Julia Deneva
+* Justin A. Ellis
+* Maarten van Kerkwijk
+* Matt Pitkin
+* Ben Shapiro-Albert
+* Chris Sheehy
+* Renee Spiewak
+* Michele Vallisneri

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,8 @@ If you want access to the source code, example notebooks, and tests, you can ins
 cloning the source repository from GitHub, then install
 it, ensuring that all dependencies needed to run PINT are available::
 
+    $ git checkout https://github.com/nanograv/PINT.git
+    $ cd PINT
     $ pip install .
 
 Complete installation instructions are availble here_.

--- a/docs/basic-installation.rst
+++ b/docs/basic-installation.rst
@@ -13,4 +13,11 @@ By default this will install in your system site-packages.  Depending on your sy
 to install it for just yourself (e.g. if you don't have permission to write in the system site-packages), or you may want to create a 
 virtualenv to work on PINT (using a virtualenv is highly recommended by the PINT developers).
 
+If you want access to the source code, example notebooks, and tests, you can install from source, by 
+cloning the source repository from GitHub, then install it, ensuring that all dependencies needed to run PINT are available::
+
+    $ git checkout https://github.com/nanograv/PINT.git
+    $ cd PINT
+    $ pip install .
+
 If this fails, or for more explicit installation and troubleshooting instructions see :ref:`Installation`.

--- a/docs/examples/build_model_from_scratch.md
+++ b/docs/examples/build_model_from_scratch.md
@@ -271,7 +271,7 @@ The prefix type of parameters have to use `prefixParameter` class from `pint.mod
 ```python
 # Add prefix parameters
 dmx_0003 = p.prefixParameter(
-    parameter_type="float", name="DMX_0003", value=None, unit=u.pc / u.cm ** 3
+    parameter_type="float", name="DMX_0003", value=None, units=u.pc / u.cm ** 3
 )
 
 tm.components["DispersionDMX"].add_param(dmx_0003, setup=True)
@@ -290,10 +290,10 @@ However only adding DMX_0003 is not enough, since one DMX parameter also need a 
 
 ```python
 dmxr1_0003 = p.prefixParameter(
-    parameter_type="mjd", name="DMXR1_0003", value=None, unit=u.day
+    parameter_type="mjd", name="DMXR1_0003", value=None, units=u.day
 )  # DMXR1 is a type of MJD parameter internally.
 dmxr2_0003 = p.prefixParameter(
-    parameter_type="mjd", name="DMXR2_0003", value=None, unit=u.day
+    parameter_type="mjd", name="DMXR2_0003", value=None, units=u.day
 )  # DMXR1 is a type of MJD parameter internally.
 
 tm.components["DispersionDMX"].add_param(dmxr1_0003, setup=True)

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -197,7 +197,7 @@ class Fitter(object):
         s = "Fitted model using {} method with {} free parameters to {} TOAs\n".format(
             self.method, len(self.get_fitparams()), self.toas.ntoas
         )
-        s += "Prefit residuals {}, Postfit residuals {}\n".format(
+        s += "Prefit residuals Wrms = {}, Postfit residuals Wrms = {}\n".format(
             self.resids_init.rms_weighted(), self.resids.rms_weighted()
         )
         s += "Chisq = {:.3f} for {} d.o.f. for reduced Chisq of {:.3f}\n".format(

--- a/src/pint/models/absolute_phase.py
+++ b/src/pint/models/absolute_phase.py
@@ -26,7 +26,9 @@ class AbsPhase(PhaseComponent):
     def __init__(self):
         super(AbsPhase, self).__init__()
         self.add_param(
-            MJDParameter(name="TZRMJD", description="Epoch of the zero phase.")
+            MJDParameter(
+                name="TZRMJD", description="Epoch of the zero phase.", time_scale="utc"
+            )
         )
         self.add_param(
             strParameter(

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -31,7 +31,11 @@ class Astrometry(DelayComponent):
     def __init__(self):
         super(Astrometry, self).__init__()
         self.add_param(
-            MJDParameter(name="POSEPOCH", description="Reference epoch for position")
+            MJDParameter(
+                name="POSEPOCH",
+                description="Reference epoch for position",
+                time_scale="tdb",
+            )
         )
 
         self.add_param(

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -84,7 +84,9 @@ class DispersionDM(Dispersion):
             )
         )
         self.add_param(
-            MJDParameter(name="DMEPOCH", description="Epoch of DM measurement")
+            MJDParameter(
+                name="DMEPOCH", description="Epoch of DM measurement", time_scale="tdb"
+            )
         )
 
         self.dm_value_funcs += [self.base_dm]

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -753,7 +753,7 @@ class MJDParameter(Parameter):
     aliases : list, optional
         An optional list of strings specifying alternate names that can also
         be accepted for this parameter.
-    time_scale : str, optional, default 'utc'
+    time_scale : str, optional, default 'tdb'
         MJD parameter time scale.
 
     Example::
@@ -772,7 +772,7 @@ class MJDParameter(Parameter):
         frozen=True,
         continuous=True,
         aliases=None,
-        time_scale="utc",
+        time_scale="tdb",
         **kwargs
     ):
         self._time_scale = time_scale

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -971,11 +971,10 @@ class TOAs(object):
 
     def unselect(self):
         """Return to previous selected version of the TOA table (stored in stack)."""
-        if hasattr(self, "table_selects"):
-            # may raise an exception about an empty list
+        try:
             self.table = self.table_selects.pop()
-        else:
-            raise ValueError("No previous TOA table found.  No changes made.")
+        except (AttributeError, IndexError) as e:
+            log.error("No previous TOA table found.  No changes made.")
 
     def pickle(self, filename=None):
         """Write the TOAs to a .pickle file with optional filename."""

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1101,6 +1101,10 @@ def pulsar_mass(pb, x, mc, inc):
         Companion mass in u.solMass
     inc : Angle
         Inclination angle, in u.deg or u.rad
+
+    Returns
+    -------
+    mass : Quantity in u.solMass
     """
     massfunct = mass_funct(pb, x)
 
@@ -1108,7 +1112,7 @@ def pulsar_mass(pb, x, mc, inc):
     def localmf(mp, mc=mc, mf=massfunct, i=inc):
         return (mass_funct2(mp * u.solMass, mc, i) - mf).value
 
-    return zeros.bisect(localmf, 0.0, 1000.0)
+    return zeros.bisect(localmf, 0.0, 1000.0) * u.solMass
 
 
 def companion_mass(pb, x, inc=60.0 * u.deg, mpsr=1.4 * u.solMass):
@@ -1127,6 +1131,10 @@ def companion_mass(pb, x, inc=60.0 * u.deg, mpsr=1.4 * u.solMass):
         Inclination angle, in u.deg or u.rad. Default is 60 deg.
     mpsr : Quantity, optional
         Pulsar mass in u.solMass. Default is 1.4 Msun
+
+    Returns
+    -------
+    mass : Quantity in u.solMass
     """
     massfunct = mass_funct(pb, x)
 
@@ -1134,7 +1142,7 @@ def companion_mass(pb, x, inc=60.0 * u.deg, mpsr=1.4 * u.solMass):
     def localmf(mc, mp=mpsr, mf=massfunct, i=inc):
         return (mass_funct2(mp, mc * u.solMass, i) - mf).value
 
-    return zeros.bisect(localmf, 0.001, 1000.1)
+    return zeros.bisect(localmf, 0.001, 1000.1) * u.solMass
 
 
 def ELL1_check(A1, E, TRES, NTOA, outstring=True):


### PR DESCRIPTION
- Changed MJParameter so the default timescale is 'tdb' and explicitly set the timescale on all uses of MJDPameter so DMEPOCH and POSEPOCH will be 'tdb' instead of 'utc'
- Some documentation and print statement updates
- Added dmxranges2() with a different algorithm for creating DMX ranges
