### PR TITLE
Catch TypeError when SINI is missing (i.e., None)

### DIFF
--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -419,7 +419,7 @@ class Fitter(object):
                             np.arcsin(self.model.SINI.quantity),
                         )
                         s += "Pulsar mass (Shapiro Delay) = {}".format(psrmass)
-                    except ValueError:
+                    except (TypeError, ValueError):
                         pass
 
         return s


### PR DESCRIPTION
With ELL1 binary models, SINI is often `None`, which doesn't get caught by the `try` block that's supposed to catch missing SINI values in `fitter.get_summary()` since it produces a `TypeError` rather than a `ValueError`, creating a mysterious error message for whoever called `get_summary()`. This fixes that by catching `TypeError` in addition to `ValueError`.