### PR TITLE
Fix bug caused by the true anomaly calculation giving negative angles

### DIFF
--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -568,11 +568,11 @@ class TimingModel:
         elif anom.lower().startswith("ecc"):
             anoms = bbi.E()
         elif anom.lower() == "true":
-            anoms = bbi.nu()
+            anoms = bbi.nu()  # can be negative
         else:
             raise ValueError("anom='%s' is not a recognized type of anomaly" % anom)
         # Make sure all angles are between 0-2*pi
-        anoms = np.fmod(anoms.value, 2 * np.pi)
+        anoms = np.remainder(anoms.value, 2 * np.pi)
         if radians:  # return with radian units
             return anoms * u.rad
         else:  # return as unitless cycles from 0-1
@@ -610,7 +610,7 @@ class TimingModel:
 
         def funct(t):
             nu = self.orbital_phase(t, anom="true")
-            return np.fmod((nu + bbi.omega()).value, 2 * np.pi) - np.pi / 2
+            return np.remainder((nu + bbi.omega()).value, 2 * np.pi) - np.pi / 2
 
         # Handle the input time(s)
         if isinstance(baryMJD, time.Time):
@@ -628,7 +628,7 @@ class TimingModel:
             # Compute the true anomalies and omegas for those times
             nus = self.orbital_phase(ts, anom="true")
             omegas = bbi.omega()
-            x = np.fmod((nus + omegas).value, 2 * np.pi) - np.pi / 2
+            x = np.remainder((nus + omegas).value, 2 * np.pi) - np.pi / 2
             # find the lowest index where x is just below 0
             for lb in range(len(x)):
                 if x[lb] < 0 and x[lb + 1] > 0:

--- a/tests/test_orbit_phase.py
+++ b/tests/test_orbit_phase.py
@@ -86,8 +86,10 @@ class TestOrbitPhase(unittest.TestCase):
         omega = mJ0737.components["BinaryDD"].binary_instance.omega().value
         # Conjunction occurs when nu + OM == 90 deg
         assert np.isclose(
-            np.degrees(np.fmod(nu + omega, 2 * np.pi)), 90.0
+            np.degrees(np.remainder(nu + omega, 2 * np.pi)), 90.0
         ), "J0737 conjunction time gives bad true anomaly"
         # Now verify we can get 2 results from .conjunction
         x = mJ0737.conjunction([55586.0, 55586.2])
         assert len(x) == 2, "conjunction is not returning an array"
+        # make sure true anomaly before T0 is positive
+        assert mJ0737.orbital_phase(52000.0, anom="true").value > 0.0


### PR DESCRIPTION
Turns out that the binary orbit calcs give negative angles only for true anomaly if the time in question is before T0.  This makes all anomalies from `.orbital_phase()` positive and between 0-2pi radians.

This was found using the `.conjunction()` method, which barfed for an early date.

Fixed by using `np.remainder()` rather than `np.fmod()`
