### PR TITLE
Allow no toa for the noise model parameter

### DIFF
--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -10,6 +10,7 @@ from pint.models.parameter import floatParameter, maskParameter
 from pint.models.timing_model import Component
 from collections import OrderedDict
 
+
 class NoiseComponent(Component):
     def __init__(self,):
         super(NoiseComponent, self).__init__()

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -44,7 +44,7 @@ class NoiseComponent(Component):
                 )
             if not suppress_warning:
                 log.warning(msg)
-            return no_toa_param
+        return no_toa_param
 
 
 class ScaleToaError(NoiseComponent):

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -84,9 +84,7 @@ def missingTOAs_msg(parameter_names):
     if len(parameter_names) == 1:
         msg = f"Parameter {parameter_names[0]} does not correspond to any TOAs"
     elif len(parameter_names) > 1:
-        msg = (
-            f"Parameters {' '.join(parameter_names)} do not correspond to any TOAs"
-        )
+        msg = f"Parameters {' '.join(parameter_names)} do not correspond to any TOAs"
     else:
         raise ValueError("Incorrect attempt to construct MissingTOAs")
     return msg
@@ -2006,7 +2004,7 @@ class TimingModel(object):
                     warning_parameters.append(msg)
 
         # The component level of validate_toas only accepts the bad_parameters,
-        # not warning parameters. 
+        # not warning parameters.
         for c in self.components.values():
             try:
                 c.validate_toas(toas)
@@ -2018,7 +2016,6 @@ class TimingModel(object):
             log.warning(missingTOAs_msg(warning_parameters))
         if bad_parameters:
             raise MissingTOAs(bad_parameters)
-
 
     def setup(self):
         """Run setup methods on all components."""

--- a/tests/test_fitter_error_checking.py
+++ b/tests/test_fitter_error_checking.py
@@ -66,15 +66,24 @@ def test_jump_no_toas():
 
 
 def test_noise_no_toa():
-    model = get_model(io.StringIO("\n".join([par_base, "EFAC -fe L_wide 0",
-                                                       "EQUAD -fe L_wide 0",
-                                                       "ECORR -fe L_wide 0"])))
+    model = get_model(
+        io.StringIO(
+            "\n".join(
+                [
+                    par_base,
+                    "EFAC -fe L_wide 0",
+                    "EQUAD -fe L_wide 0",
+                    "ECORR -fe L_wide 0",
+                ]
+            )
+        )
+    )
     toas = make_fake_toas(57000, 57900, 10, model)
     assert len(model.EFAC1.select_toa_mask(toas)) == 0
     assert len(model.EQUAD1.select_toa_mask(toas)) == 0
     assert len(model.ECORR1.select_toa_mask(toas)) == 0
     fitter = pint.fitter.WLSFitter(toas, model)
-    # Should be only warning 
+    # Should be only warning
     fitter.fit_toas()
 
 

--- a/tests/test_fitter_error_checking.py
+++ b/tests/test_fitter_error_checking.py
@@ -78,19 +78,6 @@ def test_noise_no_toa():
     fitter.fit_toas()
 
 
-def test_GLS_fit_no_toa():
-    os.chdir(datadir)
-    m = get_model("B1855+09_NANOGrav_9yv1.gls.par")
-    t = get_TOAs("B1855+09_NANOGrav_9yv1.tim")
-    # add the mask parameter with no TOAs
-    mcorr1 = maskParameter(name='ECORR', key='-f', key_value='fake_backend', value=1, units=u.us)
-    m.add_param_from_top(mcorr1, 'EcorrNoise', setup=True)
-    print(m.params)
-    assert 'ECORR5' in m.params
-    fitter = GLSFitter(t, m)
-    chi2 = fitter.fit_toas()
-
-
 def test_dm_barycentered():
     model = get_model(io.StringIO(par_base))
     toas = make_fake_toas(57000, 57900, 10, model, obs="@", freq=np.inf)

--- a/tests/test_gls_fitter.py
+++ b/tests/test_gls_fitter.py
@@ -79,15 +79,18 @@ class TestGLS(unittest.TestCase):
     def test_has_correlated_errors(self):
         assert self.f.resids.model.has_correlated_errors
 
-
     def test_GLS_fit_no_toa(self):
         # add the mask parameter with no TOAs
-        mcorr1 = maskParameter(name='ECORR', key='-f', key_value='fake_backend', value=1, units=u.us)
-        mcorr2 = maskParameter(name='ECORR', key='-f', key_value='fake_backend2', value=1, units=u.us)
-        self.m.add_param_from_top(mcorr1, 'EcorrNoise', setup=True)
-        self.m.add_param_from_top(mcorr2, 'EcorrNoise', setup=True)
-        assert 'ECORR5' in self.m.params
-        assert 'ECORR6' in self.m.params
+        mcorr1 = maskParameter(
+            name="ECORR", key="-f", key_value="fake_backend", value=1, units=u.us
+        )
+        mcorr2 = maskParameter(
+            name="ECORR", key="-f", key_value="fake_backend2", value=1, units=u.us
+        )
+        self.m.add_param_from_top(mcorr1, "EcorrNoise", setup=True)
+        self.m.add_param_from_top(mcorr2, "EcorrNoise", setup=True)
+        assert "ECORR5" in self.m.params
+        assert "ECORR6" in self.m.params
         fitter = GLSFitter(self.t, self.m)
         chi2 = fitter.fit_toas()
         assert fitter.resids.dof == 3914

--- a/tests/test_gls_fitter.py
+++ b/tests/test_gls_fitter.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import numpy as np
 
 import pint.models.model_builder as mb
+from pint.models.parameter import maskParameter
 from pint import toa
 from pint.fitter import GLSFitter
 from pinttestdata import datadir
@@ -77,3 +78,17 @@ class TestGLS(unittest.TestCase):
 
     def test_has_correlated_errors(self):
         assert self.f.resids.model.has_correlated_errors
+
+
+    def test_GLS_fit_no_toa(self):
+        # add the mask parameter with no TOAs
+        mcorr1 = maskParameter(name='ECORR', key='-f', key_value='fake_backend', value=1, units=u.us)
+        mcorr2 = maskParameter(name='ECORR', key='-f', key_value='fake_backend2', value=1, units=u.us)
+        self.m.add_param_from_top(mcorr1, 'EcorrNoise', setup=True)
+        self.m.add_param_from_top(mcorr2, 'EcorrNoise', setup=True)
+        assert 'ECORR5' in self.m.params
+        assert 'ECORR6' in self.m.params
+        fitter = GLSFitter(self.t, self.m)
+        chi2 = fitter.fit_toas()
+        assert fitter.resids.dof == 3914
+        assert chi2 < 3900


### PR DESCRIPTION
The noise design matrix falls when ECORR does not have TOAs. Since the noise parameters are not fitted ECORR's validate_toa() never gets ran. This PR fix the failing and add the warning print for the noise model's validate_toas.  