### PR TITLE
Verbosity fix

### DIFF
--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1525,7 +1525,7 @@ class TimingModel:
         M[:, mask] /= F0.value
         return M, params, units
 
-    def compare(self, othermodel, nodmx=True, threshold_sigma=3.0, verbosity="max"):
+    def compare(self, othermodel, nodmx=True, threshold_sigma=3.0, unc_rat_threshold=1.05, verbosity="max"):
         """Print comparison with another model
 
         Parameters
@@ -1538,6 +1538,10 @@ class TimingModel:
         threshold_sigma : float
             Pulsar parameters for which diff_sigma > threshold will be printed
             with an exclamation point at the end of the line
+        unc_rat_threshold : float
+            Pulsar parameters for which the uncertainty has increased by a 
+            factor of unc_rat_threshold will be printed with an asterisk at 
+            the end of the line
         verbosity : string
             Dictates amount of information returned. Options include "max",
             "med", and "min", which have the following results:
@@ -1692,7 +1696,7 @@ class TimingModel:
                             par.uncertainty is not None
                             and otherpar.uncertainty is not None
                         ):
-                            if 1.01 * par.uncertainty < otherpar.uncertainty:
+                            if unc_rat_threshold * par.uncertainty < otherpar.uncertainty:
                                 newstr += " *"
                     newstr += "\n"
             else:
@@ -1727,7 +1731,7 @@ class TimingModel:
                             par.uncertainty is not None
                             and otherpar.uncertainty is not None
                         ):
-                            if 1.01 * par.uncertainty < otherpar.uncertainty:
+                            if  par.uncertainty*unc_rat_threshold < otherpar.uncertainty:
                                 newstr += " *"
                         newstr += "\n"
                     else:
@@ -1777,7 +1781,7 @@ class TimingModel:
                             par.uncertainty is not None
                             and otherpar.uncertainty is not None
                         ):
-                            if par.uncertainty < otherpar.uncertainty:
+                            if par.uncertainty*unc_rat_threshold < otherpar.uncertainty:
                                 newstr += " *"
                     newstr += "\n"
 

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1641,9 +1641,9 @@ class TimingModel:
                         newstr += " {:>28s}\n".format("Missing")
                     if otherpar.quantity != par.quantity:
                         log.info(
-                                    "Parameter %s not fit, but has changed between these models"
-                                    % par.name
-                                )
+                            "Parameter %s not fit, but has changed between these models"
+                            % par.name
+                        )
                 else:
                     # If fitted, print both values with uncertainties
                     if par.units == u.hourangle:
@@ -1685,7 +1685,7 @@ class TimingModel:
                             newstr += " {:>10.2f}".format(diff_sigma2)
                             if abs(diff_sigma2) > threshold_sigma:
                                 newstr += " !"
-                    #except (AttributeError, TypeError):
+                    # except (AttributeError, TypeError):
                     #    pass
                     if otherpar is not None:
                         if (

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1589,7 +1589,8 @@ class TimingModel:
             "---------", "----------", "----------", "----------", "----------"
         )
         log.info("Comparing ephemerides for PSR %s" % self.PSR.value)
-        log.info("Threshold sigma = %f" % threshold_sigma)
+        log.info("Threshold sigma = %2.2f" % threshold_sigma)
+        log.info("Threshold uncertainty ratio = %2.2f" % unc_rat_threshold)
         log.info("Creating a copy of Model 2")
         if verbosity == "max":
             log.info("Maximum verbosity - printing all parameters")
@@ -1725,18 +1726,28 @@ class TimingModel:
                             newstr += " {:28f}".format(otherpar.value)
                         if otherpar.value != par.value:
                             sys.stdout.flush()
-                            if par.name == "START" or par.name == "FINISH":
+                            if par.name in ["START","FINISH","CHI2","NTOA"]:
+                                if verbosity == 'max':
+                                    log.info(
+                                        "Parameter %s has changed between these models"
+                                        % par.name
+                                    )
+                            elif isinstance(par,boolParameter):
+                                if otherpar.value is True:
+                                    status='ON'
+                                else:
+                                    status='OFF'
                                 log.info(
-                                    "Parameter %s not fit, but has changed between these models"
-                                    % par.name
-                                )
+                                        "Parameter %s has changed between these models (turned %s in model 2)"
+                                        % (par.name, status)
+                                    )
                             else:
                                 log.warning(
                                     "Parameter %s not fit, but has changed between these models"
                                     % par.name
                                 )
+                                newstr += " !"
                             log.handlers[0].flush()
-                            newstr += " !"
                         if (
                             par.uncertainty is not None
                             and otherpar.uncertainty is not None

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1729,9 +1729,14 @@ class TimingModel:
                         newstr += " {:>28s}\n".format("Missing")
                 else:
                     # If fitted, print both values with uncertainties
-                    newstr += "{:14s} {:28SP}".format(
-                        pn, ufloat(par.value, par.uncertainty.value)
-                    )
+                    if par.uncertainty is not None:
+                        newstr += "{:14s} {:28SP}".format(
+                            pn, ufloat(par.value, par.uncertainty.value)
+                        )
+                    else:
+                        newstr += "{:14s} {:28SP}".format(
+                            pn, ufloat(par.value)
+                        )
                     if otherpar is not None and otherpar.value is not None:
                         try:
                             newstr += " {:28SP}".format(

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1734,8 +1734,8 @@ class TimingModel:
                             pn, ufloat(par.value, par.uncertainty.value)
                         )
                     else:
-                        newstr += "{:14s} {:28SP}".format(
-                            pn, ufloat(par.value)
+                        newstr += "{:14s} {:28f}".format(
+                            pn, float(par.value)
                         )
                     if otherpar is not None and otherpar.value is not None:
                         try:

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1639,6 +1639,11 @@ class TimingModel:
                         newstr += " {:>28s}\n".format(str(otherpar.quantity))
                     else:
                         newstr += " {:>28s}\n".format("Missing")
+                    if otherpar.quantity != par.quantity:
+                        log.info(
+                                    "Parameter %s not fit, but has changed between these models"
+                                    % par.name
+                                )
                 else:
                     # If fitted, print both values with uncertainties
                     if par.units == u.hourangle:
@@ -1664,9 +1669,9 @@ class TimingModel:
                                 newstr += " {:>28s}".format("Missing")
                     else:
                         newstr += " {:>28s}".format("Missing")
-                    try:
-                        diff = otherpar.value - par.value
-                        diff_sigma = diff / par.uncertainty.value
+                    if otherpar.value is not None:
+                        diff = otherpar.quantity - par.quantity
+                        diff_sigma = (diff / par.uncertainty).decompose()
                         if abs(diff_sigma) != np.inf:
                             newstr += " {:>10.2f}".format(diff_sigma)
                             if abs(diff_sigma) > threshold_sigma:
@@ -1675,13 +1680,13 @@ class TimingModel:
                                 newstr += "  "
                         else:
                             newstr += "           "
-                        diff_sigma2 = diff / otherpar.uncertainty.value
+                        diff_sigma2 = (diff / otherpar.uncertainty).decompose()
                         if abs(diff_sigma2) != np.inf:
                             newstr += " {:>10.2f}".format(diff_sigma2)
                             if abs(diff_sigma2) > threshold_sigma:
                                 newstr += " !"
-                    except (AttributeError, TypeError):
-                        pass
+                    #except (AttributeError, TypeError):
+                    #    pass
                     if otherpar is not None:
                         if (
                             par.uncertainty is not None

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1525,7 +1525,14 @@ class TimingModel:
         M[:, mask] /= F0.value
         return M, params, units
 
-    def compare(self, othermodel, nodmx=True, threshold_sigma=3.0, unc_rat_threshold=1.05, verbosity="max"):
+    def compare(
+        self,
+        othermodel,
+        nodmx=True,
+        threshold_sigma=3.0,
+        unc_rat_threshold=1.05,
+        verbosity="max",
+    ):
         """Print comparison with another model
 
         Parameters
