### PR TITLE
fix wrong chi2 calculation

### DIFF
--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1181,7 +1181,10 @@ class GLSFitter(Fitter):
                 fitpv[pn] = np.longdouble((pv + dpv) / fitp[pn].units)
                 # NOTE We need some way to use the parameter limits.
                 fitperrs[pn] = errs[uind]
-            self.minimize_func(list(fitpv.values()), *list(fitp.keys()))
+            newparams = dict(zip(list(fitp.keys()), list(fitpv.values())))
+            self.set_params(newparams)
+            self.update_resids()
+            # self.minimize_func(list(fitpv.values()), *list(fitp.keys()))
             # Update Uncertainties
             self.set_param_uncertainties(fitperrs)
 
@@ -1512,7 +1515,10 @@ class WidebandTOAFitter(Fitter):  # Is GLSFitter the best here?
                 fitpv[pn] = np.longdouble((pv + dpv) / fitp[pn].units)
                 # NOTE We need some way to use the parameter limits.
                 fitperrs[pn] = errs[uind]
-            self.minimize_func(list(fitpv.values()), *list(fitp.keys()))
+            newparams = dict(zip(list(fitp.keys()), list(fitpv.values())))
+            self.set_params(newparams)
+            self.update_resids()
+            # self.minimize_func(list(fitpv.values()), *list(fitp.keys()))
             # Update Uncertainties
             self.set_param_uncertainties(fitperrs)
 

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -9,6 +9,7 @@ dispersion measures (:class:`pint.residuals.WidebandTOAResiduals`).
 from __future__ import absolute_import, division, print_function
 
 import collections
+import copy
 import warnings
 
 import astropy.units as u
@@ -347,9 +348,11 @@ class Residuals:
             # Use GLS but don't actually fit
             from pint.fitter import GLSFitter
 
-            f = GLSFitter(self.toas, self.model, residuals=self)
+            m = copy.deepcopy(self.model)
+            m.free_parameters = []
+            f = GLSFitter(self.toas, m, residuals=self)
             try:
-                return f.fit_toas(maxiter=0, full_cov=full_cov)
+                return f.fit_toas(maxiter=1, full_cov=full_cov)
             except LinAlgError as e:
                 log.warning(
                     "Degenerate conditions encountered when "

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -204,9 +204,7 @@ def test_residuals_wideband_chi2():
 
 
 # @pytest.mark.xfail()
-@pytest.mark.parametrize(
-    "full_cov", [pytest.param(True, marks=pytest.mark.xfail), False]
-)
+@pytest.mark.parametrize("full_cov", [True, False])
 def test_gls_chi2_real_data(full_cov):
     model = get_model(
         StringIO(
@@ -223,7 +221,6 @@ def test_gls_chi2_real_data(full_cov):
             """
         )
     )
-    # model.free_params = ["ELAT", "ELONG"]
     toas = make_fake_toas(57000, 59000, 40, model=model, error=1 * u.us)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
     f = GLSFitter(toas, model)
@@ -231,7 +228,7 @@ def test_gls_chi2_real_data(full_cov):
     assert_allclose(fit_chi2, f.resids.calc_chi2(full_cov=full_cov))
 
 
-@pytest.mark.xfail()
+@pytest.mark.xfail(reason="numerical instability maybe?")
 def test_gls_chi2_full_cov():
     model = get_model(
         StringIO(
@@ -248,6 +245,7 @@ def test_gls_chi2_full_cov():
             """
         )
     )
+    model.free_params = ["ELAT", "ELONG"]
     toas = make_fake_toas(57000, 59000, 1000, model=model, error=1 * u.us)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
     r = Residuals(toas, model)

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -203,6 +203,7 @@ def test_residuals_wideband_chi2():
     assert f.fit_toas() == r.chi2
 
 
+@pytest.mark.xfail()
 @pytest.mark.parametrize("full_cov", [True, False])
 def test_gls_chi2_real_data(full_cov):
     model = get_model(
@@ -225,3 +226,26 @@ def test_gls_chi2_real_data(full_cov):
     f = GLSFitter(toas, model)
     fit_chi2 = f.fit_toas(maxiter=10, full_cov=full_cov)
     assert_allclose(fit_chi2, f.resids.calc_chi2(full_cov=full_cov))
+
+
+@pytest.mark.xfail()
+def test_gls_chi2_full_cov():
+    model = get_model(
+        StringIO(
+            """
+            PSRJ J1234+5678
+            ELAT 0
+            ELONG 0
+            DM 10
+            F0 1
+            PEPOCH 58000
+            TNRedAmp -14.227505410948254
+            TNRedGam 4.91353
+            TNRedC 45
+            """
+        )
+    )
+    toas = make_fake_toas(57000, 59000, 1000, model=model, error=1 * u.us)
+    toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
+    r = Residuals(toas, model)
+    assert_allclose(r.calc_chi2(full_cov=True), r.calc_chi2(full_cov=False))

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -8,15 +8,15 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.time import TimeDelta
-from pinttestdata import datadir
 from numpy.testing import assert_allclose
+from pinttestdata import datadir
 
+from pint.fitter import GLSFitter, WidebandTOAFitter, WLSFitter
 from pint.models import get_model
 from pint.models.dispersion_model import Dispersion
 from pint.residuals import CombinedResiduals, Residuals, WidebandTOAResiduals
 from pint.toa import get_TOAs, make_fake_toas
 from pint.utils import weighted_mean
-from pint.fitter import WLSFitter, GLSFitter, WidebandTOAFitter
 
 os.chdir(datadir)
 
@@ -155,6 +155,7 @@ def test_residuals_wls_chi2():
         )
     )
     toas = make_fake_toas(57000, 59000, 20, model=model, error=1 * u.us)
