### PR TITLE
Use pulse numbers if present

### DIFF
--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1240,10 +1240,10 @@ class WidebandTOAFitter(Fitter):  # Is GLSFitter the best here?
                 "data have to match the fit data names."
             )
         self.fit_data = fit_data
-        if self.track_mode is not None:
+        if track_mode is not None:
             if "toa" not in additional_args:
                 additional_args["toa"] = {}
-            additional_args["toa"]["track_mode"] = self.track_mode
+            additional_args["toa"]["track_mode"] = track_mode
         self.additional_args = additional_args
         # Get the makers for fitting parts.
         self.reset_model()

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1216,7 +1216,12 @@ class WidebandTOAFitter(Fitter):  # Is GLSFitter the best here?
     """
 
     def __init__(
-        self, fit_data, model, fit_data_names=["toa", "dm"], additional_args={}
+        self,
+        fit_data,
+        model,
+        fit_data_names=["toa", "dm"],
+        track_mode=None,
+        additional_args={},
     ):
 
         self.model_init = model
@@ -1235,6 +1240,10 @@ class WidebandTOAFitter(Fitter):  # Is GLSFitter the best here?
                 "data have to match the fit data names."
             )
         self.fit_data = fit_data
+        if self.track_mode is not None:
+            if "toa" not in additional_args:
+                additional_args["toa"] = {}
+            additional_args["toa"]["track_mode"] = self.track_mode
         self.additional_args = additional_args
         # Get the makers for fitting parts.
         self.reset_model()

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1618,16 +1618,15 @@ class TOAs:
         self.table["delta_pulse_number"] += dphs
 
         # Then, add pulse_number as a table column if possible
-        try:
-            pns = [float(flags.get("pn", np.nan)) for flags in self.table["flags"]]
-            self.table["pulse_number"] = pns
-            self.table["pulse_number"].unit = u.dimensionless_unscaled
+        pns = [float(flags.get("pn", np.nan)) for flags in self.table["flags"]]
+        if np.all(np.isnan(pns)):
+            raise ValueError("No pulse numbers found")
+        self.table["pulse_number"] = pns
+        self.table["pulse_number"].unit = u.dimensionless_unscaled
 
-            # Remove pn from dictionary to prevent redundancies
-            for flags in self.table["flags"]:
-                del flags["pn"]
-        except KeyError:
-            raise ValueError("Not all TOAs have pn flags")
+        # Remove pn from dictionary to prevent redundancies
+        for flags in self.table["flags"]:
+            del flags["pn"]
 
     def compute_pulse_numbers(self, model):
         """Set pulse numbers (in TOA table column pulse_numbers) based on model.
@@ -1746,7 +1745,10 @@ class TOAs:
         # If pulse numbers were added to flags, remove them again
         if pnChange:
             for flags in self.table["flags"]:
-                del flags["pn"]
+                try:
+                    del flags["pn"]
+                except KeyError:
+                    pass
 
         if not handle:
             outf.close()

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1389,7 +1389,7 @@ class TOAs:
         if "pn" in self.table["flags"][0]:
             if "pulse_number" in self.table.colnames:
                 raise ValueError("Pulse number cannot be both a column and a TOA flag")
-            return np.array(flags["pn"] for flags in self.table["flags"])
+            return np.array(flags.get("pn", np.nan) for flags in self.table["flags"])
         elif "pulse_number" in self.table.colnames:
             return self.table["pulse_number"]
         else:
@@ -1619,7 +1619,7 @@ class TOAs:
 
         # Then, add pulse_number as a table column if possible
         try:
-            pns = [flags["pn"] for flags in self.table["flags"]]
+            pns = [float(flags.get("pn", np.nan)) for flags in self.table["flags"]]
             self.table["pulse_number"] = pns
             self.table["pulse_number"].unit = u.dimensionless_unscaled
 
@@ -1714,7 +1714,9 @@ class TOAs:
         if "pulse_number" in self.table.colnames:
             pnChange = True
             for i in range(len(self.table["flags"])):
-                self.table["flags"][i]["pn"] = self.table["pulse_number"][i]
+                pn = self.table["pulse_number"][i]
+                if not np.isnan(pn):
+                    self.table["flags"][i]["pn"] = pn
 
         for (toatime, toaerr, freq, obs, flags) in zip(
             self.table["mjd"],

--- a/tests/test_pulse_number.py
+++ b/tests/test_pulse_number.py
@@ -1,10 +1,12 @@
 #!/usr/bin/python
+from io import StringIO
 import os
 import pytest
 from copy import deepcopy
 
 import numpy as np
 from astropy import units as u
+from numpy.testing import assert_almost_equal
 
 from pint.residuals import Residuals
 from pinttestdata import datadir
@@ -139,3 +141,12 @@ def test_fitter_respects_pulse_numbers(fitter, model, fake_toas):
     f_2 = fitter(t, m_2, track_mode="use_pulse_numbers")
     f_2.fit_toas()
     assert abs(f_2.model.F0.quantity - model.F0.quantity) < 0.01 * delta_f
+
+
+@pytest.mark.xfail(reason="partial pulse numbers not supported yet")
+def test_partial_pulse_numbers(model, toas):
+    r = Residuals(toas, model, track_mode="use_pulse_numbers")
+    toas_2 = deepcopy(toas)
+    toas_2.table["pulse_number"][1] = np.nan
+    r2 = Residuals(toas_2, model, track_mode="use_pulse_numbers")
+    assert_almost_equal(r.time_resids[2:].value, r2.time_resids[2:].value)


### PR DESCRIPTION
Currently pulse numbers are ignored unless `track_mode="use_pulse_numbers"` is specified. With this PR, TOAs with pulse numbers take advantage of them.