### PR TITLE
Improvements to satellite observatories.

### DIFF
--- a/src/pint/observatory/__init__.py
+++ b/src/pint/observatory/__init__.py
@@ -274,7 +274,7 @@ class Observatory:
         """
         raise NotImplementedError
 
-    def posvel(self, t, ephem):
+    def posvel(self, t, ephem, group=None):
         """Return observatory position and velocity for the given times.
 
         Postion is relative to solar system barycenter; times are

--- a/src/pint/observatory/special_locations.py
+++ b/src/pint/observatory/special_locations.py
@@ -46,10 +46,6 @@ class SpecialLocation(Observatory):
         like 'BIPM2015'
     """ % bipm_default
 
-    # def clock_corrections(self, t):
-    #    log.info('Special observatory location. No clock corrections applied.')
-    #    return numpy.zeros(t.shape)*u.s
-
     def __init__(
         self,
         name,
@@ -57,6 +53,7 @@ class SpecialLocation(Observatory):
         include_gps=True,
         include_bipm=True,
         bipm_version=bipm_default,
+        overwrite=False,
     ):
         # GPS corrections not implemented yet
         self.include_gps = include_gps
@@ -151,13 +148,13 @@ class BarycenterObs(SpecialLocation):
     def tempo2_code(self):
         return "bat"
 
-    def get_gcrs(self, t, ephem=None, grp=None):
+    def get_gcrs(self, t, ephem=None):
         if ephem is None:
             raise ValueError("Ephemeris needed for BarycenterObs get_gcrs")
         ssb_pv = objPosVel_wrt_SSB("earth", t, ephem)
         return -1 * ssb_pv.pos
 
-    def posvel(self, t, ephem):
+    def posvel(self, t, ephem, group=None):
         vdim = (3,) + t.shape
         return PosVel(
             np.zeros(vdim) * u.m,
@@ -189,11 +186,11 @@ class GeocenterObs(SpecialLocation):
     def tempo2_code(self):
         return "coe"
 
-    def get_gcrs(self, t, ephem=None, grp=None):
+    def get_gcrs(self, t, ephem=None):
         vdim = (3,) + t.shape
         return np.zeros(vdim) * u.m
 
-    def posvel(self, t, ephem):
+    def posvel(self, t, ephem, group=None):
         return objPosVel_wrt_SSB("earth", t, ephem)
 
 
@@ -214,17 +211,16 @@ class T2SpacecraftObs(SpecialLocation):
     def tempo_code(self):
         return None
 
-    def get_gcrs(self, t, ephem=None, grp=None):
+    def get_gcrs(self, t, group, ephem=None):
         """Return spacecraft GCRS position; this assumes position flags in tim file are in km"""
 
-        if grp is None:
+        if group is None:
             raise ValueError("TOA group table needed for SpacecraftObs get_gcrs")
 
         try:
-            # Is there a better way to do this?
-            x = np.array([flags["telx"] for flags in grp["flags"]])
-            y = np.array([flags["tely"] for flags in grp["flags"]])
-            z = np.array([flags["telz"] for flags in grp["flags"]])
+            x = np.array([flags["telx"] for flags in group["flags"]])
+            y = np.array([flags["tely"] for flags in group["flags"]])
+            z = np.array([flags["telz"] for flags in group["flags"]])
         except:
             log.error(
                 "Missing flag. TOA line should have telx,tely,telz flags for GCRS position in km."
@@ -245,17 +241,16 @@ class T2SpacecraftObs(SpecialLocation):
 
         return pos * u.km
 
-    def posvel_gcrs(self, t, grp):
+    def posvel_gcrs(self, t, group, ephem=None):
         """Return spacecraft GCRS position and velocity; this assumes position flags in tim file are in km and velocity flags are in km/s"""
 
-        if grp is None:
+        if group is None:
             raise ValueError("TOA group table needed for SpacecraftObs posvel_gcrs")
 
         try:
-            # Is there a better way to do this?
-            vx = np.array([flags["vx"] for flags in grp["flags"]])
-            vy = np.array([flags["vy"] for flags in grp["flags"]])
-            vz = np.array([flags["vz"] for flags in grp["flags"]])
+            vx = np.array([flags["vx"] for flags in group["flags"]])
+            vy = np.array([flags["vy"] for flags in group["flags"]])
+            vz = np.array([flags["vz"] for flags in group["flags"]])
         except:
             log.error(
                 "Missing flag. TOA line should have vx,vy,vz flags for GCRS velocity in km/s."
@@ -274,18 +269,21 @@ class T2SpacecraftObs(SpecialLocation):
                 vdim.shape,
             )
 
-        pos_geo = self.get_gcrs(t, ephem=None, grp=grp)
+        pos_geo = self.get_gcrs(t, group, ephem=None)
 
         stl_posvel = PosVel(pos_geo, vel_geo, origin="earth", obj="spacecraft")
         return stl_posvel
 
-    def posvel(self, t, ephem, grp):
+    def posvel(self, t, ephem, group=None):
+
+        if group is None:
+            raise ValueError("TOA group table needed for SpacecraftObs posvel")
 
         # Compute vector from SSB to Earth
         geo_posvel = objPosVel_wrt_SSB("earth", t, ephem)
 
         # Spacecraft posvel w.r.t. Earth
-        stl_posvel = self.posvel_gcrs(t, grp)
+        stl_posvel = self.posvel_gcrs(t, group)
 
         # Vector add to geo_posvel to get full posvel vector w.r.t. SSB.
         return geo_posvel + stl_posvel
@@ -295,5 +293,4 @@ class T2SpacecraftObs(SpecialLocation):
 BarycenterObs("barycenter", aliases=["@", "ssb", "bary", "bat"])
 GeocenterObs("geocenter", aliases=["0", "o", "coe", "geo"])
 T2SpacecraftObs("stl_geo", aliases=["STL_GEO"])
-# TODO -- change name/docstring for SpacecraftObs
 # TODO -- BIPM issue

--- a/src/pint/observatory/topo_obs.py
+++ b/src/pint/observatory/topo_obs.py
@@ -318,7 +318,7 @@ class TopoObs(Observatory):
         )
         return obs_geocenter_pv.pos
 
-    def posvel(self, t, ephem):
+    def posvel(self, t, ephem, group=None):
         if t.isscalar:
             t = Time([t])
         earth_pv = objPosVel_wrt_SSB("earth", t, ephem)

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -2020,7 +2020,7 @@ class TOAs:
             tdb = time.Time(grp["tdb"], precision=9)
 
             if isinstance(site, T2SpacecraftObs):
-                ssb_obs = site.posvel(tdb, ephem, grp)
+                ssb_obs = site.posvel(tdb, ephem, group=grp)
             else:
                 ssb_obs = site.posvel(tdb, ephem)
 

--- a/tests/test_satobs.py
+++ b/tests/test_satobs.py
@@ -1,0 +1,41 @@
+import os
+import pytest
+
+from astropy.time import Time
+import numpy as np
+
+from pint.observatory.satellite_obs import get_satellite_observatory
+from pinttestdata import datadir
+
+
+def test_good_calls():
+    # ensure that valid entries are accepted
+    ft2file = os.path.join(datadir, "lat_spacecraft_weekly_w323_p202_v001.fits")
+    fermi_obs = get_satellite_observatory("Fermi", ft2file, overwrite=True)
+    tt_mjd = fermi_obs.FT2["MJD_TT"]
+    good_times = Time(
+        tt_mjd[:: len(tt_mjd) // 10] + (np.random.rand(1) * 4 - 2) / (60 * 24),
+        format="mjd",
+        scale="tt",
+    )
+    # NB this also tests calls with a vector Time
+    fermi_obs._check_bounds(good_times)
+
+
+def test_bad_calls():
+    # find an SAA passage, which will be internal
+    ft2file = os.path.join(datadir, "lat_spacecraft_weekly_w323_p202_v001.fits")
+    fermi_obs = get_satellite_observatory("Fermi", ft2file, overwrite=True)
+    tt_mjd = fermi_obs.FT2["MJD_TT"]
+    saa_idx = np.argmax((tt_mjd[1:] - tt_mjd[:-1]))
+    bad_time_saa = Time(tt_mjd[saa_idx] + 3.0 / (60 * 24), format="mjd", scale="tt")
+    # and test extrapolation from the ends
+    # NB this also tests calls with a scalar Time
+    bad_time_end = Time(tt_mjd[-1] + 3.0 / (60 * 24), format="mjd", scale="tt")
+    bad_time_beg = Time(tt_mjd[0] - 3.0 / (60 * 24), format="mjd", scale="tt")
+    with pytest.raises(ValueError):
+        fermi_obs._check_bounds(bad_time_saa)
+    with pytest.raises(ValueError):
+        fermi_obs._check_bounds(bad_time_end)
+    with pytest.raises(ValueError):
+        fermi_obs._check_bounds(bad_time_beg)


### PR DESCRIPTION
This is a follow-up PR to further unify and improve support for satellite observatories.

1. Merged all current spacecraft into single SatelliteObs class, removing the special case for NICER.  The previous NICER special case had code that checked against extrapolating an orbit tabulation too far.
2. Now, all orbiting observatories perform an check when the user requests S/C position/velocity information to ensure that the requested time lies within N minutes of a tabulated point, where N=2 by default.
3. That makes them all trivially do the same thing, with special coded needed only to load the particular S/C information file for each mission.
4. Removed some redundant code in posvel/posvel_gcrs.
5. Added a basic test suite for the bounds checking.

In addition, this PR restores and simplifies the "groups" kwarg that's needed for T2SpacecraftObs.