### PR TITLE
Default set POSEPOCH w/ warning

### DIFF
--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -233,17 +233,17 @@ class AstrometryEquatorial(Astrometry):
         for p in ("RAJ", "DECJ"):
             if getattr(self, p).value is None:
                 raise MissingParameter("Astrometry", p)
-        # If PM is included, check for POSEPOCH
-        if self.PMRA.value != 0.0 or self.PMDEC.value != 0.0:
-            if self.POSEPOCH.quantity is None:
-                if self.PEPOCH.quantity is None:
-                    raise MissingParameter(
-                        "AstrometryEquatorial",
-                        "POSEPOCH",
-                        "POSEPOCH or PEPOCH are required if PM is set.",
-                    )
-                else:
-                    self.POSEPOCH.quantity = self.PEPOCH.quantity
+        # Check for POSEPOCH
+        if self.POSEPOCH.quantity is None:
+            if self.PEPOCH.quantity is None:
+                raise MissingParameter(
+                    "AstrometryEquatorial",
+                    "POSEPOCH",
+                    "POSEPOCH or PEPOCH are required if PM is set.",
+                )
+            else:
+                log.warning("POSEPOCH not found; using PEPOCH unless set explicitly!")
+                self.POSEPOCH.quantity = self.PEPOCH.quantity
 
     def print_par(self):
         result = ""
@@ -512,17 +512,17 @@ class AstrometryEcliptic(Astrometry):
         for p in ("ELONG", "ELAT"):
             if getattr(self, p).value is None:
                 raise MissingParameter("AstrometryEcliptic", p)
-        # If PM is included, check for POSEPOCH
-        if self.PMELONG.value != 0.0 or self.PMELAT.value != 0.0:
-            if self.POSEPOCH.quantity is None:
-                if self.PEPOCH.quantity is None:
-                    raise MissingParameter(
-                        "Astrometry",
-                        "POSEPOCH",
-                        "POSEPOCH or PEPOCH are required if PM is set.",
-                    )
-                else:
-                    self.POSEPOCH.quantity = self.PEPOCH.quantity
+        # Check for POSEPOCH
+        if self.POSEPOCH.quantity is None:
+            if self.PEPOCH.quantity is None:
+                raise MissingParameter(
+                    "Astrometry",
+                    "POSEPOCH",
+                    "POSEPOCH or PEPOCH are required if PM is set.",
+                )
+            else:
+                log.warning("POSEPOCH not found; using PEPOCH unless set explicitly!")
+                self.POSEPOCH.quantity = self.PEPOCH.quantity
 
     def barycentric_radio_freq(self, toas):
         """Return radio frequencies (MHz) of the toas corrected for Earth motion"""

--- a/tests/test_model_manual.py
+++ b/tests/test_model_manual.py
@@ -168,7 +168,8 @@ def test_simple_manual():
     tm.validate()  # This should work.
 
     # When there is no POSEPOCH set, it should inherit the value from PEPOCH as a default.  Check that this is true.
-    assert (tm.POSEPOCH.value == tm.PEPOCH.value)
+    assert tm.POSEPOCH.value == tm.PEPOCH.value
+
 
 def test_add_all_components():
     # models_by_category = defaultdict(list)

--- a/tests/test_model_manual.py
+++ b/tests/test_model_manual.py
@@ -163,9 +163,11 @@ def test_simple_manual():
 
     tm.RAJ.value = "19:59:48"
     tm.DECJ.value = "20:48:36"
-    tm.F0.value = 622.122030511927 * u.Hz
+    tm.F0.quantity = 622.122030511927 * u.Hz
+    tm.PEPOCH.value = 48196.0
     tm.validate()  # This should work.
 
+    assert (tm.POSEPOCH.value == tm.PEPOCH.value)
 
 def test_add_all_components():
     # models_by_category = defaultdict(list)

--- a/tests/test_model_manual.py
+++ b/tests/test_model_manual.py
@@ -167,6 +167,7 @@ def test_simple_manual():
     tm.PEPOCH.value = 48196.0
     tm.validate()  # This should work.
 
+    # When there is no POSEPOCH set, it should inherit the value from PEPOCH as a default.  Check that this is true.
     assert (tm.POSEPOCH.value == tm.PEPOCH.value)
 
 def test_add_all_components():


### PR DESCRIPTION
I removed the conditional `if self.PMRA.value != 0.0 or self.PMDEC.value != 0.0:` in astrometry self.validate() functions so that POSEPOCH is set to be PEPOCH (if not none) by default. I also added a warning that is triggered when this happens.