### PR TITLE
Getattr cleanup

### DIFF
--- a/src/pint/models/absolute_phase.py
+++ b/src/pint/models/absolute_phase.py
@@ -114,7 +114,7 @@ class AbsPhase(PhaseComponent):
         """ Calculate the TZRMJD if one not given.
         TZRMJD = first toa after PEPOCH.
         """
-        PEPOCH = self.PEPOCH.quantity.mjd
+        PEPOCH = self._parent.PEPOCH.quantity.mjd
         # TODO: add warning for PEPOCH far away from center of data?
         TZRMJD = min([i for i in toas.get_mjds() if i > PEPOCH * u.d])
         self.TZRMJD.quantity = TZRMJD.value

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -99,7 +99,7 @@ class Astrometry(DelayComponent):
         rd = dict()
 
         # TODO: Should delay not have units of u.second?
-        delay = self.delay(toas)
+        delay = self._parent.delay(toas)
 
         # TODO: tbl['tdbld'].quantity should have units of u.day
         # NOTE: Do we need to include the delay here?
@@ -235,7 +235,7 @@ class AstrometryEquatorial(Astrometry):
                 raise MissingParameter("Astrometry", p)
         # Check for POSEPOCH
         if self.POSEPOCH.quantity is None:
-            if self.PEPOCH.quantity is None:
+            if self._parent.PEPOCH.quantity is None:
                 raise MissingParameter(
                     "AstrometryEquatorial",
                     "POSEPOCH",
@@ -243,7 +243,7 @@ class AstrometryEquatorial(Astrometry):
                 )
             else:
                 log.warning("POSEPOCH not found; using PEPOCH unless set explicitly!")
-                self.POSEPOCH.quantity = self.PEPOCH.quantity
+                self.POSEPOCH.quantity = self._parent.PEPOCH.quantity
 
     def print_par(self):
         result = ""
@@ -304,7 +304,7 @@ class AstrometryEquatorial(Astrometry):
 
     def coords_as_ECL(self, epoch=None, ecl=None):
         """Return the pulsar's ecliptic coordinates as an astropy coordinate object.
-        
+
         The value used for the obliquity of the ecliptic can be controlled with the
         `ecl` keyword, which should be one of the codes listed in `ecliptic.dat`.
         If `ecl` is left unspecified, the global default IERS2010 will be used.
@@ -318,7 +318,7 @@ class AstrometryEquatorial(Astrometry):
 
     def coords_as_GAL(self, epoch=None):
         """Return the pulsar's galactic coordinates as an astropy coordinate object.
-        
+
         """
         pos_icrs = self.get_psr_coords(epoch=epoch)
         return pos_icrs.transform_to(coords.Galactic)
@@ -510,7 +510,7 @@ class AstrometryEcliptic(Astrometry):
                 raise MissingParameter("AstrometryEcliptic", p)
         # Check for POSEPOCH
         if self.POSEPOCH.quantity is None:
-            if self.PEPOCH.quantity is None:
+            if self._parent.PEPOCH.quantity is None:
                 raise MissingParameter(
                     "Astrometry",
                     "POSEPOCH",
@@ -518,7 +518,7 @@ class AstrometryEcliptic(Astrometry):
                 )
             else:
                 log.warning("POSEPOCH not found; using PEPOCH unless set explicitly!")
-                self.POSEPOCH.quantity = self.PEPOCH.quantity
+                self.POSEPOCH.quantity = self._parent.PEPOCH.quantity
 
     def barycentric_radio_freq(self, toas):
         """Return radio frequencies (MHz) of the toas corrected for Earth motion"""
@@ -582,14 +582,14 @@ class AstrometryEcliptic(Astrometry):
 
     def coords_as_GAL(self, epoch=None):
         """Return the pulsar's galactic coordinates as an astropy coordinate object.
-        
+
         """
         pos_ecl = self.get_psr_coords(epoch=epoch)
         return pos_ecl.transform_to(coords.Galactic)
 
     def coords_as_ECL(self, epoch=None, ecl=None):
         """Return the pulsar's ecliptic coordinates as an astropy coordinate object.
-        
+
         The value used for the obliquity of the ecliptic can be controlled with the
         `ecl` keyword, which should be one of the codes listed in `ecliptic.dat`.
         If `ecl` is left unspecified, the model's ECL parameter will be used.

--- a/src/pint/models/binary_ddk.py
+++ b/src/pint/models/binary_ddk.py
@@ -57,7 +57,7 @@ class BinaryDDK(BinaryDD):
 
     @property
     def PMRA_DDK(self):
