### PR TITLE
Compute masses

### DIFF
--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1260,6 +1260,8 @@ def pulsar_mass(pb, x, mc, inc):
     cb = 2 * massfunct * mc
     cc = massfunct * mc ** 2 - (mc * np.sin(inc)) ** 3
     # solve it directly
+    # this has to be the positive branch of the quadratic
+    # because the vertex is at -mc, so the negative branch will always be < 0
     return ((-cb + np.sqrt(cb ** 2 - 4 * ca * cc)) / (2 * ca)).to(u.Msun)
 
 

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1184,6 +1184,12 @@ def mass_funct(pb, x):
     f_m : Quantity
         Mass function in solar masses
     """
+    if not isinstance(x, u.quantity.Quantity):
+        raise ValueError(
+            f"The projected semi-major axis x should be a Quantity but is {x}."
+        )
+    if not isinstance(pb, u.quantity.Quantity):
+        raise ValueError(f"The binary period pb should be a Quantity but is {pb}.")
     fm = 4.0 * np.pi ** 2 * x ** 3 / (const.G * pb ** 2)
     return fm.to(u.solMass)
 
@@ -1205,6 +1211,13 @@ def mass_funct2(mp, mc, i):
     Inclination is such that edge on is `i = 90*u.deg`
     An 'average' orbit has cos(i) = 0.5, or `i = 60*u.deg`
     """
+    if not (isinstance(i, angles.Angle) or isinstance(i, u.quantity.Quantity)):
+        raise ValueError(f"The inclination should be an Angle but is {i}.")
+    if not isinstance(mc, u.quantity.Quantity):
+        raise ValueError(f"The companion mass should be a Quantity but is {mc}.")
+    if not isinstance(mp, u.quantity.Quantity):
+        raise ValueError(f"The pulsar mass should be a Quantity but is {mp}.")
+
     return (mc * np.sin(i)) ** 3.0 / (mc + mp) ** 2.0
 
 

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1256,13 +1256,15 @@ def pulsar_mass(pb, x, mc, inc):
 
     # This then forms a quadratic equation of the form:
     # ca*Mp**2 + cb*Mp + cc = 0
+    sini = np.sin(inc)
     ca = massfunct
     cb = 2 * massfunct * mc
-    cc = massfunct * mc ** 2 - (mc * np.sin(inc)) ** 3
+    # cc = massfunct * mc ** 2 - (mc * sini) ** 3
     # solve it directly
     # this has to be the positive branch of the quadratic
     # because the vertex is at -mc, so the negative branch will always be < 0
-    return ((-cb + np.sqrt(cb ** 2 - 4 * ca * cc)) / (2 * ca)).to(u.Msun)
+    # return ((-cb + np.sqrt(cb ** 2 - 4 * ca * cc)) / (2 * ca)).to(u.Msun)
+    return ((-cb + np.sqrt(4 * massfunct * mc ** 3 * sini ** 3)) / (2 * ca)).to(u.Msun)
 
 
 def companion_mass(pb, x, inc=60.0 * u.deg, mpsr=1.4 * u.solMass):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -640,32 +640,27 @@ def test_pmtot():
 
 
 def test_mass_function():
-    pb = 1.0 * u.d
-    x = 2.0 * pint.ls
 
     # Mass function
     # RHS of Eqn. 8.34 in Lorimer & Kramer (2008)
     # this should be 4* pi**2 * x**3 / (G * Pb**2)
     # in appropriate units
-    assert np.isclose(mass_funct(pb, x), 0.008589595519643776 * u.solMass)
+    assert np.isclose(
+        mass_funct(1.0 * u.d, 2.0 * pint.ls), 0.008589595519643776 * u.solMass
+    )
 
 
 def test_mass_function_error_without_quantity_x():
-    pb = 1.0 * u.d
-    x = 2.0 * pint.ls
-
     # Mass function
     with pytest.raises(ValueError):
-        mass_funct(pb, x.value)
+        mass_funct(1.0 * u.d, 2.0)
 
 
 def test_mass_function_error_without_quantity_pb():
