### PR TITLE
Allow a whole lot of X-ray missions

### DIFF
--- a/src/pint/event_toas.py
+++ b/src/pint/event_toas.py
@@ -207,8 +207,15 @@ def load_fits_TOAs(
     """
     # Load photon times from event file
     hdulist = pyfits.open(eventname)
+    if mission not in mission_config:
+        log.warning("Mission not recognized. Using generic")
+        mission = "generic"
 
-    if extension is not None and isinstance(extension, str) and hdulist[1].name not in extension.split(","):
+    if (
+        extension is not None
+        and isinstance(extension, str)
+        and hdulist[1].name not in extension.split(",")
+    ):
         raise RuntimeError(
             "First table in FITS file"
             + "must be {}. Found {}".format(extension, hdulist[1].name)

--- a/src/pint/event_toas.py
+++ b/src/pint/event_toas.py
@@ -16,6 +16,7 @@ __all__ = [
     "load_XMM_TOAs",
 ]
 
+
 def read_mission_info_from_heasoft():
     """Read all the relevant information about missions in xselect.mdb."""
 
@@ -53,6 +54,7 @@ def read_mission_info_from_heasoft():
             previous_db_step[data[-1]] = value
     return db
 
+
 # fits_extension can be a single name or a comma-separated list of allowed
 # extension names.
 # For weight we use the same conventions used for Fermi: None, a valid FITS
@@ -65,22 +67,23 @@ mission_config = {
     },
 }
 
+# Allow local TOAs for those missions that have a load_<MISSION>_TOAs method
+for mission in ["nustar", "nicer", "xte"]:
+    mission_config[mission] = {}
+    mission_config[mission].update(mission_config["generic"])
+    mission_config["allow_local"] = True
 
 # Read the relevant information from $HEADAS/bin/xselect.mdb, if present
 for mission, data in read_mission_info_from_heasoft().items():
-    mission_config[mission] = {'allow_local': False}
+    mission_config[mission] = {"allow_local": False}
     mission_config[mission]["fits_extension"] = data["events"]
-    mission_config[mission]["fits_columns"] = {'ecol': data["ecol"]}
-
-# Allow local TOAs for those missions that have a load_<MISSION>_TOAs method
-for mission in ['nustar', 'nicer', 'xte']:
-    mission_config[mission]['allow_local'] = True
+    mission_config[mission]["fits_columns"] = {"ecol": data["ecol"]}
 
 # Fix xte
-mission_config['xte']['fits_columns'] = {'ecol': 'PHA'}
+mission_config["xte"]["fits_columns"] = {"ecol": "PHA"}
 # The event extension is called in different ways for different data modes, but
-# it is always the same
-mission_config['xte']['fits_extension'] = 1
+# it is always no. 1.
+mission_config["xte"]["fits_extension"] = 1
 
 
 def _default_obs_and_scale(mission, timesys, timeref):

--- a/src/pint/event_toas.py
+++ b/src/pint/event_toas.py
@@ -208,10 +208,14 @@ def load_fits_TOAs(
     # Load photon times from event file
     hdulist = pyfits.open(eventname)
 
-    if extension is not None and hdulist[1].name not in extension.split(","):
+    if extension is not None and isinstance(extension, str) and hdulist[1].name not in extension.split(","):
         raise RuntimeError(
             "First table in FITS file"
             + "must be {}. Found {}".format(extension, hdulist[1].name)
+        )
+    if isinstance(extension, int) and extension != 1:
+        raise ValueError(
+            "At the moment, only data in the first FITS extension is supported"
         )
 
     if timesys is None:

--- a/src/pint/event_toas.py
+++ b/src/pint/event_toas.py
@@ -59,31 +59,43 @@ def read_mission_info_from_heasoft():
 # extension names.
 # For weight we use the same conventions used for Fermi: None, a valid FITS
 # extension name or CALC.
-mission_config = {
-    "generic": {
-        "fits_extension": 1,
-        "allow_local": False,
-        "fits_columns": {"pi": "PI"},
-    },
-}
+def create_mission_config():
+    mission_config = {
+        "generic": {
+            "fits_extension": 1,
+            "allow_local": False,
+            "fits_columns": {"pi": "PI"},
+        },
+    }
 
-# Allow local TOAs for those missions that have a load_<MISSION>_TOAs method
-for mission in ["nustar", "nicer", "xte"]:
-    mission_config[mission] = {}
-    mission_config[mission].update(mission_config["generic"])
-    mission_config["allow_local"] = True
+    # Allow local TOAs for those missions that have a load_<MISSION>_TOAs method
+    for mission in ["nustar", "nicer", "xte"]:
+        mission_config[mission] = {}
+        mission_config[mission].update(mission_config["generic"])
+        mission_config["allow_local"] = True
 
-# Read the relevant information from $HEADAS/bin/xselect.mdb, if present
-for mission, data in read_mission_info_from_heasoft().items():
-    mission_config[mission] = {"allow_local": False}
-    mission_config[mission]["fits_extension"] = data["events"]
-    mission_config[mission]["fits_columns"] = {"ecol": data["ecol"]}
+    # Read the relevant information from $HEADAS/bin/xselect.mdb, if present
+    for mission, data in read_mission_info_from_heasoft().items():
+        mission_config[mission] = {"allow_local": False}
+        ext = 1
+        if "events" in data:
+            ext = data["events"]
+        cols = {}
+        if "ecol" in data:
+            ecol = data["ecol"]
+            cols = {"ecol": ecol}
+        mission_config[mission]["fits_extension"] = ext
+        mission_config[mission]["fits_columns"] = cols
 
-# Fix xte
-mission_config["xte"]["fits_columns"] = {"ecol": "PHA"}
-# The event extension is called in different ways for different data modes, but
-# it is always no. 1.
-mission_config["xte"]["fits_extension"] = 1
+    # Fix xte
+    mission_config["xte"]["fits_columns"] = {"ecol": "PHA"}
+    # The event extension is called in different ways for different data modes, but
+    # it is always no. 1.
+    mission_config["xte"]["fits_extension"] = 1
+    return mission_config
+
+
+mission_config = create_mission_config()
 
 
 def _default_obs_and_scale(mission, timesys, timeref):

--- a/src/pint/observatory/satellite_obs.py
+++ b/src/pint/observatory/satellite_obs.py
@@ -256,7 +256,7 @@ def load_orbit(obs_name, orb_filename):
         return load_Fermi_FT2(orb_filename)
     elif "nicer" in lower_name:
         return load_FPorbit(orb_filename)
-    elif "rxte" in lower_name:
+    elif "xte" in lower_name:
         return load_FPorbit(orb_filename)
     elif "nustar" in lower_name:
         return load_nustar_orbit(orb_filename)
@@ -311,7 +311,7 @@ class SatelliteObs(SpecialLocation):
 
     def _check_bounds(self, t):
         """ Ensure t is within maxextrap of the closest S/C measurement.
-        
+
         The purpose is to catch cases where there is missing S/C orbital
         information.  A common case would be providing an "FT2" file that
         is shorter than the photon data, or building an FT2 file that is

--- a/src/pint/scripts/photonphase.py
+++ b/src/pint/scripts/photonphase.py
@@ -9,13 +9,7 @@ from astropy import log
 import pint.models
 import pint.residuals
 import pint.toa as toa
-from pint.event_toas import (
-    load_NICER_TOAs,
-    load_NuSTAR_TOAs,
-    load_RXTE_TOAs,
-    load_XMM_TOAs,
-    load_fits_TOAs
-)
+from pint.event_toas import load_event_TOAs, load_fits_TOAs
 from pint.eventstats import h2sig, hm
 from pint.fits_utils import read_fits_event_mjds
 from pint.observatory.satellite_obs import get_satellite_observatory
@@ -122,40 +116,26 @@ def main(argv=None):
         )
     )
 
