### PR TITLE
Toa cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project, at least loosely, adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Now preserves the name column in tempo2 files (PR #926)
+- make_fake_toas now uses ephemeris and other settings from the model (PR #926)
+### Added
+- get_TOAs can read and cache multiple .tim files (PR #926)
+- pickling can be done manually with load_pickle and save_pickle (PR #926)
+- TOAs can be checked against the files they were loaded from with check_hashes() (PR #926)
+- TOAs can now be checked for equality with == (PR #926)
+
 ## [0.8.1] - 2021-01-07
-## Fixed
+### Fixed
 - Right click to delete TOAs in pintk now works
 - Added exception if orbit extrapolates for satellite observatories
 - Fixed Actions to compute and upload coverage
@@ -14,12 +24,12 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Added GitHub Actions for CI testing
 - Fix setup.cfg to disable Py2.7 support
 - Fixed bug in 
-## Removed
+### Removed
 - Removed two unused files
 - Removed use of Travis-CI
-## Changed
+### Changed
 - Sped up some tests
-## Added
+### Added
 - Added Python 3.9 support
 - Added DMX support functions add_DMX_range() and remove_DMX_range()
 - Improvements to make_fake_toas() to support wideband TOAs

--- a/docs/examples/PINT_walkthrough.py
+++ b/docs/examples/PINT_walkthrough.py
@@ -60,6 +60,7 @@ a = toa.TOA(
     freq=1400.0 * u.MHz,
     obs="GBT",
     backend="GUPPI",
+    name="guppi_56789.fits",
 )
 print(a)
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -5,9 +5,16 @@ Reference
 
 This section is to provide specific detail for when you know what you're looking for.
 
+Useful starting places:
+
+* :mod:`pint.toa` - Reading, manipulating, and writing TOAs objects
+* :func:`pint.models.model_builder.get_model` - Loading TimingModel objects
+* :class:`pint.models.timing_model.TimingModel` - Working with TimingModel objects
+* :mod:`pint.fitter` - Fitter objects
+
 .. toctree::
    :maxdepth: 3
-   
+
    timingmodels
    command-line
    api/pint

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -323,6 +323,7 @@ def get_model_and_toas(
     planets=None,
     usepickle=False,
     tdb_method="default",
+    picklefilename=None,
 ):
     """Load a timing model and a related TOAs, using model commands as needed
 
@@ -345,13 +346,17 @@ def get_model_and_toas(
         Defaults to False.
     usepickle : bool
         Whether to try to use pickle-based caching of loaded clock-corrected TOAs objects.
-    tdb_method : string
-        Which method to use for the clock correction to TDB.
+    tdb_method : str
+        Which method to use for the clock correction to TDB. See
+        :func:`pint.observatory.Observatory.get_TDBs` for details.
+    picklefilename : str or None
+        Filename to use for caching loaded file. Defaults to adding ``.pickle.gz`` to the
+        filename of the timfile, if there is one and only one. If no filename is available,
+        or multiple filenames are provided, a specific filename must be provided.
 
     Returns
     -------
     A tuple with (model instance, TOAs instance)
-
     """
     mm = get_model(parfile)
     tt = get_TOAs(
@@ -363,6 +368,8 @@ def get_model_and_toas(
         include_gps=include_gps,
         planets=planets,
         usepickle=usepickle,
+        tdb_method=tdb_method,
+        picklefilename=picklefilename,
     )
     return mm, tt
 

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -552,12 +552,13 @@ def main(argv=None):
     target = tc if weightcol == "CALC" else None
 
     # TODO: make this properly handle long double
-    if not args.usepickle or (
-        not (
-            os.path.isfile(eventfile + ".pickle")
-            or os.path.isfile(eventfile + ".pickle.gz")
-        )
-    ):
+    ts = None
+    if args.usepickle:
+        try:
+            ts = toa.load_pickle(eventfile)
+        except IOError:
+            pass
+    if ts is None:
         # Read event file and return list of TOA objects
         tl = fermi.load_Fermi_TOAs(
             eventfile, weightcolumn=weightcol, targetcoord=target, minweight=minWeight
@@ -578,12 +579,7 @@ def main(argv=None):
         ts.filename = eventfile
         ts.compute_TDBs()
         ts.compute_posvels(ephem="DE421", planets=False)
-        ts.pickle()
-    else:  # read the events in as a pickle file
-        picklefile = toa._check_pickle(eventfile)
-        if not picklefile:
-            picklefile = eventfile
-        ts = toa.TOAs(picklefile)
+        toa.save_pickle(ts)
 
     if weightcol is not None:
         if weightcol == "CALC":

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -148,7 +148,8 @@ def get_TOAs(
     usepickle : bool
         Whether to try to use pickle-based caching of loaded clock-corrected TOAs objects.
     tdb_method : str
-        Which method to use for the clock correction to TDB.
+        Which method to use for the clock correction to TDB. See
+        :func:`pint.observatory.Observatory.get_TDBs` for details.
     picklefilename : str or None
         Filename to use for caching loaded file. Defaults to adding ``.pickle.gz`` to the
         filename of the timfile, if there is one and only one. If no filename is available,

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -229,7 +229,6 @@ def get_TOAs(
                 log.info("Pickle contains wrong bipm_version")
                 updatepickle = True
     if not usepickle or updatepickle:
-        # FIXME: handle lists
         if isinstance(timfile, str) or hasattr(timfile, "readlines"):
             t = TOAs(timfile)
         else:

--- a/tests/test_tim_writing.py
+++ b/tests/test_tim_writing.py
@@ -42,6 +42,7 @@ def do_roundtrip(toas, format="tempo2", **kwargs):
     assert np.all(toas.get_obss() == toas_2.get_obss())
     assert np.all(toas.get_pulse_numbers() == toas_2.get_pulse_numbers())
     assert np.all(toas.get_flags() == toas_2.get_flags())
+    return toas_2
 
 
 def test_basic():
@@ -145,7 +146,20 @@ some_barycentered 999999.999 56400.000000000000000   1.000  @{}
 
 
 def test_pulse_number():
-    f = StringIO(basic_tim_header + basic_tim)
-    t = get_TOAs(f)
+    t = get_TOAs(StringIO(basic_tim_header + basic_tim))
     t.table["pulse_number"] = np.random.randint(10 ** 9, size=t.ntoas)
     do_roundtrip(t)
+
+
+def test_name_preservation():
+    f = StringIO(basic_tim_header + basic_tim)
+    t = get_TOAs(f)
+    v, _ = t.get_flag_value("name")
+    v = set(v)
+    assert "53453.000000.3.000.000.9y.x.ff" in v
+    assert "puppi_56577_B1855+09_0547.9y.x.ff" in v
+    t2 = do_roundtrip(t)
+    v, _ = t2.get_flag_value("name")
+    v = set(v)
+    assert "53453.000000.3.000.000.9y.x.ff" in v
+    assert "puppi_56577_B1855+09_0547.9y.x.ff" in v

--- a/tests/test_toa_pickle.py
+++ b/tests/test_toa_pickle.py
@@ -54,7 +54,7 @@ def test_pickle_works(temp_tim):
 
 def test_pickle_used(temp_tim):
     tt, tp = temp_tim
-    assert not hasattr(toa.get_TOAs(tt, usepickle=True), "was_pickled")
+    assert not toa.get_TOAs(tt, usepickle=True).was_pickled
     assert toa.get_TOAs(tt, usepickle=True).was_pickled
 
 
@@ -102,4 +102,4 @@ def test_pickle_invalidated_time(temp_tim):
     time.sleep(1)
     with open(tt, "at") as f:
         f.write("\n")
-    assert not hasattr(toa.get_TOAs(tt, usepickle=True), "was_pickled")
+    assert not toa.get_TOAs(tt, usepickle=True).was_pickled

--- a/tests/test_toa_pickle.py
+++ b/tests/test_toa_pickle.py
@@ -52,31 +52,25 @@ def test_pickle_works(temp_tim):
     toa.get_TOAs(tt, usepickle=True)
 
 
-def test_pickle_used(temp_tim, monkeypatch):
+def test_pickle_used(temp_tim):
     tt, tp = temp_tim
-    toa.get_TOAs(tt, usepickle=True)
-
-    def no(*args, **kwargs):
-        raise ValueError
-
-    monkeypatch.setattr(toa.TOAs, "read_pickle_file", no)
-    with pytest.raises(ValueError):
-        toa.get_TOAs(tt, usepickle=True)
+    assert not hasattr(toa.get_TOAs(tt, usepickle=True), "was_pickled")
+    assert toa.get_TOAs(tt, usepickle=True).was_pickled
 
 
-def test_pickle_used_settings(temp_tim, monkeypatch):
+def test_pickle_used_settings(temp_tim):
     tt, tp = temp_tim
     toa.get_TOAs(tt, usepickle=True, ephem="de436")
     assert toa.get_TOAs(tt, usepickle=True).ephem == "de436"
 
 
-def test_pickle_changed_ephem(temp_tim, monkeypatch):
+def test_pickle_changed_ephem(temp_tim):
     tt, tp = temp_tim
     toa.get_TOAs(tt, usepickle=True, ephem="de436")
     assert toa.get_TOAs(tt, usepickle=True, ephem="de421").ephem == "de421"
 
 
-def test_pickle_changed_planets(temp_tim, monkeypatch):
+def test_pickle_changed_planets(temp_tim):
     tt, tp = temp_tim
     toa.get_TOAs(tt, usepickle=True, planets=True)
     assert not toa.get_TOAs(tt, usepickle=True, planets=False).planets
@@ -90,7 +84,7 @@ def test_pickle_changed_planets(temp_tim, monkeypatch):
         ("include_gps", True, False),
     ],
 )
-def test_pickle_invalidated_settings(temp_tim, monkeypatch, k, v, wv):
+def test_pickle_invalidated_settings(temp_tim, k, v, wv):
     tt, tp = temp_tim
     d = {}
     d[k] = v
@@ -100,17 +94,9 @@ def test_pickle_invalidated_settings(temp_tim, monkeypatch, k, v, wv):
     assert toa.get_TOAs(tt, usepickle=True, **wd).clock_corr_info[k] == wv
 
 
-def test_pickle_invalidated_time(temp_tim, monkeypatch):
+def test_pickle_invalidated_time(temp_tim):
     tt, tp = temp_tim
     toa.get_TOAs(tt, usepickle=True)
-
-    rpf = toa.TOAs.read_pickle_file
-
-    def change(self, *args, **kwargs):
-        rpf(self, *args, **kwargs)
-        self.was_pickled = True
-
-    monkeypatch.setattr(toa.TOAs, "read_pickle_file", change)
     assert toa.get_TOAs(tt, usepickle=True).was_pickled
 
     time.sleep(1)

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -14,6 +14,8 @@ from astropy.utils.iers import conf
 
 conf.auto_max_age = None
 
+os.chdir(datadir)
+
 simplepar = """
 PSR              1748-2021E
 RAJ       17:48:52.75  1
@@ -166,3 +168,26 @@ def test_bipm_default():
         StringIO(simplepar.replace("BIPM2017", "BIPM")), "test1.tim"
     )
     assert t.clock_corr_info["bipm_version"] == "BIPM"
+
+
+def test_toas_comparison():
+    parstr = StringIO(simplepar)
+    m = get_model(parstr)
+    x = toa.get_TOAs("test1.tim", model=m)
+    y = toa.get_TOAs("test1.tim", model=m)
+    assert x == y
+
+
+def test_toas_comparison_unequal():
+    parstr = StringIO(simplepar)
+    m = get_model(parstr)
+    x = toa.get_TOAs("test1.tim", model=m, ephem="de436")
+    y = toa.get_TOAs("test1.tim", model=m)
+    assert x != y
+
+
+def test_toas_read_list():
+    x = toa.get_TOAs("test1.tim")
+    toas, commands = toa.read_toa_file("test1.tim")
+    y = toa.get_TOAs_list(toas, commands=commands, filename=x.filename)
+    assert x == y

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import pytest
 import numpy as np
+import shutil
 from io import StringIO
 
 from hypothesis import given
@@ -141,6 +142,16 @@ def test_tttai():
     assert y.clock_corr_info["include_bipm"] == False
 
 
+def test_toa_check_hashes(tmpdir):
+    tf = os.path.join(tmpdir, "file.tim")
+    shutil.copy("NGC6440E.tim", tf)
+    t = toa.get_TOAs(tf)
+    assert t.check_hashes()
+    with open(tf, "at") as f:
+        f.write("\n")
+    assert not t.check_hashes()
+
+
 def test_toa_merge():
     filenames = ["NGC6440E.tim", "testtimes.tim", "parkes.toa"]
     toas = [toa.get_TOAs(ff) for ff in filenames]
@@ -164,6 +175,7 @@ def test_toa_merge():
     toas[0].ephem = "DE436"
     with pytest.raises(TypeError):
         nt = toa.merge_TOAs(toas)
+    assert nt.check_hashes()
 
 
 def test_bipm_default():
@@ -192,7 +204,7 @@ def test_toas_comparison_unequal():
 def test_toas_read_list():
     x = toa.get_TOAs("test1.tim")
     toas, commands = toa.read_toa_file("test1.tim")
-    y = toa.get_TOAs_list(toas, commands=commands, filename=x.filename)
+    y = toa.get_TOAs_list(toas, commands=commands, filename=x.filename, hashes=x.hashes)
     assert x == y
 
 


### PR DESCRIPTION
Substantial simplifications of the inner workings of `toa.py`; in particular abolishing `self.toas`.

- Now preserves the name column in tempo2 files
- make_fake_toas now uses ephemeris and other settings from the model
- get_TOAs can read and cache multiple .tim files
- pickling can be done manually with load_pickle and save_pickle
- TOAs can be checked against the files they were loaded from with check_hashes()
- TOAs can now be checked for equality with ==
