### PR TITLE
Allow renaming of .tim files

### DIFF
--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -204,7 +204,7 @@ def get_TOAs(
             updatepickle = True
         else:
             if hasattr(t, "hashes"):
-                if not t.check_hashes():
+                if not t.check_hashes(timfile):
                     updatepickle = True
                     log.info("Pickle based on files that have changed")
             else:
@@ -1493,10 +1493,43 @@ class TOAs:
         )
         return sorted_mjds[i], sorted_mjds[s[i]]
 
-    def check_hashes(self):
-        """Determine whether the input files are the same as when loaded."""
-        for f, v in self.hashes.items():
-            if _compute_hash(f) != v:
+    def check_hashes(self, timfile=None):
+        """Determine whether the input files are the same as when loaded.
+
+        Parameters
+        ----------
+        timfile : str or list of str or file-like or None
+            If provided this should match the list of files the TOAs object was loaded from.
+            If this is a string or list of strings, and the number matches the number of
+            files this TOAs object was loaded from, it is assumed that these are supposed to
+            be the same files, re-named or moved; their contents are then checked. If the
+            contents or the number doesn't match, this function returns False.
+
+        Returns
+        -------
+        bool
+            True if the contents of the TOAs object matches the content of the files.
+        """
+        if self.filename is None:
+            return True
+        elif isinstance(self.filename, str):
+            filenames = [self.filename]
+        else:
+            filenames = self.filename
+
+        if timfile is None:
+            timfiles = filenames
+        elif hasattr(timfile, "readlines"):
+            return True
+        elif isinstance(timfile, str):
+            timfiles = [timfile]
+        else:
+            timfiles = list(timfile)
+        if len(timfiles) != len(filenames):
+            return False
+
+        for t, f in zip(timfiles, filenames):
+            if _compute_hash(t) != self.hashes[f]:
                 return False
         return True
 

--- a/tests/test_toa_pickle.py
+++ b/tests/test_toa_pickle.py
@@ -103,3 +103,14 @@ def test_pickle_invalidated_time(temp_tim):
     with open(tt, "at") as f:
         f.write("\n")
     assert not toa.get_TOAs(tt, usepickle=True).was_pickled
+
+
+def test_pickle_moved(temp_tim):
+    tt, tp = temp_tim
+    tt2 = tt + ".also.tim"
+    shutil.copy(tt, tt2)
+    toa.get_TOAs(tt, usepickle=True, picklefilename=tp)
+    assert toa.get_TOAs(tt2, usepickle=True, picklefilename=tp).was_pickled
+    with open(tt2, "at") as f:
+        f.write("\n")
+    assert not toa.get_TOAs(tt2, usepickle=True, picklefilename=tp).was_pickled


### PR DESCRIPTION
If `.tim` files are renamed, pickles should be smart enough to invalidate themselves, if necessary, even if the original files are unchanged.