### PR TITLE
Fix to Prefit Plotting Postfit Resids in Pintk

### DIFF
--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -523,7 +523,7 @@ class Pulsar:
         )
 
         # plot the prefit without jumps
-        pm_no_jumps = copy.deepcopy(self.postfit_model)
+        pm_no_jumps = copy.deepcopy(self.prefit_model)
         for param in pm_no_jumps.params:
             if param.startswith("JUMP"):
                 getattr(pm_no_jumps, param).value = 0.0


### PR DESCRIPTION
This PR fixes issue #973 in which the prefit residuals were plotting the postfit residuals after a fit in pintk.