-    if hdr["TELESCOP"] == "NICER":
+    telescope = hdr["TELESCOP"].lower()
 
-        # Instantiate NICER observatory once so it gets added to the observatory registry
-        if args.orbfile is not None:
-            log.info("Setting up NICER observatory")
-            get_satellite_observatory("NICER", args.orbfile)
-        # Read event file and return list of TOA objects
+    # Instantiate observatory once so it gets added to the observatory registry
+    if args.orbfile is not None:
+        log.info(f"Setting up {telescope.upper()} observatory")
         try:
-            tl = load_NICER_TOAs(args.eventfile, minmjd=minmjd, maxmjd=maxmjd)
-        except KeyError:
+            get_satellite_observatory(telescope, args.orbfile)
+        except Exception:
             log.error(
-                "Observatory not recognized.  This probably means you need to provide an orbit file or barycenter the event file."
+                "The orbit file is not recognized. It is likely that this mission is not supported. "
+                "Please barycenter the event file using the official mission tools before processing with PINT"
             )
-            sys.exit(1)
-    elif hdr["TELESCOP"] == "XTE":
-
-        # Instantiate RXTE observatory once so it gets added to the observatory registry
-        if args.orbfile is not None:
-            # Determine what observatory type is.
-            log.info("Setting up RXTE observatory")
-            get_satellite_observatory("RXTE", args.orbfile)
-        # Read event file and return list of TOA objects
-        tl = load_RXTE_TOAs(args.eventfile, minmjd=minmjd, maxmjd=maxmjd)
-    elif hdr["TELESCOP"].startswith("XMM"):
-        # Not loading orbit file here, since that is not yet supported.
-        tl = load_XMM_TOAs(args.eventfile, minmjd=minmjd, maxmjd=maxmjd)
-    elif hdr["TELESCOP"].lower().startswith("nustar"):
-        if args.orbfile is not None:
-            log.info("Setting up NuSTAR observatory")
-            get_satellite_observatory("NuSTAR", args.orbfile)
-        tl = load_NuSTAR_TOAs(args.eventfile, minmjd=minmjd, maxmjd=maxmjd)
-    else:
-        log.info("Using generic satellite information")
-        tl = load_fits_TOAs(args.eventfile, mission="generic", minmjd=minmjd, maxmjd=maxmjd)
+    # Read event file and return list of TOA objects
+    try:
+        tl = load_event_TOAs(args.eventfile, telescope, minmjd=minmjd, maxmjd=maxmjd)
+    except KeyError:
+        log.error(
+            "Observatory not recognized. This probably means you need to provide an orbit file or barycenter the event file."
+        )
+        sys.exit(1)
 
     # Now convert to TOAs object and compute TDBs and posvels
     if len(tl) == 0:

--- a/src/pint/scripts/photonphase.py
+++ b/src/pint/scripts/photonphase.py
@@ -14,6 +14,7 @@ from pint.event_toas import (
     load_NuSTAR_TOAs,
     load_RXTE_TOAs,
     load_XMM_TOAs,
+    load_fits_TOAs
 )
 from pint.eventstats import h2sig, hm
 from pint.fits_utils import read_fits_event_mjds
@@ -153,12 +154,8 @@ def main(argv=None):
             get_satellite_observatory("NuSTAR", args.orbfile)
         tl = load_NuSTAR_TOAs(args.eventfile, minmjd=minmjd, maxmjd=maxmjd)
     else:
-        log.error(
-            "FITS file not recognized, TELESCOPE = {0}, INSTRUMENT = {1}".format(
-                hdr["TELESCOP"], hdr["INSTRUME"]
-            )
-        )
-        sys.exit(1)
+        log.info("Using generic satellite information")
+        tl = load_fits_TOAs(args.eventfile, mission="generic", minmjd=minmjd, maxmjd=maxmjd)
 
     # Now convert to TOAs object and compute TDBs and posvels
     if len(tl) == 0:

--- a/src/pint/scripts/photonphase.py
+++ b/src/pint/scripts/photonphase.py
@@ -221,7 +221,7 @@ def main(argv=None):
             data_to_add["PULSE_PHASE"] = [phases, "D"]
 
         if args.absphase:
-            data_to_add["ABS_PHASE"] = [iphss - negmask, "K"]
+            data_to_add["ABS_PHASE"] = [iphss, "K"]
 
         if args.barytime:
             bats = modelin.get_barycentric_toas(ts)

--- a/tests/test_event_toas.py
+++ b/tests/test_event_toas.py
@@ -1,0 +1,14 @@
+from pint.event_toas import read_mission_info_from_heasoft
+
+
+def test_xselect_mdb_is_found_headas(monkeypatch, tmp_path):
+    """Test event file reading."""
+    path = tmp_path / 'bin'
+    path.mkdir()
+    f = path / 'xselect.mdb'
+    f.write_text("MAXI:submkey       NONE\nMAXI:instkey       INSTRUME")
+
+    monkeypatch.setenv("HEADAS", tmp_path)
+
+    info = read_mission_info_from_heasoft()
+    assert "NUSTAR" not in info

--- a/tests/test_event_toas.py
+++ b/tests/test_event_toas.py
@@ -1,4 +1,9 @@
-from pint.event_toas import read_mission_info_from_heasoft
+import os
+import pytest
+
+from pint.event_toas import read_mission_info_from_heasoft, create_mission_config
+from pint.event_toas import load_fits_TOAs
+from pinttestdata import datadir
 
 
 def test_xselect_mdb_is_found_headas(monkeypatch, tmp_path):
@@ -11,4 +16,38 @@ def test_xselect_mdb_is_found_headas(monkeypatch, tmp_path):
     monkeypatch.setenv("HEADAS", tmp_path)
 
     info = read_mission_info_from_heasoft()