-    pb = 1.0 * u.d
-    x = 2.0 * pint.ls
 
     # Mass function
     with pytest.raises(ValueError):
-        mass_funct(pb.value, x)
+        mass_funct(1.0, 2.0 * pint.ls)
 
 
 def test_other_mass_function():
@@ -680,8 +675,6 @@ def test_other_mass_function():
 
 
 def test_other_mass_function_error_without_quantity_mp():
-    pb = 1.0 * u.d
-    x = 2.0 * pint.ls
 
     # Mass function, second form
     with pytest.raises(ValueError):
@@ -689,8 +682,6 @@ def test_other_mass_function_error_without_quantity_mp():
 
 
 def test_other_mass_function_error_without_quantity_mc():
-    pb = 1.0 * u.d
-    x = 2.0 * pint.ls
 
     # Mass function, second form
     with pytest.raises(ValueError):
@@ -698,8 +689,6 @@ def test_other_mass_function_error_without_quantity_mc():
 
 
 def test_other_mass_function_error_without_quantity_inc():
-    pb = 1.0 * u.d
-    x = 2.0 * pint.ls
 
     # Mass function, second form
     with pytest.raises(ValueError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -649,12 +649,22 @@ def test_psr_utils():
 
     # Mass function
     assert np.isclose(mass_funct(pb, x), 0.008589595519643776 * u.solMass)
+    with pytest.raises(ValueError):
+        mass_funct(pb.value, x)
+    with pytest.raises(ValueError):
+        mass_funct(pb, x.value)
 
     # Mass function, second form
     assert np.isclose(
         mass_funct2(1.4 * u.solMass, 0.2 * u.solMass, 60.0 * u.deg),
         0.0020297470401197783 * u.solMass,
     )
+    with pytest.raises(ValueError):
+        mass_funct2(1.4, 0.2 * u.solMass, 60.0 * u.deg)
+    with pytest.raises(ValueError):
+        mass_funct2(1.4 * u.solMass, 0.2, 60.0 * u.deg)
+    with pytest.raises(ValueError):
+        mass_funct2(1.4 * u.solMass, 0.2 * u.solMass, 60.0)
 
     # Characteristic age
     assert np.isclose(
@@ -727,6 +737,23 @@ def test_masses(Mpsr, Mc, Pb, incl):
     assert np.isclose(
         companion_mass(Pb * u.day, x, mpsr=Mpsr * u.Msun, inc=incl * u.deg), Mc * u.Msun
     )
+    # and test exceptions
+    with pytest.raises(ValueError):
+        companion_mass(Pb * u.day, x, mpsr=Mpsr * u.Msun, inc=incl)
+    with pytest.raises(ValueError):
+        companion_mass(Pb * u.day, x.value, mpsr=Mpsr * u.Msun, inc=incl * u.deg)
+    with pytest.raises(ValueError):
+        companion_mass(Pb, x, mpsr=Mpsr * u.Msun, inc=incl * u.deg)
+    with pytest.raises(ValueError):
+        companion_mass(Pb * u.day, x, mpsr=Mpsr, inc=incl * u.deg)
+    with pytest.raises(ValueError):
+        pulsar_mass(Pb, x, Mc * u.Msun, inc=incl * u.deg)
+    with pytest.raises(ValueError):
+        pulsar_mass(Pb * u.day, x.value, Mc * u.Msun, inc=incl * u.deg)
+    with pytest.raises(ValueError):
+        pulsar_mass(Pb * u.day, x, Mc, inc=incl * u.deg)
+    with pytest.raises(ValueError):
+        pulsar_mass(Pb * u.day, x, Mc * u.Msun, inc=incl)
 
 
 def test_ftest():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,6 +44,14 @@ from pint.utils import (
     lines_of,
     open_or_use,
     taylor_horner,
+    companion_mass,
+    mass_funct,
+    mass_funct2,
+    pulsar_age,
+    pulsar_B,
+    pulsar_B_lightcyl,
+    pulsar_edot,
+    pulsar_mass,
 )
 
 
@@ -631,72 +639,97 @@ def test_pmtot():
         pmtot(m2)
 
 
-def test_psr_utils():
-
-    from pint.utils import (
-        companion_mass,
-        mass_funct,
-        mass_funct2,
-        pulsar_age,
-        pulsar_B,
-        pulsar_B_lightcyl,
-        pulsar_edot,
-        pulsar_mass,
-    )
-
+def test_mass_function():
     pb = 1.0 * u.d
     x = 2.0 * pint.ls
 
     # Mass function
     assert np.isclose(mass_funct(pb, x), 0.008589595519643776 * u.solMass)
-    with pytest.raises(ValueError):
-        mass_funct(pb.value, x)
+
+
+def test_mass_function_error_without_quantity_x():
+    pb = 1.0 * u.d
+    x = 2.0 * pint.ls
+
+    # Mass function
     with pytest.raises(ValueError):
         mass_funct(pb, x.value)
+
+
+def test_mass_function_error_without_quantity_pb():
+    pb = 1.0 * u.d
+    x = 2.0 * pint.ls
+
+    # Mass function
+    with pytest.raises(ValueError):
+        mass_funct(pb.value, x)
+
+
+def test_other_mass_function():
+    pb = 1.0 * u.d
+    x = 2.0 * pint.ls
 
     # Mass function, second form
     assert np.isclose(
         mass_funct2(1.4 * u.solMass, 0.2 * u.solMass, 60.0 * u.deg),
         0.0020297470401197783 * u.solMass,
     )
+
+
+def test_other_mass_function_error_without_quantity_mp():
+    pb = 1.0 * u.d
+    x = 2.0 * pint.ls
+
+    # Mass function, second form
     with pytest.raises(ValueError):
         mass_funct2(1.4, 0.2 * u.solMass, 60.0 * u.deg)
+
+
+def test_other_mass_function_error_without_quantity_mc():
+    pb = 1.0 * u.d
+    x = 2.0 * pint.ls
+
+    # Mass function, second form
     with pytest.raises(ValueError):
         mass_funct2(1.4 * u.solMass, 0.2, 60.0 * u.deg)
+
+
+def test_other_mass_function_error_without_quantity_inc():
+    pb = 1.0 * u.d
+    x = 2.0 * pint.ls
+
+    # Mass function, second form
     with pytest.raises(ValueError):
         mass_funct2(1.4 * u.solMass, 0.2 * u.solMass, 60.0)
 
+
+def test_characteristic_age():
     # Characteristic age
     assert np.isclose(
         pulsar_age(0.033 * u.Hz, -2.0e-15 * u.Hz / u.s), 261426.72446573884 * u.yr
     )
 
+
+def test_Edot():
     # Edot
     assert np.isclose(
         pulsar_edot(0.033 * u.Hz, -2.0e-15 * u.Hz / u.s),
         2.6055755618875905e30 * u.erg / u.s,
     )
 
+
+def test_Bfield():
     # B
     assert np.isclose(
         pulsar_B(0.033 * u.Hz, -2.0e-15 * u.Hz / u.s), 238722891596281.66 * u.G
     )
 
+
+def test_Blc():
     # B_lc
     assert np.isclose(
         pulsar_B_lightcyl(0.033 * u.Hz, -2.0e-15 * u.Hz / u.s),
         0.07774704753236616 * u.G,
-    )
-
-    # companion mass
-    assert np.isclose(
-        companion_mass(pb, x, inc=90 * u.deg, mpsr=1.4 * u.Msun),
-        0.2906422269961084 * u.Msun,
-    )
-
-    # pulsar mass
-    assert np.isclose(
-        pulsar_mass(pb, x, 0.4 * u.Msun, inc=90 * u.deg), 2.329629042176839 * u.Msun
     )
 
 
@@ -706,21 +739,10 @@ def test_psr_utils():
     floats(min_value=0.04, max_value=1000),
     floats(min_value=0.1, max_value=90),
 )
-def test_masses(Mpsr, Mc, Pb, incl):
+def test_companion_mass(Mpsr, Mc, Pb, incl):
     """
-    test pulsar and companion mass calculations for a range of values
+    test companion mass calculations for a range of values
     """
-    assume(incl > 0)
-    assume(incl <= 90)
-    assume(Mpsr > 0)
-    assume(Mc > 0)
-    assume(Pb > 0)
-
-    from pint.utils import (
-        companion_mass,
-        pulsar_mass,
-    )
-
     Mtot = (Mc + Mpsr) * u.Msun
     # full semi-major axis
     a = (c.G * Mtot * (Pb * u.day / (2 * np.pi)) ** 2) ** (1.0 / 3)
@@ -728,32 +750,105 @@ def test_masses(Mpsr, Mc, Pb, incl):
     apsr = (Mc * u.Msun / Mtot) * a
     # projected
     x = (apsr * np.sin(incl * u.deg)).to(pint.ls)
-
-    # computed pulsar mass
-    assert np.isclose(
-        pulsar_mass(Pb * u.day, x, Mc * u.Msun, inc=incl * u.deg), Mpsr * u.Msun
-    )
     # computed companion mass
     assert np.isclose(
         companion_mass(Pb * u.day, x, mpsr=Mpsr * u.Msun, inc=incl * u.deg), Mc * u.Msun
     )
-    # and test exceptions
+
+
+@given(
+    floats(min_value=0.5, max_value=3),
+    floats(min_value=0.01, max_value=10),
+    floats(min_value=0.04, max_value=1000),
+    floats(min_value=0.1, max_value=90),
+)
+def test_pulsar_mass(Mpsr, Mc, Pb, incl):
+    """
+    test pulsar mass calculations for a range of values
+    """
+    Mtot = (Mc + Mpsr) * u.Msun
+    # full semi-major axis
+    a = (c.G * Mtot * (Pb * u.day / (2 * np.pi)) ** 2) ** (1.0 / 3)
+    # pulsar semi-major axis
+    apsr = (Mc * u.Msun / Mtot) * a
+    # projected
+    x = (apsr * np.sin(incl * u.deg)).to(pint.ls)
+    # computed pulsar mass
+    assert np.isclose(
+        pulsar_mass(Pb * u.day, x, Mc * u.Msun, inc=incl * u.deg), Mpsr * u.Msun
+    )
+
+
+def test_pulsar_mass_error_noquantity_inc():
+    Pb = 1.0 * u.d
+    x = 2.0 * pint.ls
+    inc = 60 * u.deg
+    Mc = 0.5 * u.solMass
     with pytest.raises(ValueError):
-        companion_mass(Pb * u.day, x, mpsr=Mpsr * u.Msun, inc=incl)
+        pulsar_mass(Pb, x, Mc, inc=inc.value)
+
+
+def test_pulsar_mass_error_noquantity_Mc():
+    Pb = 1.0 * u.d
+    x = 2.0 * pint.ls
+    inc = 60 * u.deg
+    Mc = 0.5 * u.solMass
     with pytest.raises(ValueError):
-        companion_mass(Pb * u.day, x.value, mpsr=Mpsr * u.Msun, inc=incl * u.deg)
+        pulsar_mass(Pb, x, Mc.value, inc=inc)
+
+
+def test_pulsar_mass_error_noquantity_x():
+    Pb = 1.0 * u.d
+    x = 2.0 * pint.ls
+    inc = 60 * u.deg
+    Mc = 0.5 * u.solMass
     with pytest.raises(ValueError):
-        companion_mass(Pb, x, mpsr=Mpsr * u.Msun, inc=incl * u.deg)
+        pulsar_mass(Pb, x.value, Mc, inc=inc)
+
+
+def test_pulsar_mass_error_noquantity_Pb():
+    Pb = 1.0 * u.d
+    x = 2.0 * pint.ls
+    inc = 60 * u.deg
+    Mc = 0.5 * u.solMass
     with pytest.raises(ValueError):
-        companion_mass(Pb * u.day, x, mpsr=Mpsr, inc=incl * u.deg)
+        pulsar_mass(Pb.value, x, Mc, inc=inc)
+
+
+def test_companion_mass_error_noquantity_inc():
+    Pb = 1.0 * u.d
+    x = 2.0 * pint.ls
+    inc = 60 * u.deg
+    Mpsr = 1.4 * u.solMass
     with pytest.raises(ValueError):
-        pulsar_mass(Pb, x, Mc * u.Msun, inc=incl * u.deg)
+        pulsar_mass(Pb, x, Mpsr, inc=inc.value)
+
+
+def test_companion_mass_error_noquantity_Mpsr():
+    Pb = 1.0 * u.d
+    x = 2.0 * pint.ls
+    inc = 60 * u.deg
+    Mpsr = 1.4 * u.solMass
     with pytest.raises(ValueError):
-        pulsar_mass(Pb * u.day, x.value, Mc * u.Msun, inc=incl * u.deg)
+        pulsar_mass(Pb, x, Mpsr.value, inc=inc)
+
+
+def test_companion_mass_error_noquantity_x():
+    Pb = 1.0 * u.d
+    x = 2.0 * pint.ls
+    inc = 60 * u.deg
+    Mpsr = 1.4 * u.solMass
     with pytest.raises(ValueError):
-        pulsar_mass(Pb * u.day, x, Mc, inc=incl * u.deg)
+        pulsar_mass(Pb, x.value, Mpsr, inc=inc)
+
+
+def test_companion_mass_error_noquantity_Pb():
+    Pb = 1.0 * u.d
+    x = 2.0 * pint.ls
+    inc = 60 * u.deg
+    Mpsr = 1.4 * u.solMass
     with pytest.raises(ValueError):
-        pulsar_mass(Pb * u.day, x, Mc * u.Msun, inc=incl)
+        pulsar_mass(Pb.value, x, Mpsr, inc=inc)
 
 
 def test_ftest():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -677,6 +677,17 @@ def test_psr_utils():
         0.07774704753236616 * u.G,
     )
 
