### PR TITLE
Covariance matrix fixes

### DIFF
--- a/docs/examples/check_phase_connection.py
+++ b/docs/examples/check_phase_connection.py
@@ -8,9 +8,9 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.5.1
 #   kernelspec:
-#     display_name: Python [conda env:pintdev]
+#     display_name: Python 3
 #     language: python
-#     name: conda-env-pintdev-py
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/examples/check_phase_connection.py
+++ b/docs/examples/check_phase_connection.py
@@ -1,0 +1,88 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.5.1
+#   kernelspec:
+#     display_name: Python [conda env:pintdev]
+#     language: python
+#     name: conda-env-pintdev-py
+# ---
+
+# %% [markdown]
+# ## Check for phase connection
+#
+# This notebook is meant to answer a common type of question: when I have a solution for a pulsar that goes from ${\rm MJD}_1$ to ${\rm MJD}_2$, can I confidently phase connect it to other data starting at ${\rm MJD}_3$?  What is the phase uncertainty bridging the gap from $\Delta t={\rm MJD}_3-{\rm MJD}_2$?
+#
+# This notebook will start with standard pulsar timing.  It will then use the `utils/calculate_random_models` function to propagate the phase uncertainties forward and examine what happens.
+
+# %%
+import matplotlib.pyplot as plt
+import numpy as np
+import astropy.units as u
+
+import pint.fitter, pint.toa
+from pint.models import get_model_and_toas
+from pint import utils
+
+# %%
+# use the same data as `time_a_pulsar` notebook
+parfile = "NGC6440E.par"
+timfile = "NGC6440E.tim"
+
+# %%
+# we will do this very simply - ignoring some of the TOA filtering
+m, t = get_model_and_toas(parfile, timfile)
+f = pint.fitter.WLSFitter(t, m)
+f.fit_toas()
+
+# %%
+print("Current free parameters: ",f.model.free_params)
+
+# %%
+print("Current last TOA: MJD {}".format(f.model.FINISH.quantity))
+
+# %%
+# pretend we have new observations starting at MJD 59000
+# we don't need to track things continuously over that gap, but it helps us visualize what's happening
+# so make fake TOAs to cover the gap
+MJDmax = 59000
+# the number of TOAs is arbitrary since it's mostly for visualization
+tnew = pint.toa.make_fake_toas(f.model.FINISH.value, MJDmax, 50, f.model)
+    
+
+# %%
+# make fake models crossing from the last existing TOA to the start of new observations
+dphase, mrand = utils.calculate_random_models(f, tnew, Nmodels=100)
+# this is the difference in time across the gap
+dt = tnew.get_mjds() - f.model.PEPOCH.value * u.d
+
+# %% [markdown]
+# Compare against an analytic prediction which focused on the uncertainties from $F_0$ and $F_1 = \dot F$:
+# $$
+# \Delta \phi^2 = (\sigma_{F0} \Delta t)^2 + (0.5 \sigma_{F1} \Delta t^2)^2
+# $$
+# where $\Delta t$ is the gap over which we are extrapolating the solution.
+
+# %%
+analytic = np.sqrt(
+            (f.model.F0.uncertainty * dt) ** 2
+            + (0.5 * f.model.F1.uncertainty * dt ** 2) ** 2
+        ).decompose()
+
+# %%
+plt.plot(tnew.get_mjds(), dphase.std(axis=0), label="All Free")
+tnew.get_mjds() - f.model.PEPOCH.value * u.d
+plt.plot(tnew.get_mjds(),analytic,label="Analytic",)
+plt.xlabel("MJD")
+plt.ylabel("Phase Uncertainty (cycles)")
+plt.legend()
+
+# %% [markdown]
+# You can see that the max uncertainty is about 0.14 cycles.  So that means that even at $3\sigma$ confidence, we can be sure that we will have $<1$ cycle uncertainty in extrapolating from the end of the existing solution to MJD 59000.  The analytic solution has the same shape as the numerical solution although it is slightly lower, which makes sense since the analytic solution ignores the covariance between $F_0$ and $F_1$, plus uncertainties on the other free parameters ($\alpha$, $\delta$, ${\rm DM}$).
+
+# %%

--- a/docs/examples/check_phase_connection.py
+++ b/docs/examples/check_phase_connection.py
@@ -77,9 +77,7 @@ analytic = np.sqrt(
 plt.plot(tnew.get_mjds(), dphase.std(axis=0), label="All Free")
 tnew.get_mjds() - f.model.PEPOCH.value * u.d
 plt.plot(
-    tnew.get_mjds(),
-    analytic,
-    label="Analytic",
+    tnew.get_mjds(), analytic, label="Analytic",
 )
 plt.xlabel("MJD")
 plt.ylabel("Phase Uncertainty (cycles)")

--- a/docs/examples/check_phase_connection.py
+++ b/docs/examples/check_phase_connection.py
@@ -41,7 +41,7 @@ f = pint.fitter.WLSFitter(t, m)
 f.fit_toas()
 
 # %%
-print("Current free parameters: ",f.model.free_params)
+print("Current free parameters: ", f.model.free_params)
 
 # %%
 print("Current last TOA: MJD {}".format(f.model.FINISH.quantity))
@@ -53,7 +53,7 @@ print("Current last TOA: MJD {}".format(f.model.FINISH.quantity))
 MJDmax = 59000
 # the number of TOAs is arbitrary since it's mostly for visualization
 tnew = pint.toa.make_fake_toas(f.model.FINISH.value, MJDmax, 50, f.model)
-    
+
 
 # %%
 # make fake models crossing from the last existing TOA to the start of new observations
@@ -70,14 +70,17 @@ dt = tnew.get_mjds() - f.model.PEPOCH.value * u.d
 
 # %%
 analytic = np.sqrt(
-            (f.model.F0.uncertainty * dt) ** 2
-            + (0.5 * f.model.F1.uncertainty * dt ** 2) ** 2
-        ).decompose()
+    (f.model.F0.uncertainty * dt) ** 2 + (0.5 * f.model.F1.uncertainty * dt ** 2) ** 2
+).decompose()
 
 # %%
 plt.plot(tnew.get_mjds(), dphase.std(axis=0), label="All Free")
 tnew.get_mjds() - f.model.PEPOCH.value * u.d
-plt.plot(tnew.get_mjds(),analytic,label="Analytic",)
+plt.plot(
+    tnew.get_mjds(),
+    analytic,
+    label="Analytic",
+)
 plt.xlabel("MJD")
 plt.ylabel("Phase Uncertainty (cycles)")
 plt.legend()

--- a/docs/examples/fit_NGC6440E.py
+++ b/docs/examples/fit_NGC6440E.py
@@ -65,7 +65,7 @@ print("RMS in phase is", f.resids.phase_resids.std())
 print("RMS in time is", f.resids.time_resids.std().to(u.us))
 
 # Show the parameter correlation matrix
-corm = f.get_correlation_matrix(pretty_print=True)
+corm = f.get_parameter_correlation_matrix(pretty_print=True)
 
 f.print_summary()
 

--- a/docs/examples/time_a_pulsar.py
+++ b/docs/examples/time_a_pulsar.py
@@ -75,7 +75,7 @@ print("RMS in time is", f.resids.time_resids.std().to(u.us))
 
 # %%
 # Show the parameter correlation matrix
-corm = f.get_correlation_matrix(pretty_print=True)
+corm = f.get_parameter_correlation_matrix(pretty_print=True)
 
 # %%
 f.print_summary()

--- a/docs/examples/understanding_fitters.py
+++ b/docs/examples/understanding_fitters.py
@@ -85,7 +85,7 @@ wlsfit.resids.model.has_correlated_errors
 
 # %%
 # You can request a pretty-printed covariance matrix
