### PR TITLE
Fix Noise design matrix index in the fitter

### DIFF
--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -220,7 +220,7 @@ class Fitter:
         self.is_wideband = False
         self.converged = False
 
-    def fit_toas(self, maxiter=None):
+    def fit_toas(self, maxiter=None, debug=False):
         """Run fitting operation.
 
         This method needs to be implemented by subclasses. All implemenations
@@ -1018,6 +1018,7 @@ class DownhillFitter(Fitter):
         required_chi2_decrease=1e-2,
         max_chi2_increase=1e-2,
         min_lambda=1e-3,
+        debug=False
     ):
         """Carry out a cautious downhill fit.
 
@@ -1246,7 +1247,7 @@ class DownhillWLSFitter(DownhillFitter):
         )
         self.method = "downhill_wls"
 
-    def fit_toas(self, maxiter=10, threshold=None, **kwargs):
+    def fit_toas(self, maxiter=10, threshold=None, debug=False, **kwargs):
         """Fit TOAs.
 
         This is mostly implemented in
@@ -1264,7 +1265,7 @@ class DownhillWLSFitter(DownhillFitter):
             :func:`pint.fitter.DownhillFitter.fit_toas`
         """
         self.threshold = threshold
-        super().fit_toas(maxiter=maxiter, **kwargs)
+        super().fit_toas(maxiter=maxiter, debug=debug, **kwargs)
 
     def create_state(self):
         return WLSState(self, self.model)
@@ -1402,7 +1403,7 @@ class DownhillGLSFitter(DownhillFitter):
             self, self.model, full_cov=self.full_cov, threshold=self.threshold
         )
 
-    def fit_toas(self, maxiter=10, threshold=0, full_cov=False, **kwargs):
+    def fit_toas(self, maxiter=10, threshold=0, full_cov=False, debug=False, **kwargs):
         """Fit TOAs.
 
         This is mostly implemented in
@@ -1424,7 +1425,7 @@ class DownhillGLSFitter(DownhillFitter):
         """
         self.threshold = threshold
         self.full_cov = full_cov
-        r = super().fit_toas(maxiter=maxiter, **kwargs)
+        r = super().fit_toas(maxiter=maxiter, debug=debug, **kwargs)
         # FIXME: set up noise residuals et cetera
         # Compute the noise realizations if possible
         ntmpar = len(self.model.free_params)
@@ -1442,7 +1443,12 @@ class DownhillGLSFitter(DownhillFitter):
                     )
                     * u.s
                 )
+                if debug:
+                    setattr(self.resids, comp+'_M', (self.current_state.M[:, p0:p1], self.current_state.xhat[p0:p1]))
+                    setattr(self.resids, comp+'_M_index', (p0, p1))
             self.resids.noise_resids = noise_resids
+            if debug:
+                setattr(self.resids, 'norm', self.current_state.norm)
 
         return r
 
@@ -1671,7 +1677,7 @@ class WidebandDownhillFitter(DownhillFitter):
             self, self.model, full_cov=self.full_cov, threshold=self.threshold
         )
 
-    def fit_toas(self, maxiter=10, threshold=1e-14, full_cov=False, **kwargs):
+    def fit_toas(self, maxiter=10, threshold=1e-14, full_cov=False, debug=False, **kwargs):
         """Fit TOAs.
 
         This is mostly implemented in
@@ -1694,7 +1700,7 @@ class WidebandDownhillFitter(DownhillFitter):
         self.threshold = threshold
         self.full_cov = full_cov
         # FIXME: set up noise residuals et cetera
-        r = super().fit_toas(maxiter=maxiter, **kwargs)
+        r = super().fit_toas(maxiter=maxiter, debug=debug, **kwargs)
         # Compute the noise realizations if possible
         ntmpar = len(self.model.free_params)
         if not self.full_cov:
@@ -1711,7 +1717,13 @@ class WidebandDownhillFitter(DownhillFitter):
                     )
                     * u.s
                 )
+                if debug:
+                    setattr(self.resids, comp+'_M', (self.current_state.M[:, p0:p1],
+                        self.current_state.xhat[p0:p1]))
+                    setattr(self.resids, comp+'_M_index', (p0, p1))
             self.resids.noise_resids = noise_resids
+            if debug:
+                setattr(self.resids, 'norm', self.current_state.norm)
         return r
 
 
@@ -1730,7 +1742,7 @@ class PowellFitter(Fitter):
         super().__init__(toas, model, residuals=residuals, track_mode=track_mode)
         self.method = "Powell"
 
-    def fit_toas(self, maxiter=20):
+    def fit_toas(self, maxiter=20, debug=False):
         """Carry out the fitting procedure."""
         # check that params of timing model have necessary components
         self.model.validate()
@@ -1778,7 +1790,7 @@ class WLSFitter(Fitter):
         )
         self.method = "weighted_least_square"
 
-    def fit_toas(self, maxiter=1, threshold=None):
+    def fit_toas(self, maxiter=1, threshold=None, debug=False):
         """Run a linear weighted least-squared fitting method.
 
         Parameters
