### PR TITLE
Translate test fixture to decorator

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,6 +22,7 @@ In alphabetical order:
 * Chris Sheehy
 * Michele Vallisneri
 * Rutger van Haasteren
+* Zac Hatfield-Dodds
 
 Other contributors
 ------------------


### PR DESCRIPTION
This pattern is safer for Hypothesis, as the context is refreshed each time the inner test function is invoked instead of just once for all inputs.  (if it *is* safe to share the fixture, it can be declared as `@pytest.fixture(scope="module")` to say so and Hypothesis won't complain)

Ref #659, [hypothesis release notes](https://hypothesis.readthedocs.io/en/latest/changes.html#v5-6-0).  CC @paulray; this fixes the seven Hypothesis-related warnings you had.