@@ -1696,7 +1703,10 @@ class TimingModel:
                             par.uncertainty is not None
                             and otherpar.uncertainty is not None
                         ):
-                            if unc_rat_threshold * par.uncertainty < otherpar.uncertainty:
+                            if (
+                                unc_rat_threshold * par.uncertainty
+                                < otherpar.uncertainty
+                            ):
                                 newstr += " *"
                     newstr += "\n"
             else:
@@ -1731,7 +1741,10 @@ class TimingModel:
                             par.uncertainty is not None
                             and otherpar.uncertainty is not None
                         ):
-                            if  par.uncertainty*unc_rat_threshold < otherpar.uncertainty:
+                            if (
+                                par.uncertainty * unc_rat_threshold
+                                < otherpar.uncertainty
+                            ):
                                 newstr += " *"
                         newstr += "\n"
                     else:
@@ -1781,7 +1794,10 @@ class TimingModel:
                             par.uncertainty is not None
                             and otherpar.uncertainty is not None
                         ):
-                            if par.uncertainty*unc_rat_threshold < otherpar.uncertainty:
+                            if (
+                                par.uncertainty * unc_rat_threshold
+                                < otherpar.uncertainty
+                            ):
                                 newstr += " *"
                     newstr += "\n"
 

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1734,9 +1734,7 @@ class TimingModel:
                             pn, ufloat(par.value, par.uncertainty.value)
                         )
                     else:
-                        newstr += "{:14s} {:28f}".format(
-                            pn, float(par.value)
-                        )
+                        newstr += "{:14s} {:28f}".format(pn, float(par.value))
                     if otherpar is not None and otherpar.value is not None:
                         try:
                             newstr += " {:28SP}".format(

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -5,6 +5,7 @@ import astropy.units as u
 import pint
 import pint.models as mod
 import os
+import io
 from copy import deepcopy as cp
 from pinttestdata import datadir
 
@@ -103,3 +104,58 @@ class TestCompare(unittest.TestCase):
                 if not accumulate_changes:
                     modelcp = cp(model)
         assert True, "Failure in uncertainty changing test"
+
+    def test_missing_uncertainties(self):
+        # Removes uncertainties from both models and attempts to use compare.
+
+        par_base1 = """
+            PSR J1234+5612
+            RAJ 14:34:01.00 
+            DECJ 56:14:00.00
+            F0 1 
+            PEPOCH 57000
+            DM 10 
+            DMEPOCH 57000
+            DM1 2
+            DMX     0.0
+            DMX_0001   1.0 
+            DMXR1_0001     58000.0
+            DMXR2_0001     58000.0
+            """
+
+        par_base2 = """
+            PSR J1234+5612
+            RAJ 14:34:01.00 
+            DECJ 56:14:00.00
+            F0 1  
+            PEPOCH 58000 
+            DM 10
+            DMEPOCH 57000
+            DM1 2 
+            DMX     0.0
+            DMX_0001   1.0 
+            DMXR1_0001     58000.0
+            DMXR2_0001     58000.0
+            """
+
+        model_1 = mod.get_model(io.StringIO(par_base1))
+        model_2 = mod.get_model(io.StringIO(par_base2))
+
+        for pn in model_1.params_ordered[1:]:
+            param1 = getattr(model_1, pn)
+            param2 = getattr(model_2, pn)
+            if (
+                param1 is None
+                or param2 is None
+                or param1.uncertainty is None
+                or param2.uncertainty is None
+            ):
+                continue
+            param1.frozen = False
+            param2.frozen = False
+            param1.uncertainty = 0.1 * param1.quantity
+            model_1.compare(model_2)
+            model_2.compare(model_1)
+            model_1 = mod.get_model(io.StringIO(par_base1))
+            model_2 = mod.get_model(io.StringIO(par_base2))
+        assert True, "Failure in missing uncertainty test"


### PR DESCRIPTION
per issue https://github.com/nanograv/PINT/issues/984, I have adjusted the verbosity of a few of the components. This includes:
1. changing language when components are boolean
2. reducing log level from WARNING to INFO for START/FINISH/CHI2/NTOA
3. including these logger statements only when in "max" verbosity level 

If there are other parameters that should be reported less/more often, or if there are parameters that would be better suited for different INFO/WARNING language, please comment those parameters and changes here.  