### PR TITLE
change_dmepoch works even if DMEPOCH not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 ### Fixed
 - Now ensures T2CMETHOD is IAU2000B if it is set at all; likewise DILATEFREQ and TIMEEPH (PR #970)
 - Merging TOAs objects now ensures that their index columns don't overlap (PR #1029)
+- change_dmepoch now works even if DMEPOCH is not set (PR #1025)
 ### Added
 - DownhillWLSFitter, DownhillGLSFitter, WidebandDownhillFitter are new Fitters that are more careful about convergence than the existing ones (PR #975)
 - Fitters have a .is_wideband boolean attribute (PR #975)

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -262,8 +262,7 @@ class DispersionDM(Dispersion):
         dm_terms = np.longdouble(np.zeros(len(dms)))
         dm_terms[order] = np.longdouble(1.0)
         if self.DMEPOCH.value is None:
-            v = dms[order].value
-            if order > 0 and v is not None and v != 0:
+            if any(t.value != 0 for t in dms[1:]):
                 raise ValueError(f"DMEPOCH is not set but {param_name} is not zero")
             DMEPOCH = tbl["tdbld"][0]
         else:

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -281,12 +281,17 @@ class DispersionDM(Dispersion):
         else:
             new_epoch = Time(new_epoch, scale="tdb", format="mjd", precision=9)
 
+        dmterms = [0.0 * u.Unit("")] + self.get_DM_terms()
         if self.DMEPOCH.value is None:
-            raise ValueError("DMEPOCH is not currently set.")
+            self.DMEPOCH.value = new_epoch
+            if len(dmterms) > 2:
+                raise ValueError(
+                    f"DMEPOCH is not currently set but there are "
+                    f"{len(dmterms)-2} derivatives."
+                )
 
         dmepoch_ld = self.DMEPOCH.quantity.tdb.mjd_long
         dt = (new_epoch.tdb.mjd_long - dmepoch_ld) * u.day
-        dmterms = [0.0 * u.Unit("")] + self.get_DM_terms()
 
         for n in range(len(dmterms) - 1):
             cur_deriv = self.DM if n == 0 else getattr(self, "DM{}".format(n))

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -217,7 +217,7 @@ class DispersionDM(Dispersion):
             dm_terms_value = [d.value for d in dm_terms]
             dm = taylor_horner(dt_value, dm_terms_value)
         else:
-            dm = dm_terms_value[0]
+            dm = dm_terms[0].value
         return dm * self.DM.units
 
     def constant_dispersion_delay(self, toas, acc_delay=None):

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -213,11 +213,11 @@ class DispersionDM(Dispersion):
                 raise ValueError(
                     "DMEPOCH not set but some derivatives are not zero: {dm_terms}"
                 ) from e
-            dt_value = (dt.to(u.yr)).value
-            dm_terms_value = [d.value for d in dm_terms]
-            dm = taylor_horner(dt_value, dm_terms_value)
+            dt_value = dt.to_value(u.yr)
         else:
-            dm = dm_terms[0].value
+            dt_value = np.zeros(len(toas), dtype=np.longdouble)
+        dm_terms_value = [d.value for d in dm_terms]
+        dm = taylor_horner(dt_value, dm_terms_value)
         return dm * self.DM.units
 
     def constant_dispersion_delay(self, toas, acc_delay=None):
@@ -263,7 +263,7 @@ class DispersionDM(Dispersion):
         dm_terms[order] = np.longdouble(1.0)
         if self.DMEPOCH.value is None:
             v = dms[order].value
-            if v is not None and v != 0:
+            if order > 0 and v is not None and v != 0:
                 raise ValueError(f"DMEPOCH is not set but {param_name} is not zero")
             DMEPOCH = tbl["tdbld"][0]
         else:

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -284,11 +284,6 @@ class DispersionDM(Dispersion):
         dmterms = [0.0 * u.Unit("")] + self.get_DM_terms()
         if self.DMEPOCH.value is None:
             self.DMEPOCH.value = new_epoch
-            if len(dmterms) > 2:
-                raise ValueError(
-                    f"DMEPOCH is not currently set but there are "
-                    f"{len(dmterms)-2} derivatives."
-                )
 
         dmepoch_ld = self.DMEPOCH.quantity.tdb.mjd_long
         dt = (new_epoch.tdb.mjd_long - dmepoch_ld) * u.day

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -24,7 +24,7 @@ class Dispersion(DelayComponent):
     """A base dispersion timing model."""
 
     def __init__(self):
-        super(Dispersion, self).__init__()
+        super().__init__()
         self.dm_value_funcs = []
         self.dm_deriv_funcs = {}
 
@@ -136,7 +136,7 @@ class DispersionDM(Dispersion):
     category = "dispersion_constant"
 
     def __init__(self):
-        super(DispersionDM, self).__init__()
+        super().__init__()
         self.add_param(
             floatParameter(
                 name="DM",
@@ -168,7 +168,7 @@ class DispersionDM(Dispersion):
         self.delay_funcs_component += [self.constant_dispersion_delay]
 
     def setup(self):
-        super(Dispersion, self).setup()
+        super().setup()
         base_dms = list(self.get_prefix_mapping_component("DM").values())
         base_dms += ["DM"]
 
@@ -178,7 +178,7 @@ class DispersionDM(Dispersion):
 
     def validate(self):
         """Validate the DM parameters input."""
-        super(Dispersion, self).validate()
+        super().validate()
         # If DM1 is set, we need DMEPOCH
         if self.DM1.value != 0.0:
             if self.DMEPOCH.value is None:
@@ -312,7 +312,7 @@ class DispersionDMX(Dispersion):
     category = "dispersion_dmx"
 
     def __init__(self):
-        super(DispersionDMX, self).__init__()
+        super().__init__()
         # DMX is for info output right now
         self.add_param(
             floatParameter(
@@ -453,7 +453,7 @@ class DispersionDMX(Dispersion):
         return np.array(inds)
 
     def setup(self):
-        super(DispersionDMX, self).setup()
+        super().setup()
         # Get DMX mapping.
         # Register the DMX derivatives
         for prefix_par in self.get_params_of_type("prefixParameter"):
@@ -463,7 +463,7 @@ class DispersionDMX(Dispersion):
 
     def validate(self):
         """Validate the DMX parameters."""
-        super(DispersionDMX, self).validate()
+        super().validate()
         DMX_mapping = self.get_prefix_mapping_component("DMX_")
         DMXR1_mapping = self.get_prefix_mapping_component("DMXR1_")
         DMXR2_mapping = self.get_prefix_mapping_component("DMXR2_")
@@ -576,7 +576,7 @@ class DispersionJump(Dispersion):
     category = "dispersion_jump"
 
     def __init__(self):
-        super(DispersionJump, self).__init__()
+        super().__init__()
         self.dm_value_funcs += [self.jump_dm]
         # Dispersion jump only model the dm values.
 
@@ -590,7 +590,7 @@ class DispersionJump(Dispersion):
         )
 
     def setup(self):
-        super(DispersionJump, self).setup()
+        super().setup()
         self.dm_jumps = []
         for mask_par in self.get_params_of_type("maskParameter"):
             if mask_par.startswith("DMJUMP"):
@@ -604,7 +604,7 @@ class DispersionJump(Dispersion):
             self.register_deriv_funcs(self.d_delay_d_dmjump, j)
 
     def validate(self):
-        super(DispersionJump, self).validate()
+        super().validate()
 
     def jump_dm(self, toas):
         """Return the DM jump for each dm section collected by dmjump parameters.

--- a/tests/test_change_epoch.py
+++ b/tests/test_change_epoch.py
@@ -142,7 +142,7 @@ def test_unset_dmepoch_raises(times):
     with pytest.raises(ValueError):
         model.base_dm(times)
     with pytest.raises(ValueError):
-        model.d_dm_d_DMs(times, "DM1")
+        model.d_dm_d_DMs(times, "DM")
 
 
 @pytest.fixture(

--- a/tests/test_change_epoch.py
+++ b/tests/test_change_epoch.py
@@ -142,7 +142,7 @@ def test_unset_dmepoch_raises(times):
     with pytest.raises(ValueError):
         model.base_dm(times)
     with pytest.raises(ValueError):
-        model.d_dm_d_DMs(times, "DM")
+        model.d_dm_d_DMs(times, "DM1")
 
 
 @pytest.fixture(

--- a/tests/test_change_epoch.py
+++ b/tests/test_change_epoch.py
@@ -1,3 +1,5 @@
+import io
+import copy
 import os.path
 
 import astropy.units as u
@@ -6,6 +8,7 @@ import pint
 import pytest
 from astropy.time import Time
 from pint import models
+import pint.toa
 
 from pinttestdata import datadir
 
@@ -14,6 +17,13 @@ from pinttestdata import datadir
 def model(request):
     parfile = os.path.join(datadir, request.param)
     return models.get_model(parfile)
+
+
+@pytest.fixture
+def times():
+    return pint.toa.get_TOAs_list(
+        [pint.toa.TOA(t) for t in np.linspace(56000, 57000, 5)]
+    )
 
 
 def test_change_pepoch(model):
@@ -52,6 +62,49 @@ def test_change_dmepoch():
     DM_at_t0 = model.DM.quantity + model.DM1.quantity * epoch_diff.to(u.s)
     model.change_dmepoch(t0)
     assert np.abs(model.DM.quantity - DM_at_t0) < 1e-8 * u.pc / u.cm ** 3
+
+
+def test_change_dmepoch_times(times):
+    parfile = os.path.join(datadir, "J2229+2643_dm1.par")
+    model = models.get_model(parfile)
+    dms = model.base_dm(times)
+    model.change_dmepoch(Time(56000, scale="tdb", format="mjd"))
+    assert np.all(np.abs(model.base_dm(times) - dms) < 1e-8 * u.pc / u.cm ** 3)
+
+
+def test_change_dmepoch_unset(times):
+    model = models.get_model(
+        io.StringIO(
+            """
+            PSR J1234+5678
+            F0 1
+            PEPOCH 56000
+            ELAT 0
+            ELONG 0
+            DM 10
+            """
+        )
+    )
+    dms = model.base_dm(times)
+    model.change_dmepoch(Time(56000, scale="tdb", format="mjd"))
+    assert np.all(np.abs(model.base_dm(times) - dms) < 1e-8 * u.pc / u.cm ** 3)
+
+
+def test_change_dmepoch_unset_exception(times):
+    with pytest.raises(ValueError):
+        model = models.get_model(
+            io.StringIO(
+                """
+                PSR J1234+5678
+                F0 1
+                PEPOCH 56000
+                ELAT 0
+                ELONG 0
+                DM 10
+                DM1 1e-10
+                """
+            )
+        )
 
 
 @pytest.fixture(

--- a/tests/test_change_epoch.py
+++ b/tests/test_change_epoch.py
@@ -92,7 +92,7 @@ def test_change_dmepoch_unset(times):
 
 def test_change_dmepoch_unset_exception(times):
     with pytest.raises(ValueError):
-        model = models.get_model(
+        models.get_model(
             io.StringIO(
                 """
                 PSR J1234+5678
@@ -105,6 +105,44 @@ def test_change_dmepoch_unset_exception(times):
                 """
             )
         )
+
+
+def test_change_dmepoch_unset_python_exception(times):
+    model = models.get_model(
+        io.StringIO(
+            """
+            PSR J1234+5678
+            F0 1
+            PEPOCH 56000
+            ELAT 0
+            ELONG 0
+            DM 10
+            """
+        )
+    )
+    model.DM1.value = 7
+    with pytest.raises(ValueError):
+        model.change_dmepoch(56000)
+
+
+def test_unset_dmepoch_raises(times):
+    model = models.get_model(
+        io.StringIO(
+            """
+            PSR J1234+5678
+            F0 1
+            PEPOCH 56000
+            ELAT 0
+            ELONG 0
+            DM 10
+            """
+        )
+    )
+    model.DM1.value = 7
+    with pytest.raises(ValueError):
+        model.base_dm(times)
+    with pytest.raises(ValueError):
+        model.d_dm_d_DMs(times, "DM")
 
 
 @pytest.fixture(


### PR DESCRIPTION
This allows `TimingModel.compare` to work even when the second model doesn't have DMEPOCH set; this comes up in NANOGrav timing_analysis summaries.

Fixes #1024