@@ -1906,7 +1918,7 @@ class GLSFitter(Fitter):
         )
         self.method = "generalized_least_square"
 
-    def fit_toas(self, maxiter=1, threshold=0, full_cov=False):
+    def fit_toas(self, maxiter=1, threshold=0, full_cov=False, debug=False):
         """Run a generalized least-squares fitting method.
 
         A first attempt is made to solve the fitting problem by Cholesky
@@ -2072,7 +2084,12 @@ class GLSFitter(Fitter):
                     p0 = noise_dims[comp][0] + ntmpar + 1
                     p1 = p0 + noise_dims[comp][1]
                     noise_resids[comp] = np.dot(M[:, p0:p1], xhat[p0:p1]) * u.s
+                    if debug:
+                        setattr(self.resids, comp+'_M', (M[:, p0:p1], xhat[p0:p1]))
+                        setattr(self.resids, comp+'_M_index', (p0, p1))
                 self.resids.noise_resids = noise_resids
+                if debug:
+                    setattr(self.resids, 'norm', norm)
 
         self.update_model(chi2)
 
@@ -2256,7 +2273,7 @@ class WidebandTOAFitter(Fitter):  # Is GLSFitter the best here?
                 scaled_sigmas_no_unit.append(scaled_sigma)
         return np.hstack(scaled_sigmas_no_unit)
 
-    def fit_toas(self, maxiter=1, threshold=0, full_cov=False):
+    def fit_toas(self, maxiter=1, threshold=0, full_cov=False, debug=False):
         """Carry out a generalized least-squares fitting procedure.
 
         The algorithm here is essentially the same as used in
@@ -2413,7 +2430,12 @@ class WidebandTOAFitter(Fitter):  # Is GLSFitter the best here?
                     p0 = noise_dims[comp][0] + ntmpar + 1
                     p1 = p0 + noise_dims[comp][1]
                     noise_resids[comp] = np.dot(M[:, p0:p1], xhat[p0:p1]) * u.s
+                    if debug:
+                        setattr(self.resids, comp+'_M', (M[:, p0:p1], xhat[p0:p1]))
+                        setattr(self.resids, comp+'_M_index', (p0, p1))
                 self.resids.noise_resids = noise_resids
+                if debug:
+                    setattr(self.resids, 'norm', norm)
 
         self.update_model(chi2)
 
@@ -2431,6 +2453,7 @@ class LMFitter(Fitter):
         lambda_factor_invalid=10,
         threshold=1e-14,
         min_lambda=0.5,
+        debug=False
     ):
         current_state = self.create_state()
         try:
@@ -2537,9 +2560,9 @@ class LMFitter(Fitter):
             # could be a finally I suppose? but I'm not sure we want to update if something
             # seriou went wrong.
             log.info("KeyboardInterrupt detected, updating Fitter")
-            self.update_from_state(current_state)
+            self.update_from_state(current_state, debug=debug)
             raise
-        self.update_from_state(current_state)
+        self.update_from_state(current_state, debug=debug)
         return self.converged
 
 
@@ -2574,12 +2597,12 @@ class WidebandLMFitter(LMFitter):
             self, self.model, full_cov=self.full_cov, threshold=self.threshold
         )
 
-    def fit_toas(self, maxiter=50, full_cov=False, **kwargs):
+    def fit_toas(self, maxiter=50, full_cov=False, debug=False, **kwargs):
         self.full_cov = full_cov
         # FIXME: set up noise residuals et cetera
-        return super().fit_toas(maxiter=maxiter, **kwargs)
+        return super().fit_toas(maxiter=maxiter, debug=debug, **kwargs)
 
-    def update_from_state(self, state):
+    def update_from_state(self, state, debug=False):
         # Nicer not to keep this if we have a choice, it introduces reference cycles
         self.current_state = state
         self.model = state.model
