### PR TITLE
Adding Python 3.9 to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ jobs:
         - python: "3.6"
         - python: "3.7"
         - python: "3.8"
+        - python: "3.9"
         - name: "tox"
           language: python
           python:

--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -566,8 +566,8 @@ class Pulsar(object):
             redge = ledge = 0.5
             npoints = 200
         else:
-            redge = ledge = 0.2
-            npoints = 150
+            redge = ledge = 1.0
+            npoints = 250
         # Check to see if too recent
         nowish = (Time.now().mjd - 40) * u.d
         if maxMJD + spanMJDs * redge > nowish:


### PR DESCRIPTION
Enabled Python 3.9 in travis. That is working.
I'm still seeing the inexplicable failures under 3.7.