-    assert "NUSTAR" not in info
+    assert "nustar" not in info
+
+
+def test_create_mission_config_headas(monkeypatch, tmp_path):
+    """Test event file reading."""
+    path = tmp_path / 'bin'
+    path.mkdir()
+    f = path / 'xselect.mdb'
+    f.write_text("MAXI:submkey       NONE\nMAXI:instkey       INSTRUME")
+
+    monkeypatch.setenv("HEADAS", tmp_path)
+
+    info = create_mission_config()
+    assert "xte" in info
+    assert info['xte']['fits_extension'] == 1
+
+
+def test_load_events_wrongext_raises():
+    eventfile_nicer_topo = os.path.join(datadir, "sgr1830kgfilt.evt")
+    msg = "At the moment, only data in the first FITS extension"
+    with pytest.raises(ValueError) as excinfo:
+        # Not sure how to test that the warning is raised, with Astropy's log system
+        # Anyway, here I'm testing another error
+        load_fits_TOAs(eventfile_nicer_topo, mission="xdsgse", extension=2)
+    assert msg in str(excinfo.value)
+
+
+def test_load_events_wrongext_text_raises():
+    eventfile_nicer_topo = os.path.join(datadir, "sgr1830kgfilt.evt")
+    msg = "First table in FITS file"
+    with pytest.raises(RuntimeError) as excinfo:
+        # Not sure how to test that the warning is raised, with Astropy's log system
+        # Anyway, here I'm testing another error
+        load_fits_TOAs(eventfile_nicer_topo, mission="xdsgse", extension="dafasdfa")
+    assert msg in str(excinfo.value)

--- a/tests/test_event_toas.py
+++ b/tests/test_event_toas.py
@@ -24,10 +24,19 @@ def test_create_mission_config_headas(monkeypatch, tmp_path):
     path = tmp_path / "bin"
     path.mkdir()
     f = path / "xselect.mdb"
-    f.write_text("MAXI:submkey       NONE\nMAXI:instkey       INSTRUME")
+    f.write_text("!\nINTEGRAL:events       EVENTS\nINTEGRAL:ecol     PHA")
+    f.write_text("!\nINTEGRAL:SPI:ecol     PHA")
 
     monkeypatch.setenv("HEADAS", tmp_path)
 
+    info = create_mission_config()
+    assert "xte" in info
+    assert info["xte"]["fits_extension"] == 1
+
+
+def test_create_mission_config_headas_missing_file_no_fail(monkeypatch, tmp_path):
+    """Test event file reading."""
+    monkeypatch.setenv("HEADAS", tmp_path)
     info = create_mission_config()
     assert "xte" in info
     assert info["xte"]["fits_extension"] == 1

--- a/tests/test_event_toas.py
+++ b/tests/test_event_toas.py
@@ -8,9 +8,9 @@ from pinttestdata import datadir
 
 def test_xselect_mdb_is_found_headas(monkeypatch, tmp_path):
     """Test event file reading."""
-    path = tmp_path / 'bin'
+    path = tmp_path / "bin"
     path.mkdir()
-    f = path / 'xselect.mdb'
+    f = path / "xselect.mdb"
     f.write_text("MAXI:submkey       NONE\nMAXI:instkey       INSTRUME")
 
     monkeypatch.setenv("HEADAS", tmp_path)
@@ -21,16 +21,16 @@ def test_xselect_mdb_is_found_headas(monkeypatch, tmp_path):
 
 def test_create_mission_config_headas(monkeypatch, tmp_path):
     """Test event file reading."""
-    path = tmp_path / 'bin'
+    path = tmp_path / "bin"
     path.mkdir()
-    f = path / 'xselect.mdb'
+    f = path / "xselect.mdb"
     f.write_text("MAXI:submkey       NONE\nMAXI:instkey       INSTRUME")
 
     monkeypatch.setenv("HEADAS", tmp_path)
 
     info = create_mission_config()
     assert "xte" in info
-    assert info['xte']['fits_extension'] == 1
+    assert info["xte"]["fits_extension"] == 1
 
 
 def test_load_events_wrongext_raises():


### PR DESCRIPTION
By the way, let us make PINT understand data from many more missions.

This should work with all currently supported missions, plus many more. And if a mission is not known, it just calls it "generic" and tries to read the data from the first FITS extension (of course, data have to be barycentered, orbit files would be trickier!).

- [x] Basic implementation
- [x] Make it work without HEADAS (minor fix)
- [x] Make missions in xselect.mdb non-generic (this has little use for now, but it can be important if we decide to filter by PI or perform some other data selection)