-cov = wlsfit.get_covariance_matrix(pretty_print=True)
+cov = wlsfit.get_parameter_covariance_matrix(pretty_print=True)
 
 # %%
 # plot() will make a plot of the post-fit residuals

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -67,6 +67,7 @@ import pint.utils
 from pint.models.parameter import AngleParameter, boolParameter, strParameter
 from pint.pint_matrix import (
     CovarianceMatrix,
+    CorrelationMatrix,
     CovarianceMatrixMaker,
     DesignMatrixMaker,
     combine_covariance_matrix,
@@ -1897,7 +1898,7 @@ class WLSFitter(Fitter):
             self.covariance_matrix = CovarianceMatrix(covariance_matrix, covariance_matrix_labels)
             
             # correlation matrix = 1s in diagonal, use for comparison to tempo/tempo2 cov matrix
-            self.correlation_matrix = CovarianceMatrix(sigma_cov, covariance_matrix_labels)
+            self.correlation_matrix = CorrelationMatrix(sigma_cov, covariance_matrix_labels)
             self.fac = fac
             self.errors = errors
 

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -658,10 +658,13 @@ class Fitter:
                     cm = self.parameter_correlation_matrix.matrix
                 else:
                     # exclude that
-                    # todo: restore original order?
-                    fps = self.parameter_correlation_matrix.get_all_label_names() - set(
-                        ["Offset"]
-                    )
+                    fps = [
+                        x
+                        for x in self.parameter_correlation_matrix.get_label_names(
+                            axis=0
+                        )
+                        if not x == "Offset"
+                    ]
                     new_matrix = self.parameter_correlation_matrix.get_label_matrix(fps)
                     return new_matrix.prettyprint(prec=prec)
             if pretty_print:

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -2330,9 +2330,7 @@ class WidebandTOAFitter(Fitter):  # Is GLSFitter the best here?
         else:
             raise ValueError("No method to access data error is provided.")
 
-    def scaled_all_sigma(
-        self,
-    ):
+    def scaled_all_sigma(self):
         """Scale all data's uncertainty.
 
         If the function of scaled_`data`_sigma is not given, it will just

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -578,7 +578,9 @@ class Fitter:
         """Return the model's design matrix for these TOAs."""
         return self.model.designmatrix(toas=self.toas, incfrozen=False, incoffset=True)
 
-    def get_parameter_covariance_matrix(self, with_phase=False, pretty_print=False, prec=3):
+    def get_parameter_covariance_matrix(
+        self, with_phase=False, pretty_print=False, prec=3
+    ):
         """Show the parameter covariance matrix post-fit.
 
         If with_phase, then show and return the phase column as well.
@@ -603,7 +605,9 @@ class Fitter:
                     # exclude that
                     fps = [
                         x
-                        for x in self.parameter_covariance_matrix.get_label_names(axis=0)
+                        for x in self.parameter_covariance_matrix.get_label_names(
+                            axis=0
+                        )
                         if not x == "Offset"
                     ]
                     new_matrix = self.parameter_covariance_matrix.get_label_matrix(fps)
@@ -629,7 +633,9 @@ class Fitter:
             log.error("You must run .fit_toas() before accessing the covariance matrix")
             raise AttributeError
 
-    def get_parameter_correlation_matrix(self, with_phase=False, pretty_print=False, prec=3):
+    def get_parameter_correlation_matrix(
+        self, with_phase=False, pretty_print=False, prec=3
+    ):
         """Show the parameter correlation matrix post-fit.
 
         If with_phase, then show and return the phase column as well.
@@ -653,7 +659,9 @@ class Fitter:
                 else:
                     # exclude that
                     # todo: restore original order?
-                    fps = self.parameter_correlation_matrix.get_all_label_names() - set(["Offset"])
+                    fps = self.parameter_correlation_matrix.get_all_label_names() - set(
+                        ["Offset"]
+                    )
                     new_matrix = self.parameter_correlation_matrix.get_label_matrix(fps)
                     return new_matrix.prettyprint(prec=prec)
             if pretty_print:
@@ -1147,7 +1155,9 @@ class DownhillFitter(Fitter):
         self.model = self.current_state.model
         self.resids = self.current_state.resids
         # TODO: make this CovarianceMatrix
-        self.parameter_covariance_matrix = self.current_state.parameter_covariance_matrix
+        self.parameter_covariance_matrix = (
+            self.current_state.parameter_covariance_matrix
+        )
         if isinstance(self.parameter_covariance_matrix, np.ndarray):
             self.errors = np.sqrt(np.diag(self.parameter_covariance_matrix))
             self.parameter_correlation_matrix = (
@@ -1255,9 +1265,7 @@ class WLSState(ModelState):
         for i, (param, unit) in enumerate(zip(params, units)):
             covariance_matrix_labels[param] = (i, i + 1, unit)
         # covariance matrix is 2D and symmetric
-        covariance_matrix_labels = [
-            covariance_matrix_labels
-            ] * 2
+        covariance_matrix_labels = [covariance_matrix_labels] * 2
         self.parameter_covariance_matrix_labels = covariance_matrix_labels
 
         # The delta-parameter values
@@ -1278,8 +1286,9 @@ class WLSState(ModelState):
         # The post-fit parameter covariance matrix
         #   Sigma = V s^-2 V^T
         Sigma = np.dot(self.Vt.T / (self.s ** 2), self.Vt)
-        return CovarianceMatrix((Sigma / self.fac).T / self.fac,
-                                self.parameter_covariance_matrix_labels)
+        return CovarianceMatrix(
+            (Sigma / self.fac).T / self.fac, self.parameter_covariance_matrix_labels
+        )
 
 
 class DownhillWLSFitter(DownhillFitter):
@@ -1340,9 +1349,7 @@ class GLSState(ModelState):
         for i, (param, unit) in enumerate(zip(params, units)):
             covariance_matrix_labels[param] = (i, i + 1, unit)
         # covariance matrix is 2D and symmetric
-        covariance_matrix_labels = [
-            covariance_matrix_labels
-            ] * 2
+        covariance_matrix_labels = [covariance_matrix_labels] * 2
         self.parameter_covariance_matrix_labels = covariance_matrix_labels
 
         residuals = self.resids.time_resids.to(u.s).value
@@ -1432,8 +1439,9 @@ class GLSState(ModelState):
         # make sure we compute the SVD
         self.step
         xvar = np.dot(self.Vt.T / self.s, self.Vt)
-        return CovarianceMatrix((xvar / self.norm).T / self.norm,
-                                self.parameter_covariance_matrix_labels)
+        return CovarianceMatrix(
+            (xvar / self.norm).T / self.norm, self.parameter_covariance_matrix_labels
+        )
 
 
 class DownhillGLSFitter(DownhillFitter):
@@ -2123,10 +2131,10 @@ class GLSFitter(Fitter):
             for i, (param, unit) in enumerate(zip(params, units)):
                 covariance_matrix_labels[param] = (i, i + 1, unit)
             # covariance matrix is 2D and symmetric
-            covariance_matrix_labels = [
-                covariance_matrix_labels
-            ] * covmat.ndim
-            self.parameter_covariance_matrix = CovarianceMatrix(covmat, covariance_matrix_labels)
+            covariance_matrix_labels = [covariance_matrix_labels] * covmat.ndim
+            self.parameter_covariance_matrix = CovarianceMatrix(
+                covmat, covariance_matrix_labels
+            )
             self.parameter_correlation_matrix = CorrelationMatrix(
                 (covmat / errs).T / errs, covariance_matrix_labels
             )
@@ -2302,7 +2310,9 @@ class WidebandTOAFitter(Fitter):  # Is GLSFitter the best here?
         else:
             raise ValueError("No method to access data error is provided.")
 
-    def scaled_all_sigma(self,):
+    def scaled_all_sigma(
+        self,
+    ):
         """Scale all data's uncertainty.
 
         If the function of scaled_`data`_sigma is not given, it will just
@@ -2471,10 +2481,10 @@ class WidebandTOAFitter(Fitter):  # Is GLSFitter the best here?
             for i, (param, unit) in enumerate(zip(params, units)):
                 covariance_matrix_labels[param] = (i, i + 1, unit)
             # covariance matrix is 2D and symmetric
-            covariance_matrix_labels = [
-                covariance_matrix_labels
-            ] * covmat.ndim
-            self.parameter_covariance_matrix = CovarianceMatrix(covmat, covariance_matrix_labels)
+            covariance_matrix_labels = [covariance_matrix_labels] * covmat.ndim
+            self.parameter_covariance_matrix = CovarianceMatrix(
+                covmat, covariance_matrix_labels
+            )
             self.parameter_correlation_matrix = CorrelationMatrix(
                 (covmat / errs).T / errs, covariance_matrix_labels
             )
@@ -2689,7 +2699,9 @@ class WidebandLMFitter(LMFitter):
                     log.debug(f"Unexpected parameter {p}")
             else:
                 pm.uncertainty = e * pm.units
-        self.parameter_correlation_matrix = (self.parameter_covariance_matrix / self.errors).T / self.errors
+        self.parameter_correlation_matrix = (
+            self.parameter_covariance_matrix / self.errors
+        ).T / self.errors
         self.update_model(state.chi2)
         # Compute the noise realizations if possible
         ntmpar = len(self.model.free_params)

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1174,20 +1174,11 @@ class DownhillFitter(Fitter):
         # collect results
         self.model = self.current_state.model
         self.resids = self.current_state.resids
-        # TODO: make this CovarianceMatrix
         self.parameter_covariance_matrix = (
             self.current_state.parameter_covariance_matrix
         )
-        if isinstance(self.parameter_covariance_matrix, np.ndarray):
-            self.errors = np.sqrt(np.diag(self.parameter_covariance_matrix))
-            self.parameter_correlation_matrix = (
-                self.parameter_covariance_matrix / self.errors
-            ).T / self.errors
-        elif isinstance(self.parameter_covariance_matrix, CovarianceMatrix):
-            self.errors = np.sqrt(np.diag(self.parameter_covariance_matrix.matrix))
-            self.parameter_correlation_matrix = (
-                self.parameter_covariance_matrix.matrix / self.errors
-            ).T / self.errors
+        self.errors = np.sqrt(np.diag(self.parameter_covariance_matrix.matrix))
+        self.parameter_correlation_matrix = self.parameter_covariance_matrix.to_correlation_matrix()
         for p, e in zip(self.current_state.params, self.errors):
             try:
                 log.debug(f"Setting {getattr(self.model, p)} uncertainty to {e}")

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -647,14 +647,14 @@ class Fitter:
                     cm = cm[1:, 1:]
             elif isinstance(self.parameter_correlation_matrix, CorrelationMatrix):
                 if with_phase:
-                    return self.correlation_matrix.prettyprint(prec=prec)
-                    fps = self.correlation_matrix.get_label_names(axis=0)
-                    cm = self.correlation_matrix.matrix
+                    return self.parameter_correlation_matrix.prettyprint(prec=prec)
+                    fps = self.parameter_correlation_matrix.get_label_names(axis=0)
+                    cm = self.parameter_correlation_matrix.matrix
                 else:
                     # exclude that
                     # todo: restore original order?
-                    fps = self.correlation_matrix.get_all_label_names() - set(["Offset"])
-                    new_matrix = self.correlation_matrix.get_label_matrix(fps)
+                    fps = self.parameter_correlation_matrix.get_all_label_names() - set(["Offset"])
+                    new_matrix = self.parameter_correlation_matrix.get_label_matrix(fps)
                     return new_matrix.prettyprint(prec=prec)
             if pretty_print:
                 lens = [max(len(fp) + 2, prec + 4) for fp in fps]

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -32,7 +32,7 @@ Fitters in use::
     PMRA                                   0                              mas / yr
     PMDEC                                  0                              mas / yr
     F0                               61.4855          61.485476554373(18) Hz
-    F1                            -1.181e-15            -1.1813(14)×10⁻¹⁵ Hz / s
+    F1                            -1.181e-15            -1.1813(14)x10-15 Hz / s
     PEPOCH                             53750                              d
     CORRECT_TROPOSPHERE                    N                              None
     PLANET_SHAPIRO                         N                              None

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -954,6 +954,14 @@ class Fitter:
         """
         self.model.set_param_uncertainties(fitp)
 
+    @property
+    def covariance_matrix(self):
+        warn(
+            "This parameter is deprecated. Use `parameter_covariance_matrix` instead of `covariance_matrix`",
+            category=DeprecationWarning,
+        )
+        return self.parameter_covariance_matrix
+
 
 class InvalidModelParameters(ValueError):
     pass
@@ -1010,10 +1018,11 @@ class ModelState:
     def parameter_covariance_matrix(self):
         raise NotImplementedError
 
+    @property
     def covariance_matrix(self):
-        warnings.warn(
-            "Use 'parameter_covariance_matrix' instead of 'covariance_matrix'",
-            DeprecationWarning,
+        warn(
+            "This parameter is deprecated.  Use `parameter_covariance_matrix` instead of `covariance_matrix`",
+            category=DeprecationWarning,
         )
         return self.parameter_covariance_matrix
 

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -2422,8 +2422,17 @@ class WidebandTOAFitter(Fitter):  # Is GLSFitter the best here?
             dpars = xhat / norm
             errs = np.sqrt(np.diag(xvar)) / norm
             covmat = (xvar / norm).T / norm
-            self.covariance_matrix = covmat
-            self.correlation_matrix = (covmat / errs).T / errs
+            # TODO: seems like doing this on every iteration is wasteful, and we should just do it once and then update the matrix
+            covariance_matrix_labels = {}
+            for i,(param,unit) in enumerate(zip(params,units)):
+                covariance_matrix_labels[param]= (i, i+1, unit)
+            # covariance matrix is 2D and symmetric
+            covariance_matrix_labels = [covariance_matrix_labels]*covariance_matrix.ndim
+            self.covariance_matrix = CovarianceMatrix(covmat, covariance_matrix_labels)
+            self.correlation_matrix = CorrelationMatrix((covmat / errs).T / errs, covariance_matrix_labels)
+
+            #self.covariance_matrix = covmat
+            #self.correlation_matrix = (covmat / errs).T / errs
 
             for ii, pn in enumerate(fitp.keys()):
                 uind = params.index(pn)  # Index of designmatrix

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1723,8 +1723,16 @@ class WidebandState(ModelState):
     def parameter_covariance_matrix(self):
         # make sure we compute the SVD
         xvar = np.dot(self.Vt.T / self.s, self.Vt)
-        # TODO: make this CovarianceMatrix?
-        return (xvar / self.norm).T / self.norm
+        # is this the best place to do this?
+        covariance_matrix_labels = {}
+        for i, (param, unit) in enumerate(zip(self.params, self.units)):
+            covariance_matrix_labels[param] = (i, i + 1, unit)
+        # covariance matrix is 2D and symmetric
+        covariance_matrix_labels = [covariance_matrix_labels] * 2
+
+        return CovarianceMatrix(
+            (xvar / self.norm).T / self.norm, covariance_matrix_labels
+        )
 
 
 class WidebandDownhillFitter(DownhillFitter):

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1178,7 +1178,9 @@ class DownhillFitter(Fitter):
             self.current_state.parameter_covariance_matrix
         )
         self.errors = np.sqrt(np.diag(self.parameter_covariance_matrix.matrix))
-        self.parameter_correlation_matrix = self.parameter_covariance_matrix.to_correlation_matrix()
+        self.parameter_correlation_matrix = (
+            self.parameter_covariance_matrix.to_correlation_matrix()
+        )
         for p, e in zip(self.current_state.params, self.errors):
             try:
                 log.debug(f"Setting {getattr(self.model, p)} uncertainty to {e}")

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1147,7 +1147,7 @@ class DownhillFitter(Fitter):
         self.model = self.current_state.model
         self.resids = self.current_state.resids
         # TODO: make this CovarianceMatrix
-        self.parameter_covariance_matrix = self.current_state.covariance_matrix
+        self.parameter_covariance_matrix = self.current_state.parameter_covariance_matrix
         if isinstance(self.parameter_covariance_matrix, np.ndarray):
             self.errors = np.sqrt(np.diag(self.parameter_covariance_matrix))
             self.parameter_correlation_matrix = (
@@ -1254,6 +1254,10 @@ class WLSState(ModelState):
         covariance_matrix_labels = {}
         for i, (param, unit) in enumerate(zip(params, units)):
             covariance_matrix_labels[param] = (i, i + 1, unit)
+        # covariance matrix is 2D and symmetric
+        covariance_matrix_labels = [
+            covariance_matrix_labels
+            ] * 2
         self.parameter_covariance_matrix_labels = covariance_matrix_labels
 
         # The delta-parameter values
@@ -1335,6 +1339,10 @@ class GLSState(ModelState):
         covariance_matrix_labels = {}
         for i, (param, unit) in enumerate(zip(params, units)):
             covariance_matrix_labels[param] = (i, i + 1, unit)
+        # covariance matrix is 2D and symmetric
+        covariance_matrix_labels = [
+            covariance_matrix_labels
+            ] * 2
         self.parameter_covariance_matrix_labels = covariance_matrix_labels
 
         residuals = self.resids.time_resids.to(u.s).value
@@ -1425,7 +1433,7 @@ class GLSState(ModelState):
         self.step
         xvar = np.dot(self.Vt.T / self.s, self.Vt)
         return CovarianceMatrix((xvar / self.norm).T / self.norm,
-                                self.parameter_covariance_labels)
+                                self.parameter_covariance_matrix_labels)
 
 
 class DownhillGLSFitter(DownhillFitter):
@@ -2117,7 +2125,7 @@ class GLSFitter(Fitter):
             # covariance matrix is 2D and symmetric
             covariance_matrix_labels = [
                 covariance_matrix_labels
-            ] * covariance_matrix.ndim
+            ] * covmat.ndim
             self.parameter_covariance_matrix = CovarianceMatrix(covmat, covariance_matrix_labels)
             self.parameter_correlation_matrix = CorrelationMatrix(
                 (covmat / errs).T / errs, covariance_matrix_labels
@@ -2465,7 +2473,7 @@ class WidebandTOAFitter(Fitter):  # Is GLSFitter the best here?
             # covariance matrix is 2D and symmetric
             covariance_matrix_labels = [
                 covariance_matrix_labels
-            ] * covariance_matrix.ndim
+            ] * covmat.ndim
             self.parameter_covariance_matrix = CovarianceMatrix(covmat, covariance_matrix_labels)
             self.parameter_correlation_matrix = CorrelationMatrix(
                 (covmat / errs).T / errs, covariance_matrix_labels

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -611,7 +611,8 @@ class Fitter:
                         if not x == "Offset"
                     ]
                     new_matrix = self.parameter_covariance_matrix.get_label_matrix(fps)
-                    return new_matrix.prettyprint(prec=prec)
+                    print(new_matrix.prettyprint(prec=prec))
+                    return new_matrix
             if pretty_print:
                 lens = [max(len(fp) + 2, prec + 8) for fp in fps]
                 maxlen = max(lens)

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1009,6 +1009,13 @@ class ModelState:
     def parameter_covariance_matrix(self):
         raise NotImplementedError
 
+    def covariance_matrix(self):
+        warnings.warn(
+            "Use 'parameter_covariance_matrix' instead of 'covariance_matrix'",
+            DeprecationWarning,
+        )
+        return self.parameter_covariance_matrix
+
     def predicted_chi2(self, step, lambda_):
         """Predict the chi2 after taking a step based on the linear approximation"""
         raise NotImplementedError

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -88,6 +88,10 @@ class PintMatrix:
         axis: int (optional)
             axis for the label lookup
 
+        Returns
+        -------
+        labels : list of label names for each dimension
+
         """
         labels = []
         if axis is None:
@@ -104,6 +108,10 @@ class PintMatrix:
 
     def get_all_label_names(self):
         """return all possible unique label names
+
+        Returns
+        -------
+        labels : set of unique label names across all dimensions
 
         TODO: preserve order?
         """
@@ -122,6 +130,11 @@ class PintMatrix:
             Name of the label.
         axis: int (optional)
             axis for the label lookup
+
+        Returns
+        -------
+        sizes : list of (start,stop) indices for the given label across each dimension
+
         """
         lb_sizes = []
         lbs = self.get_label(label, axis=axis)
@@ -142,6 +155,20 @@ class PintMatrix:
         return label_entry[1][0]
 
     def get_axis_labels(self, axis):
+        """Get the axis labels for the specified axis
+
+        Parameters
+        ----------
+        axis: int 
+            axis for the label lookup
+
+        Returns
+        -------
+        labels : list of (name, (start,stop,unit) for the given axis
+
+
+        TODO: does this just replicate self.axis_labels[axis]?  Is the sort meaningful?
+        """
         dim_label = list(self.axis_labels[axis].items())
         dim_label.sort(key=self._get_label_start)
         return dim_label
@@ -150,8 +177,19 @@ class PintMatrix:
         """Get the label entry and its dimension.
         If axis is specified, will only be along that axis
 
-        We assume the labels are unique in the matrix.
+        Parameters
+        ----------
+        label: str
+            label to lookup
+        axis: int, optional
+            axis for the label lookup
+
+        Returns
+        -------
+        labels : list of (name, axis, start,stop,unit) for the given label
         """
+
+        # We assume the labels are unique in the matrix.
         all_label = []
         for ii, dim in enumerate(self.axis_labels):
             if label in dim.keys():
@@ -181,7 +219,18 @@ class PintMatrix:
             )
 
     def get_label_slice(self, labels):
