### PR TITLE
Troposphere Delay Model

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,6 +24,7 @@ As listed in the PINT paper:
 * Ross Jennings
 * Matteo Bachetti
 * Rutger van Haasteren
+* Chloe Champagne
 * Jonathan Colen
 * Camryn Phillips
 * Josef Zimmerman
@@ -35,7 +36,6 @@ Other contributors (alphabetical)
 ---------------------------------
 
 * Bastian Beischer
-* Chloe Champagne
 * Chris Deil
 * Julia Deneva
 * Justin A. Ellis

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,6 +26,7 @@ As listed in the PINT paper:
 * Rutger van Haasteren
 * Jonathan Colen
 * Camryn Phillips
+* Josef Zimmerman
 * Kevin Stovall
 * Michael Lam
 * Rick Jenet

--- a/src/pint/models/__init__.py
+++ b/src/pint/models/__init__.py
@@ -10,6 +10,7 @@ from pint.models.binary_ell1 import BinaryELL1, BinaryELL1H
 from pint.models.dispersion_model import DispersionDM, DispersionDMX
 from pint.models.frequency_dependent import FD
 from pint.models.glitch import Glitch
+from pint.models.ifunc import IFunc
 from pint.models.jump import DelayJump, PhaseJump
 from pint.models.model_builder import get_model
 from pint.models.noise_model import EcorrNoise, PLRedNoise, ScaleToaError
@@ -18,9 +19,9 @@ from pint.models.solar_wind_dispersion import SolarWindDispersion
 from pint.models.spindown import Spindown
 
 # Import the main timing model classes
-from pint.models.timing_model import TimingModel, DEFAULT_ORDER
+from pint.models.timing_model import DEFAULT_ORDER, TimingModel
+from pint.models.troposphere_delay import TroposphereDelay
 from pint.models.wave import Wave
