### PR TITLE
Addgalactic

### DIFF
--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -302,6 +302,13 @@ class AstrometryEquatorial(Astrometry):
         pos_icrs = self.get_psr_coords(epoch=epoch)
         return pos_icrs.transform_to(PulsarEcliptic(ecl=ecl))
 
+    def coords_as_GAL(self, epoch=None):
+        """Return the pulsar's galactic coordinates as an astropy coordinate object.
+        
+        """
+        pos_icrs = self.get_psr_coords(epoch=epoch)
+        return pos_icrs.transform_to(coords.Galactic)
+
     def get_params_as_ICRS(self):
         result = {
             "RAJ": self.RAJ.quantity,
@@ -545,6 +552,13 @@ class AstrometryEcliptic(Astrometry):
         """Return the pulsar's ICRS coordinates as an astropy coordinate object."""
         pos_ecl = self.get_psr_coords(epoch=epoch)
         return pos_ecl.transform_to(coords.ICRS)
+
+    def coords_as_GAL(self, epoch=None):
+        """Return the pulsar's galactic coordinates as an astropy coordinate object.
+        
+        """
+        pos_ecl = self.get_psr_coords(epoch=epoch)
+        return pos_ecl.transform_to(coords.Galactic)
 
     def coords_as_ECL(self, epoch=None, ecl=None):
         """Return the pulsar's ecliptic coordinates as an astropy coordinate object.

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -272,16 +272,20 @@ class AstrometryEquatorial(Astrometry):
             dRA = 0.0 * u.hourangle
             dDEC = 0.0 * u.deg
             broadcast = 1
+            newepoch = self.POSEPOCH.quantity
         else:
             dt = (epoch - self.POSEPOCH.quantity.mjd) * u.d
             dRA = dt * self.PMRA.quantity / numpy.cos(self.DECJ.quantity.radian)
             dDEC = dt * self.PMDEC.quantity
             broadcast = numpy.ones_like(epoch)
-        return coords.ICRS(
+            newepoch = Time(epoch, format="mjd")
+        return coords.SkyCoord(
             ra=self.RAJ.quantity + dRA,
             dec=self.DECJ.quantity + dDEC,
             pm_ra_cosdec=self.PMRA.quantity * broadcast,
             pm_dec=self.PMDEC.quantity * broadcast,
+            obstime=newepoch,
+            frame=coords.ICRS,
         )
 
     def coords_as_ICRS(self, epoch=None):
@@ -533,18 +537,22 @@ class AstrometryEcliptic(Astrometry):
             dELONG = 0.0 * self.ELONG.units
             dELAT = 0.0 * self.ELAT.units
             broadcast = 1
+            newepoch = self.POSEPOCH.quantity
         else:
             dt = (epoch - self.POSEPOCH.quantity.mjd) * u.d
             dELONG = dt * self.PMELONG.quantity / numpy.cos(self.ELAT.quantity.radian)
             dELAT = dt * self.PMELAT.quantity
             broadcast = numpy.ones_like(epoch)
+            newepoch = Time(epoch, format="mjd")
 
-        pos_ecl = PulsarEcliptic(
+        pos_ecl = coords.SkyCoord(
             obliquity=obliquity,
             lon=self.ELONG.quantity + dELONG,
             lat=self.ELAT.quantity + dELAT,
             pm_lon_coslat=self.PMELONG.quantity * broadcast,
             pm_lat=self.PMELAT.quantity * broadcast,
+            frame=PulsarEcliptic,
+            obstime=newepoch,
         )
         return pos_ecl
 

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1400,19 +1400,20 @@ def FTest(chi2_1, dof_1, chi2_2, dof_2):
 
 
 def add_dummy_distance(c, distance=1 * u.kpc):
-    """Adds a dummy distance to a SkyCoord object for applying proper motion
+    """
+    Adds a dummy distance to a SkyCoord object for applying proper motion
 
     Parameters
-      ----------
-      c: `astropy.coordinates.sky_coordinate.SkyCoord` object
-          current SkyCoord object without distance but with proper motion and obstime
-      distance: `Quantity`, optional
-          distance to supply
+    ----------
+    c: `astropy.coordinates.sky_coordinate.SkyCoord` object
+        current SkyCoord object without distance but with proper motion and obstime
+    distance: `Quantity`, optional
+        distance to supply
 
-      Returns
-      -------
-      cnew
-          new SkyCoord object with a distance attached
+    Returns
+    -------
+    cnew
+        new SkyCoord object with a distance attached
     """
 
     if c.frame.data.differentials == {}:
@@ -1480,17 +1481,18 @@ def add_dummy_distance(c, distance=1 * u.kpc):
 
 
 def remove_dummy_distance(c):
-    """Removes a dummy distance from a SkyCoord object after applying proper motion
+    """
+    Removes a dummy distance from a SkyCoord object after applying proper motion
 
     Parameters
-      ----------
-      c: `astropy.coordinates.sky_coordinate.SkyCoord` object
-          current SkyCoord object with distance and with proper motion and obstime
+    ----------
+    c: `astropy.coordinates.sky_coordinate.SkyCoord` object
+        current SkyCoord object with distance and with proper motion and obstime
 
-      Returns
-      -------
-      cnew
-          new SkyCoord object with a distance removed
+    Returns
+    -------
+    cnew
+        new SkyCoord object with a distance removed
     """
 
     if c.frame.data.differentials == {}:

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 import astropy.units as u
 from astropy import log
 import astropy.constants as const
+import astropy.coordinates as coords
 import numpy as np
 import six
 import scipy.optimize.zeros as zeros
@@ -14,6 +15,9 @@ from scipy.special import fdtrc
 
 
 from io import StringIO
+
+import pint.pulsar_ecliptic
+
 
 __all__ = [
     "PosVel",
@@ -46,6 +50,8 @@ __all__ = [
     "pulsar_B",
     "pulsar_B_lightcyl",
     "FTest",
+    "add_dummy_distance",
+    "remove_dummy_distance",
 ]
 
 
@@ -1391,3 +1397,157 @@ def FTest(chi2_1, dof_1, chi2_2, dof_2):
             log.warning("Models have equal degrees of freedom, cannot preform F-test.")
         ft = False
     return ft
+
+
+def add_dummy_distance(c, distance=1 * u.kpc):
+    """Adds a dummy distance to a SkyCoord object for applying proper motion
+
+    Parameters
+      ----------
+      c: `astropy.coordinates.sky_coordinate.SkyCoord` object
+          current SkyCoord object without distance but with proper motion and obstime
+      distance: `Quantity`, optional
+          distance to supply
+
+      Returns
+      -------
+      cnew
+          new SkyCoord object with a distance attached
+    """
+
+    if c.frame.data.differentials == {}:
+        log.warning(
+            "No proper motions available for %r: returning coordinates unchanged" % c
+        )
+        return c
+    if c.obstime is None:
+        log.warning("No obstime available for %r: returning coordinates unchanged" % c)
+        return c
+
+    if isinstance(c.frame, coords.builtin_frames.icrs.ICRS):
+        if hasattr(c, "pm_ra_cosdec"):
+            cnew = coords.SkyCoord(
+                ra=c.ra,
+                dec=c.dec,
+                pm_ra_cosdec=c.pm_ra_cosdec,
+                pm_dec=c.pm_dec,
+                obstime=c.obstime,
+                distance=distance,
+                frame=coords.ICRS,
+            )
+        else:
+            # it seems that after applying proper motions
+            # it changes the RA pm to pm_ra instead of pm_ra_cosdec
+            # although the value seems the same
+            cnew = coords.SkyCoord(
+                ra=c.ra,
+                dec=c.dec,
+                pm_ra_cosdec=c.pm_ra,
+                pm_dec=c.pm_dec,
+                obstime=c.obstime,
+                distance=distance,
+                frame=coords.ICRS,
+            )
+
+        return cnew
+    elif isinstance(c.frame, coords.builtin_frames.galactic.Galactic):
+        cnew = coords.SkyCoord(
+            l=c.l,
+            b=c.b,
+            pm_l_cosb=c.pm_l_cosb,
+            pm_b=c.pm_b,
+            obstime=c.obstime,
+            distance=distance,
+            frame=coords.Galactic,
+        )
+        return cnew
+    elif isinstance(c.frame, pint.pulsar_ecliptic.PulsarEcliptic):
+        cnew = coords.SkyCoord(
+            lon=c.lon,
+            lat=c.lat,
+            pm_lon_coslat=c.pm_lon_coslat,
+            pm_lat=c.pm_lat,
+            obstime=c.obstime,
+            distance=distance,
+            frame=pint.pulsar_ecliptic.PulsarEcliptic,
+        )
+        return cnew
+    else:
+        log.warning(
+            "Do not know coordinate frame for %r: returning coordinates unchanged" % c
+        )
+        return c
+
+
+def remove_dummy_distance(c):
+    """Removes a dummy distance from a SkyCoord object after applying proper motion
+
+    Parameters
+      ----------
+      c: `astropy.coordinates.sky_coordinate.SkyCoord` object
+          current SkyCoord object with distance and with proper motion and obstime
+
+      Returns
+      -------
+      cnew
+          new SkyCoord object with a distance removed
+    """
+
+    if c.frame.data.differentials == {}:
+        log.warning(
+            "No proper motions available for %r: returning coordinates unchanged" % c
+        )
+        return c
+    if c.obstime is None:
+        log.warning("No obstime available for %r: returning coordinates unchanged" % c)
+        return c
+
+    if isinstance(c.frame, coords.builtin_frames.icrs.ICRS):
+        if hasattr(c, "pm_ra_cosdec"):
+
+            cnew = coords.SkyCoord(
+                ra=c.ra,
+                dec=c.dec,
+                pm_ra_cosdec=c.pm_ra_cosdec,
+                pm_dec=c.pm_dec,
+                obstime=c.obstime,
+                frame=coords.ICRS,
+            )
+        else:
+            # it seems that after applying proper motions
+            # it changes the RA pm to pm_ra instead of pm_ra_cosdec
+            # although the value seems the same
+            cnew = coords.SkyCoord(
+                ra=c.ra,
+                dec=c.dec,
+                pm_ra_cosdec=c.pm_ra,
+                pm_dec=c.pm_dec,
+                obstime=c.obstime,
+                frame=coords.ICRS,
+            )
+        return cnew
+    elif isinstance(c.frame, coords.builtin_frames.galactic.Galactic):
+        cnew = coords.SkyCoord(
+            l=c.l,
+            b=c.b,
+            pm_l_cosb=c.pm_l_cosb,
+            pm_b=c.pm_b,
+            obstime=c.obstime,
+            frame=coords.Galactic,
+        )
+        return cnew
+    elif isinstance(c.frame, pint.pulsar_ecliptic.PulsarEcliptic):
+        cnew = coords.SkyCoord(
+            lon=c.lon,
+            lat=c.lat,
+            pm_lon_coslat=c.pm_lon_coslat,
+            pm_lat=c.pm_lat,
+            obstime=c.obstime,
+            frame=pint.pulsar_ecliptic.PulsarEcliptic,
+        )
+        return cnew
+    else:
+        log.warning(
+            "Do not know coordinate frame for %r: returning coordinates unchanged" % c
+        )
+        return c

--- a/tests/test_Galactic.py
+++ b/tests/test_Galactic.py
@@ -1,0 +1,191 @@
+import logging
+import os
+import unittest
+
+import astropy.units as u
+import numpy as np
+
+import pint.models.model_builder as mb
+import pint.toa as toa
+import test_derivative_utils as tdu
+from pint.residuals import Residuals
+from pinttestdata import datadir
+from pint.pulsar_ecliptic import PulsarEcliptic
+
+import astropy.coordinates
+import astropy.time
+
+
+class TestGalactic(unittest.TestCase):
+    """Test conversion from equatorial/ecliptic -> Galactic coordinates as astropy objects"""
+
+    @classmethod
+    def setUpClass(cls):
+        # J0613 is in equatorial
+        cls.parfileJ0613 = os.path.join(
+            datadir, "J0613-0200_NANOGrav_dfg+12_TAI_FB90.par"
+        )
+        cls.modelJ0613 = mb.get_model(cls.parfileJ0613)
+
+        # B1855+09 is in ecliptic
+        cls.parfileB1855 = os.path.join(datadir, "B1855+09_NANOGrav_9yv1.gls.par")
+        cls.modelB1855 = mb.get_model(cls.parfileB1855)
+
+        cls.log = logging.getLogger("TestGalactic")
+
+    def test_proper_motion(self):
+        """
+        use the PINT and astropy proper motion calculations and compare
+        """
+
+        # make a test SkyCoord object
+        # make sure it has obstime and distance supplied
+        # to use it for conversions as well
+        J0613_icrs = self.modelJ0613.coords_as_ICRS()
+        J0613_icrs_now = astropy.coordinates.SkyCoord(
+            ra=J0613_icrs.ra,
+            dec=J0613_icrs.dec,
+            pm_ra_cosdec=J0613_icrs.pm_ra_cosdec,
+            pm_dec=J0613_icrs.pm_dec,
+            distance=1 * u.kpc,
+            obstime=self.modelJ0613.POSEPOCH.quantity,
+        )
+        newepoch = self.modelJ0613.POSEPOCH.quantity.mjd + 100
+        # now do it for a future epoch
+        J0613_icrs = self.modelJ0613.coords_as_ICRS(epoch=newepoch)
+        # and use the coordinates now but use astropy's space motion
+        J0613_icrs_now_to_then = J0613_icrs_now.apply_space_motion(
+            new_obstime=astropy.time.Time(newepoch, format="mjd")
+        )
+        sep = J0613_icrs.separation(J0613_icrs_now_to_then)
+        msg = (
+            "Applying proper motion for +100d failed with separation %.1e arcsec"
+            % sep.arcsec
+        )
+        assert sep < 1e-6 * u.arcsec, msg
+
+    def test_equatorial_to_galactic(self):
+        """
+        start with a pulsar in equatorial coordinates
+        convert to Galactic and make sure the positions are consistent
+
+        then apply the space motion to the equatorial object & convert to Galactic
+        compare that to the Galactic object w/ space motion
+        
+        """
+
+        # make a test SkyCoord object
+        # make sure it has obstime and distance supplied
+        # to use it for conversions as well
+        J0613_icrs = self.modelJ0613.coords_as_ICRS()
+        J0613_icrs_now = astropy.coordinates.SkyCoord(
+            ra=J0613_icrs.ra,
+            dec=J0613_icrs.dec,
+            pm_ra_cosdec=J0613_icrs.pm_ra_cosdec,
+            pm_dec=J0613_icrs.pm_dec,
+            distance=1 * u.kpc,
+            obstime=self.modelJ0613.POSEPOCH.quantity,
+        )
+
+        J0613_galactic = self.modelJ0613.coords_as_GAL()
+        J0613_galactic_now = astropy.coordinates.SkyCoord(
+            l=J0613_galactic.l,
+            b=J0613_galactic.b,
+            pm_l_cosb=J0613_galactic.pm_l_cosb,
+            pm_b=J0613_galactic.pm_b,
+            distance=1 * u.kpc,
+            obstime=self.modelJ0613.POSEPOCH.quantity,
+            frame=astropy.coordinates.Galactic,
+        )
+
+        newepoch = self.modelJ0613.POSEPOCH.quantity.mjd + 100
+
+        # what I get converting within astropy
+        J0613_galactic_comparison = J0613_icrs_now.transform_to(
+            astropy.coordinates.Galactic
+        )
+        sep = J0613_galactic_now.separation(J0613_galactic_comparison)
+        msg = (
+            "Equatorial to Galactic conversion for now failed with separation %.1e arcsec"
+            % sep.arcsec
+        )
+        assert sep < 1e-5 * u.arcsec, msg
+
+        print(J0613_icrs_now)
+        print(J0613_galactic_now)
+
+        J0613_icrs = self.modelJ0613.coords_as_ICRS(epoch=newepoch)
+        # what I get converting within astropy
+        J0613_galactic_comparison = J0613_icrs.transform_to(
+            astropy.coordinates.Galactic
+        )
+        J0613_galactic_then = J0613_galactic_now.apply_space_motion(
+            new_obstime=astropy.time.Time(newepoch, format="mjd")
+        )
+        sep = J0613_galactic_then.separation(J0613_galactic_comparison)
+        msg = (
+            "Equatorial to Galactic conversion for +100d failed with separation %.1e arcsec"
+            % sep.arcsec
+        )
+        assert sep < 1e-6 * u.arcsec, msg
+
+    def test_ecliptic_to_galactic(self):
+        """
+        start with a pulsar in ecliptic coordinates
+        convert to Galactic and make sure the positions are consistent
+
+        then apply the space motion to the ecliptic object & convert to Galactic
+        compare that to the Galactic object w/ space motion
+        
+        """
+
+        # make a test SkyCoord object
+        # make sure it has obstime and distance supplied
+        # to use it for conversions as well
+        B1855_ECL = self.modelB1855.coords_as_ECL()
+        B1855_ECL_now = astropy.coordinates.SkyCoord(
+            lon=B1855_ECL.lon,
+            lat=B1855_ECL.lat,
+            pm_lon_coslat=B1855_ECL.pm_lon_coslat,
+            pm_lat=B1855_ECL.pm_lat,
+            distance=1 * u.kpc,
+            obstime=self.modelB1855.POSEPOCH.quantity,
+            frame=PulsarEcliptic,
+        )
+
+        B1855_galactic = self.modelB1855.coords_as_GAL()
+        B1855_galactic_now = astropy.coordinates.SkyCoord(
+            l=B1855_galactic.l,
+            b=B1855_galactic.b,
+            pm_l_cosb=B1855_galactic.pm_l_cosb,
+            pm_b=B1855_galactic.pm_b,
+            distance=1 * u.kpc,
+            obstime=self.modelB1855.POSEPOCH.quantity,
+            frame=astropy.coordinates.Galactic,
+        )
+
+        newepoch = self.modelB1855.POSEPOCH.quantity.mjd + 100
+
+        # what I get converting within astropy
+        B1855_galactic_comparison = B1855_ECL_now.transform_to(
+            astropy.coordinates.Galactic
+        )
+        sep = B1855_galactic_now.separation(B1855_galactic_comparison)
+        msg = (
+            "Ecliptic to Galactic conversion for now failed with separation %.1e arcsec"
+            % sep.arcsec
+        )
+        assert sep < 1e-4 * u.arcsec, msg
+
+        B1855_ECL = self.modelB1855.coords_as_ECL(epoch=newepoch)
+        # what I get converting within astropy
+        B1855_galactic_comparison = B1855_ECL.transform_to(astropy.coordinates.Galactic)
+        B1855_galactic_then = B1855_galactic_now.apply_space_motion(
+            new_obstime=astropy.time.Time(newepoch, format="mjd")
+        )
+        sep = B1855_galactic_then.separation(B1855_galactic_comparison)
+        msg = (
+            "Ecliptic to Galactic conversion for +100d failed with separation %.1e arcsec"
+            % sep.arcsec
+        )
+        assert sep < 1e-6 * u.arcsec, msg

--- a/tests/test_Galactic.py
+++ b/tests/test_Galactic.py
@@ -48,8 +48,6 @@ class TestGalactic(unittest.TestCase):
         # now do it for a future epoch
         J0613_icrs = self.modelJ0613.coords_as_ICRS(epoch=newepoch)
         # and use the coordinates now but use astropy's space motion
-        print(J0613_icrs)
-        print(J0613_icrs_now)
         print(
             J0613_icrs_now.apply_space_motion(
                 new_obstime=astropy.time.Time(newepoch, format="mjd")
@@ -59,6 +57,19 @@ class TestGalactic(unittest.TestCase):
             J0613_icrs_now.apply_space_motion(
                 new_obstime=astropy.time.Time(newepoch, format="mjd")
             )
+        )
+        sep = J0613_icrs.separation(J0613_icrs_now_to_then)
+        msg = (
+            "Applying proper motion for +100d failed with separation %.1e arcsec"
+            % sep.arcsec
+        )
+        assert sep < 1e-6 * u.arcsec, msg
+
+        # make sure it can support newepoch supplied as a Time object
+        newepoch = astropy.time.Time(newepoch, format="mjd")
+        J0613_icrs = self.modelJ0613.coords_as_ICRS(epoch=newepoch)
+        J0613_icrs_now_to_then = utils.remove_dummy_distance(
+            J0613_icrs_now.apply_space_motion(new_obstime=newepoch,)
         )
         sep = J0613_icrs.separation(J0613_icrs_now_to_then)
         msg = (

--- a/tests/test_Galactic.py
+++ b/tests/test_Galactic.py
@@ -11,6 +11,7 @@ import test_derivative_utils as tdu
 from pint.residuals import Residuals
 from pinttestdata import datadir
 from pint.pulsar_ecliptic import PulsarEcliptic
+from pint import utils
 
 import astropy.coordinates
 import astropy.time
@@ -42,20 +43,22 @@ class TestGalactic(unittest.TestCase):
         # make sure it has obstime and distance supplied
         # to use it for conversions as well
         J0613_icrs = self.modelJ0613.coords_as_ICRS()
-        J0613_icrs_now = astropy.coordinates.SkyCoord(
-            ra=J0613_icrs.ra,
-            dec=J0613_icrs.dec,
-            pm_ra_cosdec=J0613_icrs.pm_ra_cosdec,
-            pm_dec=J0613_icrs.pm_dec,
-            distance=1 * u.kpc,
-            obstime=self.modelJ0613.POSEPOCH.quantity,
-        )
+        J0613_icrs_now = utils.add_dummy_distance(J0613_icrs)
         newepoch = self.modelJ0613.POSEPOCH.quantity.mjd + 100
         # now do it for a future epoch
         J0613_icrs = self.modelJ0613.coords_as_ICRS(epoch=newepoch)
         # and use the coordinates now but use astropy's space motion
-        J0613_icrs_now_to_then = J0613_icrs_now.apply_space_motion(
-            new_obstime=astropy.time.Time(newepoch, format="mjd")
+        print(J0613_icrs)
+        print(J0613_icrs_now)
+        print(
+            J0613_icrs_now.apply_space_motion(
+                new_obstime=astropy.time.Time(newepoch, format="mjd")
+            )
+        )
+        J0613_icrs_now_to_then = utils.remove_dummy_distance(
+            J0613_icrs_now.apply_space_motion(
+                new_obstime=astropy.time.Time(newepoch, format="mjd")
+            )
         )
         sep = J0613_icrs.separation(J0613_icrs_now_to_then)
         msg = (
@@ -78,25 +81,10 @@ class TestGalactic(unittest.TestCase):
         # make sure it has obstime and distance supplied
         # to use it for conversions as well
         J0613_icrs = self.modelJ0613.coords_as_ICRS()
-        J0613_icrs_now = astropy.coordinates.SkyCoord(
-            ra=J0613_icrs.ra,
-            dec=J0613_icrs.dec,
-            pm_ra_cosdec=J0613_icrs.pm_ra_cosdec,
-            pm_dec=J0613_icrs.pm_dec,
-            distance=1 * u.kpc,
-            obstime=self.modelJ0613.POSEPOCH.quantity,
-        )
+        J0613_icrs_now = utils.add_dummy_distance(J0613_icrs)
 
         J0613_galactic = self.modelJ0613.coords_as_GAL()
-        J0613_galactic_now = astropy.coordinates.SkyCoord(
-            l=J0613_galactic.l,
-            b=J0613_galactic.b,
-            pm_l_cosb=J0613_galactic.pm_l_cosb,
-            pm_b=J0613_galactic.pm_b,
-            distance=1 * u.kpc,
-            obstime=self.modelJ0613.POSEPOCH.quantity,
-            frame=astropy.coordinates.Galactic,
-        )
+        J0613_galactic_now = utils.add_dummy_distance(J0613_galactic)
 
         newepoch = self.modelJ0613.POSEPOCH.quantity.mjd + 100
 
@@ -119,8 +107,10 @@ class TestGalactic(unittest.TestCase):
         J0613_galactic_comparison = J0613_icrs.transform_to(
             astropy.coordinates.Galactic
         )
-        J0613_galactic_then = J0613_galactic_now.apply_space_motion(
-            new_obstime=astropy.time.Time(newepoch, format="mjd")
+        J0613_galactic_then = utils.remove_dummy_distance(
+            J0613_galactic_now.apply_space_motion(
+                new_obstime=astropy.time.Time(newepoch, format="mjd")
+            )
         )
         sep = J0613_galactic_then.separation(J0613_galactic_comparison)
         msg = (
@@ -143,26 +133,10 @@ class TestGalactic(unittest.TestCase):
         # make sure it has obstime and distance supplied
         # to use it for conversions as well
         B1855_ECL = self.modelB1855.coords_as_ECL()
-        B1855_ECL_now = astropy.coordinates.SkyCoord(
-            lon=B1855_ECL.lon,
-            lat=B1855_ECL.lat,
-            pm_lon_coslat=B1855_ECL.pm_lon_coslat,
-            pm_lat=B1855_ECL.pm_lat,
-            distance=1 * u.kpc,
-            obstime=self.modelB1855.POSEPOCH.quantity,
-            frame=PulsarEcliptic,
-        )
+        B1855_ECL_now = utils.add_dummy_distance(B1855_ECL)
 
         B1855_galactic = self.modelB1855.coords_as_GAL()
-        B1855_galactic_now = astropy.coordinates.SkyCoord(
-            l=B1855_galactic.l,
-            b=B1855_galactic.b,
-            pm_l_cosb=B1855_galactic.pm_l_cosb,
-            pm_b=B1855_galactic.pm_b,
-            distance=1 * u.kpc,
-            obstime=self.modelB1855.POSEPOCH.quantity,
-            frame=astropy.coordinates.Galactic,
-        )
+        B1855_galactic_now = utils.add_dummy_distance(B1855_galactic)
 
         newepoch = self.modelB1855.POSEPOCH.quantity.mjd + 100
 
@@ -180,8 +154,10 @@ class TestGalactic(unittest.TestCase):
         B1855_ECL = self.modelB1855.coords_as_ECL(epoch=newepoch)
         # what I get converting within astropy
         B1855_galactic_comparison = B1855_ECL.transform_to(astropy.coordinates.Galactic)
-        B1855_galactic_then = B1855_galactic_now.apply_space_motion(
-            new_obstime=astropy.time.Time(newepoch, format="mjd")
+        B1855_galactic_then = utils.remove_dummy_distance(
+            B1855_galactic_now.apply_space_motion(
+                new_obstime=astropy.time.Time(newepoch, format="mjd")
+            )
         )
         sep = B1855_galactic_then.separation(B1855_galactic_comparison)
         msg = (


### PR DESCRIPTION
An attempt to add utilities for returning `astropy` `SkyCoord` objects in Galactic coordinates including proper motions.

I have put in some basic unit tests.  These do
* a check of the basic proper motion corrections using the `astropy` and `PINT` routines in native coordinates
* a check of the conversions for t=now and some time in the future using `astropy` and `PINT` routines

the precisions for these comparisons are a bit arbitrary.  I found that most were good to ~1 uas, but some were worse (~100 uas).  Not sure of the origin of that discrepancy.