-        """Return the given label slices."""
+        """Return the given label slices.
+
+        Parameters
+        ----------
+        labels: list of str
+            labels to lookup
+
+        Returns
+        -------
+        slice, labels : slice into original matrix and labels of new (sliced) matrix
+
+        """
         dim_slices = dict([(d, slice(None)) for d in range(self.ndim)])
         new_labels = dict([(d, {}) for d in range(self.ndim)])
         for lb in labels:
@@ -200,7 +249,18 @@ class PintMatrix:
         return np.ix_(*list(dim_slices.values())), list(new_labels.values())
 
     def get_label_matrix(self, labels):
-        """Get a sub-matrix data according to the given labels."""
+        """Get a sub-matrix data according to the given labels.
+
+        Parameters
+        ----------
+        labels: list of str
+            labels to lookup
+
+        Returns
+        -------
+        PintMatrix : new matrix with only the specified labels
+
+        """
         slice, new_labels = self.get_label_slice(labels)
         return PintMatrix(self.matrix[slice], new_labels)
 

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -5,6 +5,7 @@ import numpy as np
 from itertools import combinations
 import astropy.units as u
 from collections import OrderedDict
+from warnings import warn
 import copy
 
 
@@ -236,6 +237,10 @@ class PintMatrix:
 
         DEPRECATED - use get_label(..., axis=axis)
         """
+        warn(
+            "This method is deprecated. Use `parameter_covariance_matrix.get_label(..., axis=axis)[0]` instead of `parameter_covariance_matrix.get_label_along_axis(...)",
+            category=DeprecationWarning,
+        )
         label_in_one_axis = self.axis_labels[axis]
         if label_name in label_in_one_axis.keys():
             return (label_name, axis) + label_in_one_axis[label_name]

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -183,8 +183,6 @@ class PintMatrix:
         -------
         labels : list of (name, (start,stop,unit) for the given axis
 
-
-        TODO: does this just replicate self.axis_labels[axis]?  Is the sort meaningful?
         """
         dim_label = list(self.axis_labels[axis].items())
         dim_label.sort(key=self._get_label_start)

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -155,7 +155,7 @@ class PintMatrix:
     def match_labels_along_axis(self, pint_matrix, axis):
         """Match one axis' labels index between the current matrix and input pint matrix.
 
-        The labels will be matched along axises, not cross the axises.
+        The labels will be matched along axes, not cross the axes.
 
         Parameters
         ----------
@@ -197,7 +197,7 @@ class DesignMatrix(PintMatrix):
     matrix : `numpy.ndarray`
         Design matrix values.
     axis_labels : list of dictionary
-        The labels of the axises. Each list element contains the names and
+        The labels of the axes. Each list element contains the names and
         indices of the labels for the dimension.
         [{dim0_label0: (start, end, unit), dim0_label1:(start, end, unit)},{dim1_label0:...}]
         The start and end follows the python slice convention (i.e.,

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -258,11 +258,11 @@ class PintMatrix:
 
         Returns
         -------
-        PintMatrix : new matrix with only the specified labels
+        PintMatrix : new matrix with only the specified labels (or relevant subclass)
 
         """
         slice, new_labels = self.get_label_slice(labels)
