### PR TITLE
Add Name color mode to pintk

### DIFF
--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -476,7 +476,12 @@ class PlkWidget(tk.Frame):
 
         self.psr = None
 
-        self.color_modes = [cm.DefaultMode(self), cm.FreqMode(self), cm.ObsMode(self)]
+        self.color_modes = [
+            cm.DefaultMode(self),
+            cm.FreqMode(self),
+            cm.ObsMode(self),
+            cm.NameMode(self),
+        ]
         self.current_mode = "default"
 
     def initPlk(self):


### PR DESCRIPTION
This mode separates datasets with a different "name" flag. 
One way I find this particularly useful highlighting observations from multiple MJDs in the residual vs orbital phase diagram

E.g.
```
FORMAT 1
tag01 0 57493.29081938248561 43092.105601477146 @
tag01 0 57493.696026763554848 43092.105601477146 @
tag01 0 57494.10111587466475 43092.105601477146 @
tag01 0 57494.506340379746106 43092.105601477146 @
(....)
tag22 0 56701.297031975041772 42889.94064429915 @
tag22 0 56701.373972272981245 42889.94064429915 @
tag23 0 56721.46048120475498 42881.111056571055 @
tag23 0 56721.751502036480506 42881.111056571055 @
tag23 0 56722.042638285861685 42881.111056571055 @

```
<img width="626" alt="image" src="https://user-images.githubusercontent.com/7190189/102776405-f2089d80-438e-11eb-851a-c15291a31c52.png">
<img width="625" alt="image" src="https://user-images.githubusercontent.com/7190189/102776774-a60a2880-438f-11eb-86b5-c77cb38f49ac.png">

