### PR TITLE
Test for and fix merge_toas numbering bug

### DIFF
--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -2241,7 +2241,7 @@ def merge_TOAs(TOAs_list):
     # We do not ensure that the command list is flat
     nt.commands = [tt.commands for tt in TOAs_list]
     # Now do the actual table stacking
-    start_index = nt.max_index + 1
+    start_index = 0
     tables = []
     for tt in TOAs_list:
         t = copy.deepcopy(tt.table)


### PR DESCRIPTION
Currently a bug results in all the TOAs getting a too-large `index` value when you merge TOAs objects.