### PR TITLE
Don't try to parse .tim files as if they were pickles.

### DIFF
--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -303,7 +303,7 @@ def load_pickle(toafilename, picklefilename=None):
         If no pickle is found.
     """
     picklefilenames = (
-        [toafilename + ext for ext in (".pickle.gz", ".pickle", "")]
+        [toafilename + ext for ext in (".pickle.gz", ".pickle")]
         if picklefilename is None
         else [picklefilename]
     )

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -303,7 +303,7 @@ def load_pickle(toafilename, picklefilename=None):
         If no pickle is found.
     """
     picklefilenames = (
-        [toafilename + ext for ext in (".pickle.gz", ".pickle")]
+        [toafilename + ext for ext in (".pickle.gz", ".pickle", "")]
         if picklefilename is None
         else [picklefilename]
     )
@@ -313,12 +313,12 @@ def load_pickle(toafilename, picklefilename=None):
         try:
             with gzip.open(fn, "rb") as f:
                 lf = pickle.load(f)
-        except (IOError, pickle.UnpicklingError):
+        except (IOError, pickle.UnpicklingError, ValueError):
             pass
         try:
             with open(fn, "rb") as f:
                 lf = pickle.load(f)
-        except (IOError, pickle.UnpicklingError):
+        except (IOError, pickle.UnpicklingError, ValueError):
             pass
     if lf is not None:
         lf.was_pickled = True


### PR DESCRIPTION
This fixes the bug I mentioned on the telecon.  It was trying to read a .tim file as if it was a pickle. Now it tries to unpickle only files that end in .pickle or .pickle.gz.