### PR TITLE
Fix bug when ECORR has no TOAs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,24 @@
+import os
+import hypothesis
+
+# Tell Hypothesis that we might be running slow tests, to print the seed blob
+# so we can easily reproduce failures from CI, and derive a fuzzing profile
+# to try many more inputs when we detect a scheduled build or when specifically
+# requested using the HYPOTHESIS_PROFILE=fuzz environment variable or
+# `pytest --hypothesis-profile=fuzz ...` argument.
+
+hypothesis.settings.register_profile(
+    "ci", deadline=None, print_blob=True, derandomize=True
+)
+hypothesis.settings.register_profile(
+    "fuzzing", deadline=None, print_blob=True, max_examples=1000
+)
+default = (
+    "fuzzing"
+    if (
+        os.environ.get("IS_CRON") == "true"
+        and os.environ.get("ARCH_ON_CI") not in ("aarch64", "ppc64le")
+    )
+    else "ci"
+)  # noqa: E501
+hypothesis.settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", default))

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,9 @@
 import os
 import hypothesis
 
+# This setup is drawn from Astropy and might not be entirely relevant to us;
+# in particular we don't have a cron run for slow tests.
+
 # Tell Hypothesis that we might be running slow tests, to print the seed blob
 # so we can easily reproduce failures from CI, and derive a fuzzing profile
 # to try many more inputs when we detect a scheduled build or when specifically

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -150,10 +150,17 @@ class ScaleToaError(NoiseComponent):
             if equad.quantity is None:
                 continue
             mask = equad.select_toa_mask(toas)
-            sigma_scaled[mask] = np.hypot(sigma_scaled[mask], equad.quantity)
+            if np.any(mask):
+                sigma_scaled[mask] = np.hypot(sigma_scaled[mask], equad.quantity)
+            else:
+                warnings.warn(f"EQUAD {equad} has no TOAs")
         for efac_name in self.EFACs:
             efac = getattr(self, efac_name)
-            sigma_scaled[efac.select_toa_mask(toas)] *= efac.quantity
+            mask = efac.select_toa_mask(toas)
+            if np.any(mask):
+                sigma_scaled[mask] *= efac.quantity
+            else:
+                warnings.warn(f"EFAC {efac} has no TOAs")
         return sigma_scaled
 
     def sigma_scaled_cov_matrix(self, toas):

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -1,6 +1,8 @@
 """Pulsar timing noise models."""
 
 import copy
+import warnings
+
 import astropy.units as u
 import numpy as np
 from astropy import log
@@ -331,6 +333,7 @@ class EcorrNoise(NoiseComponent):
             if np.any(mask):
                 umats.append(create_quantization_matrix(t[mask]))
             else:
+                warnings.warn(f"ECORR {ec} has no TOAs")
                 umats.append(np.zeros((0, 0)))
         nc = sum(u.shape[1] for u in umats)
         umat = np.zeros((len(t), nc))

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -328,7 +328,10 @@ class EcorrNoise(NoiseComponent):
         umats = []
         for ec in ecorrs:
             mask = ec.select_toa_mask(toas)
-            umats.append(create_quantization_matrix(t[mask]))
+            if np.any(mask):
+                umats.append(create_quantization_matrix(t[mask]))
+            else:
+                umats.append(np.zeros((0, 0)))
         nc = sum(u.shape[1] for u in umats)
         umat = np.zeros((len(t), nc))
         weight = np.zeros(nc)

--- a/tests/test_fitter_error_checking.py
+++ b/tests/test_fitter_error_checking.py
@@ -134,12 +134,13 @@ def test_jump_everything_wideband():
         assert not np.isnan(fitter.model[p].value)
 
 
-def test_unused_ecorr():
-    model = get_model(io.StringIO("\n".join([par_base, "ECORR TEL ao 0"])))
+@pytest.mark.parametrize("param, value", [("ECORR", 0), ("EQUAD", 0), ("EFAC", 1)])
+def test_unused_noise_model_parameter(param, value):
+    model = get_model(io.StringIO("\n".join([par_base, f"{param} TEL ao {value}"])))
     toas = make_fake_toas(58000, 58900, 10, model, obs="barycenter", freq=np.inf)
     model.free_params = ["F0"]
     fitter = pint.fitter.GLSFitter(toas, model)
-    with pytest.warns(UserWarning, match="ECORR"):
+    with pytest.warns(UserWarning, match=param):
         fitter.fit_toas()
 
 

--- a/tests/test_fitter_error_checking.py
+++ b/tests/test_fitter_error_checking.py
@@ -134,6 +134,14 @@ def test_jump_everything_wideband():
         assert not np.isnan(fitter.model[p].value)
 
 
+def test_unused_ecorr():
+    model = get_model(io.StringIO("\n".join([par_base, "ECORR TEL ao 0"])))
+    toas = make_fake_toas(58000, 58900, 10, model, obs="barycenter", freq=np.inf)
+    model.free_params = ["F0"]
+    fitter = pint.fitter.GLSFitter(toas, model)
+    fitter.fit_toas()
+
+
 @pytest.mark.parametrize(
     "Fitter", [pint.fitter.GLSFitter, pint.fitter.WidebandTOAFitter]
 )

--- a/tests/test_fitter_error_checking.py
+++ b/tests/test_fitter_error_checking.py
@@ -139,7 +139,8 @@ def test_unused_ecorr():
     toas = make_fake_toas(58000, 58900, 10, model, obs="barycenter", freq=np.inf)
     model.free_params = ["F0"]
     fitter = pint.fitter.GLSFitter(toas, model)
-    fitter.fit_toas()
+    with pytest.warns(UserWarning, match="ECORR"):
+        fitter.fit_toas()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Currently if an ECORR selects no TOAs, there is a crash while trying to build the noise design matrix. This PR fixes that (and just emits a warning).

Incidentially includes an improved `hypothesis` configuration.