### PR TITLE
Check for Mixed Coord. Systems in Par File

### DIFF
--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -177,7 +177,8 @@ class ModelBuilder(object):
         return prefixs
 
     def build_model(self, parfile=None, name=""):
-        """Read parfile using the model_instance attribute.
+        """Read parfile using the model_instance attribute. Throws error if 
+           mismatched coordinate systems detected.
         Parameters
         ---------
         name: str, optional
@@ -187,6 +188,25 @@ class ModelBuilder(object):
         """
         if parfile is not None:
             self.get_comp_from_parfile(parfile)
+            # ensure coordinate systems match for POS and PM
+            if "RAJ" in self.preprocess_parfile(parfile).keys():
+                if "PMELONG" in self.preprocess_parfile(parfile):
+                    raise AttributeError(
+                        "Cannot have Ecliptic PM with Equatorial POS in par file."
+                    )
+                elif "PMELAT" in self.preprocess_parfile(parfile):
+                    raise AttributeError(
+                        "Cannot have Ecliptic PM with Equatorial POS in par file."
+                    )
+            elif "ELONG" in self.preprocess_parfile(parfile).keys():
+                if "PMRA" in self.preprocess_parfile(parfile):
+                    raise AttributeError(
+                        "Cannot have Equatorial PM with Ecliptic POS in par file."
+                    )
+                elif "PMDEC" in self.preprocess_parfile(parfile):
+                    raise AttributeError(
+                        "Cannot have Equatorial PM with Ecliptic POS in par file."
+                    )
         sorted_comps = self.sort_components()
         self.timing_model = TimingModel(name, sorted_comps)
         param_inModel = self.timing_model.get_params_mapping()

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -192,20 +192,20 @@ class ModelBuilder(object):
             if "RAJ" in self.preprocess_parfile(parfile).keys():
                 if "PMELONG" in self.preprocess_parfile(parfile):
                     raise AttributeError(
-                        "Cannot have Ecliptic PM with Equatorial POS in par file."
+                        "Cannot have Ecliptic proper motion parameters (PMELONG/PMELAT) with Equatorial position parameters (RAJ/DECJ) in par file."
                     )
                 elif "PMELAT" in self.preprocess_parfile(parfile):
                     raise AttributeError(
-                        "Cannot have Ecliptic PM with Equatorial POS in par file."
+                        "Cannot have Ecliptic proper motion parameters (PMELONG/PMELAT) with Equatorial position parameters (RAJ/DECJ) in par file."
                     )
             elif "ELONG" in self.preprocess_parfile(parfile).keys():
                 if "PMRA" in self.preprocess_parfile(parfile):
                     raise AttributeError(
-                        "Cannot have Equatorial PM with Ecliptic POS in par file."
+                        "Cannot have Equatorial proper motion parameters (PMRA/PMDEC) with Ecliptic position parameters (ELONG/ELAT) in par file."
                     )
                 elif "PMDEC" in self.preprocess_parfile(parfile):
                     raise AttributeError(
-                        "Cannot have Equatorial PM with Ecliptic POS in par file."
+                        "Cannot have Equatorial proper motion parameters (PMRA/PMDEC) with Ecliptic position parameters (ELONG/ELAT) in par file."
                     )
         sorted_comps = self.sort_components()
         self.timing_model = TimingModel(name, sorted_comps)

--- a/tests/test_model_manual.py
+++ b/tests/test_model_manual.py
@@ -106,7 +106,7 @@ def test_ecliptic(gm):
     assert "AstrometryEcliptic" in m.components
 
 
-bad_trouble = ["J1923+2515_NANOGrav_9yv1.gls.par"]
+bad_trouble = ["J1923+2515_NANOGrav_9yv1.gls.par", "J1744-1134.basic.ecliptic.par"]
 
 
 @pytest.mark.parametrize("parfile", glob(join(datadir, "*.par")))


### PR DESCRIPTION
Adds a check when reading in `.par` file to make sure POS and PM coordinate systems are the same.