### PR TITLE
Fix a couple of small bugs for extrapolation checking.

### DIFF
--- a/src/pint/observatory/satellite_obs.py
+++ b/src/pint/observatory/satellite_obs.py
@@ -285,14 +285,15 @@ class SatelliteObs(SpecialLocation):
     def __init__(self, name, ft2name, maxextrap=2, overwrite=False):
         self.FT2 = load_orbit(name, ft2name)
 
-        # Now build the interpolator here:
+        # Now build the interpolator.  This extrapolation will fail quickly,
+        # which is where maxextrap comes in.
         tt = self.FT2["MJD_TT"]
-        self.X = InterpolatedUnivariateSpline(tt, self.FT2["X"], ext="raise")
-        self.Y = InterpolatedUnivariateSpline(tt, self.FT2["Y"], ext="raise")
-        self.Z = InterpolatedUnivariateSpline(tt, self.FT2["Z"], ext="raise")
-        self.Vx = InterpolatedUnivariateSpline(tt, self.FT2["Vx"], ext="raise")
-        self.Vy = InterpolatedUnivariateSpline(tt, self.FT2["Vy"], ext="raise")
-        self.Vz = InterpolatedUnivariateSpline(tt, self.FT2["Vz"], ext="raise")
+        self.X = InterpolatedUnivariateSpline(tt, self.FT2["X"], ext="extrapolate")
+        self.Y = InterpolatedUnivariateSpline(tt, self.FT2["Y"], ext="extrapolate")
+        self.Z = InterpolatedUnivariateSpline(tt, self.FT2["Z"], ext="extrapolate")
+        self.Vx = InterpolatedUnivariateSpline(tt, self.FT2["Vx"], ext="extrapolate")
+        self.Vy = InterpolatedUnivariateSpline(tt, self.FT2["Vy"], ext="extrapolate")
+        self.Vz = InterpolatedUnivariateSpline(tt, self.FT2["Vz"], ext="extrapolate")
         self._geocenter = EarthLocation.from_geocentric(0.0 * u.m, 0.0 * u.m, 0.0 * u.m)
         self._maxextrap = maxextrap
         super(SatelliteObs, self).__init__(name=name, overwrite=overwrite)
@@ -324,12 +325,11 @@ class SatelliteObs(SpecialLocation):
         ft2_tt = self.FT2["MJD_TT"]
         in_tt = np.atleast_1d(t.tt.mjd)
         i0 = np.searchsorted(ft2_tt, in_tt)
-        i0[i0 == 0] = 1
-        i0[i0 == len(ft2_tt)] = len(i0) - 1
+        i0 = np.clip(i0, 1, len(ft2_tt) - 1, out=i0)
         dright = np.abs(ft2_tt[i0] - in_tt)
         dleft = np.abs(ft2_tt[i0 - 1] - in_tt)
         min_duration = np.minimum(dright, dleft)
-        if np.any(min_duration > self._maxextrap / (60 * 24)):
+        if np.any(min_duration > (self._maxextrap / (60 * 24))):
             log.error(
                 "Extrapolating S/C position by more than %d minutes!" % self._maxextrap
             )

--- a/tests/test_satobs.py
+++ b/tests/test_satobs.py
@@ -17,7 +17,7 @@ def test_good_calls():
     # add an explicit entry 20s after the last FT2 point; should pass with
     # default settings
     test_mjds = np.append(test_mjds, tt_mjd[-1] + 20.0 / 86400)
-    assert(test_mjds[-1] > tt_mjd[-1])
+    assert test_mjds[-1] > tt_mjd[-1]
     good_times = Time(test_mjds, format="mjd", scale="tt")
     # NB this also tests calls with a vector Time
     fermi_obs._check_bounds(good_times)

--- a/tests/test_satobs.py
+++ b/tests/test_satobs.py
@@ -13,11 +13,12 @@ def test_good_calls():
     ft2file = os.path.join(datadir, "lat_spacecraft_weekly_w323_p202_v001.fits")
     fermi_obs = get_satellite_observatory("Fermi", ft2file, overwrite=True)
     tt_mjd = fermi_obs.FT2["MJD_TT"]
-    good_times = Time(
-        tt_mjd[:: len(tt_mjd) // 10] + (np.random.rand(1) * 4 - 2) / (60 * 24),
-        format="mjd",
-        scale="tt",
-    )
+    test_mjds = tt_mjd[:: len(tt_mjd) // 10] + (np.random.rand(1) * 4 - 2) / (60 * 24)
+    # add an explicit entry 20s after the last FT2 point; should pass with
+    # default settings
+    test_mjds = np.append(test_mjds, tt_mjd[-1] + 20.0 / 86400)
+    assert(test_mjds[-1] > tt_mjd[-1])
+    good_times = Time(test_mjds, format="mjd", scale="tt")
     # NB this also tests calls with a vector Time
     fermi_obs._check_bounds(good_times)
 


### PR DESCRIPTION
There was a typo in the interpolation check.  additionally, changed the behavior of the spline interpolators to allow extrapolation.  (All of the machinery for capping the maximum extrapolated interval to something sane, like 2 mins, is still in place.  This change applies simply to the spline object.)

There is a specific use case for this: Fermi FT2 files have 30s intervals, typically, and the spline knots are at the "START".  An event falling in the last interval (30s) would technically be "extrapolated", and this was causing the spline object to barf.