### PR TITLE
TOAs objects now use a custom unpickler

### DIFF
--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -321,7 +321,6 @@ def load_pickle(toafilename, picklefilename=None):
         except (IOError, pickle.UnpicklingError, ValueError):
             pass
     if lf is not None:
-        lf.table = lf.table.group_by("obs")
         lf.was_pickled = True
         return lf
     raise IOError("No readable pickle found")
@@ -1322,6 +1321,12 @@ class TOAs:
         st = sd.pop("table")
         ot = od.pop("table")
         return sd == od and np.all(st == ot)
+
+    def __setstate__(self, state):
+        # Normal unpickling behaviour
+        self.__dict__.update(state)
+        # Astropy tables lose their group_by
+        self.table = self.table.group_by("obs")
 
     @property
     def ntoas(self):

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1326,7 +1326,8 @@ class TOAs:
         # Normal unpickling behaviour
         self.__dict__.update(state)
         # Astropy tables lose their group_by
-        self.table = self.table.group_by("obs")
+        if self.table.groups.keys is None:
+            self.table = self.table.group_by("obs")
 
     @property
     def ntoas(self):

--- a/tests/test_toa_pickle.py
+++ b/tests/test_toa_pickle.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python
 import os
 import pickle
-import unittest
 import shutil
 import time
+import unittest
 
 import astropy.time
 import astropy.units as u
 import numpy as np
 import pytest
+from pinttestdata import datadir
 
 import pint.models
 import pint.toa
 from pint import toa
-from pinttestdata import datadir
 
 
 @pytest.fixture
@@ -151,3 +151,13 @@ def test_astropy_group_survives_pickle(tmpdir):
 
     assert len(test_toas.table.groups.keys) == 1
     assert len(new_table.groups.keys) == 1
+
+
+def test_group_survives_plain_pickle(tmpdir):
+    test_model = pint.models.get_model(os.path.join(datadir, "NGC6440E.par"))
+    test_toas = pint.toa.make_fake_toas(58000, 59000, 5, model=test_model)
+
+    new_toas = pickle.loads(pickle.dumps(test_toas))
+
+    assert len(test_toas.table.groups.keys) == 1
+    assert len(new_toas.table.groups.keys) == 1


### PR DESCRIPTION
Not all pickling of TOAs objects goes through `load_pickle`, in particular when TOAs objects are passed between processes in `multiprocessing`. In these cases, our fix to #1014 does not get run. This PR arranges for all TOAs objects to run `group_by("obs")` when they are unpickled. This is probably what is impeding the enterprise PR https://github.com/nanograv/enterprise/pull/259