### PR TITLE
Fix astrometry time scale

### DIFF
--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -267,7 +267,7 @@ class AstrometryEquatorial(Astrometry):
         Parameters
         ----------
         epoch: `astropy.time.Time` or Float, optional
-            new epoch for position.  If Float, MJD is assumed
+            new epoch for position.  If Float, MJD(TDB) is assumed
 
         Returns
         -------
@@ -279,23 +279,18 @@ class AstrometryEquatorial(Astrometry):
 
         """
         if epoch is None or (self.PMRA.value == 0.0 and self.PMDEC.value == 0.0):
-            dRA = 0.0 * u.hourangle
-            dDEC = 0.0 * u.deg
-            broadcast = 1
-            newepoch = self.POSEPOCH.quantity
             return coords.SkyCoord(
-                ra=self.RAJ.quantity + dRA,
-                dec=self.DECJ.quantity + dDEC,
-                pm_ra_cosdec=self.PMRA.quantity * broadcast,
-                pm_dec=self.PMDEC.quantity * broadcast,
-                obstime=newepoch,
-                frame=coords.ICRS,
-            )
+                ra=self.RAJ.quantity,
+                dec=self.DECJ.quantity,
+                pm_ra_cosdec=self.PMRA.quantity,
+                pm_dec=self.PMDEC.quantity,
+                obstime=self.POSEPOCH.quantity,
+                frame=coords.ICRS)
         else:
             if isinstance(epoch, Time):
                 newepoch = epoch
             else:
-                newepoch = Time(epoch, format="mjd")
+                newepoch = Time(epoch, scale="tdb", format="mjd")
             position_now = add_dummy_distance(self.get_psr_coords())
             position_then = remove_dummy_distance(
                 position_now.apply_space_motion(new_obstime=newepoch)

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -285,7 +285,8 @@ class AstrometryEquatorial(Astrometry):
                 pm_ra_cosdec=self.PMRA.quantity,
                 pm_dec=self.PMDEC.quantity,
                 obstime=self.POSEPOCH.quantity,
-                frame=coords.ICRS)
+                frame=coords.ICRS,
+            )
         else:
             if isinstance(epoch, Time):
                 newepoch = epoch
@@ -560,8 +561,9 @@ class AstrometryEcliptic(Astrometry):
                 lat=self.ELAT.quantity,
                 pm_lon_coslat=self.PMELONG.quantity,
                 pm_lat=self.PMELAT.quantity,
-                frame=PulsarEcliptic,
                 obstime=self.POSEPOCH.quantity,
+                frame=PulsarEcliptic,
+            )
         else:
             if isinstance(epoch, Time):
                 newepoch = epoch

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -530,10 +530,21 @@ class AstrometryEcliptic(Astrometry):
         return tbl["freq"] * (1.0 - v_dot_L_array / const.c)
 
     def get_psr_coords(self, epoch=None):
-        """Returns pulsar sky coordinates as an astropy ecliptic coordinates
-        object. Pulsar coordinates will be computed at current coordinates.
+        """Returns pulsar sky coordinates as an astropy ecliptic coordinate instance.
+
+        Parameters
+        ----------
+        epoch: `astropy.time.Time` or Float, optional
+            new epoch for position.  If Float, MJD(TDB) is assumed
+
+        Returns
+        -------
+        position
+        PulsarEcliptic SkyCoord object optionally with proper motion applied
+
         If epoch (MJD) is specified, proper motion is included to return
         the position at the given epoch.
+
         """
         try:
             obliquity = OBL[self.ECL.value]
@@ -543,27 +554,24 @@ class AstrometryEcliptic(Astrometry):
                 "Check your pint/datafile/ecliptic.dat file."
             )
         if epoch is None or (self.PMELONG.value == 0.0 and self.PMELAT.value == 0.0):
