### PR TITLE
Update emcee requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ astropy>=3.2,!=4.0.1,!=4.0.1.post1
 scipy>=0.18.1
 jplephem>=2.6
 matplotlib>=1.5.3
-emcee>=3.0
+emcee>=3.0.1
 corner>=2.0.1
 uncertainties


### PR DESCRIPTION
emcee 3.0.1 and later support long doubles.

This PR might should be accompanied by a test that the MCMC fitter preserves long double accuracy.

Closes #565 