### PR TITLE
Avoid unnecessary 'More than one component' warning

### DIFF
--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -1421,7 +1421,7 @@ class maskParameter(floatParameter):
     def name_matches(self, name):
         if super(maskParameter, self).name_matches(name):
             return True
-        else:
+        elif self.index == 1:
             name_idx = name + str(self.index)
             return super(maskParameter, self).name_matches(name_idx)
 


### PR DESCRIPTION
Fixes #627. The issue there was that, when reading in a par file containing mask parameters, PINT would see the first line containing a specific kind of parameter as pertinent to all the parameters of that kind, causing it to complain (for no good reason) that they all made use of that line. For example, in a par file with multiple JUMPs that weren't explicitly numbered, the parameters JUMP1, JUMP2, etc. would all try to use the first JUMP line (and would fill themselves in with the appropriate values). For subsequent JUMP lines, PINT would recognize them as duplicates, and so treat them as if they started "JUMP2", "JUMP3", etc., so there was no real issue -- the JUMP2, etc. parameters would overwrite the original, incorrect values with new, correct ones.

This PR is a one-line change that avoids the whole situation by making it so that only the first `maskParameter` of a given kind (JUMP1 in the example) is considered to match a line starting with the un-numbered name (JUMP). Since the duplicates all get numbers added to them (the second JUMP becomes JUMP2, etc.), there's no need to have them match un-numbered lines, and doing so just creates the confusing warning.