-            dELONG = 0.0 * self.ELONG.units
-            dELAT = 0.0 * self.ELAT.units
-            broadcast = 1
-            newepoch = self.POSEPOCH.quantity
+            return coords.SkyCoord(
+                obliquity=obliquity,
+                lon=self.ELONG.quantity,
+                lat=self.ELAT.quantity,
+                pm_lon_coslat=self.PMELONG.quantity,
+                pm_lat=self.PMELAT.quantity,
+                frame=PulsarEcliptic,
+                obstime=self.POSEPOCH.quantity,
         else:
-            dt = (epoch - self.POSEPOCH.quantity.mjd) * u.d
-            dELONG = dt * self.PMELONG.quantity / numpy.cos(self.ELAT.quantity.radian)
-            dELAT = dt * self.PMELAT.quantity
-            broadcast = numpy.ones_like(epoch)
-            newepoch = Time(epoch, format="mjd")
-
-        pos_ecl = coords.SkyCoord(
-            obliquity=obliquity,
-            lon=self.ELONG.quantity + dELONG,
-            lat=self.ELAT.quantity + dELAT,
-            pm_lon_coslat=self.PMELONG.quantity * broadcast,
-            pm_lat=self.PMELAT.quantity * broadcast,
-            frame=PulsarEcliptic,
-            obstime=newepoch,
-        )
-        return pos_ecl
+            if isinstance(epoch, Time):
+                newepoch = epoch
+            else:
+                newepoch = Time(epoch, scale="tdb", format="mjd")
+            position_now = add_dummy_distance(self.get_psr_coords())
+            position_then = remove_dummy_distance(
+                position_now.apply_space_motion(new_obstime=newepoch)
+            )
+            return position_then
 
     def coords_as_ICRS(self, epoch=None):
         """Return the pulsar's ICRS coordinates as an astropy coordinate object."""

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -541,7 +541,7 @@ class AstrometryEcliptic(Astrometry):
         Returns
         -------
         position
-        PulsarEcliptic SkyCoord object optionally with proper motion applied
+            PulsarEcliptic SkyCoord object optionally with proper motion applied
 
         If epoch (MJD) is specified, proper motion is included to return
         the position at the given epoch.

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1470,6 +1470,7 @@ def add_dummy_distance(c, distance=1 * u.kpc):
             pm_lat=c.pm_lat,
             obstime=c.obstime,
             distance=distance,
+            obliquity=c.obliquity,
             frame=pint.pulsar_ecliptic.PulsarEcliptic,
         )
         return cnew
@@ -1545,6 +1546,7 @@ def remove_dummy_distance(c):
             pm_lon_coslat=c.pm_lon_coslat,
             pm_lat=c.pm_lat,
             obstime=c.obstime,
+            obliquity=c.obliquity,
             frame=pint.pulsar_ecliptic.PulsarEcliptic,
         )
         return cnew

--- a/tests/test_Galactic.py
+++ b/tests/test_Galactic.py
@@ -16,6 +16,7 @@ from pint import utils
 import astropy.coordinates
 import astropy.time
 
+
 class TestGalactic(unittest.TestCase):
     """Test conversion from equatorial/ecliptic -> Galactic coordinates as astropy objects"""
 
@@ -79,10 +80,13 @@ class TestGalactic(unittest.TestCase):
 
         # sanity check that evaluation at POSEPOCH returns something very close to 0
         J0613_icrs = self.modelJ0613.coords_as_ICRS()
-        J0613_icrs_alt = self.modelJ0613.coords_as_ICRS(epoch=self.modelJ0613.POSEPOCH.quantity.mjd)
+        J0613_icrs_alt = self.modelJ0613.coords_as_ICRS(
+            epoch=self.modelJ0613.POSEPOCH.quantity.mjd
+        )
         sep = J0613_icrs_alt.separation(J0613_icrs)
         msg = (
-            "Sanity check evaluating application of proper motion at POSEPOCH failed with separation %.1e arcsec" % sep.arcsec
+            "Sanity check evaluating application of proper motion at POSEPOCH failed with separation %.1e arcsec"
+            % sep.arcsec
         )
         assert sep < 1e-11 * u.arcsec, msg
 
@@ -182,5 +186,6 @@ class TestGalactic(unittest.TestCase):
         )
         assert sep < 1e-9 * u.arcsec, msg
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_Galactic.py
+++ b/tests/test_Galactic.py
@@ -16,7 +16,6 @@ from pint import utils
 import astropy.coordinates
 import astropy.time
 
-
 class TestGalactic(unittest.TestCase):
     """Test conversion from equatorial/ecliptic -> Galactic coordinates as astropy objects"""
 
@@ -50,12 +49,12 @@ class TestGalactic(unittest.TestCase):
         # and use the coordinates now but use astropy's space motion
         print(
             J0613_icrs_now.apply_space_motion(
-                new_obstime=astropy.time.Time(newepoch, format="mjd")
+                new_obstime=astropy.time.Time(newepoch, scale="tdb", format="mjd")
             )
         )
         J0613_icrs_now_to_then = utils.remove_dummy_distance(
             J0613_icrs_now.apply_space_motion(
-                new_obstime=astropy.time.Time(newepoch, format="mjd")
+                new_obstime=astropy.time.Time(newepoch, scale="tdb", format="mjd")
             )
         )
         sep = J0613_icrs.separation(J0613_icrs_now_to_then)
@@ -63,7 +62,7 @@ class TestGalactic(unittest.TestCase):
             "Applying proper motion for +100d failed with separation %.1e arcsec"
             % sep.arcsec
         )
-        assert sep < 1e-6 * u.arcsec, msg
+        assert sep < 1e-9 * u.arcsec, msg
 
         # make sure it can support newepoch supplied as a Time object
         newepoch = astropy.time.Time(newepoch, format="mjd")
@@ -76,7 +75,16 @@ class TestGalactic(unittest.TestCase):
             "Applying proper motion for +100d failed with separation %.1e arcsec"
             % sep.arcsec
         )
