### PR TITLE
Allow TOAs to be written in index order

### DIFF
--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1740,7 +1740,14 @@ class TOAs:
             self.table["index"] = np.arange(len(self))
         return self
 
-    def write_TOA_file(self, filename, name="unk", format="tempo2", commentflag=None):
+    def write_TOA_file(
+        self,
+        filename,
+        name="unk",
+        format="tempo2",
+        commentflag=None,
+        order_by_index=True,
+    ):
         """Write this object to a ``.tim`` file.
 
         This function writes the contents of this object to a (single) ``.tim``
@@ -1761,6 +1768,12 @@ class TOAs:
         commentflag : str or None
             If a string, and that string is a TOA flag, that TOA will be commented
             in the output file.  If None (or non-string), no TOAs will be commented.
+        order_by_index : bool
+            If True, write the TOAs in the order specified in the "index" column
+            (which is usually the same as the original file);
+            if False, write them in the order they occur in the TOAs object
+            (which is usually the same as the original file except that all the
+            TOAs associated with each observatory have been grouped).
         """
         try:
             # FIXME: file must be closed even if an exception occurs!
@@ -1783,12 +1796,16 @@ class TOAs:
                 if not np.isnan(pn):
                     self.table["flags"][i]["pn"] = pn
 
+        if order_by_index:
+            ix = np.argsort(self.table["index"])
+        else:
+            ix = np.arange(len(self))
         for (toatime, toaerr, freq, obs, flags) in zip(
-            self.table["mjd"],
-            self.table["error"].quantity,
-            self.table["freq"].quantity,
-            self.table["obs"],
-            self.table["flags"],
+            self.table["mjd"][ix],
+            self.table["error"][ix].quantity,
+            self.table["freq"][ix].quantity,
+            self.table["obs"][ix],
+            self.table["flags"][ix],
         ):
             obs_obj = Observatory.get(obs)
 

--- a/tests/test_tim_writing.py
+++ b/tests/test_tim_writing.py
@@ -124,6 +124,7 @@ some_barycentered 999999.999 56403.000000000000000   1.000  @  -some argument -a
                     "-flags",
                     "-obs",
                     "-clkcorr",
+                    "-to",  # FIXME: used in clock corrections? What does this do?
                 }
             ),
             from_regex(re.compile(r"[ \t]+", re.ASCII), fullmatch=True),
@@ -133,15 +134,16 @@ some_barycentered 999999.999 56403.000000000000000   1.000  @  -some argument -a
 )
 def test_flags(s):
     f = StringIO(
-        basic_tim_header
-        + """
-some_barycentered 999999.999 56400.000000000000000   1.000  @{}
-""".format(
-            s
+        "\n".join(
+            [
+                basic_tim_header,
+                f"""some_barycentered 999999.999 56400.000000000000000   1.000  @{s}""",
+                basic_tim,
+            ]
         )
-        + basic_tim
     )
-    do_roundtrip(get_TOAs(f))
+    toas = get_TOAs(f)
+    do_roundtrip(toas)
 
 
 def test_pulse_number():


### PR DESCRIPTION
Users can now write out par files in the order specified in the `index` column; this allows the tim file to reproduce the original input order; users can also set the order they like.