@@ -2608,4 +2631,9 @@ class WidebandLMFitter(LMFitter):
                 p0 = noise_dims[comp][0] + ntmpar + 1
                 p1 = p0 + noise_dims[comp][1]
                 noise_resids[comp] = np.dot(state.M[:, p0:p1], state.xhat[p0:p1]) * u.s
+                if debug:
+                    setattr(self.resids, comp+'_M', (state.M[:, p0:p1], state.xhat[p0:p1]))
+                    setattr(self.resids, comp+'_M_index', (p0, p1))
             self.resids.noise_resids = noise_resids
+            if debug:
+                setattr(self.resids, 'norm', state.norm)

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1431,10 +1431,10 @@ class DownhillGLSFitter(DownhillFitter):
         if not self.full_cov:
             noise_dims = self.model.noise_model_dimensions(self.toas)
             noise_resids = {}
-            for comp in noise_dims.keys():
+            for comp in noise_dims:
                 # The first column of designmatrix is "offset", add 1 to match
                 # the indices of noise designmatrix
-                p0 = noise_dims[comp][0] + ntmpar
+                p0 = noise_dims[comp][0] + ntmpar + 1
                 p1 = p0 + noise_dims[comp][1]
                 noise_resids[comp] = (
                     np.dot(
@@ -1700,7 +1700,7 @@ class WidebandDownhillFitter(DownhillFitter):
         if not self.full_cov:
             noise_dims = self.model.noise_model_dimensions(self.toas)
             noise_resids = {}
-            for comp in noise_dims.keys():
+            for comp in noise_dims:
                 # The first column of designmatrix is "offset", add 1 to match
                 # the indices of noise designmatrix
                 p0 = noise_dims[comp][0] + ntmpar + 1
@@ -2066,7 +2066,7 @@ class GLSFitter(Fitter):
             if not full_cov:
                 noise_dims = self.model.noise_model_dimensions(self.toas)
                 noise_resids = {}
-                for comp in noise_dims.keys():
+                for comp in noise_dims:
                     # The first column of designmatrix is "offset", add 1 to match
                     # the indices of noise designmatrix
                     p0 = noise_dims[comp][0] + ntmpar + 1
@@ -2407,7 +2407,7 @@ class WidebandTOAFitter(Fitter):  # Is GLSFitter the best here?
             if not full_cov:
                 noise_dims = self.model.noise_model_dimensions(self.toas)
                 noise_resids = {}
-                for comp in noise_dims.keys():
+                for comp in noise_dims:
                     # The first column of designmatrix is "offset", add 1 to match
                     # the indices of noise designmatrix
                     p0 = noise_dims[comp][0] + ntmpar + 1
@@ -2602,7 +2602,7 @@ class WidebandLMFitter(LMFitter):
         if not self.full_cov:
             noise_dims = self.model.noise_model_dimensions(self.toas)
             noise_resids = {}
-            for comp in noise_dims.keys():
+            for comp in noise_dims:
                 # The first column of designmatrix is "offset", add 1 to match
                 # the indices of noise designmatrix
                 p0 = noise_dims[comp][0] + ntmpar + 1

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1709,7 +1709,7 @@ class WidebandDownhillFitter(DownhillFitter):
             for comp in noise_dims:
                 # The first column of designmatrix is "offset", add 1 to match
                 # the indices of noise designmatrix
-                p0 = noise_dims[comp][0] + ntmpar + 1
+                p0 = noise_dims[comp][0] + ntmpar + 1 
                 p1 = p0 + noise_dims[comp][1]
                 noise_resids[comp] = (
                     np.dot(

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1432,6 +1432,8 @@ class DownhillGLSFitter(DownhillFitter):
             noise_dims = self.model.noise_model_dimensions(self.toas)
             noise_resids = {}
             for comp in noise_dims.keys():
+                # The first column of designmatrix is "offset", add 1 to match
+                # the indices of noise designmatrix
                 p0 = noise_dims[comp][0] + ntmpar
                 p1 = p0 + noise_dims[comp][1]
                 noise_resids[comp] = (
@@ -1699,7 +1701,9 @@ class WidebandDownhillFitter(DownhillFitter):
             noise_dims = self.model.noise_model_dimensions(self.toas)
             noise_resids = {}
             for comp in noise_dims.keys():
-                p0 = noise_dims[comp][0] + ntmpar
+                # The first column of designmatrix is "offset", add 1 to match
+                # the indices of noise designmatrix
+                p0 = noise_dims[comp][0] + ntmpar + 1
                 p1 = p0 + noise_dims[comp][1]
                 noise_resids[comp] = (
                     np.dot(
@@ -2063,7 +2067,9 @@ class GLSFitter(Fitter):
                 noise_dims = self.model.noise_model_dimensions(self.toas)
                 noise_resids = {}
                 for comp in noise_dims.keys():
-                    p0 = noise_dims[comp][0] + ntmpar
+                    # The first column of designmatrix is "offset", add 1 to match
+                    # the indices of noise designmatrix
+                    p0 = noise_dims[comp][0] + ntmpar + 1
                     p1 = p0 + noise_dims[comp][1]
                     noise_resids[comp] = np.dot(M[:, p0:p1], xhat[p0:p1]) * u.s
                 self.resids.noise_resids = noise_resids
@@ -2402,7 +2408,9 @@ class WidebandTOAFitter(Fitter):  # Is GLSFitter the best here?
                 noise_dims = self.model.noise_model_dimensions(self.toas)
                 noise_resids = {}
                 for comp in noise_dims.keys():
-                    p0 = noise_dims[comp][0] + ntmpar
+                    # The first column of designmatrix is "offset", add 1 to match
+                    # the indices of noise designmatrix
+                    p0 = noise_dims[comp][0] + ntmpar + 1
                     p1 = p0 + noise_dims[comp][1]
                     noise_resids[comp] = np.dot(M[:, p0:p1], xhat[p0:p1]) * u.s
                 self.resids.noise_resids = noise_resids
@@ -2595,7 +2603,9 @@ class WidebandLMFitter(LMFitter):
             noise_dims = self.model.noise_model_dimensions(self.toas)
             noise_resids = {}
             for comp in noise_dims.keys():
-                p0 = noise_dims[comp][0] + ntmpar
+                # The first column of designmatrix is "offset", add 1 to match
+                # the indices of noise designmatrix
+                p0 = noise_dims[comp][0] + ntmpar + 1
                 p1 = p0 + noise_dims[comp][1]
                 noise_resids[comp] = np.dot(state.M[:, p0:p1], state.xhat[p0:p1]) * u.s
             self.resids.noise_resids = noise_resids

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1018,7 +1018,7 @@ class DownhillFitter(Fitter):
         required_chi2_decrease=1e-2,
         max_chi2_increase=1e-2,
         min_lambda=1e-3,
-        debug=False
+        debug=False,
     ):
         """Carry out a cautious downhill fit.
 
@@ -1444,11 +1444,18 @@ class DownhillGLSFitter(DownhillFitter):
                     * u.s
                 )
                 if debug:
-                    setattr(self.resids, comp+'_M', (self.current_state.M[:, p0:p1], self.current_state.xhat[p0:p1]))
-                    setattr(self.resids, comp+'_M_index', (p0, p1))
+                    setattr(
+                        self.resids,
+                        comp + "_M",
+                        (
+                            self.current_state.M[:, p0:p1],
+                            self.current_state.xhat[p0:p1],
+                        ),
+                    )
+                    setattr(self.resids, comp + "_M_index", (p0, p1))
             self.resids.noise_resids = noise_resids
             if debug:
-                setattr(self.resids, 'norm', self.current_state.norm)
+                setattr(self.resids, "norm", self.current_state.norm)
 
         return r
 
@@ -1677,7 +1684,9 @@ class WidebandDownhillFitter(DownhillFitter):
             self, self.model, full_cov=self.full_cov, threshold=self.threshold
         )
 
-    def fit_toas(self, maxiter=10, threshold=1e-14, full_cov=False, debug=False, **kwargs):
+    def fit_toas(
+        self, maxiter=10, threshold=1e-14, full_cov=False, debug=False, **kwargs
+    ):
         """Fit TOAs.
 
         This is mostly implemented in
@@ -1709,7 +1718,7 @@ class WidebandDownhillFitter(DownhillFitter):
             for comp in noise_dims:
                 # The first column of designmatrix is "offset", add 1 to match
                 # the indices of noise designmatrix
-                p0 = noise_dims[comp][0] + ntmpar + 1 
+                p0 = noise_dims[comp][0] + ntmpar + 1
                 p1 = p0 + noise_dims[comp][1]
                 noise_resids[comp] = (
                     np.dot(
@@ -1718,12 +1727,18 @@ class WidebandDownhillFitter(DownhillFitter):
                     * u.s
                 )
                 if debug:
-                    setattr(self.resids, comp+'_M', (self.current_state.M[:, p0:p1],
-                        self.current_state.xhat[p0:p1]))
-                    setattr(self.resids, comp+'_M_index', (p0, p1))
+                    setattr(
+                        self.resids,
+                        comp + "_M",
+                        (
+                            self.current_state.M[:, p0:p1],
+                            self.current_state.xhat[p0:p1],
+                        ),
+                    )
+                    setattr(self.resids, comp + "_M_index", (p0, p1))
             self.resids.noise_resids = noise_resids
             if debug:
-                setattr(self.resids, 'norm', self.current_state.norm)
+                setattr(self.resids, "norm", self.current_state.norm)
         return r
 
 
@@ -2085,11 +2100,11 @@ class GLSFitter(Fitter):
                     p1 = p0 + noise_dims[comp][1]
                     noise_resids[comp] = np.dot(M[:, p0:p1], xhat[p0:p1]) * u.s
                     if debug:
-                        setattr(self.resids, comp+'_M', (M[:, p0:p1], xhat[p0:p1]))
-                        setattr(self.resids, comp+'_M_index', (p0, p1))
+                        setattr(self.resids, comp + "_M", (M[:, p0:p1], xhat[p0:p1]))
+                        setattr(self.resids, comp + "_M_index", (p0, p1))
                 self.resids.noise_resids = noise_resids
                 if debug:
-                    setattr(self.resids, 'norm', norm)
+                    setattr(self.resids, "norm", norm)
 
         self.update_model(chi2)
 
@@ -2431,11 +2446,11 @@ class WidebandTOAFitter(Fitter):  # Is GLSFitter the best here?
                     p1 = p0 + noise_dims[comp][1]
                     noise_resids[comp] = np.dot(M[:, p0:p1], xhat[p0:p1]) * u.s
                     if debug:
-                        setattr(self.resids, comp+'_M', (M[:, p0:p1], xhat[p0:p1]))
-                        setattr(self.resids, comp+'_M_index', (p0, p1))
+                        setattr(self.resids, comp + "_M", (M[:, p0:p1], xhat[p0:p1]))
+                        setattr(self.resids, comp + "_M_index", (p0, p1))
                 self.resids.noise_resids = noise_resids
                 if debug:
-                    setattr(self.resids, 'norm', norm)
+                    setattr(self.resids, "norm", norm)
 
         self.update_model(chi2)
 
@@ -2453,7 +2468,7 @@ class LMFitter(Fitter):
         lambda_factor_invalid=10,
         threshold=1e-14,
         min_lambda=0.5,
-        debug=False
+        debug=False,
     ):
         current_state = self.create_state()
         try:
@@ -2632,8 +2647,10 @@ class WidebandLMFitter(LMFitter):
                 p1 = p0 + noise_dims[comp][1]
                 noise_resids[comp] = np.dot(state.M[:, p0:p1], state.xhat[p0:p1]) * u.s
                 if debug:
-                    setattr(self.resids, comp+'_M', (state.M[:, p0:p1], state.xhat[p0:p1]))
-                    setattr(self.resids, comp+'_M_index', (p0, p1))
+                    setattr(
+                        self.resids, comp + "_M", (state.M[:, p0:p1], state.xhat[p0:p1])
+                    )
+                    setattr(self.resids, comp + "_M_index", (p0, p1))
             self.resids.noise_resids = noise_resids
             if debug:
-                setattr(self.resids, 'norm', state.norm)
+                setattr(self.resids, "norm", state.norm)

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -140,6 +140,8 @@ class Residuals:
         # only relevant if there are correlated errors
         self._chi2 = None
         self.noise_resids = {}
+        # For residual debugging
+        self.debug_info = {}
         # We should be carefully for the other type of residuals
         self.unit = unit
         # A flag to indentify if this residual object is combined with residual
@@ -511,6 +513,8 @@ class WidebandDMResiduals(Residuals):
         self.dm_data, self.dm_error, self.relevant_toas = self.get_dm_data()
         self._chi2 = None
         self._is_combined = False
+        # For residual debugging
+        self.debug_info = {}
 
     @property
     def resids(self):
@@ -655,6 +659,8 @@ class CombinedResiduals:
         for res in residuals:
             res._is_combined = True
             self.residual_objs[res.residual_type] = res
+        # For residual debugging
+        self.debug_info = {}
 
     @property
     def model(self):

--- a/tests/test_downhill_fitter.py
+++ b/tests/test_downhill_fitter.py
@@ -119,10 +119,17 @@ def test_gls_full_procedure(model_eccentric_toas_ecorr, full_cov):
     f = pint.fitter.DownhillGLSFitter(toas, model_wrong)
     f.model.free_params = ["ECC"]
 
-    f.fit_toas(maxiter=10, full_cov=full_cov)
+    f.fit_toas(maxiter=10, full_cov=full_cov, debug=True)
 
     assert f.converged
     assert abs(f.model.ECC.value - model_eccentric.ECC.value) < 1e-4
+
+    if not full_cov:
+        # Test ecorr basis
+        ec = f.model.ecorr_basis_weight_pair(f.toas)[0]
+        p0, p1 = f.resids.ecorr_noise_M_index
+        ec_backwards = f.resids.ecorr_noise_M[0] * f.resids.norm[p0:p1][np.newaxis, :]
+        assert np.all(np.isclose(ec, ec_backwards))
 
 
 @pytest.mark.parametrize("full_cov", [False, True])
@@ -134,10 +141,16 @@ def test_wideband_full_procedure(model_eccentric_toas_wb, full_cov):
     f = pint.fitter.WidebandDownhillFitter(toas, model_wrong)
     f.model.free_params = ["ECC"]
 
-    f.fit_toas(maxiter=10, full_cov=full_cov)
+    f.fit_toas(maxiter=10, full_cov=full_cov, debug=True)
 
     assert f.converged
     assert abs(f.model.ECC.value - model_eccentric.ECC.value) < 1e-4
+    if not full_cov:
+        # Test ecorr basis
+        ec = f.model.ecorr_basis_weight_pair(f.toas)[0]
+        p0, p1 = f.resids.ecorr_noise_M_index
+        ec_backwards = f.resids.ecorr_noise_M[0] * f.resids.norm[p0:p1][np.newaxis, :]
+        assert np.all(np.isclose(ec, ec_backwards[0:40, :]))
 
 
 @pytest.mark.parametrize("full_cov", [False, True])

--- a/tests/test_gls_fitter.py
+++ b/tests/test_gls_fitter.py
@@ -32,14 +32,14 @@ class TestGLS(unittest.TestCase):
             * u.us
         )
 
-    def fit(self, full_cov):
+    def fit(self, full_cov, debug=False):
         self.f.reset_model()
         self.f.update_resids()
-        self.f.fit_toas(full_cov=full_cov)
+        self.f.fit_toas(full_cov=full_cov, debug=debug)
 
     def test_gls_fitter(self):
         for full_cov in [True, False]:
-            self.fit(full_cov)
+            self.fit(full_cov, True)
             for par, val in sorted(self.t2d.items()):
                 if par not in ["F0"]:
                     v = (
@@ -61,17 +61,17 @@ class TestGLS(unittest.TestCase):
                     assert np.abs(1 - val[1] / e) < 0.1, msg
 
     def test_noise_design_matrix_index(self):
-        ntmpar = len(self.f.model.free_params)
-        Mn = self.f.model.noise_model_designmatrix(self.f.toas)
-        M, params, units = self.f.get_designmatrix()
-        M_stack = np.hstack((M, Mn))
-        noise_dims = self.f.model.noise_model_dimensions(self.f.toas)
-        # This is how the gls fitter get the noise design matrix. I don't know
-        # if there is some other way to test the index.
-        for comp in noise_dims.keys():
-            p0 = noise_dims[comp][0] + ntmpar + 1
-            p1 = p0 + noise_dims[comp][1]
-            assert np.all(M_stack[:, p0:p1] == Mn[:, p0 - ntmpar - 1 : p1 - ntmpar - 1])
+        self.fit(False, True) # get the debug infor
+        # Test red noise basis
+        pl_rd = self.f.model.pl_rn_basis_weight_pair(self.f.toas)[0]
+        p0, p1 = self.f.resids.pl_red_noise_M_index
+        pl_rd_backwards = self.f.resids.pl_red_noise_M[0] * self.f.resids.norm[p0:p1][np.newaxis, :]
+        assert np.all(np.isclose(pl_rd, pl_rd_backwards))
+        # Test ecorr basis
+        ec = self.f.model.ecorr_basis_weight_pair(self.f.toas)[0]
+        p0, p1 = self.f.resids.ecorr_noise_M_index
+        ec_backwards = self.f.resids.ecorr_noise_M[0] *  self.f.resids.norm[p0:p1][np.newaxis, :]
+        assert np.all(np.isclose(ec, ec_backwards))
 
     def test_whitening(self):
         self.fit(full_cov=False)

--- a/tests/test_gls_fitter.py
+++ b/tests/test_gls_fitter.py
@@ -61,16 +61,20 @@ class TestGLS(unittest.TestCase):
                     assert np.abs(1 - val[1] / e) < 0.1, msg
 
     def test_noise_design_matrix_index(self):
-        self.fit(False, True) # get the debug infor
+        self.fit(False, True)  # get the debug infor
         # Test red noise basis
         pl_rd = self.f.model.pl_rn_basis_weight_pair(self.f.toas)[0]
         p0, p1 = self.f.resids.pl_red_noise_M_index
-        pl_rd_backwards = self.f.resids.pl_red_noise_M[0] * self.f.resids.norm[p0:p1][np.newaxis, :]
+        pl_rd_backwards = (
+            self.f.resids.pl_red_noise_M[0] * self.f.resids.norm[p0:p1][np.newaxis, :]
+        )
         assert np.all(np.isclose(pl_rd, pl_rd_backwards))
         # Test ecorr basis
         ec = self.f.model.ecorr_basis_weight_pair(self.f.toas)[0]
         p0, p1 = self.f.resids.ecorr_noise_M_index
-        ec_backwards = self.f.resids.ecorr_noise_M[0] *  self.f.resids.norm[p0:p1][np.newaxis, :]
+        ec_backwards = (
+            self.f.resids.ecorr_noise_M[0] * self.f.resids.norm[p0:p1][np.newaxis, :]
+        )
         assert np.all(np.isclose(ec, ec_backwards))
 
     def test_whitening(self):

--- a/tests/test_gls_fitter.py
+++ b/tests/test_gls_fitter.py
@@ -61,7 +61,6 @@ class TestGLS(unittest.TestCase):
                     assert np.abs(1 - val[1] / e) < 0.1, msg
 
     def test_noise_design_matrix_index(self):
-        self.fit(full_cov=False)
         ntmpar = len(self.f.model.free_params)
         Mn = self.f.model.noise_model_designmatrix(self.f.toas)
         M, params, units = self.f.get_designmatrix()

--- a/tests/test_gls_fitter.py
+++ b/tests/test_gls_fitter.py
@@ -60,20 +60,19 @@ class TestGLS(unittest.TestCase):
                     assert np.abs(v - val[0]) <= e, msg
                     assert np.abs(1 - val[1] / e) < 0.1, msg
 
-    def test_red_noise_residual(self):
+    def test_noise_design_matrix_index(self):
         self.fit(full_cov=False)
         ntmpar = len(self.f.model.free_params)
         Mn = self.f.model.noise_model_designmatrix(self.f.toas)
         M, params, units = self.f.get_designmatrix()
         M_stack = np.hstack((M, Mn))
         noise_dims = self.f.model.noise_model_dimensions(self.f.toas)
-        noise_len = 0
+        # This is how the gls fitter get the noise design matrix. I don't know
+        # if there is some other way to test the index.
         for comp in noise_dims.keys():
             p0 = noise_dims[comp][0] + ntmpar + 1
             p1 = p0 + noise_dims[comp][1]
-            noise_len += M_stack[:, p0:p1].shape[1]
-            print(p0, p1, M_stack[:, p0:p1].shape, M_stack[:, p0:p1].mean())
-            assert  M_stack[:, p0:p1].mean() == Mn[:, p0 - ntmpar-1: p1-ntmpar-1].mean()
+            assert np.all(M_stack[:, p0:p1] == Mn[:, p0 - ntmpar - 1 : p1 - ntmpar - 1])
 
     def test_whitening(self):
         self.fit(full_cov=False)

--- a/tests/test_model_manual.py
+++ b/tests/test_model_manual.py
@@ -89,7 +89,6 @@ def test_valid_model(tmp_dir, func, name, expectation):
 def test_compare_get_model_new_and_old():
     m_new = get_model_new(parfile)
     m_old = get_model(parfile)
-    print(parfile)
     assert set(m_new.get_params_mapping().keys()) == set(
         m_old.get_params_mapping().keys()
     )

--- a/tests/test_model_manual.py
+++ b/tests/test_model_manual.py
@@ -89,7 +89,7 @@ def test_valid_model(tmp_dir, func, name, expectation):
 def test_compare_get_model_new_and_old():
     m_new = get_model_new(parfile)
     m_old = get_model(parfile)
-
+    print(parfile)
     assert set(m_new.get_params_mapping().keys()) == set(
         m_old.get_params_mapping().keys()
     )

--- a/tests/test_widebandTOA_fitting.py
+++ b/tests/test_widebandTOA_fitting.py
@@ -97,8 +97,3 @@ class TestWidebandTOAFitter:
         p0, p1 = fitter.resids.pl_red_noise_M_index
         pl_rd_backwards = fitter.resids.pl_red_noise_M[0] * fitter.resids.norm[p0:p1][np.newaxis, :]
         assert np.all(np.isclose(pl_rd, pl_rd_backwards[0:313, :]))
-        # Test ecorr basis
-        ec = fitter.model.ecorr_basis_weight_pair(fitter.toas)[0]
-        p0, p1 = fitter.resids.ecorr_noise_M_index
-        ec_backwards = fitter.resids.ecorr_noise_M[0] * fitter.resids.norm[p0:p1][np.newaxis, :]
-        assert np.all(np.isclose(ec, ec_backwards[0:313, :]))

--- a/tests/test_widebandTOA_fitting.py
+++ b/tests/test_widebandTOA_fitting.py
@@ -95,5 +95,7 @@ class TestWidebandTOAFitter:
         # Test red noise basis
         pl_rd = fitter.model.pl_rn_basis_weight_pair(fitter.toas)[0]
         p0, p1 = fitter.resids.pl_red_noise_M_index
-        pl_rd_backwards = fitter.resids.pl_red_noise_M[0] * fitter.resids.norm[p0:p1][np.newaxis, :]
+        pl_rd_backwards = (
+            fitter.resids.pl_red_noise_M[0] * fitter.resids.norm[p0:p1][np.newaxis, :]
+        )
         assert np.all(np.isclose(pl_rd, pl_rd_backwards[0:313, :]))

--- a/tests/test_widebandTOA_fitting.py
+++ b/tests/test_widebandTOA_fitting.py
@@ -84,3 +84,21 @@ class TestWidebandTOAFitter:
         diff_postfit = (postfit_pint - postfit_tempo).to(u.ns)
         assert np.abs(diff_postfit - diff_postfit.mean()).max() < 50 * u.ns
         assert np.abs(dm_rms_pre - dm_rms_post) < 5e-8 * dm_rms_pre.unit
+
+    def test_noise_design_matrix_index(self):
+        model = get_model("B1855+09_NANOGrav_12yv3.wb.gls.par")
+        toas = get_TOAs(
+            "B1855+09_NANOGrav_12yv3.wb.tim", ephem="DE436", bipm_version="BIPM2015"
+        )
+        fitter = WidebandTOAFitter(toas, model, additional_args={})
+        fitter.fit_toas(full_cov=False, debug=True)
+        # Test red noise basis
+        pl_rd = fitter.model.pl_rn_basis_weight_pair(fitter.toas)[0]
+        p0, p1 = fitter.resids.pl_red_noise_M_index
+        pl_rd_backwards = fitter.resids.pl_red_noise_M[0] * fitter.resids.norm[p0:p1][np.newaxis, :]
+        assert np.all(np.isclose(pl_rd, pl_rd_backwards[0:313, :]))
+        # Test ecorr basis
+        ec = fitter.model.ecorr_basis_weight_pair(fitter.toas)[0]
+        p0, p1 = fitter.resids.ecorr_noise_M_index
+        ec_backwards = fitter.resids.ecorr_noise_M[0] * fitter.resids.norm[p0:p1][np.newaxis, :]
+        assert np.all(np.isclose(ec, ec_backwards[0:313, :]))


### PR DESCRIPTION
The fitter gets the noise design matrix from the stack design matrix using the indices. The stack design matrix's index is labeled as 
+++++++++++++++++++++++++++++++++++++++++
           |    offset | fit parameters | Noise design matrix
+++++++++++++++++++++++++++++++++++++++++
TOAs |

In the red noise residual calculation, the offset column is not taken into consideration. The start index of the noise design matrix is 1 smaller than the real start position. This PR fixes it. 