-        return PintMatrix(self.matrix[slice], new_labels)
+        return self.__class__(self.matrix[slice], new_labels)
 
     def match_labels_along_axis(self, pint_matrix, axis):
         """Match one axis' labels index between the current matrix and input pint matrix.

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -52,10 +52,19 @@ class PintMatrix:
         self._check_index_overlap()
 
     def __getitem__(self, key):
-        return self.matrix[key]
+        """
+        Allow normal array indexing of covariance matrices.
 
-    def __setitem__(self, key, value):
-        self.matrix[key] = value
+        Parameters
+        ----------
+        key : any index into an array (int, slice, etc)
+
+
+        Returns
+        -------
+        values : covariance matrix values
+        """
+        return self.matrix[key]
 
     @property
     def ndim(self):
@@ -80,8 +89,8 @@ class PintMatrix:
         return units
 
     def get_label_names(self, axis=None):
-        """return only the names of the labels
-        along the specified axis if requested
+        """Return only the names of the labels
+        along the specified axis if requested.
 
         Parameters
         ----------
@@ -90,7 +99,7 @@ class PintMatrix:
 
         Returns
         -------
-        labels : list of label names for each dimension
+        labels : list of label names for all dimensions, or just along the specified axis
 
         """
         labels = []
@@ -106,8 +115,8 @@ class PintMatrix:
             labels.append([x[0] for x in self.get_axis_labels(dim)])
         return labels
 
