### PR TITLE
Fix buggy TimeDelta comparisons

### DIFF
--- a/docs/examples/example_dmx_ranges.py
+++ b/docs/examples/example_dmx_ranges.py
@@ -25,7 +25,7 @@ m1855.remove_component("DispersionDMX")
 
 # Build the new component with maximum DMX bin of 15 days ensuring that there are TOAs above and below 1000 MHz in each gin
 mask, dmx_comp = pint.utils.dmx_ranges(
-    ts1855, max_diff=15.0 * u.d, divide_freq=1000.0 * u.MHz
+    ts1855, binwidth=15.0 * u.d, divide_freq=1000.0 * u.MHz
 )
 
 # Mask out any TOAs that couldn't be included in a DMX range

--- a/profiling/run_profile.py
+++ b/profiling/run_profile.py
@@ -17,26 +17,22 @@ import pstats
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="PINT tool for run profiling.")
-    parser.add_argument("-f", help="The script for profiling.")
+    parser.add_argument("script", help="The script for profiling.")
     parser.add_argument(
-        "--s",
+        "--sort",
         help="The key for sort result ['cumtime','time']."
         " See https://docs.python.org/2/library/profile.html",
         type=str,
         default="time",
     )
     args = parser.parse_args()
-    try:
-        branch_name = subprocess.check_output(
-            "basename $(git symbolic-ref HEAD)", shell=True
-        )
-    except:
-        branch_name = "profile"
-    outfile = args.f.replace(".py", "_") + branch_name.strip()
-    if args.s is None:
-        cline = "python -m cProfile -o " + outfile + " " + args.f
+    outfile = args.script.replace(".py", "_profile")
+    if args.sort is None:
+        cline = "python -m cProfile -o " + outfile + " " + args.script
     else:
-        cline = "python -m cProfile -o " + outfile + " -s " + args.s + " " + args.f
+        cline = (
+            "python -m cProfile -o " + outfile + " -s " + args.sort + " " + args.script
+        )
     print(cline)
     subprocess.call(cline, shell=True)
     call_tree_line = (
@@ -46,4 +42,4 @@ if __name__ == "__main__":
     # Check stats
     p = pstats.Stats(outfile)
     p.strip_dirs()
-    p.sort_stats(args.s).print_stats(100)
+    p.sort_stats(args.sort).print_stats(100)

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -29,6 +29,7 @@ __all__ = [
     "show_param_cov_matrix",
     "dmxparse",
     "dmxstats",
+    "dmx_ranges_old",
     "dmx_ranges",
     "p_to_f",
     "pferrs",
@@ -508,7 +509,7 @@ class dmxrange:
         )
 
 
-def dmx_ranges(
+def dmx_ranges_old(
     toas,
     divide_freq=1000.0 * u.MHz,
     offset=0.01 * u.d,
@@ -683,7 +684,7 @@ def dmx_ranges(
     return mask, dmx_comp
 
 
-def dmx_ranges2(toas, divide_freq=1000.0 * u.MHz, binwidth=15.0 * u.d, verbose=False):
+def dmx_ranges(toas, divide_freq=1000.0 * u.MHz, binwidth=15.0 * u.d, verbose=False):
     """Compute initial DMX ranges for a set of TOAs
     
     This is an alternative algorithm for computing DMX ranges

--- a/tests/test_toa_writer.py
+++ b/tests/test_toa_writer.py
@@ -6,6 +6,8 @@ import pytest
 from pint import toa
 from pinttestdata import datadir
 from astropy.time import Time
+import numpy as np
+import astropy.units as u
 
 
 class TestRoundtripToFiles(unittest.TestCase):
@@ -23,8 +25,8 @@ class TestRoundtripToFiles(unittest.TestCase):
         ts.write_TOA_file("testbary.tim", format="Tempo2")
         ts2 = toa.get_TOAs("testbary.tim")
         print(ts.table, ts2.table)
-        assert ts.table["mjd"][0] - ts2.table["mjd"][0] < 1.0e-15
-        assert ts.table["tdb"][0] - ts2.table["tdb"][0] < 1.0e-15
+        assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
+        assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
     def test_roundtrip_bary_toa_TEMPOformat(self):
         # Create a barycentric TOA
@@ -34,8 +36,8 @@ class TestRoundtripToFiles(unittest.TestCase):
         ts.write_TOA_file("testbary.tim", format="TEMPO")
         ts2 = toa.get_TOAs("testbary.tim")
         print(ts.table, ts2.table)
-        assert ts.table["mjd"][0] - ts2.table["mjd"][0] < 1.0e-15
-        assert ts.table["tdb"][0] - ts2.table["tdb"][0] < 1.0e-15
+        assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
+        assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
     def test_roundtrip_topo_toa_Tempo2format(self):
         # Create a barycentric TOA
@@ -45,8 +47,8 @@ class TestRoundtripToFiles(unittest.TestCase):
         ts.write_TOA_file("testtopo.tim", format="Tempo2")
         ts2 = toa.get_TOAs("testtopo.tim")
         print(ts.table, ts2.table)
-        assert ts.table["mjd"][0] - ts2.table["mjd"][0] < 1.0e-15
-        assert ts.table["tdb"][0] - ts2.table["tdb"][0] < 1.0e-15
+        assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
+        assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
     def test_roundtrip_topo_toa_TEMPOformat(self):
         # Create a barycentric TOA
@@ -56,22 +58,22 @@ class TestRoundtripToFiles(unittest.TestCase):
         ts.write_TOA_file("testtopot1.tim", format="TEMPO")
         ts2 = toa.get_TOAs("testtopot1.tim")
         print(ts.table, ts2.table)
-        assert ts.table["mjd"][0] - ts2.table["mjd"][0] < 1.0e-15
-        assert ts.table["tdb"][0] - ts2.table["tdb"][0] < 1.0e-15
+        assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
+        assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
-    # Comment out because TEMPO2 distro doesn't include gmrt2gps.clk so far
-    # def test_roundtrip_gmrt_toa_Tempo2format(self):
-    #     if os.getenv("TEMPO2") is None:
-    #         pytest.skip("TEMPO2 evnironment variable is not set, can't run this test")
-    #     # Create a barycentric TOA
-    #     t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
-    #     t1 = toa.TOA(t1time, obs="gmrt", freq=0.0)
-    #     ts = toa.get_TOAs_list([t1], ephem="DE421")
-    #     ts.write_TOA_file("testgmrt.tim", format="Tempo2")
-    #     ts2 = toa.get_TOAs("testgmrt.tim")
-    #     print(ts.table, ts2.table)
-    #     assert ts.table["mjd"][0] - ts2.table["mjd"][0] < 1.0e-15
-    #     assert ts.table["tdb"][0] - ts2.table["tdb"][0] < 1.0e-15
+        # Comment out because TEMPO2 distro doesn't include gmrt2gps.clk so far
+        # def test_roundtrip_gmrt_toa_Tempo2format(self):
+        #     if os.getenv("TEMPO2") is None:
+        #         pytest.skip("TEMPO2 evnironment variable is not set, can't run this test")
+        #     # Create a barycentric TOA
+        #     t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
+        #     t1 = toa.TOA(t1time, obs="gmrt", freq=0.0)
+        #     ts = toa.get_TOAs_list([t1], ephem="DE421")
+        #     ts.write_TOA_file("testgmrt.tim", format="Tempo2")
+        #     ts2 = toa.get_TOAs("testgmrt.tim")
+        #     print(ts.table, ts2.table)
+        assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
+        assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
     # def test_roundtrip_ncyobs_toa_Tempo2format(self):
     #     if os.getenv("TEMPO2") is None:
@@ -83,8 +85,8 @@ class TestRoundtripToFiles(unittest.TestCase):
     #     ts.write_TOA_file("testncyobs.tim", format="Tempo2")
     #     ts2 = toa.get_TOAs("testncyobs.tim")
     #     print(ts.table, ts2.table)
-    #     assert ts.table["mjd"][0] - ts2.table["mjd"][0] < 1.0e-15
-    #     assert ts.table["tdb"][0] - ts2.table["tdb"][0] < 1.0e-15
+    #     assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15*u.d
+    #     assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15*u.d
 
     # def test_roundtrip_ncyobs_toa_TEMPOformat(self):
     #     if os.getenv("TEMPO2") is None:


### PR DESCRIPTION
I was playing with Time and TimeDelta when I found these buggy comparisons.  There are 2 problems:
1. The comparison did not take the absolute value of the TimeDelta
1. The comparison did not have units on the quantity being compared.

I think the second issue is really an astropy bug.  This should not work but does:
```
In [111]: td                                                                                                                                                              
Out[111]: <TimeDelta object: scale='tdb' format='jd' value=-4.01624200563333e-09>

In [112]: td<1                                                                                                                                                            
Out[112]: True
```
This allowed me to compare a TimeDelta to "1" without specifying the units. Is it 1 day, 1 second?  This should have failed with some kind of units exception. Do you agree @mhvk ?