### PR TITLE
Fix in Pintk to Properly Apply Pulse Numbers

### DIFF
--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -1249,8 +1249,7 @@ class PlkWidget(tk.Frame):
         elif ukey == ord(">"):
             if np.sum(self.selected) > 0:
                 selected = copy.deepcopy(self.selected)
-                ind = np.nonzero(selected)[0][0]
-                selected[ind:] = True
+                selected = ~selected
                 self.psr.add_phase_wrap(selected, 1)
                 self.updatePlot(keepAxes=False)
                 self.call_updates()
@@ -1258,8 +1257,7 @@ class PlkWidget(tk.Frame):
         elif ukey == ord("<"):
             if np.sum(self.selected) > 0:
                 selected = copy.deepcopy(self.selected)
-                ind = np.nonzero(selected)[0][0]
-                selected[ind:] = True
+                selected = ~selected
                 self.psr.add_phase_wrap(selected, -1)
                 self.updatePlot(keepAxes=False)
                 self.call_updates()

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -656,6 +656,7 @@ class PlkWidget(tk.Frame):
         """
         Reset all plot changes for this pulsar
         """
+        self.psr.use_pulse_numbers = False
         self.psr.reset_TOAs()
         self.psr.fitted = False
         self.psr = copy.deepcopy(self.base_state.psr)


### PR DESCRIPTION
Turns on pulse number tracking when pulse number added/subtracted from selection of TOAs in pintk. One main issue was that the label "pn" was being checked for in the TOA table, when the pulse numbers were actually being stored under "pulse_number" - now fixed. Another issue was the Residuals objects used weren't using the new track mode "use_pulse_numbers" - the residuals switch to this track mode when pulse numbers are added/subtracted in pintk.