### PR TITLE
Control hypothesis profile

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -12,6 +12,7 @@ on:
 env:
   SETUP_XVFB: True  # avoid issues if mpl tries to open a GUI window
   TOXARGS: '-v'
+  HYPOTHESIS_PROFILE: 'ci'
 
 jobs:
   ci-tests:

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ import hypothesis
 # requested using the HYPOTHESIS_PROFILE=fuzz environment variable or
 # `pytest --hypothesis-profile=fuzz ...` argument.
 
+hypothesis.settings.register_profile("interactive", deadline=None)
 hypothesis.settings.register_profile(
     "ci", deadline=None, print_blob=True, derandomize=True
 )
@@ -22,6 +23,6 @@ default = (
         os.environ.get("IS_CRON") == "true"
         and os.environ.get("ARCH_ON_CI") not in ("aarch64", "ppc64le")
     )
-    else "ci"
+    else "interactive"
 )  # noqa: E501
 hypothesis.settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", default))

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -84,9 +84,6 @@ near_leap_sec_days = list(
     sorted([d - 1 for d in leap_sec_days] + [d + 1 for d in leap_sec_days])
 )
 
-settings.register_profile("relaxed", deadline=2000)
-settings.load_profile("relaxed")
-
 
 @composite
 def possible_leap_sec_days(draw):

--- a/tests/test_tim_writing.py
+++ b/tests/test_tim_writing.py
@@ -110,7 +110,6 @@ some_barycentered 999999.999 56403.000000000000000   1.000  @  -some argument -a
     do_roundtrip(get_TOAs(f, **k), **k)
 
 
-@settings(deadline=None, max_examples=10)
 @given(
     lists(
         tuples(

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ addopts =
 passenv =
     HOME
     DISPLAY
+    HYPOTHESIS_PROFILE
 
 deps =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -35,8 +35,8 @@ deps =
     hypothesis
 commands =
     pip freeze
-    !cov: pytest
-    cov: pytest --pyargs tests --cov=pint --cov-config={toxinidir}/.coveragerc {posargs}
+    !cov: pytest 
+    cov: pytest -v --pyargs tests --cov=pint --cov-config={toxinidir}/.coveragerc {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml
 
 depends =


### PR DESCRIPTION
Arrange settings so we no longer get annoying hypothesis test failures due to timeouts; also use randomness when interactive but not on CI.