-        params = self.get_params_as_ICRS()
+        params = self._parent.get_params_as_ICRS()
         par_obj = floatParameter(
             name="PMRA",
             units="mas/year",
@@ -68,7 +68,7 @@ class BinaryDDK(BinaryDD):
 
     @property
     def PMDEC_DDK(self):
-        params = self.get_params_as_ICRS()
+        params = self._parent.get_params_as_ICRS()
         par_obj = floatParameter(
             name="PMDEC",
             units="mas/year",

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -39,16 +39,15 @@ class Dispersion(DelayComponent):
         frequency is much larger than plasma frequency.
         """
         # dm delay
-        dmdelay = DM * DMconst / freq ** 2.0
+        dmdelay = DM * DMconst / freq.to(u.MHz) ** 2.0
         return dmdelay.to(u.s)
 
     def dispersion_type_delay(self, toas):
-        tbl = toas.table
         try:
-            bfreq = self.barycentric_radio_freq(toas)
+            bfreq = self._parent.barycentric_radio_freq(toas)
         except AttributeError:
             warn("Using topocentric frequency for dedispersion!")
-            bfreq = tbl["freq"]
+            bfreq = toas.table["freq"]
 
         dm = self.dm_value(toas)
         return self.dispersion_time_delay(dm, bfreq)
@@ -71,7 +70,7 @@ class Dispersion(DelayComponent):
         else:
             toas_table = toas.table
 
-        dm = np.zeros(len(toas_table)) * self.DM.units
+        dm = np.zeros(len(toas_table)) * self._parent.DM.units
 
         for dm_f in self.dm_value_funcs:
             dm += dm_f(toas)
@@ -91,10 +90,10 @@ class Dispersion(DelayComponent):
             but not used in this function.
         """
         try:
-            bfreq = self.barycentric_radio_freq(toas)
+            bfreq = self._parent.barycentric_radio_freq(toas)
         except AttributeError:
             warn("Using topocentric frequency for dedispersion!")
-            bfreq = tbl["freq"]
+            bfreq = toas.table["freq"]
         param_unit = getattr(self, param_name).units
         d_dm_d_dmparam = np.zeros(toas.ntoas) * u.pc / u.cm ** 3 / param_unit
         for df in self.dm_deriv_funcs[param_name]:
@@ -249,7 +248,7 @@ class DispersionDM(Dispersion):
         """
         tbl = toas.table
         try:
-            bfreq = self.barycentric_radio_freq(toas)
+            bfreq = self._parent.barycentric_radio_freq(toas)
         except AttributeError:
             warn("Using topocentric frequency for dedispersion!")
             bfreq = tbl["freq"]
@@ -406,7 +405,7 @@ class DispersionDMX(Dispersion):
             condition, tbl["mjd_float"]
         )
         # Get DMX delays
-        dm = np.zeros(len(tbl)) * self.DM.units
+        dm = np.zeros(len(tbl)) * self._parent.DM.units
         for k, v in select_idx.items():
             dm[v] = getattr(self, k).quantity
         return dm
@@ -433,7 +432,7 @@ class DispersionDMX(Dispersion):
         )
 
         try:
-            bfreq = self.barycentric_radio_freq(toas)
+            bfreq = self._parent.barycentric_radio_freq(toas)
         except AttributeError:
             warn("Using topocentric frequency for dedispersion!")
             bfreq = tbl["freq"]

--- a/src/pint/models/frequency_dependent.py
+++ b/src/pint/models/frequency_dependent.py
@@ -62,12 +62,12 @@ class FD(DelayComponent):
         """
         tbl = toas.table
         try:
-            bfreq = self.barycentric_radio_freq(toas)
+            bfreq = self._parent.barycentric_radio_freq(toas)
         except AttributeError:
             warn("Using topocentric frequency for frequency dependent delay!")
             bfreq = tbl["freq"]
         FD_mapping = self.get_prefix_mapping_component("FD")
-        log_freq = np.log(bfreq.to_value(u.GHz))
+        log_freq = np.log(bfreq.to(u.GHz).value)
         non_finite = np.invert(np.isfinite(log_freq))
         log_freq[non_finite] = 0.0
         FD_coeff = [
@@ -85,7 +85,7 @@ class FD(DelayComponent):
         """
         tbl = toas.table
         try:
-            bfreq = self.barycentric_radio_freq(toas)
+            bfreq = self._parent.barycentric_radio_freq(toas)
         except AttributeError:
             warn(
                 "Using topocentric frequency for frequency dependent delay derivative!"

--- a/src/pint/models/ifunc.py
+++ b/src/pint/models/ifunc.py
@@ -75,7 +75,7 @@ class IFunc(PhaseComponent):
             raise MissingParameter(
                 "IFunc", "SIFUNC", "SIFUNC is required if IFUNC entries are present."
             )
-        if (not hasattr(self, "F0")) or (self.F0.quantity is None):
+        if (not hasattr(self._parent, "F0")) or (self._parent.F0.quantity is None):
             raise MissingParameter(
                 "IFunc", "F0", "F0 is required if IFUNC entries are present."
             )
@@ -132,5 +132,5 @@ class IFunc(PhaseComponent):
         else:
             raise ValueError("Interpolation type %d not supported.".format(itype))
 
-        phase = ((times * u.s) * self.F0.quantity).to(u.dimensionless_unscaled)
+        phase = ((times * u.s) * self._parent.F0.quantity).to(u.dimensionless_unscaled)
         return phase

--- a/src/pint/models/jump.py
+++ b/src/pint/models/jump.py
@@ -7,11 +7,7 @@ import astropy.units as u
 import numpy
 
 from pint.models.parameter import maskParameter
-from pint.models.timing_model import (
-    DelayComponent,
-    MissingParameter,
-    PhaseComponent,
-)
+from pint.models.timing_model import DelayComponent, MissingParameter, PhaseComponent
 
 
 class DelayJump(DelayComponent):
@@ -108,13 +104,13 @@ class PhaseJump(PhaseComponent):
         F0.
         """
         tbl = toas.table
-        jphase = numpy.zeros(len(tbl)) * (self.JUMP1.units * self.F0.units)
+        jphase = numpy.zeros(len(tbl)) * (self.JUMP1.units * self._parent.F0.units)
         for jump in self.jumps:
             jump_par = getattr(self, jump)
             mask = jump_par.select_toa_mask(toas)
             # NOTE: Currently parfile jump value has opposite sign with our
             # phase calculation.
-            jphase[mask] += jump_par.quantity * self.F0.quantity
+            jphase[mask] += jump_par.quantity * self._parent.F0.quantity
         return jphase
 
     def d_phase_d_jump(self, toas, jump_param, delay):
@@ -122,8 +118,8 @@ class PhaseJump(PhaseComponent):
         jpar = getattr(self, jump_param)
         d_phase_d_j = numpy.zeros(len(tbl))
         mask = jpar.select_toa_mask(toas)
-        d_phase_d_j[mask] = self.F0.value
-        return (d_phase_d_j * self.F0.units).to(1 / u.second)
+        d_phase_d_j[mask] = self._parent.F0.value
+        return (d_phase_d_j * self._parent.F0.units).to(1 / u.second)
 
     def print_par(self):
         result = ""
@@ -138,7 +134,7 @@ class PhaseJump(PhaseComponent):
 
     def get_jump_param_objects(self):
         """
-        Returns a list of the maskParameter objects representing the jumps 
+        Returns a list of the maskParameter objects representing the jumps
         in this PhaseJump object.
         """
         jump_obs = [getattr(self, jump) for jump in self.jumps]

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -190,6 +190,7 @@ class ScaleDmError(NoiseComponent):
 
     def __init__(self,):
         super(ScaleDmError, self).__init__()
+        self.introduces_correlated_errors = True
         self.add_param(
             maskParameter(
                 name="DMEFAC",

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -182,7 +182,6 @@ class ScaleDmError(NoiseComponent):
     Note
     ----
     Ref: NanoGrav 12.5 yrs wideband data
-
     """
 
     register = True
@@ -190,7 +189,7 @@ class ScaleDmError(NoiseComponent):
 
     def __init__(self,):
         super(ScaleDmError, self).__init__()
-        self.introduces_correlated_errors = True
+        self.introduces_correlated_errors = False
         self.add_param(
             maskParameter(
                 name="DMEFAC",

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -42,6 +42,7 @@ class ScaleToaError(NoiseComponent):
 
     def __init__(self,):
         super(ScaleToaError, self).__init__()
+        self.introduces_correlated_errors = False
         self.add_param(
             maskParameter(
                 name="EFAC",
@@ -209,9 +210,7 @@ class ScaleDmError(NoiseComponent):
         )
 
         self.dm_covariance_matrix_funcs_component = [self.dm_sigma_scaled_cov_matrix]
-        self.scaled_dm_sigma_funcs += [
-            self.scale_dm_sigma,
-        ]
+        self.scaled_dm_sigma_funcs += [self.scale_dm_sigma]
         self._paired_DMEFAC_DMEQUAD = None
 
     def setup(self):

--- a/src/pint/models/pulsar_binary.py
+++ b/src/pint/models/pulsar_binary.py
@@ -179,16 +179,6 @@ class PulsarBinary(DelayComponent):
                     )
                 par_method()
 
-                # try:
-                #     par_method()
-                # except Exception as e:
-                #     raise MissingParameter(
-                #         self.binary_model_name,
-                #         p
-                #         + " is present but somehow broken for '%s'."
-                #         % self.binary_model_name,
-                #     ) from e
-
     # With new parameter class set up, do we need this?
     def apply_units(self):
         """Apply units to parameter value."""
@@ -285,7 +275,9 @@ class PulsarBinary(DelayComponent):
         (FB2, FB3, etc.) are ignored in computing the new T0, even if present in
         the model. If high-precision results are necessary, especially for models
         containing higher derivatives of orbital frequency, consider re-fitting
-        the model to a set of TOAs.
+        the model to a set of TOAs. The use of :func:`pint.toa.make_fake_toas`
+        and the :class:`pint.fitter.Fitter` option ``track_mode="use_pulse_number"``
+        can make this extremely simple.
 
         Parameters
         ----------

--- a/src/pint/models/pulsar_binary.py
+++ b/src/pint/models/pulsar_binary.py
@@ -177,15 +177,17 @@ class PulsarBinary(DelayComponent):
                         self.binary_model_name,
                         p + " is required for '%s'." % self.binary_model_name,
                     )
-                try:
-                    par_method()
-                except:
-                    raise MissingParameter(
-                        self.binary_model_name,
-                        p
-                        + " is present but somehow broken for '%s'."
-                        % self.binary_model_name,
-                    )
+                par_method()
+
+                # try:
+                #     par_method()
+                # except Exception as e:
+                #     raise MissingParameter(
+                #         self.binary_model_name,
+                #         p
+                #         + " is present but somehow broken for '%s'."
+                #         % self.binary_model_name,
+                #     ) from e
 
     # With new parameter class set up, do we need this?
     def apply_units(self):
@@ -207,12 +209,12 @@ class PulsarBinary(DelayComponent):
             if acc_delay is None:
                 # If the accumulated delay is not provided, calculate and
                 # use the barycentered TOAS
-                self.barycentric_time = self.get_barycentric_toas(toas)
+                self.barycentric_time = self._parent.get_barycentric_toas(toas)
             else:
                 self.barycentric_time = tbl["tdbld"] * u.day - acc_delay
             updates["barycentric_toa"] = self.barycentric_time
             updates["obs_pos"] = tbl["ssb_obs_pos"].quantity
-            updates["psr_pos"] = self.ssb_to_psb_xyz_ICRS(
+            updates["psr_pos"] = self._parent.ssb_to_psb_xyz_ICRS(
                 epoch=tbl["tdbld"].astype(np.float64)
             )
         for par in self.binary_instance.binary_params:
@@ -296,7 +298,7 @@ class PulsarBinary(DelayComponent):
             new_epoch = Time(new_epoch, scale="tdb", format="mjd", precision=9)
 
         try:
-            FB2 = self.FB2.quantity
+            self.FB2.quantity
             log.warning(
                 "Ignoring orbital frequency derivatives higher than FB1"
                 "in computing new T0"

--- a/src/pint/models/solar_system_shapiro.py
+++ b/src/pint/models/solar_system_shapiro.py
@@ -99,12 +99,14 @@ class SolarSystemShapiro(DelayComponent):
         delay = numpy.zeros(len(tbl))
         for ii, key in enumerate(tbl.groups.keys):
             grp = tbl.groups[ii]
-            obs = tbl.groups.keys[ii]["obs"]
+            # obs = tbl.groups.keys[ii]["obs"]
             loind, hiind = tbl.groups.indices[ii : ii + 2]
             if key["obs"].lower() == "barycenter":
                 log.debug("Skipping Shapiro delay for Barycentric TOAs")
                 continue
-            psr_dir = self.ssb_to_psb_xyz_ICRS(epoch=grp["tdbld"].astype(numpy.float64))
+            psr_dir = self._parent.ssb_to_psb_xyz_ICRS(
+                epoch=grp["tdbld"].astype(numpy.float64)
+            )
             delay[loind:hiind] += self.ss_obj_shapiro_delay(
                 grp["obs_sun_pos"], psr_dir, self._ss_mass_sec["sun"]
             )

--- a/src/pint/models/solar_wind_dispersion.py
+++ b/src/pint/models/solar_wind_dispersion.py
@@ -69,7 +69,7 @@ class SolarWindDispersion(Dispersion):
         """
         tbl = toas.table
         rvec = tbl["obs_sun_pos"].quantity
-        pos = self.ssb_to_psb_xyz_ICRS(epoch=tbl["tdbld"].astype(np.float64))
+        pos = self._parent.ssb_to_psb_xyz_ICRS(epoch=tbl["tdbld"].astype(np.float64))
         r = np.sqrt(np.sum(rvec * rvec, axis=1))
         cos_theta = (np.sum(rvec * pos, axis=1) / r).to(u.Unit(""))
         theta = np.arccos(cos_theta).to(

--- a/src/pint/models/stand_alone_psr_binaries/DDK_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/DDK_model.py
@@ -105,7 +105,8 @@ class DDKmodel(DDmodel):
     @SINI.setter
     def SINI(self, val):
         log.warning(
-            "DDK model uses KIN as inclination angle. SINI will not be" " used."
+            "DDK model uses KIN as inclination angle. SINI will not be "
+            "used. This happens every time a DDK model is constructed."
         )
 
     # @property

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1432,6 +1432,7 @@ class TimingModel(object):
 
     def compare(self, othermodel, nodmx=True, threshold_sigma=3.0, verbosity="max"):
         """Print comparison with another model
+
         Parameters
         ----------
         othermodel

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -126,10 +126,10 @@ class TimingModel(object):
     ``model.coords_as_GAL()``.
 
     Components in a TimingModel objects are accessible through the
-    ``model.components`` property, and they can also be accessed by using their
-    class name to index the TimingModel, as ``model["Spindown"]``. They can be
-    added and removed with methods on this object, and for many of them
-    additional parameters in families (``DMXEP_1234``) can be added.
+    ``model.components`` property, using their class name to index the
+    TimingModel, as ``model.components["Spindown"]``. They can be added and
+    removed with methods on this object, and for many of them additional
+    parameters in families (``DMXEP_1234``) can be added.
 
     Parameters in a TimingModel object are listed in the ``model.params`` and
     ``model.params_ordered`` objects. Each Parameter can be set as free or

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -113,12 +113,37 @@ def property_exists(f):
 
 
 class TimingModel(object):
-    """Base class for timing models and components.
+    """Timing model object built from Components.
 
-    Base-level object provides an interface for implementing pulsar timing
-    models. A timing model contains different model components, for example
-    astrometry delays and spindown phase. All the components will be stored in
-    a dictionary by category. Each category is kept as an ordered list.
+    This object is the primary object to represent a timing model in PINT.  It
+    is normally constructed with :func:`pint.models.model_builder.get_model`,
+    and it contains a variety of Component objects, each representing a
+    physical process that either introduces delays in the pulse arrival time or
+    introduces shifts in the pulse arrival phase.  These components have
+    parameters, described by :class:`pint.models.parameter.Parameter` objects,
+    and methods. Both the parameters and the methods are accessible through
+    this object using attribute access, for example as ``model.F0`` or
+    ``model.coords_as_GAL()``.
+
+    Components in a TimingModel objects are accessible through the
+    ``model.components`` property, and they can also be accessed by using their
+    class name to index the TimingModel, as ``model["Spindown"]``. They can be
+    added and removed with methods on this object, and for many of them
+    additional parameters in families (``DMXEP_1234``) can be added.
+
+    Parameters in a TimingModel object are listed in the ``model.params`` and
+    ``model.params_ordered`` objects. Each Parameter can be set as free or
+    frozen using its ``.frozen`` attribute, and a list of the free parameters
+    is available through the ``model.free_params`` property; this can also
+    be used to set which parameters are free. Several methods are available
+    to get and set some or all parameters in the forms of dictionaries.
+
+    TimingModel objects also support a number of functions for computing
+    various things like orbital phase, and barycentric versions of TOAs,
+    as well as the various derivatives and matrices needed to support fitting.
+
+    TimingModel objects can be written out to ``.par`` files using
+    :func:`pint.models.timing_model.TimingModel.as_parfile`.
 
     Parameters
     ----------
@@ -135,7 +160,6 @@ class TimingModel(object):
     'time delay'. In pulsar timing different astrophysics phenomenons are separated to
     time model components for handling a specific emission or propagation effect.
 
-    All timing model component classes should subclass this timing model base class.
     Each timing model component generally requires the following parts:
 
         - Timing Parameters
@@ -156,7 +180,6 @@ class TimingModel(object):
     top_level_params : list
         Names of parameters belonging to the TimingModel as a whole
         rather than to any particular component.
-
     """
 
     def __init__(self, name="", components=[]):
@@ -165,7 +188,6 @@ class TimingModel(object):
                 "First parameter should be the model name, was {!r}".format(name)
             )
         self.name = name
-        self.introduces_correlated_errors = False
         self.component_types = []
         self.top_level_params = []
         self.add_param_from_top(

--- a/src/pint/models/troposphere_delay.py
+++ b/src/pint/models/troposphere_delay.py
@@ -144,12 +144,13 @@ class TroposphereDelay(DelayComponent):
         """
         try:
             radec = SkyCoord(
-                self.RAJ.value * self.RAJ.units, self.DECJ.value * self.DECJ.units
+                self._parent.RAJ.value * self._parent.RAJ.units,
+                self._parent.DECJ.value * self._parent.DECJ.units,
             )  # just do this once instead of adjusting over time
         except AttributeError:
             radec = SkyCoord(
-                self.ELONG.value * self.ELONG.units,
-                self.ELAT.value * self.ELAT.units,
+                self._parent.ELONG.value * self._parent.ELONG.units,
+                self._parent.ELAT.value * self._parent.ELAT.units,
                 frame="barycentricmeanecliptic",
             )
         return radec

--- a/src/pint/models/wave.py
+++ b/src/pint/models/wave.py
@@ -69,7 +69,7 @@ class Wave(PhaseComponent):
             else:
                 self.WAVEEPOCH = self.PEPOCH
 
-        if (not hasattr(self, "F0")) or (self.F0.quantity is None):
+        if (not hasattr(self._parent, "F0")) or (self._parent.F0.quantity is None):
             raise MissingParameter(
                 "Wave", "F0", "F0 is required if WAVE entries are present."
             )
@@ -111,5 +111,5 @@ class Wave(PhaseComponent):
             times += wave_a * np.sin(wave_phase)
             times += wave_b * np.cos(wave_phase)
 
-        phase = ((times) * self.F0.quantity).to(u.dimensionless_unscaled)
+        phase = ((times) * self._parent.F0.quantity).to(u.dimensionless_unscaled)
         return phase

--- a/tests/test_timing_model.py
+++ b/tests/test_timing_model.py
@@ -2,22 +2,32 @@
 """
 from __future__ import absolute_import, division, print_function
 
-import pytest
 import os
-import numpy as np
+import warnings
+from copy import deepcopy
+
 import astropy.units as u
-from pint.models import TimingModel, DEFAULT_ORDER
-from pint.models import get_model
+import numpy as np
+import pytest
+from pinttestdata import datadir
+
 from pint.models import (
+    DEFAULT_ORDER,
     AstrometryEquatorial,
-    Spindown,
+    BinaryELL1,
     DelayJump,
     DispersionDM,
-    BinaryELL1,
+    Spindown,
+    TimingModel,
     Wave,
+    get_model,
+    parameter as p,
 )
-from pint.models import parameter as p
-from pinttestdata import datadir
+
+
+@pytest.fixture
+def model_0437():
+    return get_model(os.path.join(datadir, "J0437-4715.par"))
 
 
 class TestModelBuilding:
@@ -190,3 +200,20 @@ class TestModelBuilding:
         tfp = {"F0", "T0", "RAJ"}
         tm.free_params = tfp
         tm.set_param_uncertainties(tm.get_params_dict("free", "uncertainty"))
+
+def test_parameter_access(model_0437):
+    model_0437.F0
+
+
+def test_component_parameter_access(model_0437):
+    model_0437.components["Spindown"].F0
+
+
+def test_component_methods(model_0437):
+    model_0437.coords_as_GAL
+
+
+def test_copying(model_0437):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        deepcopy(model_0437)

--- a/tests/test_timing_model.py
+++ b/tests/test_timing_model.py
@@ -201,6 +201,7 @@ class TestModelBuilding:
         tm.free_params = tfp
         tm.set_param_uncertainties(tm.get_params_dict("free", "uncertainty"))
 
+
 def test_parameter_access(model_0437):
     model_0437.F0
 


### PR DESCRIPTION
Remove `__getattr__` from Component objects, and clean up `__getattr__` implementation on TimingModel.

Fixes #828 .