### PR TITLE
Numpy deprecations fix

### DIFF
--- a/src/pint/fits_utils.py
+++ b/src/pint/fits_utils.py
@@ -87,31 +87,29 @@ def read_fits_event_mjds(event_hdu, timecolumn="TIME"):
         TIMEZERO = 0
     else:
         try:
-            TIMEZERO = np.float(event_hdr["TIMEZERO"])
+            TIMEZERO = float(event_hdr["TIMEZERO"])
         except KeyError:
-            TIMEZERO = np.float(event_hdr["TIMEZERI"]) + np.float(event_hdr["TIMEZERF"])
+            TIMEZERO = float(event_hdr["TIMEZERI"]) + float(event_hdr["TIMEZERF"])
     log.debug("TIMEZERO = {0}".format(TIMEZERO))
 
     # Collect MJDREF
     try:
-        MJDREF = np.float(event_hdr["MJDREF"])
+        MJDREF = float(event_hdr["MJDREF"])
     except KeyError:
         # Here I have to work around an issue where the MJDREFF key is stored
         # as a string in the header and uses the "1.234D-5" syntax for floats, which
         # is not supported by Python
         if isinstance(event_hdr["MJDREFF"], (str, bytes)):
-            MJDREF = np.float(event_hdr["MJDREFI"]) + fortran_float(
-                event_hdr["MJDREFF"]
-            )
+            MJDREF = float(event_hdr["MJDREFI"]) + fortran_float(event_hdr["MJDREFF"])
         else:
-            MJDREF = np.float(event_hdr["MJDREFI"]) + np.float(event_hdr["MJDREFF"])
+            MJDREF = float(event_hdr["MJDREFI"]) + float(event_hdr["MJDREFF"])
     log.debug("MJDREF = {0}".format(MJDREF))
 
     # Should check timecolumn units to be sure they are seconds!
 
     # MJD = (TIMECOLUMN + TIMEZERO)/SECS_PER_DAY + MJDREF
     mjds = (
-        np.array(event_dat.field(timecolumn), dtype=np.float) + TIMEZERO
+        np.array(event_dat.field(timecolumn), dtype=float) + TIMEZERO
     ) / SECS_PER_DAY + MJDREF
 
     return mjds

--- a/src/pint/ltinterface.py
+++ b/src/pint/ltinterface.py
@@ -237,7 +237,7 @@ class PINTPulsar:
         if log.level < 25:
             self.t.print_summary()
 
-        self.deleted = np.zeros(self.t.ntoas, dtype=np.bool)
+        self.deleted = np.zeros(self.t.ntoas, dtype=bool)
         self._readflags()
 
     def _readflags(self):

--- a/src/pint/models/priors.py
+++ b/src/pint/models/priors.py
@@ -61,21 +61,21 @@ class Prior:
         if type(value) == np.ndarray:
             v = value.astype(np.float64, casting="same_kind")
         else:
-            v = np.float(value)
+            v = float(value)
         return self._rv.pdf(v)
 
     def logpdf(self, value):
         if type(value) == np.ndarray:
             v = value.astype(np.float64, casting="same_kind")
         else:
-            v = np.float(value)
+            v = float(value)
         return self._rv.logpdf(v)
 
 
 class RandomInclinationPrior(rv_continuous):
-    """ Prior returning the pdf for sin(i) given a uniform prior on cos(i).
+    """Prior returning the pdf for sin(i) given a uniform prior on cos(i).
 
