### PR TITLE
Fix rms functions in the pintk code

### DIFF
--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -96,7 +96,7 @@ class Pulsar(object):
         self.prefit_resids = Residuals(self.selected_toas, self.prefit_model)
         print(
             "RMS PINT residuals are %.3f us\n"
-            % self.prefit_resids.time_resids.std().to(u.us).value
+            % self.prefit_resids.time_resids.rms_weighted().to(u.us).value
         )
         self.fitter = Fitters.WLS
         self.fitted = False
@@ -184,7 +184,7 @@ class Pulsar(object):
         """
         if self.fitted:
             chi2 = self.postfit_resids.chi2
-            wrms = np.sqrt(chi2 / self.selected_toas.ntoas)
+            wrms = self.postfit_resids.rms_weighted()
             print("Post-Fit Chi2:\t\t%.8g us^2" % chi2)
             print("Post-Fit Weighted RMS:\t%.8g us" % wrms)
             print(
@@ -502,7 +502,7 @@ class Pulsar(object):
         elif self.fitter == Fitters.GLS:
             fitter = pint.fitter.GLSFitter(self.selected_toas, self.prefit_model)
         chi2 = self.prefit_resids.chi2
-        wrms = np.sqrt(chi2 / self.selected_toas.ntoas)
+        wrms = self.prefit_resids. rms_weighted()
         print("Pre-Fit Chi2:\t\t%.8g us^2" % chi2)
         print("Pre-Fit Weighted RMS:\t%.8g us" % wrms)
 

--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -502,7 +502,7 @@ class Pulsar(object):
         elif self.fitter == Fitters.GLS:
             fitter = pint.fitter.GLSFitter(self.selected_toas, self.prefit_model)
         chi2 = self.prefit_resids.chi2
-        wrms = self.prefit_resids. rms_weighted()
+        wrms = self.prefit_resids.rms_weighted()
         print("Pre-Fit Chi2:\t\t%.8g us^2" % chi2)
         print("Pre-Fit Weighted RMS:\t%.8g us" % wrms)
 


### PR DESCRIPTION
The old PINTK does not use the residuals.time_resid.std() to compute the Weighted rms. This PR uses residuals.rms_weighted(). 