-    def get_all_label_names(self):
-        """return all possible unique label names
+    def get_unique_label_names(self):
+        """Return all unique label names (there may be duplications between axes).
 
         Returns
         -------
@@ -122,7 +131,7 @@ class PintMatrix:
         return set(unique_labels)
 
     def get_label_size(self, label, axis=None):
-        """Get the size of the a label for all axes, or just the specified
+        """Get the size of the a label for all axes, or just the specified axis.
 
         Parameters
         ----------
@@ -673,9 +682,7 @@ class CovarianceMatrix(PintMatrix):
 
     def prettyprint(self, prec=3, coordinatefirst=False):
         """
-        prettyprint(self, prec=3, coordinatefirst=False)
-
-        return a version of the array formatted for printing (with labels etc)
+        Return a version of the array formatted for printing (with labels etc).
 
         Parameters
         ----------
@@ -687,7 +694,7 @@ class CovarianceMatrix(PintMatrix):
         Return
         ------
             str : matrix formatted for printing
-        
+
         """
 
         fps = self.get_label_names(axis=0)

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -159,7 +159,7 @@ class PintMatrix:
 
         Parameters
         ----------
-        axis: int 
+        axis: int
             axis for the label lookup
 
         Returns

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -54,7 +54,7 @@ class PintMatrix:
 
     def __getitem__(self, key):
         raise NotImplementedError(
-            f"Cannot access elements of {self.__class__} directly.  Use `get_label_matrix()` method to access via parameter name, or `matrix` property."
+            f"Cannot access elements of '{self.__class__}' directly.  Use `get_label_matrix()` method to access via parameter name, or `matrix` property."
         )
 
     @property

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -782,11 +782,7 @@ class CovarianceMatrix(PintMatrix):
         """
         errors = np.sqrt((self.diag()))
 
-        return CorrelationMatrix(
-            (self.matrix / errors).T / errors,
-            self.axis_labels,
-            )
-
+        return CorrelationMatrix((self.matrix / errors).T / errors, self.axis_labels)
 
 
 class CorrelationMatrix(CovarianceMatrix):

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -51,6 +51,12 @@ class PintMatrix:
         # Check label index overlap TODO: should we allow overlap?
         self._check_index_overlap()
 
+    def __getitem__(self, key):
+        return self.matrix[key]
+
+    def __setitem__(self, key, value):
+        self.matrix[key] = value
+
     @property
     def ndim(self):
         return self.matrix.ndim

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -88,6 +88,23 @@ class PintMatrix:
             units.append(self.get_axis_labels(dim))
         return units
 
+    def diag(self, k=0):
+        """
+        Extract a diagonal.
+
+        Parameters
+        ----------
+        k: int (optional)
+            Diagonal in question. The default is 0. Use k>0 for diagonals above the main diagonal, and k<0 for diagonals below the main diagonal.            
+
+        Returns
+        -------
+        out : ndarray
+            The extracted diagonal.
+
+        """
+        return np.diag(self.matrix, k=k)
+
     def get_label_names(self, axis=None):
         """Return only the names of the labels
         along the specified axis if requested.
@@ -753,6 +770,23 @@ class CovarianceMatrix(PintMatrix):
 
     def __repr__(self):
         return self.prettyprint()
+
+    def to_correlation_matrix(self):
+        """
+        Convert a covariance matrix to a correlation matrix.  Extract the diagonal elements to use as the uncertainties, and divide through by those values.
+
+        Return
+        ------
+            correlation : `CorrelationMatrix`
+
+        """
+        errors = np.sqrt((self.diag()))
+
+        return CorrelationMatrix(
+            (self.matrix / errors).T / errors,
+            self.axis_labels,
+            )
+
 
 
 class CorrelationMatrix(CovarianceMatrix):

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -700,6 +700,8 @@ class CovarianceMatrix(PintMatrix):
                 offsetfirst = False
             if ("RAJ" in fps) and ("DECJ" in fps):
                 coordinates = ["RAJ", "DECJ"]