-        p(sin i) == p(x) = x/(1-x**2)**0.5
+    p(sin i) == p(x) = x/(1-x**2)**0.5
     """
 
     def __init__(self, **kwargs):
@@ -91,9 +91,7 @@ class RandomInclinationPrior(rv_continuous):
 
 
 class UniformUnboundedRV(rv_continuous):
-    r"""A uniform prior distribution (equivalent to no prior)
-
-    """
+    r"""A uniform prior distribution (equivalent to no prior)"""
 
     # The astype() calls prevent unsafe cast messages
     def _pdf(self, x):

--- a/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
+++ b/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
@@ -20,7 +20,7 @@ class orbits:
 
     def orbit_phase(self):
         orbits = self.orbits()
-        norbits = np.array(np.floor(orbits), dtype=np.long)
+        norbits = np.array(np.floor(orbits), dtype=np.compat.long)
         phase = (orbits - norbits) * 2 * np.pi * u.rad
         return phase
 
@@ -73,8 +73,7 @@ class OrbitPB(orbits):
         super(OrbitPB, self).__init__("orbitPB", parent, orbit_params)
 
     def orbits(self,):
-        """Orbits using PB, PBDOT, XPBDOT
-        """
+        """Orbits using PB, PBDOT, XPBDOT"""
         PB = self.PB.to("second")
         PBDOT = self.PBDOT
         XPBDOT = self.XPBDOT
@@ -90,16 +89,14 @@ class OrbitPB(orbits):
         return self.PBDOT
 
     def d_orbits_d_T0(self):
-        """The derivitve of orbits respect to T0
-        """
+        """The derivitve of orbits respect to T0"""
         PB = self.PB.to("second")
         PBDOT = self.PBDOT
         XPBDOT = self.XPBDOT
         return ((PBDOT - XPBDOT) * self.tt0 / PB - 1.0) * 2 * np.pi * u.rad / PB
 
     def d_orbits_d_PB(self):
-        """dM/dPB this could be a generic function
-        """
+        """dM/dPB this could be a generic function"""
         PB = self.PB.to("second")
         PBDOT = self.PBDOT
         XPBDOT = self.XPBDOT
@@ -111,14 +108,12 @@ class OrbitPB(orbits):
         )
 
     def d_orbits_d_PBDOT(self):
-        """dM/dPBDOT this could be a generic function
-        """
+        """dM/dPBDOT this could be a generic function"""
         PB = self.PB.to("second")
         return -np.pi * u.rad * self.tt0 ** 2 / PB ** 2
 
     def d_orbits_d_XPBDOT(self):
-        """dM/dPBDOT this could be a generic function
-        """
+        """dM/dPBDOT this could be a generic function"""
         PB = self.PB.to("second")
         return -np.pi * u.rad * self.tt0 ** 2 / PB ** 2
 

--- a/src/pint/pulsar_mjd.py
+++ b/src/pint/pulsar_mjd.py
@@ -266,8 +266,8 @@ def time_from_mjd_string(s, scale="utc", format="pulsar_mjd"):
 
 def time_from_longdouble(t, scale="utc", format="pulsar_mjd"):
     t = np.longdouble(t)
-    i = np.float(np.floor(t))
-    f = np.float(t - i)
+    i = float(np.floor(t))
+    f = float(t - i)
     return astropy.time.Time(val=i, val2=f, format=format, scale=scale)
 
 
@@ -286,7 +286,7 @@ longdouble_mjd_eps = (70000 * u.day * np.finfo(np.longdouble).eps).to(u.ns)
 
 
 def time_to_longdouble(t):
-    """ Return an astropy Time value as MJD in longdouble
+    """Return an astropy Time value as MJD in longdouble
 
     The returned value is accurate to within a nanosecond, while the precision of long
     double MJDs (near the present) is roughly 0.7 ns.

--- a/src/pint/sampler.py
+++ b/src/pint/sampler.py
@@ -144,7 +144,7 @@ class EmceeSampler(MCMCSampler):
                 for ii in range(self.nwalkers):
                     pos[ii][idx] = svals[ii]
         pos[0] = fitvals
-        return [pos_i.astype(np.float) for pos_i in pos]
+        return [pos_i.astype(float) for pos_i in pos]
 
     def get_chain(self):
         """

--- a/src/pint/scripts/photonphase.py
+++ b/src/pint/scripts/photonphase.py
@@ -216,7 +216,7 @@ def main(argv=None):
         orbits = modelin.binary_instance.orbits()
         # These lines are already in orbits.orbit_phase() in binary_orbits.py.
         # What is the correct syntax is to call this function here?
-        norbits = np.array(np.floor(orbits), dtype=np.long)
+        norbits = np.array(np.floor(orbits), dtype=int)
         orbphases = orbits - norbits  # fractional phase
 
     if args.addphase or args.addorbphase:

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1289,7 +1289,7 @@ class TOAs:
     def __getitem__(self, index):
         if not hasattr(self, "table"):
             raise ValueError("This TOAs object is incomplete and does not have a table")
-        if isinstance(index, np.ndarray) and index.dtype == np.bool:
+        if isinstance(index, np.ndarray) and index.dtype == bool:
             r = copy.deepcopy(self)
             r.table = r.table[index]
             if len(r.table) > 0:
