### PR TITLE
Fix dmjump derivative

### DIFF
--- a/src/pint/fermi_toas.py
+++ b/src/pint/fermi_toas.py
@@ -202,7 +202,7 @@ def load_Fermi_TOAs(
         ]
     else:
         toalist = [
-            toa.TOA(m, obs=obs, scale=scale, energy=e, weight=w, error=1.0 * u.us,)
+            toa.TOA(m, obs=obs, scale=scale, energy=e, weight=w, error=1.0 * u.us)
             for m, e, w in zip(mjds, energies, weights)
         ]
 

--- a/src/pint/models/binary_ddk.py
+++ b/src/pint/models/binary_ddk.py
@@ -99,7 +99,6 @@ class BinaryDDK(BinaryDD):
                 raise MissingParameter(
                     "DDK", "DDK model needs proper motion parameters."
                 )
-        print(self.SINI.quantity)
         if self.SINI.quantity is not None:
             raise ValueError(
                 "DDK model does not accept `SINI` as input. Please"

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -504,7 +504,7 @@ class DispersionJump(Dispersion):
             # Note we can not use the derivative function 'd_delay_d_dmparam',
             # Since dmjump does not effect delay.
             # The function 'd_delay_d_dmparam' applies d_dm_d_dmparam first and
-            # than applys the time delay part.  
+            # than applys the time delay part.
             self.register_deriv_funcs(self.d_delay_d_dmjump, j)
 
     def validate(self):

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -500,7 +500,7 @@ class DispersionJump(Dispersion):
             if mask_par.startswith("DMJUMP"):
                 self.dm_jumps.append(mask_par)
         for j in self.dm_jumps:
-            self.register_dm_deriv_funcs(self.d_dm_d_dm_param, j)
+            self.register_dm_deriv_funcs(self.d_dm_d_dmjump, j)
             # Note we can not use the derivative function 'd_delay_d_dmparam',
             # Since dmjump does not effect delay.
             # The function 'd_delay_d_dmparam' applies d_dm_d_dmparam first and

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -500,8 +500,12 @@ class DispersionJump(Dispersion):
             if mask_par.startswith("DMJUMP"):
                 self.dm_jumps.append(mask_par)
         for j in self.dm_jumps:
-            self.register_dm_deriv_funcs(self.d_dm_d_dmjump, j)
-            self.register_deriv_funcs(self.d_delay_d_dmparam, j)
+            self.register_dm_deriv_funcs(self.d_dm_d_dm_param, j)
+            # Note we can not use the derivative function 'd_delay_d_dmparam',
+            # Since dmjump does not effect delay.
+            # The function 'd_delay_d_dmparam' applies d_dm_d_dmparam first and
+            # than applys the time delay part.  
+            self.register_deriv_funcs(self.d_delay_d_dmjump, j)
 
     def validate(self):
         super(DispersionJump, self).validate()
@@ -534,4 +538,5 @@ class DispersionJump(Dispersion):
 
         Since DMJUMPS does not affect delay, this would be zero.
         """
-        return np.zeros(toas.ntoas) * (u.s / self.DMJUMP.units)
+        dmjump = getattr(self, param_name)
+        return np.zeros(toas.ntoas) * (u.s / dmjump.units)

--- a/tests/test_wideband_dm_data.py
+++ b/tests/test_wideband_dm_data.py
@@ -121,6 +121,16 @@ class TestDMData:
             dm_jump_map[dmj.key_value[0]] = dmj
         for be in all_backends:
             assert all(dm_jump_value[toa_backends == be] == -dm_jump_map[be].quantity)
+        for dmj_param in dm_jump_params:
+            # test derivative function in the dmjump component
+            d_dm_d_dmjump = self.model.d_dm_d_dmjump(self.toas, dmj_param.name)
+            be = dmj_param.key_value
+            assert all(d_dm_d_dmjump[toa_backends == be] == -1.0 * u.Unit(''))
+            d_delay_d_dmjump = self.model.d_delay_d_dmjump(self.toas, dmj_param.name)
+            assert all(d_delay_d_dmjump == 0.0 * (u.s / dmj_param.units))
+            # Test the registered functions
+            assert self.model.delay_deriv_funcs[dmj_param.name] == [self.model.d_delay_d_dmjump]
+            assert self.model.dm_derivs[dmj_param.name] == [self.model.d_dm_d_dmjump]
 
         r = WidebandTOAResiduals(
             self.toas, self.model, dm_resid_args=dict(subtract_mean=False)

--- a/tests/test_wideband_dm_data.py
+++ b/tests/test_wideband_dm_data.py
@@ -91,6 +91,13 @@ class TestDMData:
     def setup(self):
         self.model = get_model("J1614-2230_NANOGrav_12yv3.wb.gls.par")
         self.toas = get_TOAs("J1614-2230_NANOGrav_12yv3.wb.tim")
+        toa_backends, valid_flags = self.toas.get_flag_value("fe")
+        self.toa_backends = np.array(toa_backends)
+        self.dm_jump_params = [
+            getattr(self.model, x)
+            for x in self.model.params
+            if (x.startswith("DMJUMP"))
+        ]
 
     def test_data_reading(self):
         dm_data_raw, valid = self.toas.get_flag_value("pp_dm")
@@ -107,20 +114,13 @@ class TestDMData:
 
     def test_dm_jumps(self):
         # First get the toas for jump
-        toa_backends, valid_flags = self.toas.get_flag_value("fe")
-        toa_backends = np.array(toa_backends)
-        all_backends = list(set(toa_backends))
+        all_backends = list(set(self.toa_backends))
         dm_jump_value = self.model.jump_dm(self.toas)
-        dm_jump_params = [
-            getattr(self.model, x)
-            for x in self.model.params
-            if (x.startswith("DMJUMP"))
-        ]
         dm_jump_map = {}
-        for dmj in dm_jump_params:
+        for dmj in self.dm_jump_params:
             dm_jump_map[dmj.key_value[0]] = dmj
         for be in all_backends:
-            assert all(dm_jump_value[toa_backends == be] == -dm_jump_map[be].quantity)
+            assert all(dm_jump_value[self.toa_backends == be] == -dm_jump_map[be].quantity)
 
         r = WidebandTOAResiduals(
             self.toas, self.model, dm_resid_args=dict(subtract_mean=False)
@@ -137,30 +137,20 @@ class TestDMData:
         delta_dm = r2.dm.resids_value - r.dm.resids_value
         delta_dm_intended = np.zeros_like(delta_dm)
         for i, be in enumerate(all_backends):
-            delta_dm_intended[toa_backends == be] = -(i + 1)
+            delta_dm_intended[self.toa_backends == be] = -(i + 1)
         assert np.allclose(delta_dm, delta_dm_intended)
 
     def test_dmjump_derivative(self):
         # This test is designe to test the dm jump derivatives.
         # First get the toas for jump
-        toa_backends, valid_flags = self.toas.get_flag_value("fe")
-        toa_backends = np.array(toa_backends)
-        all_backends = list(set(toa_backends))
-        dm_jump_value = self.model.jump_dm(self.toas)
-        dm_jump_params = [
-            getattr(self.model, x)
-            for x in self.model.params
-            if (x.startswith("DMJUMP"))
-        ]
-
-        for dmj_param in dm_jump_params:
+        for dmj_param in self.dm_jump_params:
             # test derivative function in the dmjump component
             d_dm_d_dmjump = self.model.d_dm_d_dmjump(self.toas, dmj_param.name)
             be = dmj_param.key_value
             # The derivative of dm with respect to dm jump is -1 for the jumped
             # TOAs/DM data, the others are zero
-            assert all(d_dm_d_dmjump[toa_backends == be] == -1.0 * u.Unit(""))
-            assert all(d_dm_d_dmjump[toa_backends != be] == 0.0 * u.Unit(""))
+            assert all(d_dm_d_dmjump[self.toa_backends == be] == -1.0 * u.Unit(""))
+            assert all(d_dm_d_dmjump[self.toa_backends != be] == 0.0 * u.Unit(""))
             d_delay_d_dmjump = self.model.d_delay_d_dmjump(self.toas, dmj_param.name)
             # The derivative of delay with respect to dm jump is 0.
             assert all(d_delay_d_dmjump == 0.0 * (u.s / dmj_param.units))

--- a/tests/test_wideband_dm_data.py
+++ b/tests/test_wideband_dm_data.py
@@ -120,7 +120,9 @@ class TestDMData:
         for dmj in self.dm_jump_params:
             dm_jump_map[dmj.key_value[0]] = dmj
         for be in all_backends:
-            assert all(dm_jump_value[self.toa_backends == be] == -dm_jump_map[be].quantity)
+            assert all(
+                dm_jump_value[self.toa_backends == be] == -dm_jump_map[be].quantity
+            )
 
         r = WidebandTOAResiduals(
             self.toas, self.model, dm_resid_args=dict(subtract_mean=False)

--- a/tests/test_wideband_dm_data.py
+++ b/tests/test_wideband_dm_data.py
@@ -125,11 +125,13 @@ class TestDMData:
             # test derivative function in the dmjump component
             d_dm_d_dmjump = self.model.d_dm_d_dmjump(self.toas, dmj_param.name)
             be = dmj_param.key_value
-            assert all(d_dm_d_dmjump[toa_backends == be] == -1.0 * u.Unit(''))
+            assert all(d_dm_d_dmjump[toa_backends == be] == -1.0 * u.Unit(""))
             d_delay_d_dmjump = self.model.d_delay_d_dmjump(self.toas, dmj_param.name)
             assert all(d_delay_d_dmjump == 0.0 * (u.s / dmj_param.units))
             # Test the registered functions
-            assert self.model.delay_deriv_funcs[dmj_param.name] == [self.model.d_delay_d_dmjump]
+            assert self.model.delay_deriv_funcs[dmj_param.name] == [
+                self.model.d_delay_d_dmjump
+            ]
             assert self.model.dm_derivs[dmj_param.name] == [self.model.d_dm_d_dmjump]
 
         r = WidebandTOAResiduals(


### PR DESCRIPTION
Fix the bug in the DMjump fitting. The DMJUMP fitting was not working due to the dmjump component registers the wrong dmjump derivative functions. 