### PR TITLE
If read model from parfile, put the parfile name in the .name attribute

### DIFF
--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -302,7 +302,12 @@ def get_model(parfile):
     except AttributeError:
         contents = None
     if contents is None:
-        return ModelBuilder(parfile).timing_model
+        # parfile is a filename and can be handled by ModelBuilder
+        mbmodel = ModelBuilder(parfile)
+        model = mbmodel.timing_model
+        if model.name=='':
+            model.name = parfile
+        return model
     else:
         with tempfile.TemporaryDirectory() as td:
             fn = os.path.join(td, "temp.par")

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -305,8 +305,7 @@ def get_model(parfile):
         # parfile is a filename and can be handled by ModelBuilder
         mbmodel = ModelBuilder(parfile)
         model = mbmodel.timing_model
-        if model.name=='':
-            model.name = parfile
+        model.name = parfile
         return model
     else:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_parfile.py
+++ b/tests/test_parfile.py
@@ -51,6 +51,8 @@ def roundtrip():
 def test_roundtrip(roundtrip):
     """Check that the round trip preserves general structure."""
     m, m2 = roundtrip
+    print(m.name, m2.name)
+    assert m.name == parfile
     assert set(m.components.keys()) == set(m2.components.keys())
     assert set(m.params) == set(m2.params)
 

--- a/tests/test_parfile.py
+++ b/tests/test_parfile.py
@@ -51,7 +51,6 @@ def roundtrip():
 def test_roundtrip(roundtrip):
     """Check that the round trip preserves general structure."""
     m, m2 = roundtrip
-    print(m.name, m2.name)
     assert m.name == parfile
     assert set(m.components.keys()) == set(m2.components.keys())
     assert set(m.params) == set(m2.params)


### PR DESCRIPTION
This helps fix #984 as the parfile name will be in the model `.name` attribute