+            elif ("ELONG" in fps) and ("ELAT" in fps):
+                coordinates = ["ELONG", "ELAT"]
                 # TODO: allow for other coordinates
             if not (
                 (fps.index(coordinates[0]) == (0 + int(offsetfirst)))

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -53,7 +53,9 @@ class PintMatrix:
         self._check_index_overlap()
 
     def __getitem__(self, key):
-        raise NotImplementedError
+        raise NotImplementedError(
+            f"Cannot access elements of {self.__class__} directly.  Use `get_label_matrix()` method to access via parameter name, or `matrix` property."
+        )
 
     @property
     def ndim(self):

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -75,7 +75,14 @@ class PintMatrix:
 
     def get_label_names(self, axis=None):
         """return only the names of the labels
-        along the specified axis if requested"""
+        along the specified axis if requested
+
+        Parameters
+        ----------
+        axis: int (optional)
+            axis for the label lookup
+
+        """
         labels = []
         if axis is None:
             r = range(len(self.axis_labels))
@@ -90,23 +97,28 @@ class PintMatrix:
         return labels
 
     def get_all_label_names(self):
-        """return all possible unique label names"""
+        """return all possible unique label names
+
+        TODO: preserve order?
+        """
         labels = self.get_label_names()
         unique_labels = []
         for l in labels:
             unique_labels += l
         return set(unique_labels)
 
-    def get_label_size(self, label):
-        """Get the size of the a label in each axis.
+    def get_label_size(self, label, axis=None):
+        """Get the size of the a label for all axes, or just the specified
 
         Parameters
         ----------
         label: str
             Name of the label.
+        axis: int (optional)
+            axis for the label lookup
         """
         lb_sizes = []
-        lbs = self.get_label(label)
+        lbs = self.get_label(label, axis=axis)
         for ii, lb in enumerate(lbs):
             size = lb[3] - lb[2]
             lb_sizes.append((ii, size))

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -12,6 +12,7 @@ __all__ = [
     "PintMatrix",
     "DesignMatrix",
     "CovarianceMatrix",
+    "CorrelationMatrix",
     "combine_design_matrices_by_quantity",
     "combine_design_matrices_by_param",
 ]
@@ -581,6 +582,8 @@ def combine_design_matrices_by_param(matrix1, matrix2, padding=0.0):
 class CovarianceMatrix(PintMatrix):
     """A class for symmetric covariance matrix."""
 
+    matrix_type = "covariance"
+
     def __init__(self, matrix, labels):
         # Check if the covariance matrix is symmetric.
         if matrix.shape[0] != matrix.shape[1]:
@@ -595,7 +598,7 @@ class CovarianceMatrix(PintMatrix):
         cm = self.matrix
         lens = [max(len(fp) + 2, prec + 8) for fp in fps]
         maxlen = max(lens)
-        sout = "\nParameter covariance matrix:"
+        sout = "\nParameter {} matrix:\n".format(self.matrix_type)
         line = "{0:^{width}}".format("", width=maxlen)
         for fp, ln in zip(fps, lens):
             line += "{0:^{width}}".format(fp, width=ln)
@@ -610,6 +613,12 @@ class CovarianceMatrix(PintMatrix):
 
     def __repr__(self):
         return self.prettyprint()
+
+
+class CorrelationMatrix(CovarianceMatrix):
+    """A class for symmetric correlation matrix."""
+
+    matrix_type = "correlation"
 
 
 class CovarianceMatrixMaker:

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -53,19 +53,7 @@ class PintMatrix:
         self._check_index_overlap()
 
     def __getitem__(self, key):
-        """
-        Allow normal array indexing of covariance matrices.
-
-        Parameters
-        ----------
-        key : any index into an array (int, slice, etc)
-
-
-        Returns
-        -------
-        values : covariance matrix values
-        """
-        return self.matrix[key]
+        raise NotImplementedError
 
     @property
     def ndim(self):

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -923,12 +923,12 @@ def dmxparse(fitter, save=False):
         DMX_keys_ma = None
 
     # Make sure that the fitter has a covariance matrix, otherwise return the initial values
-    if hasattr(fitter, "covariance_matrix"):
+    if hasattr(fitter, "parameter_covariance_matrix"):
         # now get the full parameter covariance matrix from pint
         # NOTE: we will need to increase all indices by 1 to account for the 'Offset' parameter
         # that is the first index of the designmatrix
         params = np.array(fitter.model.free_params)
-        p_cov_mat = fitter.covariance_matrix
+        p_cov_mat = fitter.parameter_covariance_matrix
         # Now we get the indices that correspond to the DMX values
         DMX_p_idxs = np.zeros(len(dmx_epochs), dtype=int)
         for ii in range(len(dmx_epochs)):

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1199,6 +1199,11 @@ def mass_funct2(mp, mc, i):
     i : Angle
         Inclination angle, in u.deg or u.rad
 
+    Returns
+    -------
+    f_m : Quantity
+        Mass function in solar masses
+
     Notes
     -----
     Inclination is such that edge on is `i = 90*u.deg`

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1562,8 +1562,8 @@ def remove_dummy_distance(c):
 
 def calculate_random_models(fitter, toas, Nmodels=100, keep_models=True, params="all"):
     """
-    calculates random models based on the covariance matrix of the `fitter` object
-    
+    Calculates random models based on the covariance matrix of the `fitter` object.
+
     returns the new phase differences compared to the original model
     optionally returns all of the random models
 
@@ -1588,8 +1588,10 @@ def calculate_random_models(fitter, toas, Nmodels=100, keep_models=True, params=
         list of random models (each is a `pint.models.timing_model.TimingModel`)
 
 
-    Note: to calculate new TOAs, you can do:
-        tnew = pint.toa.make_fake_toas(MJDmin, MJDmax, Ntoa, model=fitter.model)
+    Note
+    ----
+    To calculate new TOAs, you can do:
+        `tnew = pint.toa.make_fake_toas(MJDmin, MJDmax, Ntoa, model=fitter.model)`
     or similar
     """
     Nmjd = len(toas)

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -3,6 +3,7 @@ import re
 from contextlib import contextmanager
 from copy import deepcopy
 from io import StringIO
+from collections import OrderedDict
 
 import astropy.constants as const
 import astropy.coordinates as coords
@@ -1557,3 +1558,81 @@ def remove_dummy_distance(c):
             "Do not know coordinate frame for %r: returning coordinates unchanged" % c
         )
         return c
+
+
+def calculate_phase_uncertainties(fitter, toas, Nmodels=100, keep_models=True):
+    """
+    calculates random models based on the covariance matrix of the `fitter` object
+    
+    returns the new phase differences compared to the original model
+    optionally returns all of the random models
+
+    Parameters
+    ----------
+    fitter: `pint.fitter` object
+        current fitter object containing a model and parameter covariance matrix
+    toas: `pint.toa.TOAs` object
+        TOAs to calculate models
+    Nmodels: int (optional)
+        number of random models to calculate
+    keep_models: bool (optional)
+        whether to keep and return the individual random models (slower)
+
+    Returns
+    -------
+    dphase : np.ndarray
+        phase difference with respect to input model, size is [Nmodels, len(toas)]
+    random_models : list (optional)
+        list of random models (each is a `pint.models.timing_model.TimingModel`)
+
+
+    Note: to calculate new TOAs, you can do:
+        tnew = pint.toa.make_fake_toas(MJDmin, MJDmax, Ntoa, model=fitter.model)
+    or similar
+    """
+    Nmjd = len(toas)
+    phases_i = np.zeros((Nmodels, Nmjd))
+    phases_f = np.zeros((Nmodels, Nmjd))
+
+    cov_matrix = fitter.parameter_covariance_matrix
+    # this is a list of the parameter names in the order they appear in the coviarance matrix
+    param_names = cov_matrix.get_label_names(axis=0)
+    # this is a dictionary with the parameter values, but it might not be in the same order
+    # and it leaves out the Offset parameter
+    params = fitter.model.get_params_dict("free", "value")
+    mean_vector = np.array([params[x] for x in param_names if not x == "Offset"])
+    # remove the first column and row (absolute phase)
+    if param_names[0] == "Offset":
+        cov_matrix = cov_matrix.get_label_matrix(param_names[1:])
+        fac = fitter.fac[1:]
+        param_names = param_names[1:]
+    else:
+        fac = fitter.fac
+
+    f_rand = deepcopy(fitter)
+
+    # scale by fac
+    mean_vector = mean_vector * fac
+    scaled_cov_matrix = ((cov_matrix.matrix * fac).T * fac).T
+    random_models = []
+    for imodel in range(Nmodels):
+        # create a set of randomized parameters based on mean vector and covariance matrix
+        rparams_num = np.random.multivariate_normal(mean_vector, scaled_cov_matrix)
+        # scale params back to real units
+        for j in range(len(mean_vector)):
+            rparams_num[j] /= fac[j]
+        rparams = OrderedDict(zip(param_names, rparams_num))
+        f_rand.set_params(rparams)
+        phase = f_rand.model.phase(toas, abs_phase=True)
+        phases_i[imodel] = phase.int
+        phases_f[imodel] = phase.frac
+        if keep_models:
+            random_models.append(f_rand.model)
+            f_rand = deepcopy(fitter)
+    phases = phases_i + phases_f
+    phases0 = fitter.model.phase(toas, abs_phase=True)
+    dphase = phases - (phases0.int + phases0.frac)
+    if keep_models:
+        return dphase, random_models
+    else:
+        return dphase

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1560,9 +1560,7 @@ def remove_dummy_distance(c):
         return c
 
 
