### PR TITLE
Make solar wind use dispersion function

### DIFF
--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -40,7 +40,7 @@ class Dispersion(DelayComponent):
         """
         # dm delay
         dmdelay = DM * DMconst / freq ** 2.0
-        return dmdelay
+        return dmdelay.to(u.s)
 
     def dispersion_type_delay(self, toas):
         tbl = toas.table

--- a/tests/test_solar_wind.py
+++ b/tests/test_solar_wind.py
@@ -18,5 +18,5 @@ os.chdir(datadir)
 
 class TestSolarWind:
     def test_solar_wind_dm(self):
-        self.par =
-        self.tim = 
+        self.par = ""
+        self.tim = ""

--- a/tests/test_solar_wind.py
+++ b/tests/test_solar_wind.py
@@ -1,0 +1,22 @@
+""" Test for pint solar wind module
+"""
+
+import os
+import pytest
+import numpy as np
+import copy
+import sys
+
+import astropy.units as u
+from pint.models import get_model
+from pint.fitter import WidebandTOAFitter
+from pint.toa import get_TOAs
+from pinttestdata import datadir
+
+os.chdir(datadir)
+
+
+class TestSolarWind:
+    def test_solar_wind_dm(self):
+        self.par =
+        self.tim = 


### PR DESCRIPTION
This PR does restructure the solar wind model to use the dispersion base class's functions. It does not intend to change any calculations. It is still missing useful tests. 

@zimmyneutron I think it would be better to have your fix based on this version. But feel free to test this branch against your version. 