### PR TITLE
Keep TOA indices unique when merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 ## Unreleased
 ### Fixed
 - Now ensures T2CMETHOD is IAU2000B if it is set at all; likewise DILATEFREQ and TIMEEPH (PR #970)
+- Merging TOAs objects now ensures that their index columns don't overlap (PR #1029)
 ### Added
 - DownhillWLSFitter, DownhillGLSFitter, WidebandDownhillFitter are new Fitters that are more careful about convergence than the existing ones (PR #975)
 - Fitters have a .is_wideband boolean attribute (PR #975)
-
+- TOAs now have a .renumber() method to simplify their index column (PR #1029)
 
 ## [0.8.2] - 2021-01-27
 ### Fixed

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -2166,9 +2166,14 @@ def merge_TOAs(TOAs_list):
     # We do not ensure that the command list is flat
     nt.commands = [tt.commands for tt in TOAs_list]
     # Now do the actual table stacking
-    nt.table = table.vstack(
-        [tt.table for tt in TOAs_list], join_type="exact", metadata_conflicts="silent"
-    )
+    start_index = np.maximum.reduce(nt.table["index"]) + 1
+    tables = []
+    for tt in TOAs_list:
+        t = copy.deepcopy(tt.table)
+        t["index"] += start_index
+        start_index += np.maximum.reduce(tt.table["index"]) + 1
+        tables.append(t)
+    nt.table = table.vstack(tables, join_type="exact", metadata_conflicts="silent")
     # Fix the table meta data about filenames
     nt.table.meta["filename"] = nt.filename
     nt.hashes = {}

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1687,6 +1687,30 @@ class TOAs:
         self.compute_TDBs()
         self.compute_posvels(self.ephem, self.planets)
 
+    def renumber(self, index_order=True):
+        """Recreate the index column so the values go from 0 to len(self)-1.
+
+        This modifies the TOAs object and also returns it, for calling
+        convenience.
+
+        Parameters
+        ==========
+        index_order : bool
+            If True, preserve the order of the index column, but renumber so
+            there are no gaps. If False, number according to the order TOAs
+            occur in the object (they will be grouped by observatory).
+
+        Returns
+        =======
+        self
+        """
+        if index_order:
+            ix = np.argsort(self.table["index"])
+            self.table["index"][ix] = np.arange(len(self))
+        else:
+            self.table["index"] = np.arange(len(self))
+        return self
+
     def write_TOA_file(self, filename, name="unk", format="tempo2", commentflag=None):
         """Write this object to a ``.tim`` file.
 

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -293,3 +293,48 @@ def test_merge_indices():
         match = toas.table[toas.table["index"] == ix]
         assert len(match) == 1
         assert match[0]["tdbld"] == toas_excised.table["tdbld"][i]
+
+
+def test_renumber_subset():
+    m = get_model(StringIO(simplepar))
+    toas = toa.make_fake_toas(55000, 55500, 10, model=m, obs="ao")
+
+    sub = toas[1:-1]
+    assert 0 not in sub.table["index"]
+
+    sub.renumber()
+    assert np.all(sub.table["index"] == np.arange(len(sub)))
+
+
+def test_renumber_order():
+    m = get_model(StringIO(simplepar))
+    toas = toa.make_fake_toas(55000, 55500, 10, model=m, obs="ao")
+    rev = toas[::-1]
+    assert np.all(rev.table["index"] == np.arange(len(rev))[::-1])
+    rev.renumber()
+    assert np.all(rev.table["index"] == np.arange(len(rev))[::-1])
+    rev.renumber(index_order=False)
+    assert np.all(rev.table["index"] == np.arange(len(rev)))
+
+    rev = toas[::-1]
+    rev.renumber(index_order=True)
+    assert np.all(rev.table["index"] == np.arange(len(rev))[::-1])
+
+
+def test_renumber_subset():
+    m = get_model(StringIO(simplepar))
+    fakes = [
+        toa.make_fake_toas(55000, 55500, 5, model=m, obs="ao"),
+        toa.make_fake_toas(56000, 56500, 10, model=m, obs="gbt"),
+        toa.make_fake_toas(57000, 57500, 15, model=m, obs="@"),
+    ]
+    fakes_excised = [f[1:-1] for f in fakes]
+    toas_excised = toa.merge_TOAs(fakes_excised)
+
+    assert 0 not in toas_excised.table["index"]
+
+    toas_excised.renumber()
+    assert set(toas_excised.table["index"]) == set(range(len(toas_excised)))
+
+    toas_excised.renumber(index_order=False)
+    assert np.all(toas_excised.table["index"] == np.arange(len(toas_excised)))

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -265,3 +265,14 @@ def test_pickle_multiple(tmpdir):
     assert not toa.get_TOAs(
         filenames, model=m, usepickle=True, picklefilename=picklefilename
     ).was_pickled
+
+
+def test_merge_indices():
+    m = get_model(StringIO(simplepar))
+    fakes = [
+        toa.make_fake_toas(55000, 55500, 5, model=m, obs="ao"),
+        toa.make_fake_toas(56000, 56500, 10, model=m, obs="gbt"),
+        toa.make_fake_toas(57000, 57500, 15, model=m, obs="@"),
+    ]
+    toas = toa.merge_TOAs(fakes)
+    assert len(set(toas.table["index"])) == len(toas)

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -276,3 +276,20 @@ def test_merge_indices():
     ]
     toas = toa.merge_TOAs(fakes)
     assert len(set(toas.table["index"])) == len(toas)
+
+
+def test_merge_indices():
+    m = get_model(StringIO(simplepar))
+    fakes = [
+        toa.make_fake_toas(55000, 55500, 5, model=m, obs="ao"),
+        toa.make_fake_toas(56000, 56500, 10, model=m, obs="gbt"),
+        toa.make_fake_toas(57000, 57500, 15, model=m, obs="@"),
+    ]
+    fakes_excised = [f[1:-1] for f in fakes]
+    toas = toa.merge_TOAs(fakes)
+    toas_excised = toa.merge_TOAs(fakes_excised)
+    for i in range(len(toas_excised)):
+        ix = toas_excised.table["index"][i]
+        match = toas.table[toas.table["index"] == ix]
+        assert len(match) == 1
+        assert match[0]["tdbld"] == toas_excised.table["tdbld"][i]


### PR DESCRIPTION
This change ensures that the "index" column is usable to track TOAs as you take subsets.

It might be a better idea to record the maximum TOA number on load and keep that around, so that merging subsets doesn't re-use numbers. But that can be another PR; I think this is useful enough to just merge.