### PR TITLE
Displays warning on reduced-precision platforms instead of raising error

### DIFF
--- a/src/pint/pulsar_mjd.py
+++ b/src/pint/pulsar_mjd.py
@@ -42,13 +42,6 @@ except AttributeError:
     # fallback for Python 2
     from string import maketrans
 
-# FIXME: can we make this exception raise on install as well as on use?
-if np.finfo(np.longdouble).eps > 2e-19:
-    raise ValueError(
-        "This platform does not support extended precision "
-        "floating-point, and PINT cannot run without this."
-    )
-
 
 __all__ = [
     "Time",

--- a/src/pint/pulsar_mjd.py
+++ b/src/pint/pulsar_mjd.py
@@ -43,6 +43,21 @@ except AttributeError:
     from string import maketrans
 
 
+if np.finfo(np.longdouble).eps > 2e-19:
+    import warnings
+
+    def readable_warning(message, category, filename, lineno, line=None):
+        return "%s: %s\n" % (category.__name__, message)
+
+    warnings.formatwarning = readable_warning
+
+    msg = (
+        "This platform does not support extended precision "
+        "floating-point, and PINT will run at reduced precision."
+    )
+    warnings.warn(msg, RuntimeWarning)
+
+
 __all__ = [
     "Time",
     "PulsarMJD",


### PR DESCRIPTION
Resolves #802, I believe.

This is what the Python runtime on Windows looks like with this change:

```
>python
Python 3.8.6 | packaged by conda-forge | (default, Oct  7 2020, 18:22:52) [MSC v.1916 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import pint
RuntimeWarning: This platform does not support extended precision floating-point, and PINT will run at reduced precision.
>>>
```
A non-blocking warning is displayed that allows the user to process at their own risk.