### PR TITLE
Allow flags to comment TOAs when writing to file

### DIFF
--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1711,11 +1711,6 @@ class TOAs:
         if format.upper() in ("TEMPO2", "1"):
             outf.write("FORMAT 1\n")
 
-        # Warn the user if any of the TOAs have -ignore or -cut flags that
-        # they will be commented in the output file
-        if isinstance(commentflag, str) and len(self.get_flag_value(commentflag)[1]):
-            log.warning(f"TOAs with '-{commentflag}' flags will be commented")
-
         # Add pulse numbers to flags temporarily if there is a pulse number column
         # FIXME: everywhere else the pulse number column is called pulse_number not pn
         pnChange = False

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1731,10 +1731,9 @@ class TOAs:
             obs_obj = Observatory.get(obs)
 
             flags = flags.copy()
+            toatime_out = toatime
             if "clkcorr" in flags:
-                toatime_out = toatime - time.TimeDelta(flags["clkcorr"])
-            else:
-                toatime_out = toatime
+                toatime_out -= time.TimeDelta(flags["clkcorr"])
             out_str = (
                 "C " if isinstance(commentflag, str) and (commentflag in flags) else ""
             )

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1678,7 +1678,7 @@ class TOAs:
         self.compute_TDBs()
         self.compute_posvels(self.ephem, self.planets)
 
-    def write_TOA_file(self, filename, name="unk", format="tempo2"):
+    def write_TOA_file(self, filename, name="unk", format="tempo2", comments=True):
         """Write this object to a ``.tim`` file.
 
         This function writes the contents of this object to a (single) ``.tim``
@@ -1696,6 +1696,9 @@ class TOAs:
         format : str
             Format specifier for file ('TEMPO' or 'Princeton') or ('Tempo2' or '1');
             note that not all features may be supported in 'TEMPO' mode.
+        comments : boolean
+            If True, and there are "-ignore" or "-cut" flags, the TOAs will be
+            commented in the output file.  If False, all TOAs are uncommented.
         """
         try:
             # FIXME: file must be closed even if an exception occurs!
@@ -1737,7 +1740,9 @@ class TOAs:
                 toatime_out = toatime - time.TimeDelta(flags["clkcorr"])
             else:
                 toatime_out = toatime
