### PR TITLE
Jump gui fix

### DIFF
--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -1381,7 +1381,12 @@ class maskParameter(floatParameter):
                         "are MJD, FREQ, NAME, TEL."
                     )
         self.key = key
-        self.key_value = [key_value_parser(k) for k in key_value]
+        if key == "-gui_jump":
+            self.key_value = key_value
+        else:
+            self.key_value = [
+                key_value_parser(k) for k in key_value
+            ]  # retains string format from .par file to ensure correct data type for comparison
         self.key_value.sort()
         self.index = index
         name_param = name + str(index)

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1227,7 +1227,7 @@ class TimingModel(object):
         return result
 
     def jump_flags_to_params(self, toas):
-        """Convert jump flags in toas.table["flags"] to jump parameters in the model.
+        """Convert jump flags in toas.table["flags"] (loaded in .tim file) to jump parameters in the model.
 
         The flags processed are ``jump`` and ``gui_jump``.
         """
@@ -1238,9 +1238,9 @@ class TimingModel(object):
                 break
             elif "gui_jump" in flag_dict.keys():
                 break
-        else:
-            log.info("No jump flags to process")
-            return None
+            else:
+                log.info("No jump flags to process from .tim file")
+                return None
         for flag_dict in toas.table["flags"]:
             if "jump" in flag_dict.keys():
                 jump_nums = [

--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -368,7 +368,10 @@ class Pulsar(object):
                     for item in comp_list:
                         if isinstance(item, pint.models.jump.PhaseJump):
                             self.prefit_model.remove_component(item)
-                            if self.fitted:
+                    if self.fitted:
+                        comp_list = getattr(self.postfit_model, "PhaseComponent_list")
+                        for item in comp_list:
+                            if isinstance(item, pint.models.jump.PhaseJump):
                                 self.postfit_model.remove_component(item)
                 else:
                     self.prefit_model.components["PhaseJump"].setup()
@@ -422,7 +425,7 @@ class Pulsar(object):
 
         """JUMP check, TODO: put in fitter?"""
         if "PhaseJump" in self.prefit_model.components:
-            # if attempted fit (selected)
+            # Modifies jump flags. If attempted fit (selected)
             # A) contains only jumps, don't do the fit and return an error
             # B) excludes a jump, turn that jump off
             # C) partially contains a jump, redefine that jump only with the overlap

--- a/src/pint/toa_select.py
+++ b/src/pint/toa_select.py
@@ -121,12 +121,6 @@ class TOASelect(object):
         """
         result = {}
         for k, v in condition.items():
-            try:
-                v = int(
-                    v
-                )  # if v is a number in string format, needs to be int in order to match with column value
-            except ValueError:
-                pass
             index = np.where(column == v)[0]
             result[k] = index
         return result

--- a/src/pint/toa_select.py
+++ b/src/pint/toa_select.py
@@ -121,7 +121,14 @@ class TOASelect(object):
         """
         result = {}
         for k, v in condition.items():
+            try:
+                v = int(
+                    v
+                )  # if v is a number in string format, needs to be int in order to match with column value
+            except ValueError:
+                pass
             index = np.where(column == v)[0]
+            print("index is: " + str(index))
             result[k] = index
         return result
 

--- a/src/pint/toa_select.py
+++ b/src/pint/toa_select.py
@@ -128,7 +128,6 @@ class TOASelect(object):
             except ValueError:
                 pass
             index = np.where(column == v)[0]
-            print("index is: " + str(index))
             result[k] = index
         return result
 


### PR DESCRIPTION
This fixes some lingering bugs with adding `JUMPs` in the `GUI`. In `select_toas.py`, there was an issue with a type mismatch between the `key_value` stored in the `maskParameter` and the value stored in the TOA table, causing matching pairs not to match. I'm not sure why the `key_value` in the `maskParameter` is changed to a string (line 1384 of `parameter.py`) when I input it as an integer. I applied a fix for when a comparison is made, but a better way would probably be to keep the `key_value` as an int. I wasn't sure if there was a reason for this when `maskParameter` is used outside of  `GUI JUMPs`, so I didn't change this. I also fixed an issue with deleting the `PhaseJump` object after a fit.