### PR TITLE
Ensure output par files have appropriate T2CMETHOD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 
 ## Unreleased
 ### Fixed
-- Now ensures T2CMETHOD is IAU2000B if it is set at all
+- Now ensures T2CMETHOD is IAU2000B if it is set at all (PR #970)
 
 ## [0.8.2] - 2021-01-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project, at least loosely, adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Now ensures T2CMETHOD is IAU2000B if it is set at all
+
 ## [0.8.2] - 2021-01-27
 ### Fixed
 - Now preserves the name column in tempo2 files (PR #926)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 
 ## Unreleased
 ### Fixed
-- Now ensures T2CMETHOD is IAU2000B if it is set at all (PR #970)
+- Now ensures T2CMETHOD is IAU2000B if it is set at all; likewise DILATEFREQ and TIMEEPH (PR #970)
 
 ## [0.8.2] - 2021-01-27
 ### Fixed

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -295,8 +295,10 @@ class TimingModel:
         """
         if self.DILATEFREQ.value:
             warn("PINT does not support 'DILATEFREQ Y'")
+            self.DILATEFREQ.value = False
         if self.TIMEEPH.value not in [None, "FB90"]:
             warn("PINT only supports 'TIMEEPH FB90'")
+            self.TIMEEPH.value = "FB90"
         if self.T2CMETHOD.value not in [None, "IAU2000B"]:  # FIXME: really?
             warn("PINT only supports 'T2CMETHOD IAU2000B'")
             self.T2CMETHOD.value = "IAU2000B"

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -299,6 +299,7 @@ class TimingModel:
             warn("PINT only supports 'TIMEEPH FB90'")
         if self.T2CMETHOD.value not in [None, "IAU2000B"]:  # FIXME: really?
             warn("PINT only supports 'T2CMETHOD IAU2000B'")
+            self.T2CMETHOD.value = "IAU2000B"
         if self.UNITS.value not in [None, "TDB"]:
             raise ValueError("PINT only supports 'UNITS TDB'")
         for cp in self.components.values():

--- a/tests/test_fitter_error_checking.py
+++ b/tests/test_fitter_error_checking.py
@@ -165,7 +165,8 @@ def test_update_model_sets_things(Fitter):
     model = get_model(io.StringIO("\n".join([par_base, "JUMP TEL barycenter 0"])))
     model.INFO.value = "-f"
     model.ECL.value = "IERS2010"
-    model.TIMEEPH.value = "FB90"
+    model.TIMEEPH.value = "IF99"
+    model.DILATEFREQ.value = True
     model.T2CMETHOD.value = "IAU2000B"
     toas = make_fake_toas(58000, 59000, 10, model, obs="barycenter", freq=np.inf)
     fitter = Fitter(toas, model)

--- a/tests/test_fitter_error_checking.py
+++ b/tests/test_fitter_error_checking.py
@@ -167,7 +167,7 @@ def test_update_model_sets_things(Fitter):
     model.ECL.value = "IERS2010"
     model.TIMEEPH.value = "IF99"
     model.DILATEFREQ.value = True
-    model.T2CMETHOD.value = "IAU2000B"
+    model.T2CMETHOD.value = "TEMPO"
     toas = make_fake_toas(58000, 59000, 10, model, obs="barycenter", freq=np.inf)
     fitter = Fitter(toas, model)
     fitter.fit_toas()

--- a/tests/test_fitter_error_checking.py
+++ b/tests/test_fitter_error_checking.py
@@ -166,14 +166,14 @@ def test_update_model_sets_things(Fitter):
     model.INFO.value = "-f"
     model.ECL.value = "IERS2010"
     model.TIMEEPH.value = "FB90"
-    model.T2CMETHOD.value = "IERS2000B"
+    model.T2CMETHOD.value = "IAU2000B"
     toas = make_fake_toas(58000, 59000, 10, model, obs="barycenter", freq=np.inf)
     fitter = Fitter(toas, model)
     fitter.fit_toas()
     par_out = fitter.model.as_parfile()
     assert re.search(r"CLOCK *TT\(TAI\)", par_out)
     assert re.search(r"TIMEEPH *FB90", par_out)
-    assert re.search(r"T2CMETHOD *IERS2000B", par_out)
+    assert re.search(r"T2CMETHOD *IAU2000B", par_out)
     assert re.search(r"NE_SW *0.0", par_out)
     assert re.search(r"ECL *IERS2010", par_out)
     assert re.search(r"DILATEFREQ *N", par_out)

--- a/tests/test_fitter_error_checking.py
+++ b/tests/test_fitter_error_checking.py
@@ -161,7 +161,7 @@ def test_null_vector(Fitter):
 
 
 @pytest.mark.parametrize("Fitter", [pint.fitter.WLSFitter, pint.fitter.GLSFitter])
-def test_update_model(Fitter):
+def test_update_model_sets_things(Fitter):
     model = get_model(io.StringIO("\n".join([par_base, "JUMP TEL barycenter 0"])))
     model.INFO.value = "-f"
     model.ECL.value = "IERS2010"

--- a/tests/test_timing_model.py
+++ b/tests/test_timing_model.py
@@ -297,4 +297,10 @@ def test_free_params(lines, param, exception):
 
 def test_pepoch_late():
     model = get_model(io.StringIO(par_base))
-    t = make_fake_toas(56000, 57000, 10, model=model)
+    make_fake_toas(56000, 57000, 10, model=model)
+
+
+def test_t2cmethod_corrected():
+    with pytest.warns(UserWarning, match=".*T2CMETHOD.*"):
+        model = get_model(io.StringIO("\n".join([par_base, "T2CMETHOD TEMPO"])))
+    assert model.T2CMETHOD.value == "IAU2000B"


### PR DESCRIPTION
This makes sure that if T2CMETHOD was specified in a par file, it is specified on output, but that it is always IAU2000B since that's all PINT supports. Likewise for DILATEFREQ and TIMEEPH.