### PR TITLE
Quick jump_flags_to_params fix

### DIFF
--- a/src/pint/models/jump.py
+++ b/src/pint/models/jump.py
@@ -155,13 +155,17 @@ class PhaseJump(PhaseComponent):
             mask = jump_par.select_toa_mask(toas)
             # apply to dictionaries
             for dict in toas.table["flags"][mask]:
-                if "jump" in dict.keys():
+                if "jump" in dict.keys() and type(dict["jump"]) is list:
                     # check if jump flag already added - don't add flag twice
-                    if jump_par.index in dict["jump"]:
+                    if str(jump_par.index) in dict["jump"]:
                         continue
-                    dict["jump"].append(jump_par.index)  # otherwise, add jump flag
+                    dict["jump"].append(str(jump_par.index))  # otherwise, add jump flag
+                elif "jump" in dict.keys() and type(dict["jump"]) is str:
+                    if dict["jump"] == str(jump_par.index):
+                        continue
+                    dict["jump"] = [dict["jump"], str(jump_par.index)]
                 else:
-                    dict["jump"] = [jump_par.index]
+                    dict["jump"] = [str(jump_par.index)]
 
     def add_jump_and_flags(self, toa_table):
         """Add jump object to PhaseJump and appropriate flags to TOA tables.
@@ -221,8 +225,8 @@ class PhaseJump(PhaseComponent):
         # add appropriate flags to TOA table to link jump with appropriate TOA
         for dict1 in toa_table:
             if "jump" in dict1.keys():
-                dict1["jump"].append(ind)  # toa can have multiple jumps
+                dict1["jump"].append(str(ind))  # toa can have multiple jumps
             else:
-                dict1["jump"] = [ind]
-            dict1["gui_jump"] = ind  # toa can only have one gui_jump
+                dict1["jump"] = [str(ind)]
+            dict1["gui_jump"] = str(ind)  # toa can only have one gui_jump
         return name

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -1377,12 +1377,9 @@ class maskParameter(floatParameter):
                         "are MJD, FREQ, NAME, TEL."
                     )
         self.key = key
-        if key == "-gui_jump" or key == "-tim_jump":
-            self.key_value = key_value
-        else:
-            self.key_value = [
-                key_value_parser(k) for k in key_value
-            ]  # retains string format from .par file to ensure correct data type for comparison
+        self.key_value = [
+            key_value_parser(k) for k in key_value
+        ]  # retains string format from .par file to ensure correct data type for comparison
         self.key_value.sort()
         self.index = index
         name_param = name + str(index)

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -1377,7 +1377,7 @@ class maskParameter(floatParameter):
                         "are MJD, FREQ, NAME, TEL."
                     )
         self.key = key
-        if key == "-gui_jump":
+        if key == "-gui_jump" or key == "-tim_jump":
             self.key_value = key_value
         else:
             self.key_value = [

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1257,9 +1257,7 @@ class TimingModel:
                     )
                     self.add_param_from_top(param, "PhaseJump")
                     getattr(self, param.name).frozen = False
-                    flag_dict[
-                        "tim_jump"
-                    ] = num  # this is the value select_toa_mask uses
+                flag_dict["tim_jump"] = num  # this is the value select_toa_mask uses
         self.components["PhaseJump"].setup()
 
     def delete_jump_and_flags(self, toa_table, jump_num):

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1287,9 +1287,11 @@ class TimingModel:
                         type(dict["jump"]) is str
                     ):  # if only one jump will just hold a str of the index number, otherwise will hold a list of str indeces
                         del dict["jump"]
+                    elif len(dict["jump"]) == 1:
+                        del dict["jump"]
                     else:
                         dict["jump"].remove(str(jump_num))
-                if "gui_jump" in dict.keys() and dict["gui_jump"] == jump_num:
+                if "gui_jump" in dict.keys() and dict["gui_jump"] == str(jump_num):
                     del dict["gui_jump"]
                 # renumber jump flags at higher jump indeces in whole TOA table (held as str values, must convert to ints for subtraction and then back to str)
                 if "jump" in dict.keys():

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1257,7 +1257,9 @@ class TimingModel:
                     )
                     self.add_param_from_top(param, "PhaseJump")
                     getattr(self, param.name).frozen = False
-                flag_dict["tim_jump"] = num  # this is the value select_toa_mask uses
+                flag_dict["tim_jump"] = str(
+                    num
+                )  # this is the value select_toa_mask uses
         self.components["PhaseJump"].setup()
 
     def delete_jump_and_flags(self, toa_table, jump_num):
@@ -1280,21 +1282,24 @@ class TimingModel:
         # remove jump flags from selected TOA tables
         if toa_table is not None:
             for dict in toa_table:
-                if "jump" in dict.keys() and jump_num in dict["jump"]:
-                    if len(dict["jump"]) == 1:
+                if "jump" in dict.keys() and str(jump_num) in dict["jump"]:
+                    if (
+                        type(dict["jump"]) is str
+                    ):  # if only one jump will just hold a str of the index number, otherwise will hold a list of str indeces
                         del dict["jump"]
                     else:
-                        dict["jump"].remove(jump_num)
+                        dict["jump"].remove(str(jump_num))
                 if "gui_jump" in dict.keys() and dict["gui_jump"] == jump_num:
                     del dict["gui_jump"]
-                # renumber jump flags at higher jump indeces in whole TOA table
+                # renumber jump flags at higher jump indeces in whole TOA table (held as str values, must convert to ints for subtraction and then back to str)
                 if "jump" in dict.keys():
                     dict["jump"] = [
-                        num - 1 if num > jump_num else num for num in dict["jump"]
+                        str(int(num) - 1) if int(num) > jump_num else num
+                        for num in dict["jump"]
                     ]
-                if "gui_jump" in dict.keys() and dict["gui_jump"] > jump_num:
-                    cur_val = dict["gui_jump"]
-                    dict["gui_jump"] = cur_val - 1
+                if "gui_jump" in dict.keys() and int(dict["gui_jump"]) > jump_num:
+                    cur_val = int(dict["gui_jump"])
+                    dict["gui_jump"] = str(cur_val - 1)
 
         # if last jump deleted, remove PhaseJump object from model
         if (
@@ -1308,7 +1313,7 @@ class TimingModel:
         # if not, reindex higher index jump objects
         for i in range(jump_num + 1, len(self.jumps) + 1):
             cur_jump = getattr(self, "JUMP" + str(i))
-            cur_jump.key_value = i - 1
+            cur_jump.key_value = str(i - 1)
             new_jump = cur_jump.new_param(index=(i - 1), copy_all=True)
             self.add_param_from_top(new_jump, "PhaseJump")
             self.remove_param(cur_jump.name)

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1249,7 +1249,7 @@ class TimingModel:
                     param = maskParameter(
                         name="JUMP",
                         index=num,
-                        key="-jump",
+                        key="-tim_jump",
                         key_value=num,
                         value=0.0,
                         units="second",
@@ -1257,6 +1257,9 @@ class TimingModel:
                     )
                     self.add_param_from_top(param, "PhaseJump")
                     getattr(self, param.name).frozen = False
+                    flag_dict[
+                        "tim_jump"
+                    ] = num  # this is the value select_toa_mask uses
         self.components["PhaseJump"].setup()
 
     def delete_jump_and_flags(self, toa_table, jump_num):

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -1097,7 +1097,7 @@ class PlkWidget(tk.Frame):
                 "Return value for the jump name is not a string, jumps not updated",
             )
             return None
-        num = int(jump_name[4:])
+        num = jump_name[4:]  # string value
         jump_select = [
             True if ("jump" in dict.keys() and num in dict["jump"]) else False
             for dict in self.psr.all_toas.table["flags"]

--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -86,7 +86,7 @@ class Pulsar:
 
         # turns pre-existing jump flags in toas.table['flags'] into parameters in parfile
         # TODO: fix jump_flags_to_params
-        # self.prefit_model.jump_flags_to_params(self.all_toas)
+        self.prefit_model.jump_flags_to_params(self.all_toas)
         # adds flags to toas.table for existing jump parameters from .par file
         if "PhaseJump" in self.prefit_model.components:
             self.prefit_model.jump_params_to_flags(self.all_toas)

--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -311,7 +311,7 @@ class Pulsar:
         for num in range(1, numjumps + 1):
             # create boolean array corresponding to TOAs to be jumped
             toas_jumped = [
-                True if ("jump" in dict.keys() and num in dict["jump"]) else False
+                "jump" in dict.keys() and str(num) in dict["jump"]
                 for dict in self.all_toas.table["flags"]
             ]
             if np.array_equal(toas_jumped, selected):
@@ -362,7 +362,7 @@ class Pulsar:
                 if getattr(
                     self.prefit_model, param
                 ).frozen == False and param.startswith("JUMP"):
-                    fit_jumps.append(int(param[4:]))
+                    fit_jumps.append(param[4:])
             numjumps = self.prefit_model.components["PhaseJump"].get_number_of_jumps()
             if numjumps == 0:
                 log.warn(
@@ -371,10 +371,14 @@ class Pulsar:
                 return None
             # boolean array to determine if all selected toas are jumped
             jumps = [
-                True
-                if "jump" in dict.keys()
-                and any(num in fit_jumps for num in dict["jump"])
-                else False
+                "jump" in dict.keys()
+                and (
+                    (
+                        type(dict["jump"]) is list
+                        and any(num in fit_jumps for num in dict["jump"])
+                    )
+                    or (type(dict["jump"]) is str and dict["jump"] in fit_jumps)
+                )
                 for dict in self.all_toas.table["flags"][selected]
             ]
             if all(jumps):
@@ -393,31 +397,28 @@ class Pulsar:
                 for dict in self.all_toas.table["flags"]
             ]
             for num in range(1, numjumps + 1):
-                num = int(num)
                 # check that jump of the specified number in the range of fitted TOAs, otherwise don't include in fit
                 check_jump_in_range = [
-                    True if num in jump_num else False for jump_num in sel_jump_nums
+                    str(num) in jump_num for jump_num in sel_jump_nums
                 ]
                 if not any(check_jump_in_range):
                     getattr(self.prefit_model, "JUMP" + str(num)).frozen = True
                     continue
-                jump_select = [
-                    True if num in jump_num else False for jump_num in full_jump_nums
-                ]
+                jump_select = [str(num) in jump_num for jump_num in full_jump_nums]
                 overlap = [a and b for a, b in zip(jump_select, selected)]
                 # remove the jump flags for that num
                 for dict in self.all_toas.table["flags"]:
-                    if "jump" in dict.keys() and num in dict["jump"]:
-                        if len(dict["jump"]) == 1:
+                    if "jump" in dict.keys() and str(num) in dict["jump"]:
+                        if type(dict["jump"]) is str:
                             del dict["jump"]
                         else:
-                            dict["jump"].remove(num)
+                            dict["jump"].remove(str(num))
                 # re-add the jump using overlap as 'selected'
                 for dict in self.all_toas.table["flags"][overlap]:
                     if "jump" in dict.keys():
-                        dict["jump"].append(num)
+                        dict["jump"].append(str(num))
                     else:
-                        dict["jump"] = [num]
+                        dict["jump"] = [str(num)]
 
         if self.fitted:
             self.prefit_model = self.postfit_model

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -752,8 +752,7 @@ def read_toa_file(filename, process_includes=True, cdict=None):
                 if cdict["INFO"]:
                     newtoa.flags["info"] = cdict["INFO"]
                 if cdict["JUMP"][0]:
-                    # in list to allow jump overlap (multiple jumps/toa) and +1 since jumps start indexing at 1 rather than 0
-                    newtoa.flags["jump"] = [cdict["JUMP"][1] + 1]
+                    newtoa.flags["jump"] = str(cdict["JUMP"][1] + 1)
                 if cdict["PHASE"] != 0:
                     newtoa.flags["phase"] = cdict["PHASE"]
                 if cdict["TIME"] != 0.0:

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -40,20 +40,20 @@ def test_add_jumps_and_flags(setup_NGC6440E):
     selected_toa_ind = [1, 2, 3]  # arbitrary set of TOAs
     cp.add_jump_and_flags(setup_NGC6440E.t.table["flags"][selected_toa_ind])
     for dict in setup_NGC6440E.t.table["flags"][selected_toa_ind]:
-        assert dict["jump"] == [1]
-        assert dict["gui_jump"] == 1
+        assert dict["jump"] == ["1"]
+        assert dict["gui_jump"] == "1"
 
     # add second jump to different set of TOAs
     selected_toa_ind2 = [10, 11, 12]
     cp.add_jump_and_flags(setup_NGC6440E.t.table["flags"][selected_toa_ind2])
     # check previous jump flags unaltered
     for dict in setup_NGC6440E.t.table["flags"][selected_toa_ind]:
-        assert dict["jump"] == [1]
-        assert dict["gui_jump"] == 1
+        assert dict["jump"] == ["1"]
+        assert dict["gui_jump"] == "1"
     # check appropriate flags added
     for dict in setup_NGC6440E.t.table["flags"][selected_toa_ind2]:
-        assert dict["jump"] == [2]
-        assert dict["gui_jump"] == 2
+        assert dict["jump"] == ["2"]
+        assert dict["gui_jump"] == "2"
 
 
 def test_add_overlapping_jump(setup_NGC6440E):
@@ -68,11 +68,11 @@ def test_add_overlapping_jump(setup_NGC6440E):
     cp.add_jump_and_flags(setup_NGC6440E.t.table["flags"][selected_toa_ind3])
     # check previous jump flags unaltered
     for dict in setup_NGC6440E.t.table["flags"][selected_toa_ind]:
-        assert dict["jump"] == [1]
-        assert dict["gui_jump"] == 1
+        assert dict["jump"] == ["1"]
+        assert dict["gui_jump"] == "1"
     for dict in setup_NGC6440E.t.table["flags"][selected_toa_ind2]:
-        assert dict["jump"] == [2]
-        assert dict["gui_jump"] == 2
+        assert dict["jump"] == ["2"]
+        assert dict["gui_jump"] == "2"
     # check that no flag added to index 9
     assert "jump" not in setup_NGC6440E.t.table[9].colnames
     assert "gui_jump" not in setup_NGC6440E.t.table[9].colnames
@@ -92,8 +92,8 @@ def test_remove_jump_and_flags(setup_NGC6440E):
         assert "gui_jump" not in dict
     # check that other flags at higher indeces adjust
     for dict in setup_NGC6440E.t.table["flags"][selected_toa_ind2]:
-        assert dict["jump"] == [1]
-        assert dict["gui_jump"] == 1
+        assert dict["jump"] == ["1"]
+        assert dict["gui_jump"] == "1"
     assert len(cp.jumps) == 1
     assert "JUMP1" in cp.jumps
 
@@ -126,7 +126,7 @@ def test_jump_params_to_flags(setup_NGC6440E):
     toa_indeces = [48, 49, 54]
     for i in toa_indeces:
         assert "jump" in setup_NGC6440E.t.table["flags"][i]
-        assert setup_NGC6440E.t.table["flags"][i]["jump"][0] == 1
+        assert setup_NGC6440E.t.table["flags"][i]["jump"][0] == "1"
     # ensure no extraneous flags added to unaffected TOAs
     for i in range(setup_NGC6440E.t.ntoas):
         if i not in toa_indeces:
@@ -148,9 +148,9 @@ def test_jump_params_to_flags(setup_NGC6440E):
     intersect = np.intersect1d(toa_indeces, mask2)
     assert intersect is not []
     for i in mask2:
-        assert 2 in setup_NGC6440E.t.table["flags"][i]["jump"]
+        assert "2" in setup_NGC6440E.t.table["flags"][i]["jump"]
     for i in toa_indeces:
-        assert 1 in setup_NGC6440E.t.table["flags"][i]["jump"]
+        assert "1" in setup_NGC6440E.t.table["flags"][i]["jump"]
 
 
 def test_multijump_toa(setup_NGC6440E):
@@ -167,8 +167,8 @@ def test_multijump_toa(setup_NGC6440E):
     # check that one can still add "gui jumps" to model-jumped TOAs
     cp.add_jump_and_flags(setup_NGC6440E.t.table["flags"][selected_toa_ind])
     for dict in setup_NGC6440E.t.table["flags"][selected_toa_ind]:
-        assert dict["jump"] == [1, 2]
-        assert dict["gui_jump"] == 2
+        assert dict["jump"] == ["1", "2"]
+        assert dict["gui_jump"] == "2"
     assert len(cp.jumps) == 2
 
     setup_NGC6440E.m.delete_jump_and_flags(setup_NGC6440E.t.table["flags"], 2)

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -65,7 +65,7 @@ class TestTOAReader(unittest.TestCase):
         assert self.x.table[0]["flags"]["info"] == "test1"
 
     def test_jump(self):
-        assert self.x.table[0]["flags"]["jump"] == [1]
+        assert self.x.table[0]["flags"]["jump"] == "1"
 
     def test_info_2(self):
         assert self.x.table[3]["flags"]["info"] == "test2"
@@ -80,7 +80,7 @@ class TestTOAReader(unittest.TestCase):
         assert "time" not in self.x.table[4]["flags"]
 
     def test_jump_3(self):
-        assert self.x.table[-1]["flags"]["jump"] == [2]
+        assert self.x.table[-1]["flags"]["jump"] == "2"
 
     def test_obs(self):
         assert self.x.table[1]["obs"] == "gbt"


### PR DESCRIPTION
There were issues with the .tim jumps and their key_value being changed from an int type to a string type, causing `select_toa_mask` to fail. I modified the key for these jumps to be -tim_jump, similar to the modification with the -gui_jump, to avoid this conflicting conversion. I'm sorry these keep having issues @scottransom , this should take care of everything!