### PR TITLE
Added ability to read TOAs using commands from timing model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Fixed bug in solar wind model that prevented fitting
 - Fix pintempo script so it will respect JUMPs in the TOA file.
 ### Added
-- Added a get_model_and_toas() function in model_builder to read both, including model-based commands affecting the TOAs
-- Added ability to load TOAs including relevant commands (e.g. EPHEM, CLOCK, PLANET_SHAPIRO) from a timing model in get_TOAs()
+- Added a get_model_and_toas() function in model_builder to read both, including model-based commands affecting the TOAs (PR #889)
+- Added ability to load TOAs including relevant commands (e.g. EPHEM, CLOCK, PLANET_SHAPIRO) from a timing model in get_TOAs() (PR #889)
 - Added metadata to observatory definition, to keep track of the data origin
 - Added other bipm???? files from TEMPO2
 - Added ability to find observatories in [astropy](https://github.com/astropy/astropy-data/blob/gh-pages/coordinates/sites.json) if not present in PINT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Fixed bug in solar wind model that prevented fitting
 - Fix pintempo script so it will respect JUMPs in the TOA file.
 ### Added
+- Added a get_model_and_toas() function in model_builder to read both, including model-based commands affecting the TOAs
+- Added ability to load TOAs including relevant commands (e.g. EPHEM, CLOCK, PLANET_SHAPIRO) from a timing model in get_TOAs()
 - Added metadata to observatory definition, to keep track of the data origin
 - Added other bipm???? files from TEMPO2
 - Added ability to find observatories in [astropy](https://github.com/astropy/astropy-data/blob/gh-pages/coordinates/sites.json) if not present in PINT

--- a/docs/examples/Wideband_TOA_walkthrough.py
+++ b/docs/examples/Wideband_TOA_walkthrough.py
@@ -26,7 +26,7 @@ import matplotlib.pyplot as plt
 from astropy.visualization import quantity_support
 
 from pint.fitter import WidebandTOAFitter
-from pint.models import get_model
+from pint.models import get_model_and_toas
 from pint.toa import get_TOAs
 
 quantity_support()
@@ -35,8 +35,9 @@ quantity_support()
 # ## Set up your inputs
 
 # %%
-model = get_model("J1614-2230_NANOGrav_12yv3.wb.gls.par")
-toas = get_TOAs("J1614-2230_NANOGrav_12yv3.wb.tim", ephem="de436")
+model, toas = get_model_and_toas(
+    "J1614-2230_NANOGrav_12yv3.wb.gls.par", "J1614-2230_NANOGrav_12yv3.wb.tim"
+)
 
 # %% [markdown]
 # The DM and its uncertainty are recorded as flags, `pp_dm` and `pp_dme` on the TOAs that have them, They are not currently available as Columns in the Astropy object. On the other hand, it is not necessary that every observation have a measured DM.

--- a/docs/examples/fit_NGC6440E.py
+++ b/docs/examples/fit_NGC6440E.py
@@ -1,9 +1,10 @@
 #! /usr/bin/env python
 """Demonstrate use of pint in a script."""
 from __future__ import print_function, division
+import pint.toa
 import pint.fitter
 import pint.residuals
-import pint.models.model_builder as mb
+import pint.models as mm
 
 # import matplotlib
 # matplotlib.use('TKAgg')
@@ -17,11 +18,11 @@ parfile = os.path.join(datadir, "NGC6440E.par")
 timfile = os.path.join(datadir, "NGC6440E.tim")
 
 # Read the timing model and the TOAs
-m, t = mb.get_model_and_toas(parfile, timfile)
+m, t = mm.get_model_and_toas(parfile, timfile)
 
 # If we wanted to do things separately we could do
 # Define the timing model
-# m = mb.get_model(parfile)
+# m = mm.get_model(parfile)
 # Read in the TOAs, overriding some things from the model
 # t = pint.toa.get_TOAs(timfile, model=m)
 

--- a/docs/examples/fit_NGC6440E.py
+++ b/docs/examples/fit_NGC6440E.py
@@ -1,8 +1,6 @@
 #! /usr/bin/env python
 """Demonstrate use of pint in a script."""
 from __future__ import print_function, division
-import pint.toa
-import pint.models
 import pint.fitter
 import pint.residuals
 import pint.models.model_builder as mb
@@ -18,11 +16,14 @@ datadir = os.path.dirname(os.path.abspath(str(__file__)))
 parfile = os.path.join(datadir, "NGC6440E.par")
 timfile = os.path.join(datadir, "NGC6440E.tim")
 
-# Define the timing model
-m = mb.get_model(parfile)
+# Read the timing model and the TOAs
+m, t = mb.get_model_and_toas(parfile, timfile)
 
-# Read in the TOAs
-t = pint.toa.get_TOAs(timfile)
+# If we wanted to do things separately we could do
+# Define the timing model
+# m = mb.get_model(parfile)
+# Read in the TOAs, overriding some things from the model
+# t = pint.toa.get_TOAs(timfile, model=m)
 
 # Examples of how to select some subsets of TOAs
 # These can be un-done using t.unselect()

--- a/docs/examples/fit_NGC6440E_MCMC.py
+++ b/docs/examples/fit_NGC6440E_MCMC.py
@@ -7,7 +7,6 @@ import pint.models
 import pint.mcmc_fitter
 import pint.sampler
 import pint.residuals
-import pint.models.model_builder as mb
 import matplotlib.pyplot as plt
 import astropy.units as u
 from scipy.stats import norm, uniform
@@ -37,11 +36,8 @@ print(timfile)
 nwalkers = 50
 nsteps = 2000
 
-# Define the timing model
-m = mb.get_model(parfile)
-
-# Read in the TOAs
-t = pint.toa.get_TOAs(timfile)
+# Load the timing model and the TOAs
+m, t = pint.models.get_model_and_toas(parfile, timfile)
 
 # Print a summary of the TOAs that we have
 t.print_summary()

--- a/docs/examples/time_a_pulsar.py
+++ b/docs/examples/time_a_pulsar.py
@@ -23,8 +23,7 @@ import astropy.units as u
 import matplotlib.pyplot as plt
 
 import pint.fitter
-import pint.models
-from pint.models import get_model
+from pint.models import get_model_and_toas
 from pint.residuals import Residuals
 from pint.toa import get_TOAs
 
@@ -33,11 +32,10 @@ parfile = "NGC6440E.par"
 timfile = "NGC6440E.tim"
 
 # %%
-m = get_model(parfile)
+m, t_all = get_model_and_toas(parfile, timfile)
 m
 
 # %%
-t_all = pint.toa.get_TOAs(timfile, ephem="de436")
 t_all.print_summary()
 
 # %% [markdown]

--- a/src/pint/models/__init__.py
+++ b/src/pint/models/__init__.py
@@ -29,7 +29,7 @@ from pint.models.frequency_dependent import FD
 from pint.models.glitch import Glitch
 from pint.models.ifunc import IFunc
 from pint.models.jump import DelayJump, PhaseJump
-from pint.models.model_builder import get_model
+from pint.models.model_builder import get_model, get_model_and_toas
 from pint.models.noise_model import EcorrNoise, PLRedNoise, ScaleToaError
 from pint.models.solar_system_shapiro import SolarSystemShapiro
 from pint.models.solar_wind_dispersion import SolarWindDispersion

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -16,6 +16,7 @@ from pint.models.timing_model import (
 )
 from pint.models.parameter import maskParameter
 from pint.utils import PrefixError, interesting_lines, lines_of, split_prefixed_name
+from pint.toa import get_TOAs
 
 __all__ = ["get_model"]
 
@@ -310,6 +311,28 @@ def get_model(parfile):
             with open(fn, "wt") as f:
                 f.write(contents)
             return ModelBuilder(fn).timing_model
+
+
+def get_model_and_toas(parfile, timfile, usepickle=False):
+    """Load a timing model and a related TOAs, using model commands as needed
+
+    Parameters
+    ----------
+    parfile : str
+        The parfile name, or a file-like object to read the parfile contents from
+    timfile : str
+        The timfile name, or a file-like object to read the timfile contents from
+    usepickle : bool
+        Whether to try to use pickle-based caching of loaded clock-corrected TOAs objects
+
+    Returns
+    -------
+    A tuple with (model instance, TOAs instance)
+
+    """
+    mm = get_model(parfile)
+    tt = get_TOAs(timfile, model=mm, usepickle=usepickle)
+    return mm, tt
 
 
 def choose_model(

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -313,7 +313,17 @@ def get_model(parfile):
             return ModelBuilder(fn).timing_model
 
 
-def get_model_and_toas(parfile, timfile, usepickle=False):
+def get_model_and_toas(
+    parfile,
+    timfile,
+    ephem=None,
+    include_bipm=None,
+    bipm_version=None,
+    include_gps=None,
+    planets=None,
+    usepickle=False,
+    tdb_method="default",
+):
     """Load a timing model and a related TOAs, using model commands as needed
 
     Parameters
@@ -322,8 +332,25 @@ def get_model_and_toas(parfile, timfile, usepickle=False):
         The parfile name, or a file-like object to read the parfile contents from
     timfile : str
         The timfile name, or a file-like object to read the timfile contents from
+    include_bipm : bool or None
+        Whether to apply the BIPM clock correction. Defaults to True.
+    bipm_version : string or None
+        Which version of the BIPM tables to use for the clock correction.
+        The format must be 'BIPMXXXX' where XXXX is a year.
+    include_gps : bool or None
+        Whether to include the GPS clock correction. Defaults to True.
+    planets : bool or None
+        Whether to apply Shapiro delays based on planet positions. Note that a
+        long-standing TEMPO2 bug in this feature went unnoticed for years.
+        Defaults to False.
+    model : A valid PINT timing model or None
+        If a valid timing model is passed, model commands (such as BIPM version,
+        planet shapiro delay, and solar system ephemeris) that affect TOA loading
+        are applied.
     usepickle : bool
-        Whether to try to use pickle-based caching of loaded clock-corrected TOAs objects
+        Whether to try to use pickle-based caching of loaded clock-corrected TOAs objects.
+    tdb_method : string
+        Which method to use for the clock correction to TDB.
 
     Returns
     -------
@@ -331,7 +358,16 @@ def get_model_and_toas(parfile, timfile, usepickle=False):
 
     """
     mm = get_model(parfile)
-    tt = get_TOAs(timfile, model=mm, usepickle=usepickle)
+    tt = get_TOAs(
+        timfile,
+        model=mm,
+        ephem=ephem,
+        include_bipm=include_bipm,
+        bipm_version=bipm_version,
+        include_gps=include_gps,
+        planets=planets,
+        usepickle=usepickle,
+    )
     return mm, tt
 
 

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -42,14 +42,12 @@ ignore_params = set(
     [
         "START",
         "FINISH",
-        "CLK",
         "EPHVER",
         "UNITS",
         "TIMEEPH",
         "T2CMETHOD",
         "DILATEFREQ",
         "NTOA",
-        "CLOCK",
         "TRES",
         "TZRMJD",
         "TZRFRQ",
@@ -200,6 +198,10 @@ class TimingModel(object):
         )
         self.add_param_from_top(
             strParameter(name="EPHEM", description="Ephemeris to use"), ""
+        )
+        self.add_param_from_top(
+            strParameter(name="CLOCK", description="Timescale to use", aliases=["CLK"]),
+            "",
         )
         self.add_param_from_top(
             strParameter(name="UNITS", description="Units (TDB assumed)"), ""

--- a/src/pint/observatory/topo_obs.py
+++ b/src/pint/observatory/topo_obs.py
@@ -251,7 +251,9 @@ class TopoObs(Observatory):
             corr += self._gps_clock.evaluate(t)
 
         if self.include_bipm:
-            log.info("Applying TT(TAI) to TT(BIPM) clock correction (~27 us)")
+            log.info(
+                f"Applying TT(TAI) to TT({self.bipm_version}) clock correction (~27 us)"
+            )
             tt2tai = 32.184 * 1e6 * u.us
             if self._bipm_clock is None:
                 try:

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -155,7 +155,10 @@ def get_TOAs(
             ephem = model["EPHEM"].value
             log.info(f"Using EPHEM = {ephem} from the given model")
         if include_bipm is None and model["CLOCK"].value is not None:
-            if "BIPM" in model["CLOCK"].value:
+            if model["CLOCK"].value == "TT(TAI)":
+                include_bipm = False
+                log.info("Using CLOCK = TT(TAI), so setting include_bipm = False")
+            elif "BIPM" in model["CLOCK"].value:
                 clk = model["CLOCK"].value.strip(")").split("(")
                 if len(clk) == 2:
                     ctype, cvers = clk
@@ -1470,7 +1473,7 @@ class TOAs(object):
                 raise ValueError("Some TOAs have 'clkcorr' flag and some do not!")
         # An array of all the time corrections, one for each TOA
         log.info(
-            "Applying clock corrections (include_GPS = {0}, include_BIPM = {1})".format(
+            "Applying clock corrections (include_gps = {0}, include_bipm = {1})".format(
                 include_gps, include_bipm
             )
         )

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -169,7 +169,7 @@ def get_TOAs(
                             )
         if planets is None and model["PLANET_SHAPIRO"].value:
             planets = True
-            log.info(f"Using PLANET_SHAPIRO = True from the given model")
+            log.info("Using PLANET_SHAPIRO = True from the given model")
 
     updatepickle = False
     recalc = False
@@ -222,7 +222,7 @@ def get_TOAs(
         if t.ephem is not None:
             # If you read a .tim file using TOAs(), the ephem is None
             # and so no recalculation is needed, just calculation!
-            log.info(f"Ephem changed, recalculation needed")
+            log.info("Ephem changed, recalculation needed")
         recalc = True
         updatepickle = True
     if recalc or "tdb" not in t.table.colnames:

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -83,6 +83,7 @@ def get_TOAs(
     bipm_version=None,
     include_gps=None,
     planets=None,
+    model=None,
     usepickle=False,
     tdb_method="default",
 ):
@@ -126,11 +127,17 @@ def get_TOAs(
         Whether to apply the BIPM clock correction. Defaults to True.
     bipm_version : string or None
         Which version of the BIPM tables to use for the clock correction.
+        The format must be 'BIPMXXXX' where XXXX is a year.
     include_gps : bool or None
         Whether to include the GPS clock correction. Defaults to True.
     planets : bool or None
         Whether to apply Shapiro delays based on planet positions. Note that a
         long-standing TEMPO2 bug in this feature went unnoticed for years.
+        Defaults to False.
+    model : A valid PINT timing model or None
+        If a valid timing model is passed, model commands (such as BIPM version,
+        planet shapiro delay, and solar system ephemeris) that affect TOA loading
+        are applied.
         Defaults to False.
     usepickle : bool
         Whether to try to use pickle-based caching of loaded clock-corrected TOAs objects.
@@ -143,6 +150,27 @@ def get_TOAs(
         Completed TOAs object representing the data.
 
     """
+    if model:
+        # If the keyword args are set, override what is in the model
+        if ephem is None and model["EPHEM"].value is not None:
+            ephem = model["EPHEM"].value
+            log.info(f"Using EPHEM = {ephem} from the given model")
+        if include_bipm is None and model["CLOCK"].value is not None:
+            if "BIPM" in model["CLOCK"].value:
+                clk = model["CLOCK"].value.strip(")").split("(")
+                if len(clk) == 2:
+                    ctype, cvers = clk
+                    if ctype == "TT" and cvers.startswith("BIPM"):
+                        include_bipm = True
+                        if bipm_version is None:
+                            bipm_version = cvers
+                            log.info(
+                                f"Using CLOCK = {bipm_version} from the given model"
+                            )
+        if planets is None and model["PLANET_SHAPIRO"].value:
+            planets = True
+            log.info(f"Using PLANET_SHAPIRO = True from the given model")
+
     updatepickle = False
     recalc = False
     if usepickle:
@@ -191,7 +219,10 @@ def get_TOAs(
     if ephem is None:
         ephem = t.ephem
     elif ephem != t.ephem:
-        log.info("ephem changed, recalculation needed")
+        if t.ephem is not None:
+            # If you read a .tim file using TOAs(), the ephem is None
+            # and so no recalculation is needed, just calculation!
+            log.info(f"Ephem changed, recalculation needed")
         recalc = True
         updatepickle = True
     if recalc or "tdb" not in t.table.colnames:
@@ -200,7 +231,7 @@ def get_TOAs(
     if planets is None:
         planets = t.planets
     elif planets != t.planets:
-        log.info("planets changed, recalculation needed")
+        log.info("Planet PosVels will be calculated.")
         recalc = True
         updatepickle = True
     if recalc or "ssb_obs_pos" not in t.table.colnames:
@@ -688,7 +719,7 @@ class TOA(object):
         freq=float("inf"),
         scale=None,
         flags=None,
-        **kwargs
+        **kwargs,
     ):
         site = get_observatory(obs)
         # If MJD is already a Time, just use it. Note that this will ignore
@@ -1506,6 +1537,7 @@ class TOAs(object):
                     "ephemeris {1}! Using TDB ephemeris.".format(ephem, self.ephem)
                 )
         self.ephem = ephem
+        log.info(f"Using EPHEM = {self.ephem} for TDB calculation.")
 
         # Compute in observatory groups
         tdbs = np.zeros_like(self.table["mjd"])

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -167,6 +167,15 @@ def get_TOAs(
                             log.info(
                                 f"Using CLOCK = {bipm_version} from the given model"
                             )
+                    else:
+                        log.warning(
+                            f'CLOCK = {model["CLOCK"].value} is not implemented.  Using TT({bipm_default}) instead.'
+                        )
+            else:
+                log.warning(
+                    f'CLOCK = {model["CLOCK"].value} is not implemented.  Using TT({bipm_default}) instead.'
+                )
+
         if planets is None and model["PLANET_SHAPIRO"].value:
             planets = True
             log.info("Using PLANET_SHAPIRO = True from the given model")

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -138,7 +138,6 @@ def get_TOAs(
         If a valid timing model is passed, model commands (such as BIPM version,
         planet shapiro delay, and solar system ephemeris) that affect TOA loading
         are applied.
-        Defaults to False.
     usepickle : bool
         Whether to try to use pickle-based caching of loaded clock-corrected TOAs objects.
     tdb_method : string

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -1,7 +1,12 @@
 import os
 import unittest
 
+from io import StringIO
+
 from pint import toa
+from pint.observatory import bipm_default
+from pint.models import get_model
+from pint.models.model_builder import get_model_and_toas
 from pinttestdata import datadir
 
 # For this test, turn off the check for the age of the IERS A table
@@ -52,3 +57,67 @@ class TestTOAReader(unittest.TestCase):
 
     def test_obs(self):
         assert self.x.table[1]["obs"] == "gbt"
+
+    def test_ephem(self):
+        assert self.x.ephem == "DE421"
+
+    def test_planets(self):
+        assert self.x.planets is False
+
+    def test_clock(self):
+        assert self.x.clock_corr_info["bipm_version"] == bipm_default
+
+    def test_model_override1(self):
+        parstr = StringIO(
+            """
+PSR              1748-2021E
+RAJ       17:48:52.75  1
+DECJ      -20:21:29.0  1
+F0       61.485476554  1
+F1         -1.181D-15  1
+PEPOCH        53750.000000
+POSEPOCH      53750.000000
+DM              223.9  1
+SOLARN0               0.00
+EPHEM               DE436
+CLK              TT(BIPM2017)
+UNITS               TDB
+TIMEEPH             FB90
+T2CMETHOD           TEMPO
+CORRECT_TROPOSPHERE N
+PLANET_SHAPIRO      Y
+DILATEFREQ          N
+"""
+        )
+        m = get_model(parstr)
+        y = toa.get_TOAs("test1.tim", model=m)
+        assert y.ephem == "DE436"
+        assert y.planets is True
+        assert y.clock_corr_info["bipm_version"] == "BIPM2017"
+
+    def test_model_override2(self):
+        parstr = StringIO(
+            """
+PSR              1748-2021E
+RAJ       17:48:52.75  1
+DECJ      -20:21:29.0  1
+F0       61.485476554  1
+F1         -1.181D-15  1
+PEPOCH        53750.000000
+POSEPOCH      53750.000000
+DM              223.9  1
+SOLARN0               0.00
+EPHEM               DE436
+CLK              TT(BIPM2017)
+UNITS               TDB
+TIMEEPH             FB90
+T2CMETHOD           TEMPO
+CORRECT_TROPOSPHERE N
+PLANET_SHAPIRO      Y
+DILATEFREQ          N
+"""
+        )
+        m, y = get_model_and_toas(parstr, "test1.tim")
+        assert y.ephem == "DE436"
+        assert y.planets is True
+        assert y.clock_corr_info["bipm_version"] == "BIPM2017"

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -5,8 +5,7 @@ from io import StringIO
 
 from pint import toa
 from pint.observatory import bipm_default
-from pint.models import get_model
-from pint.models.model_builder import get_model_and_toas
+from pint.models import get_model, get_model_and_toas
 from pinttestdata import datadir
 
 # For this test, turn off the check for the age of the IERS A table
@@ -87,17 +86,35 @@ class TestTOAReader(unittest.TestCase):
     def test_clock(self):
         assert self.x.clock_corr_info["bipm_version"] == bipm_default
 
-    def test_model_override1(self):
-        parstr = StringIO(simplepar)
-        m = get_model(parstr)
-        y = toa.get_TOAs("test1.tim", model=m)
-        assert y.ephem == "DE436"
-        assert y.planets is True
-        assert y.clock_corr_info["bipm_version"] == "BIPM2017"
 
-    def test_model_override2(self):
-        parstr = StringIO(simplepar)
-        m, y = get_model_and_toas(parstr, "test1.tim")
-        assert y.ephem == "DE436"
-        assert y.planets is True
-        assert y.clock_corr_info["bipm_version"] == "BIPM2017"
+def test_model_override1():
+    parstr = StringIO(simplepar)
+    m = get_model(parstr)
+    y = toa.get_TOAs("test1.tim", model=m)
+    assert y.ephem == "DE436"
+    assert y.planets is True
+    assert y.clock_corr_info["bipm_version"] == "BIPM2017"
+
+
+def test_model_override_override():
+    parstr = StringIO(simplepar)
+    m = get_model(parstr)
+    y = toa.get_TOAs(
+        "test1.tim",
+        model=m,
+        ephem="DE405",
+        planets=False,
+        include_bipm=True,
+        bipm_version="BIPM2012",
+    )
+    assert y.ephem == "DE405"
+    assert y.planets is False
+    assert y.clock_corr_info["bipm_version"] == "BIPM2012"
+
+
+def test_model_override2():
+    parstr = StringIO(simplepar)
+    m, y = get_model_and_toas(parstr, "test1.tim")
+    assert y.ephem == "DE436"
+    assert y.planets is True
+    assert y.clock_corr_info["bipm_version"] == "BIPM2017"

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -14,6 +14,26 @@ from astropy.utils.iers import conf
 
 conf.auto_max_age = None
 
+simplepar = """
+PSR              1748-2021E
+RAJ       17:48:52.75  1
+DECJ      -20:21:29.0  1
+F0       61.485476554  1
+F1         -1.181D-15  1
+PEPOCH        53750.000000
+POSEPOCH      53750.000000
+DM              223.9  1
+SOLARN0               0.00
+EPHEM               DE436
+CLK              TT(BIPM2017)
+UNITS               TDB
+TIMEEPH             FB90
+T2CMETHOD           TEMPO
+CORRECT_TROPOSPHERE N
+PLANET_SHAPIRO      Y
+DILATEFREQ          N
+"""
+
 
 class TestTOAReader(unittest.TestCase):
     def setUp(self):
@@ -68,27 +88,7 @@ class TestTOAReader(unittest.TestCase):
         assert self.x.clock_corr_info["bipm_version"] == bipm_default
 
     def test_model_override1(self):
-        parstr = StringIO(
-            """
-PSR              1748-2021E
-RAJ       17:48:52.75  1
-DECJ      -20:21:29.0  1
-F0       61.485476554  1
-F1         -1.181D-15  1
-PEPOCH        53750.000000
-POSEPOCH      53750.000000
-DM              223.9  1
-SOLARN0               0.00
-EPHEM               DE436
-CLK              TT(BIPM2017)
-UNITS               TDB
-TIMEEPH             FB90
-T2CMETHOD           TEMPO
-CORRECT_TROPOSPHERE N
-PLANET_SHAPIRO      Y
-DILATEFREQ          N
-"""
-        )
+        parstr = StringIO(simplepar)
         m = get_model(parstr)
         y = toa.get_TOAs("test1.tim", model=m)
         assert y.ephem == "DE436"
@@ -96,27 +96,7 @@ DILATEFREQ          N
         assert y.clock_corr_info["bipm_version"] == "BIPM2017"
 
     def test_model_override2(self):
-        parstr = StringIO(
-            """
-PSR              1748-2021E
-RAJ       17:48:52.75  1
-DECJ      -20:21:29.0  1
-F0       61.485476554  1
-F1         -1.181D-15  1
-PEPOCH        53750.000000
-POSEPOCH      53750.000000
-DM              223.9  1
-SOLARN0               0.00
-EPHEM               DE436
-CLK              TT(BIPM2017)
-UNITS               TDB
-TIMEEPH             FB90
-T2CMETHOD           TEMPO
-CORRECT_TROPOSPHERE N
-PLANET_SHAPIRO      Y
-DILATEFREQ          N
-"""
-        )
+        parstr = StringIO(simplepar)
         m, y = get_model_and_toas(parstr, "test1.tim")
         assert y.ephem == "DE436"
         assert y.planets is True

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -104,6 +104,12 @@ def test_model_override2():
     assert y.clock_corr_info["bipm_version"] == "BIPM2017"
 
 
+def test_model_override_override2():
+    parstr = StringIO(simplepar)
+    m, y = get_model_and_toas(parstr, "test1.tim", ephem="DE405")
+    assert y.ephem == "DE405"
+
+
 def test_model_override_override():
     parstr = StringIO(simplepar)
     m = get_model(parstr)

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -96,6 +96,14 @@ def test_model_override1():
     assert y.clock_corr_info["bipm_version"] == "BIPM2017"
 
 
+def test_model_override2():
+    parstr = StringIO(simplepar)
+    m, y = get_model_and_toas(parstr, "test1.tim")
+    assert y.ephem == "DE436"
+    assert y.planets is True
+    assert y.clock_corr_info["bipm_version"] == "BIPM2017"
+
+
 def test_model_override_override():
     parstr = StringIO(simplepar)
     m = get_model(parstr)
@@ -112,9 +120,9 @@ def test_model_override_override():
     assert y.clock_corr_info["bipm_version"] == "BIPM2012"
 
 
-def test_model_override2():
-    parstr = StringIO(simplepar)
-    m, y = get_model_and_toas(parstr, "test1.tim")
-    assert y.ephem == "DE436"
-    assert y.planets is True
-    assert y.clock_corr_info["bipm_version"] == "BIPM2017"
+def test_tttai():
+    # This checks to make sure that CLOCK TT(TAI) is handled correctly
+    parstr = StringIO(simplepar.replace("BIPM2017", "TAI"))
+    m = get_model(parstr)
+    y = toa.get_TOAs("test1.tim", model=m)
+    assert y.clock_corr_info["include_bipm"] == False


### PR DESCRIPTION
This allows you to call get_TOAs() with a timing model as an optional keyword param so that it uses the EPHEM, CLOCK, and PLANET_SHAPIRO that the model uses.

There is also a convenience function that sits in models.model_builder that loads both the model and the TOAs in one shot.