-def calculate_phase_uncertainties(
-    fitter, toas, Nmodels=100, keep_models=True, params="all"
-):
+def calculate_random_models(fitter, toas, Nmodels=100, keep_models=True, params="all"):
     """
     calculates random models based on the covariance matrix of the `fitter` object
     

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -414,7 +414,7 @@ def show_param_cov_matrix(matrix, params, name="Covariance Matrix", switchRD=Fal
     """
 
     warn(
-        "This method is deprecated. Use `parameter_covariance_matrix.prettyprint()` instead of `show_param_cov_matrix()`"
+        "This method is deprecated. Use `parameter_covariance_matrix.prettyprint()` instead of `show_param_cov_matrix()`",
         category=DeprecationWarning,
     )
 

--- a/tests/test_parametercovariancematrix.py
+++ b/tests/test_parametercovariancematrix.py
@@ -1,0 +1,162 @@
+import numpy as np
+import os
+import unittest
+from os.path import join
+
+import astropy.units as u
+import pytest
+from pinttestdata import datadir
+
+import pint
+from pint.fitter import (
+    DownhillGLSFitter,
+    DownhillWLSFitter,
+    GLSFitter,
+    WLSFitter,
+    WidebandDownhillFitter,
+    WidebandTOAFitter,
+)
+from pint.models.model_builder import get_model
+from pint.toa import get_TOAs, make_fake_toas
+
+
+@pytest.fixture
+def wls():
+    m = get_model(join(datadir, "NGC6440E.par"))
+    t = get_TOAs(join(datadir, "NGC6440E.tim"), ephem="DE421")
+
+    wls = WLSFitter(t, m)
+    wls.fit_toas()
+
+    return wls
+
+
+@pytest.fixture
+def wb():
+    m = get_model(join(datadir, "NGC6440E.par"))
+    t = make_fake_toas(55000, 58000, 20, model=m, freq=1400 * u.MHz, dm=10 * pint.dmu)
+
+    wb = WidebandTOAFitter(t, m)
+    wb.fit_toas()
+
+    return wb
+
+
+def test_wls_covmatrix(wls):
+    uncertainties = wls.model.get_params_dict("free", "uncertainty")
+    for param in uncertainties:
+        # uncertainty based on the diagonals of the covariance matrix
+        matrix_uncertainty = np.sqrt(
+            wls.parameter_covariance_matrix.get_label_matrix([param]).matrix[0, 0]
+        )
+        if param in ["RAJ", "DECJ"]:
+            # then uncertainties are in arcsec, need to convert
+            factor = 3600
+        else:
+            factor = 1
+        assert np.isclose(uncertainties[param] / factor, matrix_uncertainty)
+
+
+def test_gls_covmatrix(wls):
+    gls = GLSFitter(wls.toas, wls.model_init)
+    gls.fit_toas()
+
+    assert np.isclose(
+        wls.parameter_covariance_matrix.matrix, gls.parameter_covariance_matrix.matrix
+    ).all()
+
+    uncertainties = gls.model.get_params_dict("free", "uncertainty")
+    for param in uncertainties:
+        # uncertainty based on the diagonals of the covariance matrix
+        matrix_uncertainty = np.sqrt(
+            gls.parameter_covariance_matrix.get_label_matrix([param]).matrix[0, 0]
+        )
+        if param in ["RAJ", "DECJ"]:
+            # then uncertainties are in arcsec, need to convert
+            factor = 3600
+        else:
+            factor = 1
+        assert np.isclose(uncertainties[param] / factor, matrix_uncertainty)
+
+
+def test_downhillwls_covmatrix(wls):
+    dh_wls = DownhillWLSFitter(wls.toas, wls.model_init)
+    dh_wls.fit_toas()
+
+    assert np.isclose(
+        wls.parameter_covariance_matrix.matrix,
+        dh_wls.parameter_covariance_matrix.matrix,
+    ).all()
+
+    uncertainties = dh_wls.model.get_params_dict("free", "uncertainty")
+    for param in uncertainties:
+        # uncertainty based on the diagonals of the covariance matrix
+        matrix_uncertainty = np.sqrt(
+            dh_wls.parameter_covariance_matrix.get_label_matrix([param]).matrix[0, 0]
+        )
+        if param in ["RAJ", "DECJ"]:
+            # then uncertainties are in arcsec, need to convert
+            factor = 3600
+        else:
+            factor = 1
+        assert np.isclose(uncertainties[param] / factor, matrix_uncertainty)
+
+
+def test_downhillgls_covmatrix(wls):
+    dh_gls = DownhillGLSFitter(wls.toas, wls.model_init)
+    dh_gls.fit_toas()
+
+    assert np.isclose(
+        wls.parameter_covariance_matrix.matrix,
+        dh_gls.parameter_covariance_matrix.matrix,
+    ).all()
+
+    uncertainties = dh_gls.model.get_params_dict("free", "uncertainty")
+    for param in uncertainties:
+        # uncertainty based on the diagonals of the covariance matrix
+        matrix_uncertainty = np.sqrt(
+            dh_gls.parameter_covariance_matrix.get_label_matrix([param]).matrix[0, 0]
+        )
+        if param in ["RAJ", "DECJ"]:
+            # then uncertainties are in arcsec, need to convert
+            factor = 3600
+        else:
+            factor = 1
+        assert np.isclose(uncertainties[param] / factor, matrix_uncertainty)
+
+
+def test_wb_covmatrix(wb):
+    uncertainties = wb.model.get_params_dict("free", "uncertainty")
+    for param in uncertainties:
+        # uncertainty based on the diagonals of the covariance matrix
+        matrix_uncertainty = np.sqrt(
+            wb.parameter_covariance_matrix.get_label_matrix([param]).matrix[0, 0]
+        )
+        if param in ["RAJ", "DECJ"]:
+            # then uncertainties are in arcsec, need to convert
+            factor = 3600
+        else:
+            factor = 1
+        assert np.isclose(uncertainties[param] / factor, matrix_uncertainty)
+
+
+def test_downhillwb_covmatrix(wb):
+    dwb = WidebandDownhillFitter(wb.toas, wb.model_init)
+    dwb.fit_toas()
+
+    assert np.isclose(
+        wb.parameter_covariance_matrix.matrix, dwb.parameter_covariance_matrix.matrix,
+    ).all()
+
+    uncertainties = dwb.model.get_params_dict("free", "uncertainty")
+    for param in uncertainties:
+        # uncertainty based on the diagonals of the covariance matrix
+        matrix_uncertainty = np.sqrt(
+            dwb.parameter_covariance_matrix.get_label_matrix([param]).matrix[0, 0]
+        )
+        if param in ["RAJ", "DECJ"]:
+            # then uncertainties are in arcsec, need to convert
+            factor = 3600
+        else:
+            factor = 1
+        assert np.isclose(uncertainties[param] / factor, matrix_uncertainty)

--- a/tests/test_random_models.py
+++ b/tests/test_random_models.py
@@ -18,10 +18,10 @@ from pint import utils
 
 
 def test_random_models():
-
     # Get model and TOAs
-    m, t = get_model_and_toas(os.path.join(datadir, "NGC6440E.par"),
-                              os.path.join(datadir, "NGC6440E.tim"))
+    m, t = get_model_and_toas(
+        os.path.join(datadir, "NGC6440E.par"), os.path.join(datadir, "NGC6440E.tim")
+    )
 
     f = fitter.WLSFitter(toas=t, model=m)
     # Do a 4-parameter fit