@@ -1297,7 +1297,7 @@ class TOAs:
             return r
         elif (
             isinstance(index, np.ndarray)
-            and index.dtype == np.int
+            and index.dtype == np.int64
             or isinstance(index, list)
         ):
             r = copy.deepcopy(self)

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -641,7 +641,7 @@ def dmx_ranges_old(
                 print("Ack!  This shouldn't be happening!")
             oldmax = DMX.max
     # Init mask to all False
-    mask = np.zeros_like(MJDs.value, dtype=np.bool)
+    mask = np.zeros_like(MJDs.value, dtype=bool)
     # Mark TOAs as True if they are in any DMX bin
     for DMX in DMXs:
         mask[np.logical_and(MJDs > DMX.min - offset, MJDs < DMX.max + offset)] = True
@@ -752,7 +752,7 @@ def dmx_ranges(toas, divide_freq=1000.0 * u.MHz, binwidth=15.0 * u.d, verbose=Fa
             DMX.sum_print()
 
     # Init mask to all False
-    mask = np.zeros_like(MJDs.value, dtype=np.bool)
+    mask = np.zeros_like(MJDs.value, dtype=bool)
     # Mark TOAs as True if they are in any DMX bin
     for DMX in DMXs:
         mask[np.logical_and(MJDs >= DMX.min, MJDs <= DMX.max)] = True
@@ -1059,7 +1059,7 @@ def weighted_mean(arrin, weights_in, inputmean=None, calcerr=False, sdev=False):
     Converted from IDL: 2006-10-23. Erin Sheldon, NYU
     Copied from PRESTO to PINT : 2020-04-18
 
-   """
+    """
     arr = arrin
     weights = weights_in
     wtot = weights.sum()

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -5,7 +5,7 @@ import numpy as np
 def test_str2longdouble():
     print("You are using numpy %s" % np.__version__)
     a = np.longdouble("0.12345678901234567890")
-    b = np.float("0.12345678901234567890")
+    b = float("0.12345678901234567890")
     # If numpy is converting to longdouble without loss of
     # precision these two numbers should be different
     assert not (a == b), (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -309,15 +309,15 @@ def mjd_strs(draw):
 @given(
     one_of(
         array_pair(
-            np.int,
+            np.int64,
             integers(min_value=40000, max_value=60000),
-            np.float,
+            float,
             floats(0, 1, allow_nan=False),
         ),
         array_pair_broadcast(
-            np.int,
+            np.int64,
             integers(min_value=40000, max_value=60000),
-            np.float,
+            float,
             floats(0, 1, allow_nan=False),
         ),
     )
@@ -334,15 +334,15 @@ def test_mjds_to_str_array(sif):
 @given(
     one_of(
         array_pair(
-            np.int,
+            np.int64,
             integers(min_value=40000, max_value=60000),
-            np.float,
+            float,
             floats(0, 1, allow_nan=False),
         ),
         array_pair_broadcast(
-            np.int,
+            np.int64,
             integers(min_value=40000, max_value=60000),
-            np.float,
+            float,
             floats(0, 1, allow_nan=False),
         ),
     )
@@ -356,15 +356,15 @@ def test_mjds_to_str_array_roundtrip_doesnt_crash(sif):
 @given(
     one_of(
         array_pair(
-            np.int,
+            np.int64,
             integers(min_value=40000, max_value=60000),
-            np.float,
+            float,
             floats(0, 1, allow_nan=False),
         ),
         array_pair_broadcast(
-            np.int,
+            np.int64,
             integers(min_value=40000, max_value=60000),
-            np.float,
+            float,
             floats(0, 1, allow_nan=False),
         ),
     )
@@ -417,7 +417,7 @@ def test_mjds_to_jds_singleton():
     assert isinstance(jd2, float)
 
 
-@given(arrays(np.object, array_shapes(), elements=mjd_strs()))
+@given(arrays(object, array_shapes(), elements=mjd_strs()))
 def test_str_to_mjds_array(s):
     i, f = str_to_mjds(s)
     assert np.shape(i) == np.shape(f) == np.shape(s)
@@ -428,15 +428,15 @@ def test_str_to_mjds_array(s):
 @given(
     one_of(
         array_pair(
-            np.int,
+            np.int64,
             integers(min_value=40000, max_value=60000),
-            np.float,
+            float,
             floats(0, 1, allow_nan=False),
         ),
         array_pair_broadcast(
-            np.int,
+            np.int64,
             integers(min_value=40000, max_value=60000),
-            np.float,
+            float,
             floats(0, 1, allow_nan=False),
         ),
     )
@@ -452,15 +452,15 @@ def test_mjds_to_jds_array(sif):
 @given(
     one_of(
         array_pair(
-            np.int,
+            np.int64,
             integers(min_value=40000, max_value=60000),
-            np.float,
+            float,
             floats(0, 1, allow_nan=False),
         ),
         array_pair_broadcast(
-            np.int,
+            np.int64,
             integers(min_value=40000, max_value=60000),
-            np.float,
+            float,
             floats(0, 1, allow_nan=False),
         ),
     )
@@ -476,15 +476,15 @@ def test_mjds_to_jds_pulsar_array(sif):
 @given(
     one_of(
         array_pair(
-            np.int,
+            np.int64,
             integers(min_value=2440000, max_value=2460000),
-            np.float,
+            float,
             floats(0, 1, allow_nan=False),
         ),
         array_pair_broadcast(
-            np.int,
+            np.int64,
             integers(min_value=2440000, max_value=2460000),
-            np.float,
+            float,
             floats(0, 1, allow_nan=False),
         ),
     )
@@ -502,15 +502,15 @@ def test_jds_to_mjds_array(s12):
 @given(
     one_of(
         array_pair(
-            np.int,
+            np.int64,
             integers(min_value=2440000, max_value=2460000),
-            np.float,
+            float,
             floats(0, 1, allow_nan=False),
         ),
         array_pair_broadcast(
-            np.int,
+            np.int64,
             integers(min_value=2440000, max_value=2460000),
-            np.float,
+            float,
             floats(0, 1, allow_nan=False),
         ),
     )


### PR DESCRIPTION
Addresses issue #964 by swapping out deprecated Numpy data types with the appropriate built-in data types. `np.int` was replaced with `np.int64` (not deprecated) in case we wanted 64 bits of precision despite the os being run on, but I can go back and change these simply to `int` if this is unnecessary. 