+    # companion mass
+    assert np.isclose(
+        companion_mass(pb, x, inc=90 * u.deg, mpsr=1.4 * u.Msun),
+        0.2906422269961084 * u.Msun,
+    )
+
+    # pulsar mass
+    assert np.isclose(
+        pulsar_mass(pb, x, 0.4 * u.Msun, inc=90 * u.deg), 2.329629042176839 * u.Msun
+    )
+
 
 def test_ftest():
     """Test for FTest. Numbers from example test."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -746,17 +746,20 @@ def test_companion_mass(Mpsr, Mc, Pb, incl):
     """
     test companion mass calculations for a range of values
     """
-    Mtot = (Mc + Mpsr) * u.Msun
+    Mc = Mc * u.Msun
+    Mpsr = Mpsr * u.Msun
+    Pb = Pb * u.day
+    incl = incl * u.deg
+
+    Mtot = Mc + Mpsr
     # full semi-major axis
-    a = (c.G * Mtot * (Pb * u.day / (2 * np.pi)) ** 2) ** (1.0 / 3)
+    a = (c.G * Mtot * (Pb / (2 * np.pi)) ** 2) ** (1.0 / 3)
     # pulsar semi-major axis
-    apsr = (Mc * u.Msun / Mtot) * a
+    apsr = (Mc / Mtot) * a
     # projected
-    x = (apsr * np.sin(incl * u.deg)).to(pint.ls)
+    x = (apsr * np.sin(incl)).to(pint.ls)
     # computed companion mass
-    assert np.isclose(
-        companion_mass(Pb * u.day, x, mpsr=Mpsr * u.Msun, inc=incl * u.deg), Mc * u.Msun
-    )
+    assert np.isclose(companion_mass(Pb, x, mpsr=Mpsr, inc=incl), Mc)
 
 
 @given(
@@ -769,20 +772,20 @@ def test_companion_mass_array(Mpsr, Mc, Pb, incl):
     """
     test companion mass calculations for a range of values given np.ndarray inputs
     """
-    Mtot = (Mc + Mpsr) * u.Msun
+    Mc = Mc * u.Msun
+    Mpsr = Mpsr * u.Msun
+    Pb = Pb * u.day
+    incl = incl * u.deg
+
+    Mtot = Mc + Mpsr
     # full semi-major axis
-    a = (c.G * Mtot * (Pb * u.day / (2 * np.pi)) ** 2) ** (1.0 / 3)
+    a = (c.G * Mtot * (Pb / (2 * np.pi)) ** 2) ** (1.0 / 3)
     # pulsar semi-major axis
-    apsr = (Mc * u.Msun / Mtot) * a
+    apsr = (Mc / Mtot) * a
     # projected
-    x = (apsr * np.sin(incl * u.deg)).to(pint.ls)
+    x = (apsr * np.sin(incl)).to(pint.ls)
     # computed companion mass
-    assert (
-        np.isclose(
-            companion_mass(Pb * u.day, x, mpsr=Mpsr * u.Msun, inc=incl * u.deg),
-            Mc * u.Msun,
-        )
-    ).all()
+    assert (np.isclose(companion_mass(Pb, x, mpsr=Mpsr, inc=incl), Mc,)).all()
 
 
 @given(
@@ -795,17 +798,20 @@ def test_pulsar_mass(Mpsr, Mc, Pb, incl):
     """
     test pulsar mass calculations for a range of values
     """
-    Mtot = (Mc + Mpsr) * u.Msun
+    Mc = Mc * u.Msun
+    Mpsr = Mpsr * u.Msun
+    Pb = Pb * u.day
+    incl = incl * u.deg
+
+    Mtot = Mc + Mpsr
     # full semi-major axis
-    a = (c.G * Mtot * (Pb * u.day / (2 * np.pi)) ** 2) ** (1.0 / 3)
+    a = (c.G * Mtot * (Pb / (2 * np.pi)) ** 2) ** (1.0 / 3)
     # pulsar semi-major axis
-    apsr = (Mc * u.Msun / Mtot) * a
+    apsr = (Mc / Mtot) * a
     # projected
-    x = (apsr * np.sin(incl * u.deg)).to(pint.ls)
+    x = (apsr * np.sin(incl)).to(pint.ls)
     # computed pulsar mass
-    assert np.isclose(
-        pulsar_mass(Pb * u.day, x, Mc * u.Msun, inc=incl * u.deg), Mpsr * u.Msun
-    )
+    assert np.isclose(pulsar_mass(Pb, x, Mc, inc=incl), Mpsr)
 
 
 @given(
@@ -818,19 +824,20 @@ def test_pulsar_mass_array(Mpsr, Mc, Pb, incl):
     """
     test pulsar mass calculations for a range of values given np.ndarray inputs
     """
-    Mtot = (Mc + Mpsr) * u.Msun
+    Mc = Mc * u.Msun
+    Mpsr = Mpsr * u.Msun
+    Pb = Pb * u.day
+    incl = incl * u.deg
+
+    Mtot = Mc + Mpsr
     # full semi-major axis
-    a = (c.G * Mtot * (Pb * u.day / (2 * np.pi)) ** 2) ** (1.0 / 3)
+    a = (c.G * Mtot * (Pb / (2 * np.pi)) ** 2) ** (1.0 / 3)
     # pulsar semi-major axis
-    apsr = (Mc * u.Msun / Mtot) * a
+    apsr = (Mc / Mtot) * a
     # projected
-    x = (apsr * np.sin(incl * u.deg)).to(pint.ls)
+    x = (apsr * np.sin(incl)).to(pint.ls)
     # computed pulsar mass
-    assert (
-        np.isclose(
-            pulsar_mass(Pb * u.day, x, Mc * u.Msun, inc=incl * u.deg), Mpsr * u.Msun
-        )
-    ).all()
+    assert (np.isclose(pulsar_mass(Pb, x, Mc, inc=incl), Mpsr)).all()
 
 
 def test_pulsar_mass_error_noquantity_inc():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -760,6 +760,32 @@ def test_companion_mass(Mpsr, Mc, Pb, incl):
 
 
 @given(
+    arrays(np.float, 10, elements=floats(0.5, 3)),
+    arrays(np.float, 10, elements=floats(0.01, 10)),
+    arrays(np.float, 10, elements=floats(0.04, 1000)),
+    arrays(np.float, 10, elements=floats(0.1, 90)),
+)
+def test_companion_mass_array(Mpsr, Mc, Pb, incl):
+    """
+    test companion mass calculations for a range of values given np.ndarray inputs
+    """
+    Mtot = (Mc + Mpsr) * u.Msun
+    # full semi-major axis
+    a = (c.G * Mtot * (Pb * u.day / (2 * np.pi)) ** 2) ** (1.0 / 3)
+    # pulsar semi-major axis
+    apsr = (Mc * u.Msun / Mtot) * a
+    # projected
+    x = (apsr * np.sin(incl * u.deg)).to(pint.ls)
+    # computed companion mass
+    assert (
+        np.isclose(
+            companion_mass(Pb * u.day, x, mpsr=Mpsr * u.Msun, inc=incl * u.deg),
+            Mc * u.Msun,
+        )
+    ).all()
+
+
+@given(
     floats(min_value=0.5, max_value=3),
     floats(min_value=0.01, max_value=10),
     floats(min_value=0.04, max_value=1000),
@@ -780,6 +806,31 @@ def test_pulsar_mass(Mpsr, Mc, Pb, incl):
     assert np.isclose(
         pulsar_mass(Pb * u.day, x, Mc * u.Msun, inc=incl * u.deg), Mpsr * u.Msun
     )
+
+
+@given(
+    arrays(np.float, 10, elements=floats(0.5, 3)),
+    arrays(np.float, 10, elements=floats(0.01, 10)),
+    arrays(np.float, 10, elements=floats(0.04, 1000)),
+    arrays(np.float, 10, elements=floats(0.1, 90)),
+)
+def test_pulsar_mass_array(Mpsr, Mc, Pb, incl):
+    """
+    test pulsar mass calculations for a range of values given np.ndarray inputs
+    """
+    Mtot = (Mc + Mpsr) * u.Msun
+    # full semi-major axis
+    a = (c.G * Mtot * (Pb * u.day / (2 * np.pi)) ** 2) ** (1.0 / 3)
+    # pulsar semi-major axis
+    apsr = (Mc * u.Msun / Mtot) * a
+    # projected
+    x = (apsr * np.sin(incl * u.deg)).to(pint.ls)
+    # computed pulsar mass
+    assert (
+        np.isclose(
+            pulsar_mass(Pb * u.day, x, Mc * u.Msun, inc=incl * u.deg), Mpsr * u.Msun
+        )
+    ).all()
 
 
 def test_pulsar_mass_error_noquantity_inc():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -644,6 +644,9 @@ def test_mass_function():
     x = 2.0 * pint.ls
 
     # Mass function
+    # RHS of Eqn. 8.34 in Lorimer & Kramer (2008)
+    # this should be 4* pi**2 * x**3 / (G * Pb**2)
+    # in appropriate units
     assert np.isclose(mass_funct(pb, x), 0.008589595519643776 * u.solMass)
 
 
@@ -666,10 +669,10 @@ def test_mass_function_error_without_quantity_pb():
 
 
 def test_other_mass_function():
-    pb = 1.0 * u.d
-    x = 2.0 * pint.ls
 
     # Mass function, second form
+    # LHS of Eqn. 8.34 in Lorimer & Kramer (2008)
+    # this should be (Mc * sin(inc))**3 / (Mp + Mc)**2
     assert np.isclose(
         mass_funct2(1.4 * u.solMass, 0.2 * u.solMass, 60.0 * u.deg),
         0.0020297470401197783 * u.solMass,


### PR DESCRIPTION
This addresses https://github.com/nanograv/PINT/issues/1044. I added tests for the functions:
`utils/companion_mass()`
`utils/pulsar_mass()`

These are both vectorized and explicitly check for and use units.

I also looked over both calculations and verified that they pick the correct roots and should not suffer from numerical instabilities, but I would appreciate a second check of that.  Specifically, for the `companion_mass()` calculation that uses the analytic roots of a cubic, which has a few different ways to do it.  I algebraically simplified the calculations and verified that there are no differences among quantities that could come close to 0, and that the only issues with 0 in a denominator are when sin(i) -> 0.