--- a/tests/test_random_models.py
+++ b/tests/test_random_models.py
@@ -59,6 +59,7 @@ def test_random_models():
     assert dphase_F.std(axis=0).max() < dphase.std(axis=0).max()
 
     # make a plot (if we can)
+    dt = tnew.get_mjds() - f.model.PEPOCH.value * u.d
     plt.close()
     p1 = plt.plot(tnew.get_mjds(), dphase.std(axis=0), label="All Free")
     p2 = plt.plot(tnew.get_mjds(), dphase_F.std(axis=0), label="F0 free")

--- a/tests/test_random_models.py
+++ b/tests/test_random_models.py
@@ -61,7 +61,7 @@ def test_random_models():
     # make a plot (if we can)
     plt.close()
     p1 = plt.plot(tnew.get_mjds(), dphase.std(axis=0), label="All Free")
-    p2 = plt.plot(tnew.get_mjds(), dphase_F.std(axis=0), label="F0/F1 free")
+    p2 = plt.plot(tnew.get_mjds(), dphase_F.std(axis=0), label="F0 free")
     dt = tnew.get_mjds() - f.model.PEPOCH.value * u.d
     p3 = plt.plot(
         tnew.get_mjds(),

--- a/tests/test_random_models.py
+++ b/tests/test_random_models.py
@@ -1,0 +1,76 @@
+#! /usr/bin/env python
+import os
+from copy import deepcopy
+
+# import matplotlib
+# matplotlib.use('TKAgg')
+import matplotlib.pyplot as plt
+import pytest
+import numpy as np
+import astropy.units as u
+
+import pint.models as tm
+from pint import fitter, toa
+from pinttestdata import datadir
+import pint.models.parameter as param
+from pint import ls
+from pint import utils
+
+
+@pytest.mark.skipif(
+    "DISPLAY" not in os.environ, reason="Needs an X server, xvfb counts"
+)
+def test_random_models():
+    # taken from test_fitter.py/test_fitter()
+    # Get model
+
+    m = tm.get_model(os.path.join(datadir, "NGC6440E.par"))
+
+    # Get TOAs
+    t = toa.TOAs(os.path.join(datadir, "NGC6440E.tim"))
+    t.apply_clock_corrections(include_bipm=False)
+    t.compute_TDBs()
+    try:
+        planet_ephems = m.PLANET_SHAPIRO.value
+    except AttributeError:
+        planet_ephems = False
+    t.compute_posvels(planets=planet_ephems)
+
+    f = fitter.WLSFitter(toas=t, model=m)
+    # Do a 4-parameter fit
+    f.model.free_params = ("F0", "F1", "RAJ", "DECJ")
+    f.fit_toas()
+
+    # this contains TOAs up through 54200
+    # make new ones starting there
+    tnew = toa.make_fake_toas(54200, 59000, 59000 - 54200, f.model)
+    dphase, mrand = utils.calculate_random_models(f, tnew, Nmodels=100)
+
+    # this is a bit stochastic, but I see typically < 0.14 cycles
+    # for the uncertainty at 59000
+    assert np.all(dphase.std(axis=0) < 0.2)
+
+    # redo it with only F0 free
+    dphase_F, mrand_F = utils.calculate_random_models(
+        f, tnew, Nmodels=100, params=["F0"]
+    )
+
+    # this should be less than the fully free version
+    assert dphase_F.std(axis=0).max() < dphase.std(axis=0).max()
+
+    # make a plot (if we can)
+    plt.close()
+    p1 = plt.plot(tnew.get_mjds(), dphase.std(axis=0), label="All Free")
+    p2 = plt.plot(tnew.get_mjds(), dphase_F.std(axis=0), label="F0/F1 free")
+    dt = tnew.get_mjds() - f.model.PEPOCH.value * u.d
+    p3 = plt.plot(
+        tnew.get_mjds(),
+        np.sqrt(
+            (f.model.F0.uncertainty * dt) ** 2
+            + (0.5 * f.model.F1.uncertainty * dt ** 2) ** 2
+        ).decompose(),
+        label="Analytic",
+    )
+    plt.xlabel("MJD")
+    plt.ylabel("Phase Uncertainty (cycles)")
+    plt.legend()

--- a/tests/test_random_models.py
+++ b/tests/test_random_models.py
@@ -9,7 +9,7 @@ import pytest
 import numpy as np
 import astropy.units as u
 
-import pint.models as tm
+from pint.models import get_model, get_model_and_toas
 from pint import fitter, toa
 from pinttestdata import datadir
 import pint.models.parameter as param
@@ -18,20 +18,10 @@ from pint import utils
 
 
 def test_random_models():
-    # taken from test_fitter.py/test_fitter()
-    # Get model
 
-    m = tm.get_model(os.path.join(datadir, "NGC6440E.par"))
-
-    # Get TOAs
-    t = toa.TOAs(os.path.join(datadir, "NGC6440E.tim"))
-    t.apply_clock_corrections(include_bipm=False)
-    t.compute_TDBs()
-    try:
-        planet_ephems = m.PLANET_SHAPIRO.value
-    except AttributeError:
-        planet_ephems = False
-    t.compute_posvels(planets=planet_ephems)
+    # Get model and TOAs
+    m, t = get_model_and_toas(os.path.join(datadir, "NGC6440E.par"),
+                              os.path.join(datadir, "NGC6440E.tim"))
 
     f = fitter.WLSFitter(toas=t, model=m)
     # Do a 4-parameter fit

--- a/tests/test_random_models.py
+++ b/tests/test_random_models.py
@@ -17,9 +17,6 @@ from pint import ls
 from pint import utils
 
 
-@pytest.mark.skipif(
-    "DISPLAY" not in os.environ, reason="Needs an X server, xvfb counts"
-)
 def test_random_models():
     # taken from test_fitter.py/test_fitter()
     # Get model
@@ -57,21 +54,3 @@ def test_random_models():
 
     # this should be less than the fully free version
     assert dphase_F.std(axis=0).max() < dphase.std(axis=0).max()
-
-    # make a plot (if we can)
-    dt = tnew.get_mjds() - f.model.PEPOCH.value * u.d
-    plt.close()
-    p1 = plt.plot(tnew.get_mjds(), dphase.std(axis=0), label="All Free")
-    p2 = plt.plot(tnew.get_mjds(), dphase_F.std(axis=0), label="F0 free")
-    dt = tnew.get_mjds() - f.model.PEPOCH.value * u.d
-    p3 = plt.plot(
-        tnew.get_mjds(),
-        np.sqrt(
-            (f.model.F0.uncertainty * dt) ** 2
-            + (0.5 * f.model.F1.uncertainty * dt ** 2) ** 2
-        ).decompose(),
-        label="Analytic",
-    )
-    plt.xlabel("MJD")
-    plt.ylabel("Phase Uncertainty (cycles)")
-    plt.legend()


### PR DESCRIPTION
This is still a WIP, but I wanted to get in a PR for the next PINT meeting.  Major changes:
* Most of the fitters now use the `CovarianceMatrix` class to preserve parameter order along with the matrix
* Some UI changes for that class (or `PintMatrix` class), mostly to simplify, a couple to extend use
* Renamed `fitter.covariance_matrix` to `fitter.parameter_covariance_matrix` to make it clear which is which (and changed other calls, tests, examples)
* Implemented new random model (`utils/calculate_random_models`) to generate random models using parameter covariance matrix
* tests for the above, plus a worked example (`examples/check_phase_connection.py`)

Still TBD:
* check that this works OK with all fitters (tests pass, not sure if other checks are needed)
* check that matrix metadata is not needlessly regenerated (parameter labels are redone on every step for some fitters, but maybe this is needed)
* I made `fitter.covariance_matrix` redirect to `fitter.parameter_covariance_matrix` for compatibility along with a deprecation warning, but I don't get the warning.  So maybe I did it wrong, and maybe we don't want this at all.