-from pint.models.ifunc import IFunc
 
 # Define a standard basic model
 StandardTimingModel = TimingModel(

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -27,7 +27,6 @@ import numpy as np
 import six
 from astropy import log
 from astropy.coordinates.angles import Angle
-
 from pint import pint_units
 from pint.models import priors
 from pint.pulsar_mjd import (
@@ -323,7 +322,7 @@ class Parameter(object):
         return str(uncertainty.to(self.units).value)
 
     def __repr__(self):
-        out = "{0:16s}{1:16s}".format(self.__class__.__name__ + "(", self.name)
+        out = "{0:16s}{1:20s}".format(self.__class__.__name__ + "(", self.name)
         if self.quantity is None:
             out += "UNSET"
             return out

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -12,20 +12,18 @@ from collections import defaultdict
 import astropy.time as time
 import astropy.units as u
 import numpy as np
+import pint
 import six
 from astropy import log
-
-import pint
-from pint.models.parameter import strParameter, maskParameter
-from pint.phase import Phase
-from pint.utils import PrefixError, interesting_lines, lines_of, split_prefixed_name
 from pint.models.parameter import (
     AngleParameter,
+    floatParameter,
+    maskParameter,
     prefixParameter,
     strParameter,
-    floatParameter,
 )
-
+from pint.phase import Phase
+from pint.utils import PrefixError, interesting_lines, lines_of, split_prefixed_name
 
 __all__ = ["DEFAULT_ORDER", "TimingModel"]
 # Parameters or lines in parfiles we don't understand but shouldn't
@@ -45,7 +43,6 @@ ignore_params = set(
         "UNITS",
         "TIMEEPH",
         "T2CMETHOD",
-        "CORRECT_TROPOSPHERE",
         "DILATEFREQ",
         "NTOA",
         "CLOCK",
@@ -69,6 +66,7 @@ ignore_prefix = set(["DMXF1_", "DMXF2_", "DMXEP_"])  # DMXEP_ for now.
 DEFAULT_ORDER = [
     "astrometry",
     "jump_delay",
+    "troposphere",
     "solar_system_shapiro",
     "solar_wind",
     "dispersion_constant",
@@ -420,7 +418,7 @@ class TimingModel(object):
         ----------
         component: str or `Component` object
             Component name or component object.
-            
+
         Returns
         -------
         comp: `Component` object
@@ -504,8 +502,8 @@ class TimingModel(object):
             self.validate()
 
     def remove_component(self, component):
-        """ Remove one component from the timing model. 
-            
+        """ Remove one component from the timing model.
+
         Parameters
         ----------
         component: str or `Component` object
@@ -571,7 +569,7 @@ class TimingModel(object):
 
     def add_param_from_top(self, param, target_component, setup=False):
         """ Add a parameter to a timing model component.
-           
+
             Parameters
             ----------
             param: str
@@ -580,7 +578,7 @@ class TimingModel(object):
                 Parameter host component name. If given as "" it would add
                 parameter to the top level `TimingModel` class
             setup: bool, optional
-                Flag to run setup() function.  
+                Flag to run setup() function.
         """
         if target_component == "":
             setattr(self, param.name, param)
@@ -1077,7 +1075,7 @@ class TimingModel(object):
 
     def compare(self, othermodel, nodmx=True):
         """Print comparison with another model
-        
+
         Parameters
         ----------
         othermodel
@@ -1087,7 +1085,7 @@ class TimingModel(object):
 
         Returns
         -------
-        str 
+        str
             Human readable comparison, for printing
         """
 

--- a/src/pint/models/troposphere_delay.py
+++ b/src/pint/models/troposphere_delay.py
@@ -364,9 +364,6 @@ class TroposphereDelay(DelayComponent):
     def _interp(x, xn, yn):
         """ vectorized 1d interpolation for 2 points only"""
         # return (x - xn[0]) * (yn[1] - yn[0]) / (xn[1] - xn[0]) + yn[0]
-        print("x", x.shape, x)
-        print("xn", xn.shape, xn)
-        print("yn", yn.shape, yn)
         f = scipy.interpolate.interp1d(xn, yn)
         return f(x)
 

--- a/src/pint/models/troposphere_delay.py
+++ b/src/pint/models/troposphere_delay.py
@@ -233,7 +233,7 @@ class TroposphereDelay(DelayComponent):
         # return 7.7 * u.ns
 
         p = self.pressure_from_altitude(H)
-        return (p / 43.921) / (
+        return (p / (43.921 * u.kPa)) / (
             const.c.value * (1 - 0.00266 * np.cos(2 * lat) - 0.00028 * H.value)
         )
 

--- a/src/pint/models/troposphere_delay.py
+++ b/src/pint/models/troposphere_delay.py
@@ -274,7 +274,7 @@ class TroposphereDelay(DelayComponent):
 
     def _coefficient_func(self, average, amplitudes, yearFraction):
         """from the Niell mapping function with annual variations"""
-        return average + 0 * amplitudes * np.cos(2 * np.pi * yearFraction)
+        return average + amplitudes * np.cos(2 * np.pi * yearFraction)
 
     def _find_latitude_index(self, lat):
         """find the index corresponding to the upper bound on latitude

--- a/src/pint/models/troposphere_delay.py
+++ b/src/pint/models/troposphere_delay.py
@@ -1,0 +1,249 @@
+"""Delay due to Earth's troposphere"""
+from __future__ import absolute_import, division, print_function
+
+from warnings import warn
+
+import astropy.constants as const
+import astropy.units as u
+import numpy as np
+import pint.utils as ut
+from astropy import log
+from astropy.coordinates import AltAz, SkyCoord
+from pint.models.timing_model import DelayComponent
+from pint.observatory import get_observatory
+from pint.toa_select import TOASelect
+
+
+class TroposphereDelay(DelayComponent):
+    """Dispersion due to the solar wind (basic model).
+
+    The model is a simple spherically-symmetric model that varies
+    only in its amplitude.
+
+    References
+    ----------
+    Madison et al. 2019, ApJ, 872, 150; Section 3.1
+    Edwards et al. 2006, MNRAS, 372, 1549; Setion 2.5.4
+
+    """
+
+    register = True
+    category = "troposphere"
+
+    # zero padding will provide constant within 15degrees of the poles or equator
+    A_AVG = (
+        np.array([0.0, 1.2769934, 1.2683230, 1.2465397, 1.2196049, 1.2045996, 0.0])
+        * 1e-3
+    )
+    B_AVG = (
+        np.array([0.0, 2.9153695, 2.9152299, 2.9288445, 2.9022565, 2.9024912, 0.0])
+        * 1e-3
+    )
+    C_AVG = (
+        np.array([0.0, 62.610505, 62.837393, 63.721774, 63.824265, 64.258455, 0.0])
+        * 1e-3
+    )
+
+    A_AMP = np.array([0.0, 0.0, 1.2709626, 2.6523662, 3.4000452, 4.1202191, 0.0]) * 1e-5
+
+    B_AMP = np.array([0.0, 0.0, 2.1414979, 3.0160779, 7.2562722, 11.723375, 0.0]) * 1e-5
+
+    C_AMP = np.array([0.0, 0.0, 9.0128400, 4.3497037, 84.795348, 170.37206, 0.0]) * 1e-5
+
+    A_HT = 2.53e-5
+    B_HT = 5.49e-3
+    C_HT = 1.14e-3
+
+    LAT = np.array([0, 15, 30, 45, 60, 75, 90]) * u.deg  # in degrees
+
+    DOY_OFFSET = -28  # add this into the MJD value to get the right phase
+
+    def __init__(self):
+        super(TroposphereDelay, self).__init__()
+        # copy over the
+        for array in [
+            self.A_AVG,
+            self.B_AVG,
+            self.C_AVG,
+            self.A_AMP,
+            self.B_AMP,
+            self.C_AMP,
+        ]:
+            array[0] = array[1]
+            array[-1] = array[-2]
+
+    def setup(self):
+        super(TroposphereDelay, self).setup()
+
+    def validate(self):
+        super(TroposphereDelay, self).validate()
+
+    def _get_target_altitude(self, obs, grp, radec):
+        transformAltaz = AltAz(location=obs, obstime=grp["mjd"])
+        alt = radec.transform_to(transformAltaz).alt  # * u.deg
+        return alt
+
+    def troposphere_delay(self, toas, model):
+        # must include model to get ra/dec of target, plus maybe proper motion?
+        tab = toas.table
+
+        radec = SkyCoord(
+            model.RAJ.value * model.RAJ.units, model.DECJ.value * model.DECJ.units
+        )  # just do this once instead of adjusting over time
+
+        # okie so I need to do this more efficiently, so i'll group by the observatory
+
+        # for loop copied from solary_system_shapiro_delay
+        tbl = toas.table
+        delay = np.zeros(len(tbl))
+        for ii, key in enumerate(tbl.groups.keys):
+            grp = tbl.groups[ii]
+            loind, hiind = tbl.groups.indices[ii : ii + 2]
+            if key["obs"].lower() == "barycenter":
+                log.debug("Skipping Troposphere delay for Barycentric TOAs")
+                continue
+
+            obs = get_observatory(tbl.groups.keys[ii]["obs"]).earth_location_itrf()
+
+            alt = self._get_target_altitude(obs, grp, radec)
+
+            # now actually calculate the atmospheric delay based on the models
+            # start with 7.7 ns and plane atmosphere
+
+            # delay[loind:hiind] = 7.7 * u.nanosecond / np.sin(alt)
+
+            delay[loind:hiind] = self.delay_model(
+                alt, obs.lat, obs.height, grp["tdbld"]
+            )
+
+        return delay
+
+    def delay_model(self, alt, lat, H, mjd):
+
+        return self.zenith_delay(lat, H.to(u.km)) * self.mapping_function(
+            alt, lat, H, mjd
+        )
+
+    def zenith_delay(self, lat, H):
+        # return 7.7 * u.ns
+
+        p = 101
+        return (
+            (p / 43.921)
+            / (const.c.value * (1 - 0.00266 * np.cos(2 * lat) + 0.00028 * H.value))
+            * u.second
+        )
+
+    def _coefficient_func(self, average, amplitudes, yearFraction):
+        return average + 0 * amplitudes * np.cos(2 * np.pi * yearFraction)
+
+    def _find_latitude_index(self, lat):
+        """
+        find the index corresponding to the upper bound on latitude
+        for nearest neighbor interpolation in the mapping function
+        """
+        absLat = np.abs(lat)
+        for lInd in range(len(self.LAT)):
+            if absLat >= self.LAT[lInd - 1]:
+                return lInd
+        # else this is an invalid latitude... huh?
+        raise ValueError("Invaid latitude: %s must be between -90 and 90 degrees" % lat)
+
+    def mapping_function(self, alt, lat, H, mjd):
+
+        # yearFraction = np.mod(jyear, 1)
+        # for now just set the year fraction to 0 and don't change anything
+        # yearFraction = np.zeros(len(mjd))  # come back and fix this later
+
+        yearFraction = self._get_year_fraction_fast(mjd, lat)
+        """
+        according to Niell, the way to use latitude interpolation is to interpolate
+        between the nearest definite latitude coefficient functions.  So that means
+        I need to calcualte the function, then I can go back and interpolate between the results.
+        I figure the easiest way to do this will be to calculate the function on the entire array
+        """
+
+        # first I need to find the nearest latitude neighbors
+        latIndex = self._find_latitude_index(lat)
+
+        aNeighbors = [
+            self._coefficient_func(self.A_AVG[i], self.A_AMP[i], yearFraction)
+            for i in range(latIndex, latIndex + 2)
+        ]
+        bNeighbors = [
+            self._coefficient_func(self.B_AVG[i], self.B_AMP[i], yearFraction)
+            for i in range(latIndex, latIndex + 2)
+        ]
+        cNeighbors = [
+            self._coefficient_func(self.C_AVG[i], self.C_AMP[i], yearFraction)
+            for i in range(latIndex, latIndex + 2)
+        ]
+
+        # now time to interpolate between them
+        latNeighbors = self.LAT[latIndex : latIndex + 2]
+
+        a = self._interp(np.abs(lat), latNeighbors, aNeighbors)
+        b = self._interp(np.abs(lat), latNeighbors, bNeighbors)
+        c = self._interp(np.abs(lat), latNeighbors, cNeighbors)
+
+        # now finally the mapping formula
+        # return 1 / np.sin(alt)
+
+        baseMap = 1 / (
+            (1 / (1 + a / (1 + b / (1 + c))))
+            / (1 / (np.sin(alt) + a / (np.sin(alt) + b / (np.sin(alt) + c))))
+        )
+
+        # now add in the mapping correction based on height
+        fcorrection = 1 / (
+            (1 / (1 + self.A_HT / (1 + self.B_HT / (1 + self.C_HT))))
+            / (
+                1
+                / (
+                    np.sin(alt)
+                    + self.A_HT / (np.sin(alt) + self.B_HT / (np.sin(alt) + self.C_HT))
+                )
+            )
+        )
+
+        return baseMap + (1 / np.sin(alt) - fcorrection) * H.to(u.km).value
+
+        """
+        for i in range(len(tab["obs"])):
+            obs = get_observatory(tab["obs"][i]).earth_location_itrf()
+            transAltaz = AltAz(location=obs, obstime=tab["mjd"][i])
+            altaz = radec.transform_to(transAltaz)
+            altitudes[i] = altaz.alt.value
+        return altitudes
+        """
+
+    @staticmethod
+    def _interp(x, xn, yn):
+        # vectorized 1d interpolation for 2 points only
+        return (x - xn[0]) * (yn[1] - yn[0]) / (xn[1] - xn[0]) + yn[0]
+
+    def _get_year_fraction_slow(self, mjd, lat):
+        """
+        use python for loop and astropy to calculate the year fraction
+        but it's more slow because of the looping
+        """
+
+        seasonOffset = 0.0
+        if lat < 0:
+            seasonOffset = 0.5
+
+        yearFraction = np.array(
+            [(i.jyear + seasonOffset + self.DOY_OFFSET / 365.25) % 1.0 for i in mjd]
+        )
+        return yearFraction
+
+    def _get_year_fraction_fast(self, tdbld, lat):
+        """
+        use numpy array arithmetic to calculate the year fraction more quickly
+        """
+        seasonOffset = 0.0
+        if lat < 0:
+            seasonOffset = 0.5
+        return np.mod(
+            2000.0 + (tdbld - 51544.5 + self.DOY_OFFSET) / (365.25) + seasonOffset, 1.0
+        )

--- a/tests/test_troposphere_model.py
+++ b/tests/test_troposphere_model.py
@@ -21,7 +21,7 @@ class TestTroposphereDelay(unittest.TestCase):
     FLOAT_THRESHOLD = 1e-12  #
 
     def setUp(self):
-        ngc = "datafile/NGC6440E"
+        ngc = "tests/datafile/NGC6440E"
 
         self.toas = toa.get_TOAs(ngc + ".tim")
         self.model = pint.models.get_model(ngc + ".par")

--- a/tests/test_troposphere_model.py
+++ b/tests/test_troposphere_model.py
@@ -21,7 +21,7 @@ class TestTroposphereDelay(unittest.TestCase):
     FLOAT_THRESHOLD = 1e-12  #
 
     def setUp(self):
-        ngc = "tests/datafile/NGC6440E"
+        ngc = "NGC6440E"
 
         self.toas = toa.get_TOAs(ngc + ".tim")
         self.model = pint.models.get_model(ngc + ".par")

--- a/tests/test_troposphere_model.py
+++ b/tests/test_troposphere_model.py
@@ -18,14 +18,26 @@ class TestTroposphereDelay(unittest.TestCase):
 
     MIN_ALT = 5  # the minimum altitude in degrees for testing the delay model
 
+    FLOAT_THRESHOLD = 1e-12  #
+
     def setUp(self):
+        ngc = "datafile/NGC6440E"
+
         self.toas = toa.get_TOAs(ngc + ".tim")
         self.model = pint.models.get_model(ngc + ".par")
+        self.modelWithTD = pint.models.get_model(ngc + ".par")
+        self.modelWithTD.CORRECT_TROPOSPHERE.value = True
+
+        self.toasInvalid = toa.get_TOAs(ngc + ".tim")
+
+        for i in range(len(self.toasInvalid.table)):
+            # adjust the timing by half a day to make them invalid
+            self.toasInvalid.table["mjd"][i] += 0.5
 
         self.testAltitudes = np.arange(self.MIN_ALT, 90, 100) * u.deg
         self.testHeights = np.array([10, 100, 1000, 5000]) * u.m
 
-        self.td = TroposphereDelay()
+        self.td = self.modelWithTD.components["TroposphereDelay"]
 
     def test_altitudes(self):
         # the troposphere delay should strictly decrease with increasing altitude above horizon
@@ -39,6 +51,21 @@ class TestTroposphereDelay(unittest.TestCase):
         heightDelays = []  # list of the delays at each height
         for h in self.testHeights:
             heightDelays.append(self.td.delay_model(self.testAltitudes, 0, h, 0))
-
-        for i in range(1, len(testHeights)):
+        for i in range(1, len(self.testHeights)):
+            print(heightDelays[i], heightDelays[i - 1])
             assert np.all(np.less(heightDelays[i], heightDelays[i - 1]))
+
+    def test_model_access(self):
+        # make sure that the model components are linked correctly to the troposphere delay
+        assert hasattr(self.model, "CORRECT_TROPOSPHERE")
+
+        # the model should have the sky coordinates defined
+        assert self.td._get_target_skycoord() is not None
+
+    def test_invalid_altitudes(self):
+        assert np.all(
+            np.less_equal(
+                np.abs(self.td.troposphere_delay(self.toasInvalid)),
+                self.FLOAT_THRESHOLD * u.s,
+            )
+        )

--- a/tests/test_troposphere_model.py
+++ b/tests/test_troposphere_model.py
@@ -10,7 +10,6 @@ import pint.observatory
 import pint.toa as toa
 from astropy.coordinates import AltAz, SkyCoord
 from astropy.time import Time
-from pint.models.troposphere_delay import TroposphereDelay
 from pint.observatory import get_observatory
 
 from pinttestdata import testdir
@@ -63,6 +62,7 @@ class TestTroposphereDelay(unittest.TestCase):
     def test_model_access(self):
         # make sure that the model components are linked correctly to the troposphere delay
         assert hasattr(self.model, "CORRECT_TROPOSPHERE")
+        assert "TroposphereDelay" in self.modelWithTD.components.keys()
 
         # the model should have the sky coordinates defined
         assert self.td._get_target_skycoord() is not None

--- a/tests/test_troposphere_model.py
+++ b/tests/test_troposphere_model.py
@@ -74,3 +74,18 @@ class TestTroposphereDelay(unittest.TestCase):
                 self.FLOAT_THRESHOLD * u.s,
             )
         )
+
+    def test_latitude_index(self):
+        # the code relies on finding the neighboring latitudes to any site
+        # for atmospheric constants defined at every 15 degrees
+        # so I will test the nearest neighbors function
+
+        l1 = self.td._find_latitude_index(20 * u.deg)
+        l2 = self.td._find_latitude_index(-80 * u.deg)
+        l3 = self.td._find_latitude_index(0 * u.deg)
+        l4 = self.td._find_latitude_index(-90 * u.deg)
+
+        assert self.td.LAT[l1] <= 20 * u.deg < self.td.LAT[l1 + 1]
+        assert self.td.LAT[l2] <= 80 * u.deg <= self.td.LAT[l2 + 1]
+        assert self.td.LAT[l3] <= 0 * u.deg <= self.td.LAT[l3 + 1]
+        assert self.td.LAT[l4] <= 90 * u.deg <= self.td.LAT[l4 + 1]

--- a/tests/test_troposphere_model.py
+++ b/tests/test_troposphere_model.py
@@ -13,6 +13,8 @@ from astropy.time import Time
 from pint.models.troposphere_delay import TroposphereDelay
 from pint.observatory import get_observatory
 
+from pinttestdata import testdir
+
 
 class TestTroposphereDelay(unittest.TestCase):
 
@@ -21,14 +23,17 @@ class TestTroposphereDelay(unittest.TestCase):
     FLOAT_THRESHOLD = 1e-12  #
 
     def setUp(self):
-        ngc = "NGC6440E"
 
-        self.toas = toa.get_TOAs(ngc + ".tim")
-        self.model = pint.models.get_model(ngc + ".par")
-        self.modelWithTD = pint.models.get_model(ngc + ".par")
+        datadir = os.path.join(testdir, "datafile")
+        # parfile = os.path.join(datadir, "J1744-1134.basic.par")
+        # ngc = os.path.join(datadir, "NGC6440E")
+
+        self.toas = toa.get_TOAs(os.path.join(datadir, "NGC6440E.tim"))
+        self.model = pint.models.get_model(os.path.join(datadir, "NGC6440E.par"))
+        self.modelWithTD = pint.models.get_model(os.path.join(datadir, "NGC6440E.par"))
         self.modelWithTD.CORRECT_TROPOSPHERE.value = True
 
-        self.toasInvalid = toa.get_TOAs(ngc + ".tim")
+        self.toasInvalid = toa.get_TOAs(os.path.join(datadir, "NGC6440E.tim"))
 
         for i in range(len(self.toasInvalid.table)):
             # adjust the timing by half a day to make them invalid

--- a/tests/test_troposphere_model.py
+++ b/tests/test_troposphere_model.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+import os
+import unittest
+
+import astropy.units as u
+import numpy as np
+import pint.models as models
+import pint.observatory
+import pint.toa as toa
+from astropy.coordinates import AltAz, SkyCoord
+from astropy.time import Time
+from pint.models.troposphere_delay import TroposphereDelay
+from pint.observatory import get_observatory
+
+
+class TestTroposphereDelay(unittest.TestCase):
+
+    MIN_ALT = 5  # the minimum altitude in degrees for testing the delay model
+
+    def setUp(self):
+        self.toas = toa.get_TOAs(ngc + ".tim")
+        self.model = pint.models.get_model(ngc + ".par")
+
+        self.testAltitudes = np.arange(self.MIN_ALT, 90, 100) * u.deg
+        self.testHeights = np.array([10, 100, 1000, 5000]) * u.m
+
+        self.td = TroposphereDelay()
+
+    def test_altitudes(self):
+        # the troposphere delay should strictly decrease with increasing altitude above horizon
+        delays = self.td.delay_model(self.testAltitudes, 0, 1000 * u.m, 0)
+
+        for i in range(1, len(delays)):
+            assert delays[i] < delays[i - 1]
+
+    def test_heights(self):
+        # higher elevation observatories should have less troposphere delay
+        heightDelays = []  # list of the delays at each height
+        for h in self.testHeights:
+            heightDelays.append(self.td.delay_model(self.testAltitudes, 0, h, 0))
+
+        for i in range(1, len(testHeights)):
+            assert np.all(np.less(heightDelays[i], heightDelays[i - 1]))


### PR DESCRIPTION
This adds a model to account for the tropospheric delay of TOAs for ground-based observatory.  It will use the location of each observatory to calculate the angular altitude of the target pulsar and corresponding delay.  

The models used are:

- Zenith hydrostatic delay based on [Davis et al. (1985)](https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/RS020i006p01593)
- Mapping function to different locations in the sky from [Niell (1996)](https://www.haystack.mit.edu/geo/pubs/NMF_JGR.pdf)
- Eventual inclusion of wet zenith delay and corresponding Niell wet mapping function