### PR TITLE
Set UNITS parameter from par file

### DIFF
--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1245,6 +1245,7 @@ class TimingModel(object):
                     wants_tcb = False
                 else:
                     wants_tcb = li
+                self.UNITS.value = k[1]
                 continue
 
             if name == "EPHVER":


### PR DESCRIPTION
This one line change makes PINT actually save the UNITS value from the par file.  Currently there is a UNITS parameter on the top level TimingModel, but it is always "UNSET". This is not good, and it means that `m.as_parfile()` does not write out UNITS TDB, so if you feed a PINT output par file to Tempo2, it sees no UNITS and assumes UNITS TCB, which is wrong.