-            out_str = "C " if ("ignore" in flags or "cut" in flags) else ""
+            out_str = (
+                "C " if (comments and ("ignore" in flags or "cut" in flags)) else ""
+            )
             out_str += format_toa_line(
                 toatime_out,
                 toaerr,

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1678,7 +1678,7 @@ class TOAs:
         self.compute_TDBs()
         self.compute_posvels(self.ephem, self.planets)
 
-    def write_TOA_file(self, filename, name="unk", format="tempo2", commentflag="cut"):
+    def write_TOA_file(self, filename, name="unk", format="tempo2", commentflag=None):
         """Write this object to a ``.tim`` file.
 
         This function writes the contents of this object to a (single) ``.tim``

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1728,11 +1728,12 @@ class TOAs:
             obs_obj = Observatory.get(obs)
 
             flags = flags.copy()
-            if "clkcorr" in flags.keys():
+            if "clkcorr" in flags:
                 toatime_out = toatime - time.TimeDelta(flags["clkcorr"])
             else:
                 toatime_out = toatime
-            out_str = format_toa_line(
+            out_str = "C " if ("ignore" in flags or "cut" in flags) else ""
+            out_str += format_toa_line(
                 toatime_out,
                 toaerr,
                 freq,

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1708,6 +1708,11 @@ class TOAs:
         if format.upper() in ("TEMPO2", "1"):
             outf.write("FORMAT 1\n")
 
+        # Warn the user if any of the TOAs have -ignore or -cut flags that
+        # they will be commented in the output file
+        if len(self.get_flag_value("ignore")[1]) or len(self.get_flag_value("cut")[1]):
+            log.warning("TOAs with '-cut' or '-ignore' flags will be commented")
+
         # Add pulse numbers to flags temporarily if there is a pulse number column
         # FIXME: everywhere else the pulse number column is called pulse_number not pn
         pnChange = False

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1678,7 +1678,7 @@ class TOAs:
         self.compute_TDBs()
         self.compute_posvels(self.ephem, self.planets)
 
-    def write_TOA_file(self, filename, name="unk", format="tempo2", comments=True):
+    def write_TOA_file(self, filename, name="unk", format="tempo2", commentflag="cut"):
         """Write this object to a ``.tim`` file.
 
         This function writes the contents of this object to a (single) ``.tim``
@@ -1696,9 +1696,9 @@ class TOAs:
         format : str
             Format specifier for file ('TEMPO' or 'Princeton') or ('Tempo2' or '1');
             note that not all features may be supported in 'TEMPO' mode.
-        comments : boolean
-            If True, and there are "-ignore" or "-cut" flags, the TOAs will be
-            commented in the output file.  If False, all TOAs are uncommented.
+        commentflag : str or None
+            If a string, and that string is a TOA flag, that TOA will be commented
+            in the output file.  If None (or non-string), no TOAs will be commented.
         """
         try:
             # FIXME: file must be closed even if an exception occurs!
@@ -1713,8 +1713,8 @@ class TOAs:
 
         # Warn the user if any of the TOAs have -ignore or -cut flags that
         # they will be commented in the output file
-        if len(self.get_flag_value("ignore")[1]) or len(self.get_flag_value("cut")[1]):
-            log.warning("TOAs with '-cut' or '-ignore' flags will be commented")
+        if isinstance(commentflag, str) and len(self.get_flag_value(commentflag)[1]):
+            log.warning(f"TOAs with '-{commentflag}' flags will be commented")
 
         # Add pulse numbers to flags temporarily if there is a pulse number column
         # FIXME: everywhere else the pulse number column is called pulse_number not pn
@@ -1741,7 +1741,7 @@ class TOAs:
             else:
                 toatime_out = toatime
             out_str = (
-                "C " if (comments and ("ignore" in flags or "cut" in flags)) else ""
+                "C " if isinstance(commentflag, str) and (commentflag in flags) else ""
             )
             out_str += format_toa_line(
                 toatime_out,

--- a/tests/test_toa_writer.py
+++ b/tests/test_toa_writer.py
@@ -42,10 +42,14 @@ class TestRoundtripToFiles(unittest.TestCase):
         # Create a barycentric TOA
         t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
         t1 = toa.TOA(t1time, obs="gbt", freq=0.0)
-        ts = toa.get_TOAs_list([t1], ephem="DE421")
+        t2 = toa.TOA(t1time, obs="gbt", freq=0.0)
+        ts = toa.get_TOAs_list([t1, t2], ephem="DE421")
+        assert ts.ntoas == 2
+        ts.table[1]["flags"]["ignore"] = True  # comment TOA
         ts.write_TOA_file("testtopo.tim", format="Tempo2")
         ts2 = toa.get_TOAs("testtopo.tim")
         print(ts.table, ts2.table)
+        assert ts2.ntoas == 1  # one should be commented
         assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
         assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 

--- a/tests/test_toa_writer.py
+++ b/tests/test_toa_writer.py
@@ -42,6 +42,17 @@ class TestRoundtripToFiles(unittest.TestCase):
         # Create a barycentric TOA
         t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
         t1 = toa.TOA(t1time, obs="gbt", freq=0.0)
+        ts = toa.get_TOAs_list([t1], ephem="DE421")
+        ts.write_TOA_file("testtopo.tim", format="Tempo2")
+        ts2 = toa.get_TOAs("testtopo.tim")
+        print(ts.table, ts2.table)
+        assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
+        assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
+
+    def test_commenting_toas(self):
+        # Create a barycentric TOA
+        t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
+        t1 = toa.TOA(t1time, obs="gbt", freq=0.0)
         t2 = toa.TOA(t1time, obs="gbt", freq=0.0)
         ts = toa.get_TOAs_list([t1, t2], ephem="DE421")
         assert ts.ntoas == 2
@@ -50,8 +61,6 @@ class TestRoundtripToFiles(unittest.TestCase):
         ts2 = toa.get_TOAs("testtopo.tim")
         print(ts.table, ts2.table)
         assert ts2.ntoas == 1  # one should be commented
-        assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
-        assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
     def test_roundtrip_topo_toa_TEMPOformat(self):
         # Create a barycentric TOA

--- a/tests/test_toa_writer.py
+++ b/tests/test_toa_writer.py
@@ -56,14 +56,17 @@ class TestRoundtripToFiles(unittest.TestCase):
         t2 = toa.TOA(t1time, obs="gbt", freq=0.0)
         ts = toa.get_TOAs_list([t1, t2], ephem="DE421")
         assert ts.ntoas == 2
-        ts.table[1]["flags"]["ignore"] = True  # comment TOA
+        ts.table[1]["flags"]["ignore"] = True  # flag one TOA
         ts.write_TOA_file("testtopo.tim", format="Tempo2")
         ts2 = toa.get_TOAs("testtopo.tim")
-        assert ts2.ntoas == 1  # one should be commented
-        ts.write_TOA_file("testtopo.tim", format="Tempo2", comments=False)
+        assert ts2.ntoas == 2  # none should be commented
+        ts.write_TOA_file("testtopo.tim", format="Tempo2", commentflag=None)
         ts3 = toa.get_TOAs("testtopo.tim")
-        print(ts.table, ts2.table, ts3.table)
-        assert ts3.ntoas == 2  # neither should be commented
+        assert ts3.ntoas == 2  # none should be commented
+        ts.write_TOA_file("testtopo.tim", format="Tempo2", commentflag="ignore")
+        ts4 = toa.get_TOAs("testtopo.tim")
+        assert ts4.ntoas == 1  # one should be commented
+        print(ts.table, ts2.table, ts3.table, ts4.table)
 
     def test_roundtrip_topo_toa_TEMPOformat(self):
         # Create a barycentric TOA

--- a/tests/test_toa_writer.py
+++ b/tests/test_toa_writer.py
@@ -56,14 +56,14 @@ def test_commenting_toas(tmpdir):
     ts.write_TOA_file(outnm)
     ts2 = toa.get_TOAs(outnm)
     assert ts2.ntoas == 2  # none should be commented
-    ts.table[0]["flags"]["cut"] = "do_not_like"  # default comment flag
-    ts.table[1]["flags"]["ignore"] = True  # flag with different flag
+    ts.table[0]["flags"]["cut"] = "do_not_like"  # cut flag
+    ts.table[1]["flags"]["ignore"] = True  # ignore flag
     ts.write_TOA_file(outnm)
-    ts3 = toa.get_TOAs(outnm)
-    assert ts3.ntoas == 1  # one should be commented
-    ts.write_TOA_file(outnm, commentflag=None)
+    ts3 = toa.get_TOAs(outnm)  # defaut is to not comment
+    assert ts3.ntoas == 2  # none should be commented by default
+    ts.write_TOA_file(outnm, commentflag="cut")
     ts4 = toa.get_TOAs(outnm)
-    assert ts4.ntoas == 2  # none should be commented
+    assert ts4.ntoas == 1  # one should be commented
     ts.write_TOA_file(outnm, commentflag="ignore")
     ts5 = toa.get_TOAs(outnm)
     assert ts5.ntoas == 1  # one should be commented

--- a/tests/test_toa_writer.py
+++ b/tests/test_toa_writer.py
@@ -23,7 +23,6 @@ class TestRoundtripToFiles(unittest.TestCase):
         ts = toa.get_TOAs_list([t1], ephem="DE421")
         ts.write_TOA_file("testbary.tim", format="Tempo2")
         ts2 = toa.get_TOAs("testbary.tim")
-        print(ts.table, ts2.table)
         assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
         assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
@@ -34,7 +33,6 @@ class TestRoundtripToFiles(unittest.TestCase):
         ts = toa.get_TOAs_list([t1], ephem="DE421")
         ts.write_TOA_file("testbary.tim", format="TEMPO")
         ts2 = toa.get_TOAs("testbary.tim")
-        print(ts.table, ts2.table)
         assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
         assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
@@ -45,7 +43,6 @@ class TestRoundtripToFiles(unittest.TestCase):
         ts = toa.get_TOAs_list([t1], ephem="DE421")
         ts.write_TOA_file("testtopo.tim", format="Tempo2")
         ts2 = toa.get_TOAs("testtopo.tim")
-        print(ts.table, ts2.table)
         assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
         assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
@@ -56,17 +53,20 @@ class TestRoundtripToFiles(unittest.TestCase):
         t2 = toa.TOA(t1time, obs="gbt", freq=0.0)
         ts = toa.get_TOAs_list([t1, t2], ephem="DE421")
         assert ts.ntoas == 2
-        ts.table[1]["flags"]["ignore"] = True  # flag one TOA
         ts.write_TOA_file("testtopo.tim", format="Tempo2")
         ts2 = toa.get_TOAs("testtopo.tim")
         assert ts2.ntoas == 2  # none should be commented
-        ts.write_TOA_file("testtopo.tim", format="Tempo2", commentflag=None)
+        ts.table[0]["flags"]["cut"] = "do not like"  # default comment flag
+        ts.table[1]["flags"]["ignore"] = True  # flag with different flag
+        ts.write_TOA_file("testtopo.tim", format="Tempo2")
         ts3 = toa.get_TOAs("testtopo.tim")
-        assert ts3.ntoas == 2  # none should be commented
-        ts.write_TOA_file("testtopo.tim", format="Tempo2", commentflag="ignore")
+        assert ts3.ntoas == 1  # one should be commented
+        ts.write_TOA_file("testtopo.tim", format="Tempo2", commentflag=None)
         ts4 = toa.get_TOAs("testtopo.tim")
-        assert ts4.ntoas == 1  # one should be commented
-        print(ts.table, ts2.table, ts3.table, ts4.table)
+        assert ts4.ntoas == 2  # none should be commented
+        ts.write_TOA_file("testtopo.tim", format="Tempo2", commentflag="ignore")
+        ts5 = toa.get_TOAs("testtopo.tim")
+        assert ts5.ntoas == 1  # one should be commented
 
     def test_roundtrip_topo_toa_TEMPOformat(self):
         # Create a barycentric TOA
@@ -75,23 +75,22 @@ class TestRoundtripToFiles(unittest.TestCase):
         ts = toa.get_TOAs_list([t1], ephem="DE421")
         ts.write_TOA_file("testtopot1.tim", format="TEMPO")
         ts2 = toa.get_TOAs("testtopot1.tim")
-        print(ts.table, ts2.table)
         assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
         assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
-        # Comment out because TEMPO2 distro doesn't include gmrt2gps.clk so far
-        # def test_roundtrip_gmrt_toa_Tempo2format(self):
-        #     if os.getenv("TEMPO2") is None:
-        #         pytest.skip("TEMPO2 evnironment variable is not set, can't run this test")
-        #     # Create a barycentric TOA
-        #     t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
-        #     t1 = toa.TOA(t1time, obs="gmrt", freq=0.0)
-        #     ts = toa.get_TOAs_list([t1], ephem="DE421")
-        #     ts.write_TOA_file("testgmrt.tim", format="Tempo2")
-        #     ts2 = toa.get_TOAs("testgmrt.tim")
-        #     print(ts.table, ts2.table)
-        assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
-        assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
+    # Comment out because TEMPO2 distro doesn't include gmrt2gps.clk so far
+    # def test_roundtrip_gmrt_toa_Tempo2format(self):
+    #     if os.getenv("TEMPO2") is None:
+    #         pytest.skip("TEMPO2 evnironment variable is not set, can't run this test")
+    #     # Create a barycentric TOA
+    #     t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
+    #     t1 = toa.TOA(t1time, obs="gmrt", freq=0.0)
+    #     ts = toa.get_TOAs_list([t1], ephem="DE421")
+    #     ts.write_TOA_file("testgmrt.tim", format="Tempo2")
+    #     ts2 = toa.get_TOAs("testgmrt.tim")
+    #     print(ts.table, ts2.table)
+    #     assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
+    #     assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
     # def test_roundtrip_ncyobs_toa_Tempo2format(self):
     #     if os.getenv("TEMPO2") is None:

--- a/tests/test_toa_writer.py
+++ b/tests/test_toa_writer.py
@@ -1,5 +1,5 @@
 import os
-import unittest
+import os.path
 import pytest
 
 from pint import toa
@@ -9,110 +9,111 @@ import numpy as np
 import astropy.units as u
 
 
-class TestRoundtripToFiles(unittest.TestCase):
-    #   @classmethod
-    #    def setUp(self):
-    #        os.chdir(datadir)
+def test_roundtrip_bary_toa_Tempo2format(tmpdir):
+    # Create a barycentric TOA
+    t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="tdb")
+    t1 = toa.TOA(t1time, obs="Barycenter", freq=0.0)
+    ts = toa.get_TOAs_list([t1], ephem="DE421")
+    outnm = os.path.join(tmpdir, "testbaryT.tim")
+    ts.write_TOA_file(outnm, format="Tempo2")
+    ts2 = toa.get_TOAs(outnm)
+    assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
+    assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
-    # Try writing and reading TEMPO and Tempo2 format .tim files
-    # Use several observatories, including Topo and Bary
-    def test_roundtrip_bary_toa_Tempo2format(self):
-        # Create a barycentric TOA
-        t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="tdb")
-        t1 = toa.TOA(t1time, obs="Barycenter", freq=0.0)
-        ts = toa.get_TOAs_list([t1], ephem="DE421")
-        ts.write_TOA_file("testbary.tim", format="Tempo2")
-        ts2 = toa.get_TOAs("testbary.tim")
-        assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
-        assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
-    def test_roundtrip_bary_toa_TEMPOformat(self):
-        # Create a barycentric TOA
-        t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="tdb")
-        t1 = toa.TOA(t1time, obs="Barycenter", freq=0.0)
-        ts = toa.get_TOAs_list([t1], ephem="DE421")
-        ts.write_TOA_file("testbary.tim", format="TEMPO")
-        ts2 = toa.get_TOAs("testbary.tim")
-        assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
-        assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
+def test_roundtrip_bary_toa_TEMPOformat(tmpdir):
+    # Create a barycentric TOA
+    t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="tdb")
+    t1 = toa.TOA(t1time, obs="Barycenter", freq=0.0)
+    ts = toa.get_TOAs_list([t1], ephem="DE421")
+    outnm = os.path.join(tmpdir, "testbaryT2.tim")
+    ts.write_TOA_file(outnm, format="TEMPO")
+    ts2 = toa.get_TOAs(outnm)
+    assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
+    assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
-    def test_roundtrip_topo_toa_Tempo2format(self):
-        # Create a barycentric TOA
-        t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
-        t1 = toa.TOA(t1time, obs="gbt", freq=0.0)
-        ts = toa.get_TOAs_list([t1], ephem="DE421")
-        ts.write_TOA_file("testtopo.tim", format="Tempo2")
-        ts2 = toa.get_TOAs("testtopo.tim")
-        assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
-        assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
-    def test_commenting_toas(self):
-        # Create a barycentric TOA
-        t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
-        t1 = toa.TOA(t1time, obs="gbt", freq=0.0)
-        t2 = toa.TOA(t1time, obs="gbt", freq=0.0)
-        ts = toa.get_TOAs_list([t1, t2], ephem="DE421")
-        assert ts.ntoas == 2
-        ts.write_TOA_file("testtopo.tim", format="Tempo2")
-        ts2 = toa.get_TOAs("testtopo.tim")
-        assert ts2.ntoas == 2  # none should be commented
-        ts.table[0]["flags"]["cut"] = "do not like"  # default comment flag
-        ts.table[1]["flags"]["ignore"] = True  # flag with different flag
-        ts.write_TOA_file("testtopo.tim", format="Tempo2")
-        ts3 = toa.get_TOAs("testtopo.tim")
-        assert ts3.ntoas == 1  # one should be commented
-        ts.write_TOA_file("testtopo.tim", format="Tempo2", commentflag=None)
-        ts4 = toa.get_TOAs("testtopo.tim")
-        assert ts4.ntoas == 2  # none should be commented
-        ts.write_TOA_file("testtopo.tim", format="Tempo2", commentflag="ignore")
-        ts5 = toa.get_TOAs("testtopo.tim")
-        assert ts5.ntoas == 1  # one should be commented
+def test_roundtrip_topo_toa_Tempo2format(tmpdir):
+    # Create a barycentric TOA
+    t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
+    t1 = toa.TOA(t1time, obs="gbt", freq=0.0)
+    ts = toa.get_TOAs_list([t1], ephem="DE421")
+    outnm = os.path.join(tmpdir, "testtopoT2.tim")
+    ts.write_TOA_file(outnm, format="Tempo2")
+    ts2 = toa.get_TOAs(outnm)
+    assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
+    assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
-    def test_roundtrip_topo_toa_TEMPOformat(self):
-        # Create a barycentric TOA
-        t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
-        t1 = toa.TOA(t1time, obs="gbt", freq=0.0)
-        ts = toa.get_TOAs_list([t1], ephem="DE421")
-        ts.write_TOA_file("testtopot1.tim", format="TEMPO")
-        ts2 = toa.get_TOAs("testtopot1.tim")
-        assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
-        assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
 
-    # Comment out because TEMPO2 distro doesn't include gmrt2gps.clk so far
-    # def test_roundtrip_gmrt_toa_Tempo2format(self):
-    #     if os.getenv("TEMPO2") is None:
-    #         pytest.skip("TEMPO2 evnironment variable is not set, can't run this test")
-    #     # Create a barycentric TOA
-    #     t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
-    #     t1 = toa.TOA(t1time, obs="gmrt", freq=0.0)
-    #     ts = toa.get_TOAs_list([t1], ephem="DE421")
-    #     ts.write_TOA_file("testgmrt.tim", format="Tempo2")
-    #     ts2 = toa.get_TOAs("testgmrt.tim")
-    #     print(ts.table, ts2.table)
-    #     assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
-    #     assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
+def test_commenting_toas(tmpdir):
+    # Create a barycentric TOA
+    t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
+    t1 = toa.TOA(t1time, obs="gbt", freq=0.0)
+    t2 = toa.TOA(t1time, obs="gbt", freq=0.0)
+    ts = toa.get_TOAs_list([t1, t2], ephem="DE421")
+    assert ts.ntoas == 2
+    outnm = os.path.join(tmpdir, "testtopo.tim")
+    ts.write_TOA_file(outnm)
+    ts2 = toa.get_TOAs(outnm)
+    assert ts2.ntoas == 2  # none should be commented
+    ts.table[0]["flags"]["cut"] = "do_not_like"  # default comment flag
+    ts.table[1]["flags"]["ignore"] = True  # flag with different flag
+    ts.write_TOA_file(outnm)
+    ts3 = toa.get_TOAs(outnm)
+    assert ts3.ntoas == 1  # one should be commented
+    ts.write_TOA_file(outnm, commentflag=None)
+    ts4 = toa.get_TOAs(outnm)
+    assert ts4.ntoas == 2  # none should be commented
+    ts.write_TOA_file(outnm, commentflag="ignore")
+    ts5 = toa.get_TOAs(outnm)
+    assert ts5.ntoas == 1  # one should be commented
 
-    # def test_roundtrip_ncyobs_toa_Tempo2format(self):
-    #     if os.getenv("TEMPO2") is None:
-    #         pytest.skip("TEMPO2 evnironment variable is not set, can't run this test")
-    #     # Create a barycentric TOA
-    #     t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
-    #     t1 = toa.TOA(t1time, obs="ncyobs", freq=0.0)
-    #     ts = toa.get_TOAs_list([t1], ephem="DE421")
-    #     ts.write_TOA_file("testncyobs.tim", format="Tempo2")
-    #     ts2 = toa.get_TOAs("testncyobs.tim")
-    #     print(ts.table, ts2.table)
-    #     assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15*u.d
-    #     assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15*u.d
 
-    # def test_roundtrip_ncyobs_toa_TEMPOformat(self):
-    #     if os.getenv("TEMPO2") is None:
-    #         pytest.skip("TEMPO2 evnironment variable is not set, can't run this test")
-    #     # Create a barycentric TOA
-    #     t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
-    #     t1 = toa.TOA(t1time, obs="ncyobs", freq=0.0)
-    #     ts = toa.get_TOAs_list([t1], ephem="DE421")
-    #     # This is an observatory that can't be represented in TEMPO format
-    #     # so it should raise an exception
-    #     with pytest.raises(ValueError):
-    #         ts.write_TOA_file("testncyobs.tim", format="TEMPO")
+def test_roundtrip_topo_toa_TEMPOformat(tmpdir):
+    # Create a barycentric TOA
+    t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
+    t1 = toa.TOA(t1time, obs="gbt", freq=0.0)
+    ts = toa.get_TOAs_list([t1], ephem="DE421")
+    outnm = os.path.join(tmpdir, "testtopot1.tim")
+    ts.write_TOA_file(outnm, format="TEMPO")
+    ts2 = toa.get_TOAs(outnm)
+    assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
+    assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
+
+
+# Comment out because TEMPO2 distro doesn't include gmrt2gps.clk so far
+# def test_roundtrip_gmrt_toa_Tempo2format(self):
+#     if os.getenv("TEMPO2") is None:
+#         pytest.skip("TEMPO2 evnironment variable is not set, can't run this test")
+#     # Create a barycentric TOA
+#     t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
+#     t1 = toa.TOA(t1time, obs="gmrt", freq=0.0)
+#     ts = toa.get_TOAs_list([t1], ephem="DE421")
+#     ts.write_TOA_file("testgmrt.tim", format="Tempo2")
+#     ts2 = toa.get_TOAs("testgmrt.tim")
+#     print(ts.table, ts2.table)
+#     assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15 * u.d
+#     assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15 * u.d
+# def test_roundtrip_ncyobs_toa_Tempo2format(self):
+#     if os.getenv("TEMPO2") is None:
+#         pytest.skip("TEMPO2 evnironment variable is not set, can't run this test")
+#     # Create a barycentric TOA
+#     t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
+#     t1 = toa.TOA(t1time, obs="ncyobs", freq=0.0)
+#     ts = toa.get_TOAs_list([t1], ephem="DE421")
+#     ts.write_TOA_file("testncyobs.tim", format="Tempo2")
+#     ts2 = toa.get_TOAs("testncyobs.tim")
+#     print(ts.table, ts2.table)
+#     assert np.abs(ts.table["mjd"][0] - ts2.table["mjd"][0]) < 1.0e-15*u.d
+#     assert np.abs(ts.table["tdb"][0] - ts2.table["tdb"][0]) < 1.0e-15*u.d
+# def test_roundtrip_ncyobs_toa_TEMPOformat(self):
+#     if os.getenv("TEMPO2") is None:
+#         pytest.skip("TEMPO2 evnironment variable is not set, can't run this test")
+#     # Create a barycentric TOA
+#     t1time = Time(58534.0, 0.0928602471130208, format="mjd", scale="utc")
+#     t1 = toa.TOA(t1time, obs="ncyobs", freq=0.0)
+#     ts = toa.get_TOAs_list([t1], ephem="DE421")
+#     # This is an observatory that can't be represented in TEMPO format
+#     # so it should raise an exception
+#     with pytest.raises(ValueError):
+#         ts.write_TOA_file("testncyobs.tim", format="TEMPO")

--- a/tests/test_toa_writer.py
+++ b/tests/test_toa_writer.py
@@ -59,8 +59,11 @@ class TestRoundtripToFiles(unittest.TestCase):
         ts.table[1]["flags"]["ignore"] = True  # comment TOA
         ts.write_TOA_file("testtopo.tim", format="Tempo2")
         ts2 = toa.get_TOAs("testtopo.tim")
-        print(ts.table, ts2.table)
         assert ts2.ntoas == 1  # one should be commented
+        ts.write_TOA_file("testtopo.tim", format="Tempo2", comments=False)
+        ts3 = toa.get_TOAs("testtopo.tim")
+        print(ts.table, ts2.table, ts3.table)
+        assert ts3.ntoas == 2  # neither should be commented
 
     def test_roundtrip_topo_toa_TEMPOformat(self):
         # Create a barycentric TOA


### PR DESCRIPTION
This is for discussion with #1011, but it seems useful and has tests.
Any TOA with an `ignore` or `cut` flag will be commented on write.