-        assert sep < 1e-6 * u.arcsec, msg
+        assert sep < 1e-9 * u.arcsec, msg
+
+        # sanity check that evaluation at POSEPOCH returns something very close to 0
+        J0613_icrs = self.modelJ0613.coords_as_ICRS()
+        J0613_icrs_alt = self.modelJ0613.coords_as_ICRS(epoch=self.modelJ0613.POSEPOCH.quantity.mjd)
+        sep = J0613_icrs_alt.separation(J0613_icrs)
+        msg = (
+            "Sanity check evaluating application of proper motion at POSEPOCH failed with separation %.1e arcsec" % sep.arcsec
+        )
+        assert sep < 1e-11 * u.arcsec, msg
 
     def test_equatorial_to_galactic(self):
         """
@@ -108,10 +116,7 @@ class TestGalactic(unittest.TestCase):
             "Equatorial to Galactic conversion for now failed with separation %.1e arcsec"
             % sep.arcsec
         )
-        assert sep < 1e-5 * u.arcsec, msg
-
-        print(J0613_icrs_now)
-        print(J0613_galactic_now)
+        assert sep < 1e-9 * u.arcsec, msg
 
         J0613_icrs = self.modelJ0613.coords_as_ICRS(epoch=newepoch)
         # what I get converting within astropy
@@ -120,7 +125,7 @@ class TestGalactic(unittest.TestCase):
         )
         J0613_galactic_then = utils.remove_dummy_distance(
             J0613_galactic_now.apply_space_motion(
-                new_obstime=astropy.time.Time(newepoch, format="mjd")
+                new_obstime=astropy.time.Time(newepoch, scale="tdb", format="mjd")
             )
         )
         sep = J0613_galactic_then.separation(J0613_galactic_comparison)
@@ -128,7 +133,7 @@ class TestGalactic(unittest.TestCase):
             "Equatorial to Galactic conversion for +100d failed with separation %.1e arcsec"
             % sep.arcsec
         )
-        assert sep < 1e-6 * u.arcsec, msg
+        assert sep < 1e-9 * u.arcsec, msg
 
     def test_ecliptic_to_galactic(self):
         """
@@ -160,14 +165,14 @@ class TestGalactic(unittest.TestCase):
             "Ecliptic to Galactic conversion for now failed with separation %.1e arcsec"
             % sep.arcsec
         )
-        assert sep < 1e-4 * u.arcsec, msg
+        assert sep < 1e-9 * u.arcsec, msg
 
         B1855_ECL = self.modelB1855.coords_as_ECL(epoch=newepoch)
         # what I get converting within astropy
         B1855_galactic_comparison = B1855_ECL.transform_to(astropy.coordinates.Galactic)
         B1855_galactic_then = utils.remove_dummy_distance(
             B1855_galactic_now.apply_space_motion(
-                new_obstime=astropy.time.Time(newepoch, format="mjd")
+                new_obstime=astropy.time.Time(newepoch, scale="tdb", format="mjd")
             )
         )
         sep = B1855_galactic_then.separation(B1855_galactic_comparison)
@@ -175,4 +180,7 @@ class TestGalactic(unittest.TestCase):
             "Ecliptic to Galactic conversion for +100d failed with separation %.1e arcsec"
             % sep.arcsec
         )
-        assert sep < 1e-6 * u.arcsec, msg
+        assert sep < 1e-9 * u.arcsec, msg
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_Galactic.py
+++ b/tests/test_Galactic.py
@@ -78,17 +78,15 @@ class TestGalactic(unittest.TestCase):
         )
         assert sep < 1e-9 * u.arcsec, msg
 
+    def test_proper_motion_identity(self):
+
         # sanity check that evaluation at POSEPOCH returns something very close to 0
         J0613_icrs = self.modelJ0613.coords_as_ICRS()
         J0613_icrs_alt = self.modelJ0613.coords_as_ICRS(
             epoch=self.modelJ0613.POSEPOCH.quantity.mjd
         )
         sep = J0613_icrs_alt.separation(J0613_icrs)
-        msg = (
-            "Sanity check evaluating application of proper motion at POSEPOCH failed with separation %.1e arcsec"
-            % sep.arcsec
-        )
-        assert sep < 1e-11 * u.arcsec, msg
+        assert sep < 1e-11 * u.arcsec
 
     def test_equatorial_to_galactic(self):
         """


### PR DESCRIPTION
See #820 for some discussion.  This fixes the issue by using scale='tdb' for the astropy.Time object that is created when the various astrometry methods are called with vector-float arguments.

During implementation, a couple of other things cropped up:
1. The "new" method of evaluating proper motion was only applied to equatorial coordinates.  I updated the get_psr_coords method of AstrometryEcliptic to use the astropy machinery.
2. I simplified the base cases (no epoch or PM==0) for both classes.
3. The "obliquity" kwarg was missing in the two "dummy distance" methods in utils.py, which meant the new method of applying the evaluating the proper motion always produced a SkyCoord with the IERS2010 obliquity of the ecliptic, which in turn was causing tests to fail.  (Lucky the tests were there!)  I added that.
4. I updated test_Galactic.py to follow the new scale=='tdb' guideline and also strengthened the precision requirements on the tests by a few orders of magnitude. 