+    np.random.seed(0)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
     r = Residuals(toas, model)
     f = WLSFitter(toas, model)
@@ -176,6 +177,7 @@ def test_residuals_gls_chi2():
         )
     )
     toas = make_fake_toas(57000, 59000, 20, model=model, error=1 * u.us)
+    np.random.seed(0)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
     r = Residuals(toas, model)
     f = GLSFitter(toas, model)
@@ -197,6 +199,7 @@ def test_residuals_wideband_chi2():
         )
     )
     toas = make_fake_toas(57000, 59000, 20, model=model, error=1 * u.us, dm=10)
+    np.random.seed(0)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
     r = Residuals(toas, model)
     f = WidebandTOAFitter(toas, model)
@@ -204,7 +207,9 @@ def test_residuals_wideband_chi2():
 
 
 # @pytest.mark.xfail()
-@pytest.mark.parametrize("full_cov", [True, False])
+@pytest.mark.parametrize(
+    "full_cov", [pytest.param(True, marks=pytest.mark.xfail), False]
+)
 def test_gls_chi2_real_data(full_cov):
     model = get_model(
         StringIO(
@@ -222,6 +227,7 @@ def test_gls_chi2_real_data(full_cov):
         )
     )
     toas = make_fake_toas(57000, 59000, 40, model=model, error=1 * u.us)
+    np.random.seed(0)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
     f = GLSFitter(toas, model)
     fit_chi2 = f.fit_toas(full_cov=full_cov)
@@ -247,6 +253,7 @@ def test_gls_chi2_full_cov():
     )
     model.free_params = ["ELAT", "ELONG"]
     toas = make_fake_toas(57000, 59000, 1000, model=model, error=1 * u.us)
+    np.random.seed(0)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
     r = Residuals(toas, model)
     assert_allclose(r.calc_chi2(full_cov=True), r.calc_chi2(full_cov=False))

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -203,8 +203,10 @@ def test_residuals_wideband_chi2():
     assert f.fit_toas() == r.chi2
 
 
-@pytest.mark.xfail()
-@pytest.mark.parametrize("full_cov", [True, False])
+# @pytest.mark.xfail()
+@pytest.mark.parametrize(
+    "full_cov", [pytest.param(True, marks=pytest.mark.xfail), False]
+)
 def test_gls_chi2_real_data(full_cov):
     model = get_model(
         StringIO(
@@ -221,10 +223,11 @@ def test_gls_chi2_real_data(full_cov):
             """
         )
     )
+    # model.free_params = ["ELAT", "ELONG"]
     toas = make_fake_toas(57000, 59000, 40, model=model, error=1 * u.us)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
     f = GLSFitter(toas, model)
-    fit_chi2 = f.fit_toas(maxiter=10, full_cov=full_cov)
+    fit_chi2 = f.fit_toas(full_cov=full_cov)
     assert_allclose(fit_chi2, f.resids.calc_chi2(full_cov=full_cov))
 
 


### PR DESCRIPTION
For GLSFitter and WidebandTOAfitter, the chi-squared calculation was just using the wrong formula. I believe it is now correct, although there are numerical headaches with some examples. We still lack good tests to verify that this is the correct computation.

The key error is that when you have a non-trivial noise model, you have to fit out the noise components (and a constant) before reporting a chi-squared value. This was not being done. Now it is, at some cost in speed.