### PR TITLE
Getitem implementation for TOAs

### DIFF
--- a/docs/examples/time_a_pulsar.md
+++ b/docs/examples/time_a_pulsar.md
@@ -15,7 +15,7 @@ jupyter:
 
 # Time a pulsar
 
-This notebook walks through a simple pulsar timing session, as one might do with TEMPO/TEMPO2: load a `.par` file, load a `.tim` file, do a fit, plot the residuals before and after. This one also displays various additional information you might find useful, and also ignores but then plots TOAs with large uncertainties.
+This notebook walks through a simple pulsar timing session, as one might do with TEMPO/TEMPO2: load a `.par` file, load a `.tim` file, do a fit, plot the residuals before and after. This one also displays various additional information you might find useful, and also ignores but then plots TOAs with large uncertainties. Similar code is available as a standalone script at [`fit_NGC6440E.py`](https://github.com/nanograv/PINT/blob/master/docs/examples/fit_NGC6440E.py)
 
 ```python
 import astropy.units as u

--- a/docs/examples/time_a_pulsar.py
+++ b/docs/examples/time_a_pulsar.py
@@ -1,23 +1,24 @@
----
-jupyter:
-  jupytext:
-    formats: ipynb,md
-    text_representation:
-      extension: .md
-      format_name: markdown
-      format_version: '1.2'
-      jupytext_version: 1.7.1
-  kernelspec:
-    display_name: Python 3
-    language: python
-    name: python3
----
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.7.1
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
 
-# Time a pulsar
+# %% [markdown]
+# # Time a pulsar
+#
+# This notebook walks through a simple pulsar timing session, as one might do with TEMPO/TEMPO2: load a `.par` file, load a `.tim` file, do a fit, plot the residuals before and after. This one also displays various additional information you might find useful, and also ignores but then plots TOAs with large uncertainties. Similar code is available as a standalone script at [`fit_NGC6440E.py`](https://github.com/nanograv/PINT/blob/master/docs/examples/fit_NGC6440E.py)
 
-This notebook walks through a simple pulsar timing session, as one might do with TEMPO/TEMPO2: load a `.par` file, load a `.tim` file, do a fit, plot the residuals before and after. This one also displays various additional information you might find useful, and also ignores but then plots TOAs with large uncertainties. Similar code is available as a standalone script at [`fit_NGC6440E.py`](https://github.com/nanograv/PINT/blob/master/docs/examples/fit_NGC6440E.py)
-
-```python
+# %%
 import astropy.units as u
 import matplotlib.pyplot as plt
 
@@ -26,35 +27,31 @@ import pint.models
 from pint.models import get_model
 from pint.residuals import Residuals
 from pint.toa import get_TOAs
-```
 
-```python
+# %%
 parfile = "NGC6440E.par"
 timfile = "NGC6440E.tim"
-```
 
-```python
+# %%
 m = get_model(parfile)
 m
-```
 
-```python
+# %%
 t_all = pint.toa.get_TOAs(timfile, ephem="de436")
 t_all.print_summary()
-```
 
-There are many messages here. As a rule messages marked `INFO` can safely be ignored, they are simply informational; take a look at them if something unexpected happens. Messages marked `WARNING` or `ERROR` are more serious. (These messages are emitted by the python `logger` module and can be suppressed or written to a log file if they are annoying.)
+# %% [markdown]
+# There are many messages here. As a rule messages marked `INFO` can safely be ignored, they are simply informational; take a look at them if something unexpected happens. Messages marked `WARNING` or `ERROR` are more serious. (These messages are emitted by the python `logger` module and can be suppressed or written to a log file if they are annoying.)
 
+# %% [markdown]
+# Let's discard the data points with uncertainties $>30\,\mu\text{s}$ - uncertainty estimation is not always reliable when the signal-to-noise is low.
 
-Let's discard the data points with uncertainties $>30\,\mu\text{s}$ - uncertainty estimation is not always reliable when the signal-to-noise is low.
-
-```python
+# %%
 error_ok = t_all.table["error"] <= 30 * u.us
 t = t_all[error_ok]
 t.print_summary()
-```
 
-```python
+# %%
 # These are pre-fit residuals
 rs = Residuals(t, m).phase_resids
 xt = t.get_mjds()
@@ -64,33 +61,28 @@ plt.title("%s Pre-Fit Timing Residuals" % m.PSR.value)
 plt.xlabel("MJD")
 plt.ylabel("Residual (phase)")
 plt.grid()
-```
 
-```python
+# %%
 f = pint.fitter.WLSFitter(t, m)
 # f = pint.fitter.PowellFitter(t, m)
 f.fit_toas()
 # f = pint.fitter.GLSFitter(t, m)
 # f.fit_toas(full_cov=True)
-```
 
-```python
+# %%
 # Print some basic params
 print("Best fit has reduced chi^2 of", f.resids.chi2_reduced)
 print("RMS in phase is", f.resids.phase_resids.std())
 print("RMS in time is", f.resids.time_resids.std().to(u.us))
-```
 
-```python
+# %%
 # Show the parameter correlation matrix
 corm = f.get_correlation_matrix(pretty_print=True)
-```
 
-```python
+# %%
 f.print_summary()
-```
 
-```python
+# %%
 plt.figure()
 plt.errorbar(
     xt.value,
@@ -102,9 +94,8 @@ plt.title("%s Post-Fit Timing Residuals" % m.PSR.value)
 plt.xlabel("MJD")
 plt.ylabel("Residual (us)")
 plt.grid()
-```
 
-```python
+# %%
 t_bad = t_all[~error_ok]
 r_bad = Residuals(t_bad, f.model)
 plt.figure()
@@ -127,12 +118,8 @@ plt.xlabel("MJD")
 plt.ylabel("Residual (us)")
 plt.grid()
 plt.legend(loc="upper left")
-```
 
-```python
+# %%
 plt.show()
-```
 
-```python
-
-```
+# %%

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -10,6 +10,7 @@ We don't really have any proper tutorials yet. But for the moment, we have a few
 .. toctree::
 
    basic-installation
+   examples/time_a_pulsar.ipynb
    examples/PINT_walkthrough.ipynb
    examples/understanding_timing_models.ipynb
    examples/understanding_parameters.ipynb

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -967,6 +967,8 @@ class TOAs(object):
         if isinstance(index, np.ndarray) and index.dtype == np.bool:
             r = copy.deepcopy(self)
             r.table = r.table[index]
+            if len(r.table) > 0:
+                r.table = r.table.group_by("obs")
             return r
         elif (
             isinstance(index, np.ndarray)

--- a/tests/test_toa_indexing.py
+++ b/tests/test_toa_indexing.py
@@ -3,8 +3,8 @@ from io import StringIO
 import numpy as np
 import pytest
 from hypothesis import given, assume
-from hypothesis.strategies import slices
-from hypothesis.extra.numpy import arrays
+from hypothesis.strategies import slices, integers, booleans, one_of, lists
+from hypothesis.extra.numpy import arrays, array_shapes
 
 from pint.toa import get_TOAs
 
@@ -55,6 +55,22 @@ def test_getitem_boolean(c):
     s = toas[c]
     assert len(s) == np.sum(c)
     assert np.all(s.get_mjds() == m[c])
+    if len(s) > 0:
+        assert np.all(s.table["mjd_float"] == s.table.group_by("obs")["mjd_float"])
+
+
+@given(
+    one_of(
+        arrays(int, array_shapes(max_dims=1), elements=integers(0, n_tim - 1)),
+        lists(integers(0, n_tim - 1)),
+    )
+)
+def test_getitem_where(a):
+    toas = get_TOAs(StringIO(tim), ephem="de421")
+    m = toas.get_mjds()
+    s = toas[a]
+    assert len(s) == len(a)
+    assert set(s.get_mjds()) == set(m[a])
     if len(s) > 0:
         assert np.all(s.table["mjd_float"] == s.table.group_by("obs")["mjd_float"])
 

--- a/tests/test_toa_indexing.py
+++ b/tests/test_toa_indexing.py
@@ -45,6 +45,7 @@ def test_select(c):
         assert np.all(
             toas.table["mjd_float"] == toas.table.group_by("obs")["mjd_float"]
         )
+        toas.get_summary()
 
 
 @given(arrays(bool, n_tim))
@@ -57,6 +58,7 @@ def test_getitem_boolean(c):
     assert np.all(s.get_mjds() == m[c])
     if len(s) > 0:
         assert np.all(s.table["mjd_float"] == s.table.group_by("obs")["mjd_float"])
+        toas.get_summary()
 
 
 @given(
@@ -73,6 +75,7 @@ def test_getitem_where(a):
     assert set(s.get_mjds()) == set(m[a])
     if len(s) > 0:
         assert np.all(s.table["mjd_float"] == s.table.group_by("obs")["mjd_float"])
+        toas.get_summary()
 
 
 @given(slices(n_tim))
@@ -83,3 +86,4 @@ def test_getitem_slice(c):
     assert set(s.get_mjds()) == set(m[c])
     if len(s) > 0:
         assert np.all(s.table["mjd_float"] == s.table.group_by("obs")["mjd_float"])
+        toas.get_summary()

--- a/tests/test_toa_indexing.py
+++ b/tests/test_toa_indexing.py
@@ -1,0 +1,69 @@
+from io import StringIO
+
+import numpy as np
+import pytest
+from hypothesis import given, assume
+from hypothesis.strategies import slices
+from hypothesis.extra.numpy import arrays
+
+from pint.toa import get_TOAs
+
+tim = """FORMAT 1
+fake 1400 54000 1.0 @ -flag thing
+fake 1400 54001 1.0 @ -flag thing
+fake 1400 54002 1.0 @ -flag other_thing
+fake 1400 54003 2.0 @ -flag thing
+fake 1400 54004 1.0 ao -flag thing
+fake 1400 54005 1.0 @ -flag thing
+fake 1400 54006 1.0 ao -flag thing
+fake 1500 54007 1.0 ao -flag thing
+fake 1500 54008 1.0 @ -flag thing
+"""
+n_tim = len(tim.split("\n")) - 2
+
+
+@pytest.mark.parametrize("high_precision", [True, False])
+def test_get_TOAs(high_precision):
+    toas = get_TOAs(StringIO(tim), ephem="de421")
+    m = toas.get_mjds(high_precision=high_precision)
+    assert isinstance(m, np.ndarray)
+    assert not np.all(
+        np.diff(m) > 0
+    ), "returned values should be grouped by observatory"
+    assert len(m) == n_tim
+
+
+@given(arrays(bool, n_tim))
+def test_select(c):
+    toas = get_TOAs(StringIO(tim), ephem="de421")
+    m = toas.get_mjds()
+    assert len(toas) == len(c)
+    toas.select(c)
+    assert len(toas) == np.sum(c)
+    assert np.all(toas.get_mjds() == m[c])
+    if len(toas) > 0:
+        assert np.all(
+            toas.table["mjd_float"] == toas.table.group_by("obs")["mjd_float"]
+        )
+
+
+@given(arrays(bool, n_tim))
+def test_getitem_boolean(c):
+    toas = get_TOAs(StringIO(tim), ephem="de421")
+    m = toas.get_mjds()
+    assert len(toas) == len(c)
+    s = toas[c]
+    assert len(s) == np.sum(c)
+    assert np.all(s.get_mjds() == m[c])
+    if len(s) > 0:
+        assert np.all(s.table["mjd_float"] == s.table.group_by("obs")["mjd_float"])
+
+
+@given(slices(n_tim))
+def test_getitem_slice(c):
+    toas = get_TOAs(StringIO(tim), ephem="de421")
+    m = toas.get_mjds()
+    s = toas[c]
+    assert set(s.get_mjds()) == set(m[c])
+    if len(s) > 0:
+        assert np.all(s.table["mjd_float"] == s.table.group_by("obs")["mjd_float"])


### PR DESCRIPTION
This allows users to use numpy-like indexing to select subsets of TOAs objects, creating new objects in the process. It supports boolean indexing, slice indexing ([::10] to pick every 10th TOA), and list indexing ([[1,3,6,9]]). `toas.select()` is marked as deprecated but nevertheless it no longer fails when handed an all-False selection.

Closes #824 