### PR TITLE
Add observatories from tempo2's observatories.dat

### DIFF
--- a/src/pint/observatory/__init__.py
+++ b/src/pint/observatory/__init__.py
@@ -136,6 +136,7 @@ class Observatory:
         # We can't do this in the import section above because this class
         # needs to exist before that file is imported.
         import pint.observatory.observatories  # noqa
+        import pint.observatory.special_locations  # noqa
 
         if name == "":
             raise KeyError("No observatory name or code provided")

--- a/src/pint/observatory/__init__.py
+++ b/src/pint/observatory/__init__.py
@@ -1,9 +1,12 @@
 import os
 import textwrap
 from collections import defaultdict
+from io import StringIO
 
 import astropy.constants as const
+import astropy.coordinates
 import astropy.units as u
+import numpy as np
 from astropy import log
 from astropy.coordinates import EarthLocation
 
@@ -11,15 +14,18 @@ import pint.solar_system_ephemerides as sse
 from pint.pulsar_mjd import Time
 from pint.utils import interesting_lines
 
-import astropy.coordinates
-
 # Include any files that define observatories here.  This will start
 # with the standard distribution files, then will read any system- or
 # user-defined files.  These can override the default settings by
 # redefining an Observatory with the same name.
 # TODO read the files from the other locations, if they exist
 
-__all__ = ["Observatory", "get_observatory", "parse_t2_observatories_dat"]
+__all__ = [
+    "Observatory",
+    "get_observatory",
+    "compare_t2_observatories_dat",
+    "compare_tempo_obsys_dat",
+]
 
 # The default BIPM to use if not explicitly specified
 # This should be the most recent BPIM file in the datafiles directory
@@ -120,14 +126,19 @@ class Observatory:
     @classmethod
     def get(cls, name):
         """Returns the Observatory instance for the specified name/alias.
+
         If the name has not been defined, an error will be raised.  Aside
         from the initial observatory definitions, this is in general the
         only way Observatory objects should be accessed.  Name-matching
-        is case-insensitive."""
+        is case-insensitive.
+        """
         # Ensure that the observatory list has been read
         # We can't do this in the import section above because this class
         # needs to exist before that file is imported.
         import pint.observatory.observatories  # noqa
+
+        if name == "":
+            raise KeyError("No observatory name or code provided")
 
         # Be case-insensitive
         name = name.lower()
@@ -324,19 +335,25 @@ def get_observatory(
     return site
 
 
-def parse_t2_observatories_dat(filename=None):
+def earth_location_distance(loc1, loc2):
+    return (
+        sum((u.Quantity(loc1.to_geocentric()) - u.Quantity(loc2.to_geocentric())) ** 2)
+    ) ** 0.5
+
+
+def compare_t2_observatories_dat(t2dir=None):
     """Read a tempo2 observatories.dat file and compare with PINT
 
     Produces a report including lines that can be added to PINT's
     observatories.py to add any observatories unknown to PINT.
     """
-    if filename is None:
+    if t2dir is None:
         t2dir = os.getenv("TEMPO2")
         if t2dir is None:
             raise ValueError(
-                "filename not provided and TEMPO2 environment variable not set"
+                "TEMPO2 directory not provided and TEMPO2 environment variable not set"
             )
-        filename = os.path.join(t2dir, "observatory", "obervatories.dat")
+    filename = os.path.join(t2dir, "observatory", "observatories.dat")
 
     report = defaultdict(list)
     with open(filename) as f:
@@ -368,17 +385,126 @@ def parse_t2_observatories_dat(filename=None):
                     continue
 
             loc = EarthLocation.from_geocentric(x * u.m, y * u.m, z * u.m)
-            if obs.earth_location_itrf() != loc:
+            oloc = obs.earth_location_itrf()
+            d = earth_location_distance(loc, oloc)
+            if d > 1 * u.m:
                 report["different"].append(
                     dict(
                         name=full_name,
+                        t2_short_name=short_name,
                         t2=loc.to_geodetic(),
-                        pint=obs.earth_location_itrf().to_geodetic(),
+                        pint=oloc.to_geodetic(),
                         topo_obs_entry=topo_obs_entry,
+                        pint_name=obs.name,
+                        pint_tempo_code=obs.tempo_code
+                        if hasattr(obs, "tempo_code")
+                        else "",
+                        pint_aliases=obs.aliases,
+                        position_difference=d,
                     )
                 )
 
             # Check whether TEMPO alias - first two letters - works and is distinct from others?
             # Check all t2 aliases also work for PINT?
             # Check ITOA code?
+            # Check time corrections?
+    return report
+
+
+def compare_tempo_obsys_dat(tempodir=None):
+    if tempodir is None:
+        tempodir = os.getenv("TEMPO")
+        if tempodir is None:
+            raise ValueError(
+                "TEMPO directory not provided and TEMPO environment variable not set"
+            )
+    filename = os.path.join(tempodir, "obsys.dat")
+
+    report = defaultdict(list)
+    with open(filename) as f:
+        for line in f.readlines():
+            if line.strip().startswith("#"):
+                continue
+            try:
+                line_io = StringIO(line)
+                x = float(line_io.read(15))
+                y = float(line_io.read(15))
+                z = float(line_io.read(15))
+                line_io.read(2)
+                icoord = line_io.read(1).strip()
+                icoord = int(icoord) if icoord else 0
+                line_io.read(2)
+                obsnam = line_io.read(20).strip().lower()
+                tempo_code = line_io.read(1)
+                tempo_code = tempo_code if tempo_code != "-" else ""
+                line_io.read(2)
+                itoa_code = line_io.read(2).strip()
+            except ValueError:
+                raise ValueError(f"unrecognized line '{line}'")
+            if icoord:
+                loc = EarthLocation.from_geocentric(x * u.m, y * u.m, z * u.m)
+            else:
+
+                def convert_angle(x):
+                    s = np.sign(x)
+                    x = np.abs(x)
+                    return s * (
+                        (x // 10000) * u.deg
+                        + ((x % 10000) // 100) * u.arcmin
+                        + (x % 100) * u.arcsec
+                    )
+
+                loc = EarthLocation.from_geodetic(
+                    -convert_angle(y), convert_angle(x), z * u.m
+                )
+                x, y, z = (a.to_value(u.m) for a in loc.to_geocentric())
+            topo_obs_entry = textwrap.dedent(
+                f"""
+                TopoObs(
+                    name='{obsnam.replace(" ","_")}',
+                    tempo_code='{tempo_code}',
+                    itoa_code='{itoa_code}',
+                    itrf_xyz=[{x}, {y}, {z}],
+                )
+                """
+            )
+            try:
+                obs = get_observatory(itoa_code)
+            except KeyError:
+                try:
+                    obs = get_observatory(tempo_code)
+                except KeyError:
+                    report["missing"].append(
+                        dict(
+                            name=obsnam,
+                            itoa_code=itoa_code,
+                            tempo_code=tempo_code,
+                            topo_obs_entry=topo_obs_entry,
+                        )
+                    )
+                    continue
+
+            oloc = obs.earth_location_itrf()
+            d = earth_location_distance(loc, oloc)
+            if d > 1 * u.m:
+                report["different"].append(
+                    dict(
+                        name=obsnam,
+                        pint_name=obs.name,
+                        pint_tempo_code=obs.tempo_code
+                        if hasattr(obs, "tempo_code")
+                        else "",
+                        pint_aliases=obs.aliases,
+                        itoa_code=itoa_code,
+                        tempo_code=tempo_code,
+                        tempo=loc.to_geodetic(),
+                        pint=oloc.to_geodetic(),
+                        position_difference=d,
+                    )
+                )
+
+            # Check whether TEMPO alias - first two letters - works and is distinct from others?
+            # Check all t2 aliases also work for PINT?
+            # Check ITOA code?
+            # Check time corrections?
     return report

--- a/src/pint/observatory/__init__.py
+++ b/src/pint/observatory/__init__.py
@@ -347,6 +347,21 @@ def compare_t2_observatories_dat(t2dir=None):
 
     Produces a report including lines that can be added to PINT's
     observatories.py to add any observatories unknown to PINT.
+
+    Parameters
+    ==========
+    t2dir : str, optional
+        Path to the TEMPO2 runtime dir; if not provided, look in the
+        TEMPO2 environment variable.
+
+    Returns
+    =======
+    dict
+        The dictionary has two entries, under the keys "different" and "missing"; each is
+        a list of observatories found in the TEMPO2 files that disagree with what PINT
+        expects. Each entry in these lists is again a dict, with various properties of the
+        observatory, including a line that might be suitable for starting an entry in the
+        PINT observatory list.
     """
     if t2dir is None:
         t2dir = os.getenv("TEMPO2")
@@ -402,6 +417,7 @@ def compare_t2_observatories_dat(t2dir=None):
                         else "",
                         pint_aliases=obs.aliases,
                         position_difference=d,
+                        pint_origin=obs.origin,
                     )
                 )
 
@@ -413,6 +429,26 @@ def compare_t2_observatories_dat(t2dir=None):
 
 
 def compare_tempo_obsys_dat(tempodir=None):
+    """Read a tempo obsys.dat file and compare with PINT
+
+    Produces a report including lines that can be added to PINT's
+    observatories.py to add any observatories unknown to PINT.
+
+    Parameters
+    ==========
+    tempodir : str, optional
+        Path to the TEMPO runtime dir; if not provided, look in the
+        TEMPO environment variable.
+
+    Returns
+    =======
+    dict
+        The dictionary has two entries, under the keys "different" and "missing"; each is
+        a list of observatories found in the TEMPO files that disagree with what PINT
+        expects. Each entry in these lists is again a dict, with various properties of the
+        observatory, including a line that might be suitable for starting an entry in the
+        PINT observatory list.
+    """
     if tempodir is None:
         tempodir = os.getenv("TEMPO")
         if tempodir is None:
@@ -501,6 +537,7 @@ def compare_tempo_obsys_dat(tempodir=None):
                         tempo=loc.to_geodetic(),
                         pint=oloc.to_geodetic(),
                         position_difference=d,
+                        pint_origin=obs.origin,
                     )
                 )
 

--- a/src/pint/observatory/observatories.py
+++ b/src/pint/observatory/observatories.py
@@ -50,7 +50,7 @@ TopoObs(
     "jodrell",
     tempo_code="8",
     itoa_code="JB",
-    aliases=["jbdfb", "jbroach", "jbafb"],
+    aliases=["jbdfb", "jbroach", "jbafb", "jbodfb", "jboafb", "jboroach"],
     itrf_xyz=[3822626.04, -154105.65, 5086486.04],
 )
 TopoObs(
@@ -65,7 +65,7 @@ TopoObs(
 )
 TopoObs(
     "ncyobs",
-    aliases=["ncyobs"],
+    aliases=["nuppi"],
     itrf_xyz=[4324165.81, 165927.11, 4670132.83],
     clock_fmt="tempo2",
     clock_file=["ncyobs2obspm.clk", "obspm2gps.clk"],
@@ -183,6 +183,8 @@ TopoObs(
     include_bipm=False,
     itrf_xyz=[-3777336.0240, 3484898.411, 3765313.6970],
 )
+
+
 TopoObs(
     "algonquin",
     itoa_code="AR",
@@ -200,3 +202,403 @@ TopoObs(
 )
 TopoObs("ata", aliases=["hcro"], itrf_xyz=[-2524263.18, -4123529.78, 4147966.36])
 TopoObs("ccera", itrf_xyz=[1093406.840, -4391945.819, 4479103.550])
+
+# Fake telescope for IPTA data challenge
+TopoObs("AXIS", aliases=["axi"], itrf_xyz=[6378138.00, 0.0, 0.0])
+
+# imported from tempo2 2021 June 7
+TopoObs(
+    name='narrabri',
+    aliases=['atca'],
+    itrf_xyz=[-4752329.7, 2790505.934, -3200483.747],
+)
+TopoObs(
+    name='nanshan',
+    aliases=['ns'],
+    itrf_xyz=[228310.702, 4631922.905, 4367064.059],
+)
+TopoObs(
+    name='uao',
+    aliases=['ns'],
+    itrf_xyz=[228310.702, 4631922.905, 4367064.059],
+)
+TopoObs(
+    name='dss_43',
+    aliases=['tid43'],
+    itrf_xyz=[-4460892.6, 2682358.9, -3674756.0],
+)
+TopoObs(
+    name='op',
+    aliases=['obspm'],
+    itrf_xyz=[4324165.81, 165927.11, 4670132.83],
+)
+TopoObs(
+    name='effelsberg_asterix',
+    aliases=['effix'],
+    itrf_xyz=[4033949.5, 486989.4, 4900430.8],
+)
+TopoObs(
+    name='leap',
+    aliases=['leap'],
+    itrf_xyz=[4033949.5, 486989.4, 4900430.8],
+)
+TopoObs(
+    name='jodrellm4',
+    aliases=['jbm4'],
+    itrf_xyz=[3822252.643, -153995.683, 5086051.443],
+)
+TopoObs(
+    name='gb300',
+    aliases=['gb300'],
+    itrf_xyz=[881856.58, -4925311.86, 3943459.7],
+)
+TopoObs(
+    name='gb140',
+    aliases=['gb140'],
+    itrf_xyz=[882872.57, -4924552.73, 3944154.92],
+)
+TopoObs(
+    name='gb853',
+    aliases=['gb853'],
+    itrf_xyz=[882315.33, -4925191.41, 3943414.05],
+)
+TopoObs(
+    name='la_palma',
+    aliases=['lap'],
+    itrf_xyz=[5327021.651, -1719555.576, 3051967.932],
+)
+TopoObs(
+    name='hartebeesthoek',
+    aliases=['hart'],
+    itrf_xyz=[5085442.78, 2668263.483, -2768697.034],
+)
+TopoObs(
+    name='warkworth_30m',
+    aliases=['wark30m'],
+    itrf_xyz=[-5115425.6, 477880.31, -3767042.81],
+)
+TopoObs(
+    name='warkworth_12m',
+    aliases=['wark12m'],
+    itrf_xyz=[-5115324.399, 477843.305, -3767192.886],
+)
+TopoObs(
+    name='lofar',
+    aliases=['lofar'],
+    itrf_xyz=[3826577.462, 461022.624, 5064892.526],
+)
+TopoObs(
+    name='de601lba',
+    aliases=['eflfrlba'],
+    itrf_xyz=[4034038.635, 487026.223, 4900280.057],
+)
+TopoObs(
+    name='de601lbh',
+    aliases=['eflfrlbh'],
+    itrf_xyz=[4034038.635, 487026.223, 4900280.057],
+)
+TopoObs(
+    name='de601hba',
+    aliases=['eflfrhba'],
+    itrf_xyz=[4034101.901, 487012.401, 4900230.21],
+)
+TopoObs(
+    name='de601',
+    aliases=['eflfr'],
+    itrf_xyz=[4034101.901, 487012.401, 4900230.21],
+)
+TopoObs(
+    name='de602lba',
+    aliases=['uwlfrlba'],
+    itrf_xyz=[4152561.068, 828868.725, 4754356.878],
+)
+TopoObs(
+    name='de602lbh',
+    aliases=['uwlfrlbh'],
+    itrf_xyz=[4152561.068, 828868.725, 4754356.878],
+)
+TopoObs(
+    name='de602hba',
+    aliases=['uwlfrhba'],
+    itrf_xyz=[4152568.416, 828788.802, 4754361.926],
+)
+TopoObs(
+    name='de602',
+    aliases=['uwlfr'],
+    itrf_xyz=[4152568.416, 828788.802, 4754361.926],
+)
+TopoObs(
+    name='de603lba',
+    aliases=['tblfrlba'],
+    itrf_xyz=[3940285.328, 816802.001, 4932392.757],
+)
+TopoObs(
+    name='de603lbh',
+    aliases=['tblfrlbh'],
+    itrf_xyz=[3940285.328, 816802.001, 4932392.757],
+)
+TopoObs(
+    name='de603hba',
+    aliases=['tblfrhba'],
+    itrf_xyz=[3940296.126, 816722.532, 4932394.152],
+)
+TopoObs(
+    name='de603',
+    aliases=['tblfr'],
+    itrf_xyz=[3940296.126, 816722.532, 4932394.152],
+)
+TopoObs(
+    name='de604lba',
+    aliases=['polfrlba'],
+    itrf_xyz=[3796327.609, 877591.315, 5032757.252],
+)
+TopoObs(
+    name='de604lbh',
+    aliases=['polfrlbh'],
+    itrf_xyz=[3796327.609, 877591.315, 5032757.252],
+)
+TopoObs(
+    name='de604hba',
+    aliases=['polfrhba'],
+    itrf_xyz=[3796380.254, 877613.809, 5032712.272],
+)
+TopoObs(
+    name='de604',
+    aliases=['polfr'],
+    itrf_xyz=[3796380.254, 877613.809, 5032712.272],
+)
+TopoObs(
+    name='de605lba',
+    aliases=['julfrlba'],
+    itrf_xyz=[4005681.742, 450968.282, 4926457.67],
+)
+TopoObs(
+    name='de605lbh',
+    aliases=['julfrlbh'],
+    itrf_xyz=[4005681.742, 450968.282, 4926457.67],
+)
+TopoObs(
+    name='de605hba',
+    aliases=['julfrhba'],
+    itrf_xyz=[4005681.407, 450968.304, 4926457.94],
+)
+TopoObs(
+    name='de605',
+    aliases=['julfr'],
+    itrf_xyz=[4005681.407, 450968.304, 4926457.94],
+)
+TopoObs(
+    name='fr606lba',
+    aliases=['frlfrlba'],
+    itrf_xyz=[4323980.155, 165608.408, 4670302.803],
+)
+TopoObs(
+    name='fr606lbh',
+    aliases=['frlfrlbh'],
+    itrf_xyz=[4323980.155, 165608.408, 4670302.803],
+)
+TopoObs(
+    name='fr606hba',
+    aliases=['frlfrhba'],
+    itrf_xyz=[4324017.054, 165545.16, 4670271.072],
+)
+TopoObs(
+    name='fr606',
+    aliases=['frlfr'],
+    itrf_xyz=[4324017.054, 165545.16, 4670271.072],
+)
+TopoObs(
+    name='se607lba',
+    aliases=['onlfrlba'],
+    itrf_xyz=[3370287.366, 712053.586, 5349991.228],
+)
+TopoObs(
+    name='se607lbh',
+    aliases=['onlfrlbh'],
+    itrf_xyz=[3370287.366, 712053.586, 5349991.228],
+)
+TopoObs(
+    name='se607hba',
+    aliases=['onlfrhba'],
+    itrf_xyz=[3370272.092, 712125.596, 5349990.934],
+)
+TopoObs(
+    name='se607',
+    aliases=['onlfr'],
+    itrf_xyz=[3370272.092, 712125.596, 5349990.934],
+)
+TopoObs(
+    name='uk608lba',
+    aliases=['uklfrlba'],
+    itrf_xyz=[4008438.796, -100310.064, 4943735.554],
+)
+TopoObs(
+    name='uk608lbh',
+    aliases=['uklfrlbh'],
+    itrf_xyz=[4008438.796, -100310.064, 4943735.554],
+)
+TopoObs(
+    name='uk608hba',
+    aliases=['uklfrhba'],
+    itrf_xyz=[4008462.28, -100376.948, 4943716.6],
+)
+TopoObs(
+    name='uk608',
+    aliases=['uklfr'],
+    itrf_xyz=[4008462.28, -100376.948, 4943716.6],
+)
+TopoObs(
+    name='de609lba',
+    aliases=['ndlfrlba'],
+    itrf_xyz=[3727207.778, 655184.9, 5117000.625],
+)
+TopoObs(
+    name='de609lbh',
+    aliases=['ndlfrlbh'],
+    itrf_xyz=[3727207.778, 655184.9, 5117000.625],
+)
+TopoObs(
+    name='de609hba',
+    aliases=['ndlfrhba'],
+    itrf_xyz=[3727218.128, 655108.821, 5117002.847],
+)
+TopoObs(
+    name='de609',
+    aliases=['ndlfr'],
+    itrf_xyz=[3727218.128, 655108.821, 5117002.847],
+)
+TopoObs(
+    name='fi609lba',
+    aliases=['filfrlba'],
+    itrf_xyz=[2136833.225, 810088.74, 5935285.279],
+)
+TopoObs(
+    name='fi609lbh',
+    aliases=['filfrlbh'],
+    itrf_xyz=[2136833.225, 810088.74, 5935285.279],
+)
+TopoObs(
+    name='fi609hba',
+    aliases=['filfrhba'],
+    itrf_xyz=[2136819.194, 810039.5757, 5935299.0536],
+)
+TopoObs(
+    name='fi609',
+    aliases=['filfr'],
+    itrf_xyz=[2136819.194, 810039.5757, 5935299.0536],
+)
+TopoObs(
+    name='utr-2',
+    aliases=['utr2'],
+    itrf_xyz=[3307865.236, 2487350.541, 4836939.784],
+)
+TopoObs(
+    name='goldstone',
+    aliases=['gs'],
+    itrf_xyz=[-2353621.22, -4641341.52, 3677052.352],
+)
+TopoObs(
+    name='shao',
+    aliases=['shao'],
+    itrf_xyz=[-2826711.951, 4679231.627, 3274665.675],
+)
+TopoObs(
+    name='pico_veleta',
+    aliases=['pv'],
+    itrf_xyz=[5088964.0, 301689.8, 3825017.0],
+)
+TopoObs(
+    name='iar1',
+    aliases=['iar1'],
+    itrf_xyz=[2765357.08, -4449628.98, -3625726.47],
+)
+TopoObs(
+    name='iar2',
+    aliases=['iar2'],
+    itrf_xyz=[2765322.49, -4449569.52, -3625825.14],
+)
+TopoObs(
+    name='kat-7',
+    aliases=['k7'],
+    itrf_xyz=[5109943.105, 2003650.7359, -3239908.3195],
+)
+TopoObs(
+    name='mkiii',
+    aliases=['jbmk3'],
+    itrf_xyz=[383395.727, -173759.585, 5077751.313],
+)
+TopoObs(
+    name='tabley',
+    aliases=['tabley'],
+    itrf_xyz=[3817176.557, -162921.17, 5089462.046],
+)
+TopoObs(
+    name='darnhall',
+    aliases=['darnhall'],
+    itrf_xyz=[3828714.504, -169458.987, 5080647.749],
+)
+TopoObs(
+    name='knockin',
+    aliases=['knockin'],
+    itrf_xyz=[3859711.492, -201995.082, 5056134.285],
+)
+TopoObs(
+    name='defford',
+    aliases=['defford'],
+    itrf_xyz=[3923069.135, -146804.404, 5009320.57],
+)
+TopoObs(
+    name='cambridge',
+    aliases=['cam'],
+    itrf_xyz=[3919982.752, 2651.982, 5013849.826],
+)
+TopoObs(
+    name='coe',
+    aliases=['coe'],
+    itrf_xyz=[0.0, 1.0, 0.0],
+)
+TopoObs(
+    name='princeton',
+    aliases=['princeton'],
+    itrf_xyz=[1288748.38, -4694221.77, 4107418.8],
+)
+TopoObs(
+    name='hamburg',
+    aliases=['hamburg'],
+    itrf_xyz=[3788815.62, 1131748.336, 5035101.19],
+)
+TopoObs(
+    name='jb_42ft',
+    aliases=['jb42'],
+    itrf_xyz=[3822294.825, -153862.275, 5085987.071],
+)
+TopoObs(
+    name='jb_mkii',
+    aliases=['jbmk2'],
+    itrf_xyz=[3822846.76, -153802.28, 5086285.9],
+)
+TopoObs(
+    name='jb_mkii_rch',
+    aliases=['jbmk2roach'],
+    itrf_xyz=[3822846.76, -153802.28, 5086285.9],
+)
+TopoObs(
+    name='jb_mkii_dfb',
+    aliases=['jbmk2dfb'],
+    itrf_xyz=[3822846.76, -153802.28, 5086285.9],
+)
+TopoObs(
+    name='lwa_sv',
+    aliases=['lwasv'],
+    itrf_xyz=[-1531155.54418, -5045324.30517, 3579583.8945],
+)
+TopoObs(
+    name='grao',
+    aliases=['grao'],
+    itrf_xyz=[6346273.531, -33779.7127, 634844.9454],
+)
+TopoObs(
+    name='srt',
+    aliases=['srt'],
+    itrf_xyz=[4865182.766, 791922.689, 4035137.174],
+)

--- a/src/pint/observatory/observatories.py
+++ b/src/pint/observatory/observatories.py
@@ -173,7 +173,7 @@ TopoObs(
 )
 TopoObs(
     "geo600",
-    aliases=["geohf", "g1"],
+    aliases=["geohf"],  # is g1 used? It was here but TEMPO uses it for the GB 140ft
     include_bipm=False,
     itrf_xyz=[3856309.9493, 666598.9563, 5019641.4172],
 )
@@ -208,397 +208,379 @@ TopoObs("AXIS", aliases=["axi"], itrf_xyz=[6378138.00, 0.0, 0.0])
 
 # imported from tempo2 2021 June 7
 TopoObs(
-    name='narrabri',
-    aliases=['atca'],
-    itrf_xyz=[-4752329.7, 2790505.934, -3200483.747],
+    name="narrabri", aliases=["atca"], itrf_xyz=[-4752329.7, 2790505.934, -3200483.747],
 )
 TopoObs(
-    name='nanshan',
-    aliases=['ns'],
-    itrf_xyz=[228310.702, 4631922.905, 4367064.059],
+    name="nanshan", aliases=["ns"], itrf_xyz=[228310.702, 4631922.905, 4367064.059],
 )
 TopoObs(
-    name='uao',
-    aliases=['ns'],
-    itrf_xyz=[228310.702, 4631922.905, 4367064.059],
+    name="uao", aliases=["ns"], itrf_xyz=[228310.702, 4631922.905, 4367064.059],
 )
 TopoObs(
-    name='dss_43',
-    aliases=['tid43'],
-    itrf_xyz=[-4460892.6, 2682358.9, -3674756.0],
+    name="dss_43", aliases=["tid43"], itrf_xyz=[-4460892.6, 2682358.9, -3674756.0],
 )
 TopoObs(
-    name='op',
-    aliases=['obspm'],
-    itrf_xyz=[4324165.81, 165927.11, 4670132.83],
+    name="op", aliases=["obspm"], itrf_xyz=[4324165.81, 165927.11, 4670132.83],
 )
 TopoObs(
-    name='effelsberg_asterix',
-    aliases=['effix'],
+    name="effelsberg_asterix",
+    aliases=["effix"],
     itrf_xyz=[4033949.5, 486989.4, 4900430.8],
 )
 TopoObs(
-    name='leap',
-    aliases=['leap'],
-    itrf_xyz=[4033949.5, 486989.4, 4900430.8],
+    name="leap", aliases=["leap"], itrf_xyz=[4033949.5, 486989.4, 4900430.8],
 )
 TopoObs(
-    name='jodrellm4',
-    aliases=['jbm4'],
+    name="jodrellm4",
+    aliases=["jbm4"],
     itrf_xyz=[3822252.643, -153995.683, 5086051.443],
 )
 TopoObs(
-    name='gb300',
-    aliases=['gb300'],
+    name="gb300",
+    aliases=["gb300"],
+    tempo_code="9",
+    itoa_code="G3",
     itrf_xyz=[881856.58, -4925311.86, 3943459.7],
 )
 TopoObs(
-    name='gb140',
-    aliases=['gb140'],
+    name="gb140",
+    aliases=["gb140"],
+    itoa_code="G1",
+    tempo_code="a",
     itrf_xyz=[882872.57, -4924552.73, 3944154.92],
 )
 TopoObs(
-    name='gb853',
-    aliases=['gb853'],
+    name="gb853",
+    aliases=["gb853"],
+    tempo_code="b",
+    itoa_code="G8",
     itrf_xyz=[882315.33, -4925191.41, 3943414.05],
 )
 TopoObs(
-    name='la_palma',
-    aliases=['lap'],
-    itrf_xyz=[5327021.651, -1719555.576, 3051967.932],
+    name="la_palma", aliases=["lap"], itrf_xyz=[5327021.651, -1719555.576, 3051967.932],
 )
 TopoObs(
-    name='hartebeesthoek',
-    aliases=['hart'],
+    name="hartebeesthoek",
+    aliases=["hart"],
     itrf_xyz=[5085442.78, 2668263.483, -2768697.034],
 )
 TopoObs(
-    name='warkworth_30m',
-    aliases=['wark30m'],
+    name="warkworth_30m",
+    aliases=["wark30m"],
     itrf_xyz=[-5115425.6, 477880.31, -3767042.81],
 )
 TopoObs(
-    name='warkworth_12m',
-    aliases=['wark12m'],
+    name="warkworth_12m",
+    aliases=["wark12m"],
     itrf_xyz=[-5115324.399, 477843.305, -3767192.886],
 )
 TopoObs(
-    name='lofar',
-    aliases=['lofar'],
+    name="lofar",
+    aliases=["lofar"],
+    tempo_code="t",
+    itoa_code="LF",
     itrf_xyz=[3826577.462, 461022.624, 5064892.526],
 )
 TopoObs(
-    name='de601lba',
-    aliases=['eflfrlba'],
+    name="de601lba",
+    aliases=["eflfrlba"],
     itrf_xyz=[4034038.635, 487026.223, 4900280.057],
 )
 TopoObs(
-    name='de601lbh',
-    aliases=['eflfrlbh'],
+    name="de601lbh",
+    aliases=["eflfrlbh"],
     itrf_xyz=[4034038.635, 487026.223, 4900280.057],
 )
 TopoObs(
-    name='de601hba',
-    aliases=['eflfrhba'],
+    name="de601hba",
+    aliases=["eflfrhba"],
     itrf_xyz=[4034101.901, 487012.401, 4900230.21],
 )
 TopoObs(
-    name='de601',
-    aliases=['eflfr'],
-    itrf_xyz=[4034101.901, 487012.401, 4900230.21],
+    name="de601", aliases=["eflfr"], itrf_xyz=[4034101.901, 487012.401, 4900230.21],
 )
 TopoObs(
-    name='de602lba',
-    aliases=['uwlfrlba'],
+    name="de602lba",
+    aliases=["uwlfrlba"],
     itrf_xyz=[4152561.068, 828868.725, 4754356.878],
 )
 TopoObs(
-    name='de602lbh',
-    aliases=['uwlfrlbh'],
+    name="de602lbh",
+    aliases=["uwlfrlbh"],
     itrf_xyz=[4152561.068, 828868.725, 4754356.878],
 )
 TopoObs(
-    name='de602hba',
-    aliases=['uwlfrhba'],
+    name="de602hba",
+    aliases=["uwlfrhba"],
     itrf_xyz=[4152568.416, 828788.802, 4754361.926],
 )
 TopoObs(
-    name='de602',
-    aliases=['uwlfr'],
-    itrf_xyz=[4152568.416, 828788.802, 4754361.926],
+    name="de602", aliases=["uwlfr"], itrf_xyz=[4152568.416, 828788.802, 4754361.926],
 )
 TopoObs(
-    name='de603lba',
-    aliases=['tblfrlba'],
+    name="de603lba",
+    aliases=["tblfrlba"],
     itrf_xyz=[3940285.328, 816802.001, 4932392.757],
 )
 TopoObs(
-    name='de603lbh',
-    aliases=['tblfrlbh'],
+    name="de603lbh",
+    aliases=["tblfrlbh"],
     itrf_xyz=[3940285.328, 816802.001, 4932392.757],
 )
 TopoObs(
-    name='de603hba',
-    aliases=['tblfrhba'],
+    name="de603hba",
+    aliases=["tblfrhba"],
     itrf_xyz=[3940296.126, 816722.532, 4932394.152],
 )
 TopoObs(
-    name='de603',
-    aliases=['tblfr'],
-    itrf_xyz=[3940296.126, 816722.532, 4932394.152],
+    name="de603", aliases=["tblfr"], itrf_xyz=[3940296.126, 816722.532, 4932394.152],
 )
 TopoObs(
-    name='de604lba',
-    aliases=['polfrlba'],
+    name="de604lba",
+    aliases=["polfrlba"],
     itrf_xyz=[3796327.609, 877591.315, 5032757.252],
 )
 TopoObs(
-    name='de604lbh',
-    aliases=['polfrlbh'],
+    name="de604lbh",
+    aliases=["polfrlbh"],
     itrf_xyz=[3796327.609, 877591.315, 5032757.252],
 )
 TopoObs(
-    name='de604hba',
-    aliases=['polfrhba'],
+    name="de604hba",
+    aliases=["polfrhba"],
     itrf_xyz=[3796380.254, 877613.809, 5032712.272],
 )
 TopoObs(
-    name='de604',
-    aliases=['polfr'],
-    itrf_xyz=[3796380.254, 877613.809, 5032712.272],
+    name="de604", aliases=["polfr"], itrf_xyz=[3796380.254, 877613.809, 5032712.272],
 )
 TopoObs(
-    name='de605lba',
-    aliases=['julfrlba'],
+    name="de605lba",
+    aliases=["julfrlba"],
     itrf_xyz=[4005681.742, 450968.282, 4926457.67],
 )
 TopoObs(
-    name='de605lbh',
-    aliases=['julfrlbh'],
+    name="de605lbh",
+    aliases=["julfrlbh"],
     itrf_xyz=[4005681.742, 450968.282, 4926457.67],
 )
 TopoObs(
-    name='de605hba',
-    aliases=['julfrhba'],
+    name="de605hba",
+    aliases=["julfrhba"],
     itrf_xyz=[4005681.407, 450968.304, 4926457.94],
 )
 TopoObs(
-    name='de605',
-    aliases=['julfr'],
-    itrf_xyz=[4005681.407, 450968.304, 4926457.94],
+    name="de605", aliases=["julfr"], itrf_xyz=[4005681.407, 450968.304, 4926457.94],
 )
 TopoObs(
-    name='fr606lba',
-    aliases=['frlfrlba'],
+    name="fr606lba",
+    aliases=["frlfrlba"],
     itrf_xyz=[4323980.155, 165608.408, 4670302.803],
 )
 TopoObs(
-    name='fr606lbh',
-    aliases=['frlfrlbh'],
+    name="fr606lbh",
+    aliases=["frlfrlbh"],
     itrf_xyz=[4323980.155, 165608.408, 4670302.803],
 )
 TopoObs(
-    name='fr606hba',
-    aliases=['frlfrhba'],
+    name="fr606hba",
+    aliases=["frlfrhba"],
     itrf_xyz=[4324017.054, 165545.16, 4670271.072],
 )
 TopoObs(
-    name='fr606',
-    aliases=['frlfr'],
-    itrf_xyz=[4324017.054, 165545.16, 4670271.072],
+    name="fr606", aliases=["frlfr"], itrf_xyz=[4324017.054, 165545.16, 4670271.072],
 )
 TopoObs(
-    name='se607lba',
-    aliases=['onlfrlba'],
+    name="se607lba",
+    aliases=["onlfrlba"],
     itrf_xyz=[3370287.366, 712053.586, 5349991.228],
 )
 TopoObs(
-    name='se607lbh',
-    aliases=['onlfrlbh'],
+    name="se607lbh",
+    aliases=["onlfrlbh"],
     itrf_xyz=[3370287.366, 712053.586, 5349991.228],
 )
 TopoObs(
-    name='se607hba',
-    aliases=['onlfrhba'],
+    name="se607hba",
+    aliases=["onlfrhba"],
     itrf_xyz=[3370272.092, 712125.596, 5349990.934],
 )
 TopoObs(
-    name='se607',
-    aliases=['onlfr'],
-    itrf_xyz=[3370272.092, 712125.596, 5349990.934],
+    name="se607", aliases=["onlfr"], itrf_xyz=[3370272.092, 712125.596, 5349990.934],
 )
 TopoObs(
-    name='uk608lba',
-    aliases=['uklfrlba'],
+    name="uk608lba",
+    aliases=["uklfrlba"],
     itrf_xyz=[4008438.796, -100310.064, 4943735.554],
 )
 TopoObs(
-    name='uk608lbh',
-    aliases=['uklfrlbh'],
+    name="uk608lbh",
+    aliases=["uklfrlbh"],
     itrf_xyz=[4008438.796, -100310.064, 4943735.554],
 )
 TopoObs(
-    name='uk608hba',
-    aliases=['uklfrhba'],
+    name="uk608hba",
+    aliases=["uklfrhba"],
     itrf_xyz=[4008462.28, -100376.948, 4943716.6],
 )
 TopoObs(
-    name='uk608',
-    aliases=['uklfr'],
-    itrf_xyz=[4008462.28, -100376.948, 4943716.6],
+    name="uk608", aliases=["uklfr"], itrf_xyz=[4008462.28, -100376.948, 4943716.6],
 )
 TopoObs(
-    name='de609lba',
-    aliases=['ndlfrlba'],
+    name="de609lba",
+    aliases=["ndlfrlba"],
     itrf_xyz=[3727207.778, 655184.9, 5117000.625],
 )
 TopoObs(
-    name='de609lbh',
-    aliases=['ndlfrlbh'],
+    name="de609lbh",
+    aliases=["ndlfrlbh"],
     itrf_xyz=[3727207.778, 655184.9, 5117000.625],
 )
 TopoObs(
-    name='de609hba',
-    aliases=['ndlfrhba'],
+    name="de609hba",
+    aliases=["ndlfrhba"],
     itrf_xyz=[3727218.128, 655108.821, 5117002.847],
 )
 TopoObs(
-    name='de609',
-    aliases=['ndlfr'],
-    itrf_xyz=[3727218.128, 655108.821, 5117002.847],
+    name="de609", aliases=["ndlfr"], itrf_xyz=[3727218.128, 655108.821, 5117002.847],
 )
 TopoObs(
-    name='fi609lba',
-    aliases=['filfrlba'],
+    name="fi609lba",
+    aliases=["filfrlba"],
     itrf_xyz=[2136833.225, 810088.74, 5935285.279],
 )
 TopoObs(
-    name='fi609lbh',
-    aliases=['filfrlbh'],
+    name="fi609lbh",
+    aliases=["filfrlbh"],
     itrf_xyz=[2136833.225, 810088.74, 5935285.279],
 )
 TopoObs(
-    name='fi609hba',
-    aliases=['filfrhba'],
+    name="fi609hba",
+    aliases=["filfrhba"],
     itrf_xyz=[2136819.194, 810039.5757, 5935299.0536],
 )
 TopoObs(
-    name='fi609',
-    aliases=['filfr'],
-    itrf_xyz=[2136819.194, 810039.5757, 5935299.0536],
+    name="fi609", aliases=["filfr"], itrf_xyz=[2136819.194, 810039.5757, 5935299.0536],
 )
 TopoObs(
-    name='utr-2',
-    aliases=['utr2'],
-    itrf_xyz=[3307865.236, 2487350.541, 4836939.784],
+    name="utr-2", aliases=["utr2"], itrf_xyz=[3307865.236, 2487350.541, 4836939.784],
 )
 TopoObs(
-    name='goldstone',
-    aliases=['gs'],
-    itrf_xyz=[-2353621.22, -4641341.52, 3677052.352],
+    name="goldstone", aliases=["gs"], itrf_xyz=[-2353621.22, -4641341.52, 3677052.352],
 )
 TopoObs(
-    name='shao',
-    aliases=['shao'],
+    name="shao",
+    aliases=["shao"],
+    tempo_code="s",
+    itoa_code="SH",
     itrf_xyz=[-2826711.951, 4679231.627, 3274665.675],
 )
 TopoObs(
-    name='pico_veleta',
-    aliases=['pv'],
-    itrf_xyz=[5088964.0, 301689.8, 3825017.0],
+    name="pico_veleta", aliases=["pv"], itrf_xyz=[5088964.0, 301689.8, 3825017.0],
 )
 TopoObs(
-    name='iar1',
-    aliases=['iar1'],
-    itrf_xyz=[2765357.08, -4449628.98, -3625726.47],
+    name="iar1", aliases=["iar1"], itrf_xyz=[2765357.08, -4449628.98, -3625726.47],
 )
 TopoObs(
-    name='iar2',
-    aliases=['iar2'],
-    itrf_xyz=[2765322.49, -4449569.52, -3625825.14],
+    name="iar2", aliases=["iar2"], itrf_xyz=[2765322.49, -4449569.52, -3625825.14],
 )
 TopoObs(
-    name='kat-7',
-    aliases=['k7'],
-    itrf_xyz=[5109943.105, 2003650.7359, -3239908.3195],
+    name="kat-7", aliases=["k7"], itrf_xyz=[5109943.105, 2003650.7359, -3239908.3195],
 )
 TopoObs(
-    name='mkiii',
-    aliases=['jbmk3'],
-    itrf_xyz=[383395.727, -173759.585, 5077751.313],
+    name="mkiii", aliases=["jbmk3"], itrf_xyz=[383395.727, -173759.585, 5077751.313],
 )
 TopoObs(
-    name='tabley',
-    aliases=['tabley'],
-    itrf_xyz=[3817176.557, -162921.17, 5089462.046],
+    name="tabley", aliases=["tabley"], itrf_xyz=[3817176.557, -162921.17, 5089462.046],
 )
 TopoObs(
-    name='darnhall',
-    aliases=['darnhall'],
+    name="darnhall",
+    aliases=["darnhall"],
     itrf_xyz=[3828714.504, -169458.987, 5080647.749],
 )
 TopoObs(
-    name='knockin',
-    aliases=['knockin'],
+    name="knockin",
+    aliases=["knockin"],
     itrf_xyz=[3859711.492, -201995.082, 5056134.285],
 )
 TopoObs(
-    name='defford',
-    aliases=['defford'],
+    name="defford",
+    aliases=["defford"],
     itrf_xyz=[3923069.135, -146804.404, 5009320.57],
 )
 TopoObs(
-    name='cambridge',
-    aliases=['cam'],
-    itrf_xyz=[3919982.752, 2651.982, 5013849.826],
+    name="cambridge", aliases=["cam"], itrf_xyz=[3919982.752, 2651.982, 5013849.826],
 )
 TopoObs(
-    name='coe',
-    aliases=['coe'],
-    itrf_xyz=[0.0, 1.0, 0.0],
+    name="coe", aliases=["coe"], itrf_xyz=[0.0, 1.0, 0.0],
 )
 TopoObs(
-    name='princeton',
-    aliases=['princeton'],
+    name="princeton",
+    aliases=["princeton"],
+    tempo_code="5",
+    itoa_code="PR",
     itrf_xyz=[1288748.38, -4694221.77, 4107418.8],
 )
 TopoObs(
-    name='hamburg',
-    aliases=['hamburg'],
-    itrf_xyz=[3788815.62, 1131748.336, 5035101.19],
+    name="hamburg", aliases=["hamburg"], itrf_xyz=[3788815.62, 1131748.336, 5035101.19],
 )
 TopoObs(
-    name='jb_42ft',
-    aliases=['jb42'],
-    itrf_xyz=[3822294.825, -153862.275, 5085987.071],
+    name="jb_42ft", aliases=["jb42"], itrf_xyz=[3822294.825, -153862.275, 5085987.071],
 )
 TopoObs(
-    name='jb_mkii',
-    aliases=['jbmk2'],
+    name="jb_mkii",
+    aliases=["jbmk2"],
+    tempo_code="h",
+    itoa_code="J2",
     itrf_xyz=[3822846.76, -153802.28, 5086285.9],
 )
 TopoObs(
-    name='jb_mkii_rch',
-    aliases=['jbmk2roach'],
+    name="jb_mkii_rch",
+    aliases=["jbmk2roach"],
     itrf_xyz=[3822846.76, -153802.28, 5086285.9],
 )
 TopoObs(
-    name='jb_mkii_dfb',
-    aliases=['jbmk2dfb'],
+    name="jb_mkii_dfb",
+    aliases=["jbmk2dfb"],
     itrf_xyz=[3822846.76, -153802.28, 5086285.9],
 )
 TopoObs(
-    name='lwa_sv',
-    aliases=['lwasv'],
+    name="lwa_sv",
+    aliases=["lwasv"],
+    itoa_code="LS",
     itrf_xyz=[-1531155.54418, -5045324.30517, 3579583.8945],
 )
 TopoObs(
-    name='grao',
-    aliases=['grao'],
-    itrf_xyz=[6346273.531, -33779.7127, 634844.9454],
+    name="grao", aliases=["grao"], itrf_xyz=[6346273.531, -33779.7127, 634844.9454],
 )
 TopoObs(
-    name='srt',
-    aliases=['srt'],
+    name="srt",
+    aliases=["srt"],
+    tempo_code="z",
+    itoa_code="SR",
     itrf_xyz=[4865182.766, 791922.689, 4035137.174],
+)
+
+# From Tempo 2021 June 8
+TopoObs(
+    name="quabbin",
+    tempo_code="2",
+    itoa_code="QU",
+    itrf_xyz=[1430913.3496148302, -4495711.383965823, 4278113.974517222],
+)
+TopoObs(
+    name="vla_site",
+    tempo_code="c",
+    itoa_code="V2",
+    itrf_xyz=[-1601135.5133304405, -5042005.480977412, 3554875.076856462],
+)
+TopoObs(
+    name="gb_20m_xyz",
+    itoa_code="G2",
+    itrf_xyz=[883772.7974, -4924385.5975, 3944042.4991],
+)
+TopoObs(
+    name="northern_cross",
+    tempo_code="d",
+    itoa_code="BO",
+    itrf_xyz=[4461242.882451464, 919559.8351226494, 4449633.220012489],
 )

--- a/src/pint/observatory/observatories.py
+++ b/src/pint/observatory/observatories.py
@@ -190,7 +190,14 @@ TopoObs(
     """,
 )
 TopoObs(
-    "ps1", tempo_code="p", itoa_code="PS", itrf_xyz=[-5461997.8, -2412559.0, 2243024.0]
+    "ps1",
+    tempo_code="p",
+    itoa_code="PS",
+    itrf_xyz=[-5461997.8, -2412559.0, 2243024.0],
+    origin="""Pan-STARRS.
+
+    Origin of this data is unknown.
+    """,
 )
 TopoObs(
     "hobart",

--- a/src/pint/observatory/observatories.py
+++ b/src/pint/observatory/observatories.py
@@ -511,9 +511,6 @@ TopoObs(
     name="cambridge", aliases=["cam"], itrf_xyz=[3919982.752, 2651.982, 5013849.826],
 )
 TopoObs(
-    name="coe", aliases=["coe"], itrf_xyz=[0.0, 1.0, 0.0],
-)
-TopoObs(
     name="princeton",
     aliases=["princeton"],
     tempo_code="5",

--- a/src/pint/observatory/observatories.py
+++ b/src/pint/observatory/observatories.py
@@ -11,7 +11,11 @@ TopoObs(
     tempo_code="1",
     itoa_code="GB",
     itrf_xyz=[882589.65, -4924872.32, 3943729.348],
-    origin="This is a test",
+    origin="""The Robert C. Byrd Green Bank Telescope.
+
+    The origin of this data is unknown but as of 2021 June 8 it agrees exactly with
+    the values used by TEMPO and TEMPO2.
+    """,
 )
 TopoObs(
     "arecibo",
@@ -19,6 +23,11 @@ TopoObs(
     itoa_code="AO",
     aliases=["aoutc"],
     itrf_xyz=[2390490.0, -5564764.0, 1994727.0],
+    origin="""The Arecibo telescope.
+
+    The origin of this data is unknown but as of 2021 June 8 it agrees exactly with
+    the values used by TEMPO and TEMPO2.
+    """,
 )
 TopoObs(
     "vla",
@@ -26,6 +35,11 @@ TopoObs(
     itoa_code="VL",
     aliases=["jvla"],
     itrf_xyz=[-1601192.0, -5041981.4, 3554871.4],
+    origin="""The Jansky Very Large Array.
+
+    The origin of this data is unknown but as of 2021 June 8 it agrees exactly with
+    the values used by TEMPO and TEMPO2.
+    """,
 )
 TopoObs(
     "meerkat",
@@ -35,6 +49,11 @@ TopoObs(
     clock_dir="TEMPO2",
     clock_file="mk2utc.clk",
     itrf_xyz=[5109360.133, 2006852.586, -3238948.127],
+    origin="""MEERKAT, used in timing mode.
+
+    The origin of this data is unknown but as of 2021 June 8 it agrees exactly with
+    the values used by TEMPO and TEMPO2.
+    """,
 )
 TopoObs(
     "parkes",
@@ -45,6 +64,11 @@ TopoObs(
     clock_dir="TEMPO2",
     clock_file="pks2gps.clk",
     itrf_xyz=[-4554231.5, 2816759.1, -3454036.3],
+    origin="""The Parkes radio telescope.
+
+    The origin of this data is unknown but as of 2021 June 8 it agrees exactly with
+    the values used by TEMPO and TEMPO2.
+    """,
 )
 TopoObs(
     "jodrell",
@@ -52,6 +76,11 @@ TopoObs(
     itoa_code="JB",
     aliases=["jbdfb", "jbroach", "jbafb", "jbodfb", "jboafb", "jboroach"],
     itrf_xyz=[3822626.04, -154105.65, 5086486.04],
+    origin="""The Lovell telescope at Jodrell Bank.
+
+    The origin of this data is unknown but as of 2021 June 8 it agrees exactly with
+    the values used by TEMPO and TEMPO2.
+    """,
 )
 TopoObs(
     "nancay",
@@ -62,6 +91,11 @@ TopoObs(
     clock_dir="TEMPO2",
     clock_file="ncy2gps.clk",
     itrf_xyz=[4324165.81, 165927.11, 4670132.83],
+    origin="""The Nançay radio telescope.
+
+    The origin of this data is unknown but as of 2021 June 8 it agrees exactly with
+    the values used by TEMPO and TEMPO2.
+    """,
 )
 TopoObs(
     "ncyobs",
@@ -70,6 +104,11 @@ TopoObs(
     clock_fmt="tempo2",
     clock_file=["ncyobs2obspm.clk", "obspm2gps.clk"],
     clock_dir="TEMPO2",
+    origin="""The Nançay radio telescope with the NUPPI back-end.
+
+    The origin of this data is unknown but as of 2021 June 8 it agrees exactly with
+    the values used by TEMPO and TEMPO2.
+    """,
 )
 TopoObs(
     "effelsberg",
@@ -80,6 +119,11 @@ TopoObs(
     clock_dir="TEMPO2",
     clock_file="eff2gps.clk",
     itrf_xyz=[4033949.5, 486989.4, 4900430.8],
+    origin="""The Effelsberg radio telescope.
+
+    The origin of this data is unknown but as of 2021 June 8 it agrees exactly with
+    the values used by TEMPO and TEMPO2.
+    """,
 )
 TopoObs(
     "gmrt",
@@ -89,30 +133,61 @@ TopoObs(
     clock_file="gmrt2gps.clk",
     clock_dir="TEMPO2",
     itrf_xyz=[1656342.30, 5797947.77, 2073243.16],
+    origin="""The Giant Metrewave Radio Telescope.
+
+    The origin of this data is unknown but as of 2021 June 8 it agrees exactly with
+    the values used by TEMPO and TEMPO2.
+    """,
 )
 TopoObs(
     "wsrt",
+    aliases=["we"],
     tempo_code="i",
     itoa_code="WS",
     clock_fmt="tempo2",
     clock_dir="TEMPO2",
     clock_file="wsrt2gps.clk",
     itrf_xyz=[3828445.659, 445223.600, 5064921.5677],
+    origin="""The Westerbork Synthesis Radio Telescope.
+
+    Note that different letters have been used in the past to indicate this telescope.
+
+    The origin of this data is unknown but as of 2021 June 8 it agrees exactly with
+    the values used by TEMPO and TEMPO2.
+    """,
 )
 TopoObs(
-    "fast", tempo_code="k", itoa_code="FA", itrf_xyz=[-1668557.0, 5506838.0, 2744934.0]
+    "fast",
+    tempo_code="k",
+    itoa_code="FA",
+    itrf_xyz=[-1668557.0, 5506838.0, 2744934.0],
+    origin="""The FAST radio telescope in China.
+
+    Origin of this data is unknown but as of 2021 June 8 it agrees exactly with the
+    TEMPO value and disagrees by about 17 km with the TEMPO2 value.
+    """,
 )
 TopoObs(
     "mwa",
     tempo_code="u",
     itoa_code="MW",
     itrf_xyz=[-2559454.08, 5095372.14, -2849057.18],
+    origin="""The Murchison Widefield Array.
+
+    Origin of this data is unknown but as of 2021 June 8 this value agrees exactly with
+    the value used by TEMPO2 and TEMPO.
+    """,
 )
 TopoObs(
     "lwa1",
     tempo_code="x",
     itoa_code="LW",
     itrf_xyz=[-1602196.60, -5042313.47, 3553971.51],
+    origin="""The LWA (long wavelength array, in New Mexico).
+
+    Origin of this data is unknown but as of 2021 June 8 this value agrees exactly with
+    the value used by TEMPO2 but disagrees with the value used by TEMPO by about 125 m.
+    """,
 )
 TopoObs(
     "ps1", tempo_code="p", itoa_code="PS", itrf_xyz=[-5461997.8, -2412559.0, 2243024.0]
@@ -122,6 +197,11 @@ TopoObs(
     tempo_code="4",
     itoa_code="HO",
     itrf_xyz=[-3950077.96, 2522377.31, -4311667.52],
+    origin="""A telescope in Hobart, Tasmania.
+
+    Origin of this data is unknown but as of 2021 June 8 this value agrees exactly with
+    the value used by TEMPO2 and TEMPO.
+    """,
 )
 TopoObs(
     "most",
@@ -131,18 +211,32 @@ TopoObs(
     clock_fmt="tempo2",
     clock_dir="TEMPO2",
     clock_file="mo2gps.clk",
+    origin="""The Molonglo Observatory Synthesis Telescope.
+
+    Origin of this data is unknown but as of 2021 June 8 this value agrees exactly with
+    the value used by TEMPO2.
+    """,
 )
 TopoObs(
     "chime",
     tempo_code="y",
     itoa_code="CH",
     itrf_xyz=[-2058795.0, -3621559.0, 4814280.0],
+    origin="""The Canadian HI Mapping Experiment.
+
+    Origin of this data is unknown but as of 2021 June 8 this value agrees exactly with
+    the value used by TEMPO2 and TEMPO.
+    """,
 )
 TopoObs(
     "magic",
     aliases=["magic"],
     include_bipm=False,
     itrf_xyz=[5326878.7967, -1719509.5201, 3051884.5175],
+    origin="""MAGIC (a ground-based gamma-ray telescope).
+
+    Origin of this data is unknown.
+    """,
 )
 
 TopoObs(
@@ -158,30 +252,58 @@ TopoObs(
     aliases=["v1"],
     include_bipm=False,
     itrf_xyz=[4546374.0990, 842989.6976, 4378576.9624],
+    origin="""The VIRGO gravitational-wave observatory.
+
+    Origin of this data is unknown but as of 2021 June 8 this value agrees exactly with
+    the value used by TEMPO2.
+    """,
 )
 TopoObs(
     "lho",
     aliases=["h1", "hanford"],
     include_bipm=False,
     itrf_xyz=[-2161414.9264, -3834695.1789, 4600350.2266],
+    origin="""The LIGO Hanford gravitational-wave observatory.
+
+    Origin of this data is unknown but as of 2021 June 8 this value agrees exactly with
+    the value used by TEMPO2.
+    """,
 )
 TopoObs(
     "llo",
     aliases=["l1", "livingston"],
     include_bipm=False,
     itrf_xyz=[-74276.0447, -5496283.7197, 3224257.0174],
+    origin="""The LIGO Livingston gravitational-wave observatory.
+
+    Origin of this data is unknown but as of 2021 June 8 this value agrees exactly with
+    the value used by TEMPO2.
+    """,
 )
 TopoObs(
     "geo600",
     aliases=["geohf"],  # is g1 used? It was here but TEMPO uses it for the GB 140ft
     include_bipm=False,
     itrf_xyz=[3856309.9493, 666598.9563, 5019641.4172],
+    origin="""The GEO600 gravitational-wave observatory.
+
+    Note that PINT used to list 'G1' as an alias for this telescope, but TEMPO accepts
+    'G1' as an alias for the Green Bank 140-foot telescope, so it was removed here.
+
+    Origin of this data is unknown but as of 2021 June 8 this value agrees exactly with
+    the value used by TEMPO2.
+    """,
 )
 TopoObs(
     "kagra",
     aliases=["k1", "lcgt"],
     include_bipm=False,
     itrf_xyz=[-3777336.0240, 3484898.411, 3765313.6970],
+    origin="""The KAGRA gravitational-wave observatory.
+
+    Origin of this data is unknown but as of 2021 June 8 this value agrees exactly with
+    the value used by TEMPO2.
+    """,
 )
 
 
@@ -190,50 +312,108 @@ TopoObs(
     itoa_code="AR",
     aliases=["aro", "ARO"],
     itrf_xyz=[918091.6472072796, -4346129.702203057, 4562012.861165226],
+    origin="""The Algonquin Radio Observatory.
+
+    The origin of this data is unknown.
+    """,
 )
 TopoObs(
     "drao",
     itoa_code="DR",
     aliases=["drao", "DRAO"],
     itrf_xyz=[-2058897.5725006417, -3621371.264826613, 4814353.577678314],
+    origin="""The Dominion Radio Astronomical Observatory.
+
+    The origin of this data is unknown.
+    """,
 )
 TopoObs(
-    "acre", aliases=["acreroad", "a", "AR"], itrf_xyz=[3573741.1, -269156.74, 5258407.3]
+    "acre",
+    aliases=["acreroad", "a", "AR"],
+    itrf_xyz=[3573741.1, -269156.74, 5258407.3],
+    origin="""The origin of this data is unknown.""",
 )
-TopoObs("ata", aliases=["hcro"], itrf_xyz=[-2524263.18, -4123529.78, 4147966.36])
-TopoObs("ccera", itrf_xyz=[1093406.840, -4391945.819, 4479103.550])
+TopoObs(
+    "ata",
+    aliases=["hcro"],
+    itrf_xyz=[-2524263.18, -4123529.78, 4147966.36],
+    origin="""The Allan telescope array.
+
+    Origin of this data is unknown but as of 2021 June 8 this value agrees exactly with
+    the value used by TEMPO2.
+    """,
+)
+TopoObs(
+    "ccera",
+    itrf_xyz=[1093406.840, -4391945.819, 4479103.550],
+    origin="""The origin of this data is unknown.""",
+)
 
 # Fake telescope for IPTA data challenge
-TopoObs("AXIS", aliases=["axi"], itrf_xyz=[6378138.00, 0.0, 0.0])
+TopoObs(
+    "AXIS",
+    aliases=["axi"],
+    itrf_xyz=[6378138.00, 0.0, 0.0],
+    origin="""Fake telescope for IPTA data challenge.
+
+    Imported from TEMPO2 observatories.dat 2021 June 7.
+    """,
+)
 
 # imported from tempo2 2021 June 7
 TopoObs(
-    name="narrabri", aliases=["atca"], itrf_xyz=[-4752329.7, 2790505.934, -3200483.747],
+    name="narrabri",
+    aliases=["atca"],
+    itrf_xyz=[-4752329.7, 2790505.934, -3200483.747],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="nanshan", aliases=["ns"], itrf_xyz=[228310.702, 4631922.905, 4367064.059],
+    name="nanshan",
+    aliases=["ns"],
+    itrf_xyz=[228310.702, 4631922.905, 4367064.059],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="uao", aliases=["ns"], itrf_xyz=[228310.702, 4631922.905, 4367064.059],
+    name="uao",
+    aliases=["ns"],
+    itrf_xyz=[228310.702, 4631922.905, 4367064.059],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="dss_43", aliases=["tid43"], itrf_xyz=[-4460892.6, 2682358.9, -3674756.0],
+    name="dss_43",
+    aliases=["tid43"],
+    itrf_xyz=[-4460892.6, 2682358.9, -3674756.0],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="op", aliases=["obspm"], itrf_xyz=[4324165.81, 165927.11, 4670132.83],
+    name="op",
+    aliases=["obspm"],
+    itrf_xyz=[4324165.81, 165927.11, 4670132.83],
+    origin="""The Nançay radio telescope.
+
+    Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="effelsberg_asterix",
     aliases=["effix"],
     itrf_xyz=[4033949.5, 486989.4, 4900430.8],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="leap", aliases=["leap"], itrf_xyz=[4033949.5, 486989.4, 4900430.8],
+    name="leap",
+    aliases=["leap"],
+    itrf_xyz=[4033949.5, 486989.4, 4900430.8],
+    origin="""The Large European Array for Pulsars.
+
+    This is the same as the position of the Effelsberg radio telescope.
+
+    Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="jodrellm4",
     aliases=["jbm4"],
     itrf_xyz=[3822252.643, -153995.683, 5086051.443],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="gb300",
@@ -241,6 +421,9 @@ TopoObs(
     tempo_code="9",
     itoa_code="G3",
     itrf_xyz=[881856.58, -4925311.86, 3943459.7],
+    origin="""The Green Bank 300-foot telescope.
+
+    Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="gb140",
@@ -248,6 +431,13 @@ TopoObs(
     itoa_code="G1",
     tempo_code="a",
     itrf_xyz=[882872.57, -4924552.73, 3944154.92],
+    origin="""The Green Bank 140-foot telescope.
+
+    Note that PINT used to accept 'G1' as an alias for the GEO600 gravitational-wave
+    observatory but that conflicted with what TEMPO accepted for this telescope
+    so that has been removed.
+
+    Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="gb853",
@@ -255,24 +445,38 @@ TopoObs(
     tempo_code="b",
     itoa_code="G8",
     itrf_xyz=[882315.33, -4925191.41, 3943414.05],
+    origin="""The Green Bank 85-3 telescope.
+
+    Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="la_palma", aliases=["lap"], itrf_xyz=[5327021.651, -1719555.576, 3051967.932],
+    name="la_palma",
+    aliases=["lap", "lapalma"],
+    itrf_xyz=[5327021.651, -1719555.576, 3051967.932],
+    origin="""La Palma observatory in the Canary Islands.
+
+    Note that as of 2021 June 8 TEMPO2's position for this observatory lists
+    it as somewhere in central Pakistan, exactly 90 degrees to the east of
+    this position.
+    """,
 )
 TopoObs(
     name="hartebeesthoek",
     aliases=["hart"],
     itrf_xyz=[5085442.78, 2668263.483, -2768697.034],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="warkworth_30m",
     aliases=["wark30m"],
     itrf_xyz=[-5115425.6, 477880.31, -3767042.81],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="warkworth_12m",
     aliases=["wark12m"],
     itrf_xyz=[-5115324.399, 477843.305, -3767192.886],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="lofar",
@@ -280,192 +484,263 @@ TopoObs(
     tempo_code="t",
     itoa_code="LF",
     itrf_xyz=[3826577.462, 461022.624, 5064892.526],
+    origin="""The Dutch low-frequency array LOFAR.
+
+    Note that other TEMPO codes have been used for this telescope.
+
+    Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de601lba",
     aliases=["eflfrlba"],
     itrf_xyz=[4034038.635, 487026.223, 4900280.057],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de601lbh",
     aliases=["eflfrlbh"],
     itrf_xyz=[4034038.635, 487026.223, 4900280.057],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de601hba",
     aliases=["eflfrhba"],
     itrf_xyz=[4034101.901, 487012.401, 4900230.21],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="de601", aliases=["eflfr"], itrf_xyz=[4034101.901, 487012.401, 4900230.21],
+    name="de601",
+    aliases=["eflfr"],
+    itrf_xyz=[4034101.901, 487012.401, 4900230.21],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de602lba",
     aliases=["uwlfrlba"],
     itrf_xyz=[4152561.068, 828868.725, 4754356.878],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de602lbh",
     aliases=["uwlfrlbh"],
     itrf_xyz=[4152561.068, 828868.725, 4754356.878],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de602hba",
     aliases=["uwlfrhba"],
     itrf_xyz=[4152568.416, 828788.802, 4754361.926],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="de602", aliases=["uwlfr"], itrf_xyz=[4152568.416, 828788.802, 4754361.926],
+    name="de602",
+    aliases=["uwlfr"],
+    itrf_xyz=[4152568.416, 828788.802, 4754361.926],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de603lba",
     aliases=["tblfrlba"],
     itrf_xyz=[3940285.328, 816802.001, 4932392.757],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de603lbh",
     aliases=["tblfrlbh"],
     itrf_xyz=[3940285.328, 816802.001, 4932392.757],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de603hba",
     aliases=["tblfrhba"],
     itrf_xyz=[3940296.126, 816722.532, 4932394.152],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="de603", aliases=["tblfr"], itrf_xyz=[3940296.126, 816722.532, 4932394.152],
+    name="de603",
+    aliases=["tblfr"],
+    itrf_xyz=[3940296.126, 816722.532, 4932394.152],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de604lba",
     aliases=["polfrlba"],
     itrf_xyz=[3796327.609, 877591.315, 5032757.252],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de604lbh",
     aliases=["polfrlbh"],
     itrf_xyz=[3796327.609, 877591.315, 5032757.252],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de604hba",
     aliases=["polfrhba"],
     itrf_xyz=[3796380.254, 877613.809, 5032712.272],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="de604", aliases=["polfr"], itrf_xyz=[3796380.254, 877613.809, 5032712.272],
+    name="de604",
+    aliases=["polfr"],
+    itrf_xyz=[3796380.254, 877613.809, 5032712.272],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de605lba",
     aliases=["julfrlba"],
     itrf_xyz=[4005681.742, 450968.282, 4926457.67],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de605lbh",
     aliases=["julfrlbh"],
     itrf_xyz=[4005681.742, 450968.282, 4926457.67],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de605hba",
     aliases=["julfrhba"],
     itrf_xyz=[4005681.407, 450968.304, 4926457.94],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="de605", aliases=["julfr"], itrf_xyz=[4005681.407, 450968.304, 4926457.94],
+    name="de605",
+    aliases=["julfr"],
+    itrf_xyz=[4005681.407, 450968.304, 4926457.94],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="fr606lba",
     aliases=["frlfrlba"],
     itrf_xyz=[4323980.155, 165608.408, 4670302.803],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="fr606lbh",
     aliases=["frlfrlbh"],
     itrf_xyz=[4323980.155, 165608.408, 4670302.803],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="fr606hba",
     aliases=["frlfrhba"],
     itrf_xyz=[4324017.054, 165545.16, 4670271.072],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="fr606", aliases=["frlfr"], itrf_xyz=[4324017.054, 165545.16, 4670271.072],
+    name="fr606",
+    aliases=["frlfr"],
+    itrf_xyz=[4324017.054, 165545.16, 4670271.072],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="se607lba",
     aliases=["onlfrlba"],
     itrf_xyz=[3370287.366, 712053.586, 5349991.228],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="se607lbh",
     aliases=["onlfrlbh"],
     itrf_xyz=[3370287.366, 712053.586, 5349991.228],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="se607hba",
     aliases=["onlfrhba"],
     itrf_xyz=[3370272.092, 712125.596, 5349990.934],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="se607", aliases=["onlfr"], itrf_xyz=[3370272.092, 712125.596, 5349990.934],
+    name="se607",
+    aliases=["onlfr"],
+    itrf_xyz=[3370272.092, 712125.596, 5349990.934],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="uk608lba",
     aliases=["uklfrlba"],
     itrf_xyz=[4008438.796, -100310.064, 4943735.554],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="uk608lbh",
     aliases=["uklfrlbh"],
     itrf_xyz=[4008438.796, -100310.064, 4943735.554],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="uk608hba",
     aliases=["uklfrhba"],
     itrf_xyz=[4008462.28, -100376.948, 4943716.6],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="uk608", aliases=["uklfr"], itrf_xyz=[4008462.28, -100376.948, 4943716.6],
+    name="uk608",
+    aliases=["uklfr"],
+    itrf_xyz=[4008462.28, -100376.948, 4943716.6],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de609lba",
     aliases=["ndlfrlba"],
     itrf_xyz=[3727207.778, 655184.9, 5117000.625],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de609lbh",
     aliases=["ndlfrlbh"],
     itrf_xyz=[3727207.778, 655184.9, 5117000.625],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="de609hba",
     aliases=["ndlfrhba"],
     itrf_xyz=[3727218.128, 655108.821, 5117002.847],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="de609", aliases=["ndlfr"], itrf_xyz=[3727218.128, 655108.821, 5117002.847],
+    name="de609",
+    aliases=["ndlfr"],
+    itrf_xyz=[3727218.128, 655108.821, 5117002.847],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="fi609lba",
     aliases=["filfrlba"],
     itrf_xyz=[2136833.225, 810088.74, 5935285.279],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="fi609lbh",
     aliases=["filfrlbh"],
     itrf_xyz=[2136833.225, 810088.74, 5935285.279],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="fi609hba",
     aliases=["filfrhba"],
     itrf_xyz=[2136819.194, 810039.5757, 5935299.0536],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="fi609", aliases=["filfr"], itrf_xyz=[2136819.194, 810039.5757, 5935299.0536],
+    name="fi609",
+    aliases=["filfr"],
+    itrf_xyz=[2136819.194, 810039.5757, 5935299.0536],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="utr-2", aliases=["utr2"], itrf_xyz=[3307865.236, 2487350.541, 4836939.784],
+    name="utr-2",
+    aliases=["utr2"],
+    itrf_xyz=[3307865.236, 2487350.541, 4836939.784],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="goldstone", aliases=["gs"], itrf_xyz=[-2353621.22, -4641341.52, 3677052.352],
+    name="goldstone",
+    aliases=["gs"],
+    itrf_xyz=[-2353621.22, -4641341.52, 3677052.352],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="shao",
@@ -473,42 +748,69 @@ TopoObs(
     tempo_code="s",
     itoa_code="SH",
     itrf_xyz=[-2826711.951, 4679231.627, 3274665.675],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="pico_veleta", aliases=["pv"], itrf_xyz=[5088964.0, 301689.8, 3825017.0],
+    name="pico_veleta",
+    aliases=["pv"],
+    tempo_code="v",
+    itoa_code="PV",
+    itrf_xyz=[5088964.0, 301689.8, 3825017.0],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="iar1", aliases=["iar1"], itrf_xyz=[2765357.08, -4449628.98, -3625726.47],
+    name="iar1",
+    aliases=["iar1"],
+    itrf_xyz=[2765357.08, -4449628.98, -3625726.47],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="iar2", aliases=["iar2"], itrf_xyz=[2765322.49, -4449569.52, -3625825.14],
+    name="iar2",
+    aliases=["iar2"],
+    itrf_xyz=[2765322.49, -4449569.52, -3625825.14],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="kat-7", aliases=["k7"], itrf_xyz=[5109943.105, 2003650.7359, -3239908.3195],
+    name="kat-7",
+    aliases=["k7"],
+    itrf_xyz=[5109943.105, 2003650.7359, -3239908.3195],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="mkiii", aliases=["jbmk3"], itrf_xyz=[383395.727, -173759.585, 5077751.313],
+    name="mkiii",
+    aliases=["jbmk3"],
+    itrf_xyz=[383395.727, -173759.585, 5077751.313],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="tabley", aliases=["tabley"], itrf_xyz=[3817176.557, -162921.17, 5089462.046],
+    name="tabley",
+    aliases=["tabley"],
+    itrf_xyz=[3817176.557, -162921.17, 5089462.046],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="darnhall",
     aliases=["darnhall"],
     itrf_xyz=[3828714.504, -169458.987, 5080647.749],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="knockin",
     aliases=["knockin"],
     itrf_xyz=[3859711.492, -201995.082, 5056134.285],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="defford",
     aliases=["defford"],
     itrf_xyz=[3923069.135, -146804.404, 5009320.57],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="cambridge", aliases=["cam"], itrf_xyz=[3919982.752, 2651.982, 5013849.826],
+    name="cambridge",
+    aliases=["cam"],
+    itrf_xyz=[3919982.752, 2651.982, 5013849.826],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="princeton",
@@ -516,12 +818,19 @@ TopoObs(
     tempo_code="5",
     itoa_code="PR",
     itrf_xyz=[1288748.38, -4694221.77, 4107418.8],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="hamburg", aliases=["hamburg"], itrf_xyz=[3788815.62, 1131748.336, 5035101.19],
+    name="hamburg",
+    aliases=["hamburg"],
+    itrf_xyz=[3788815.62, 1131748.336, 5035101.19],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="jb_42ft", aliases=["jb42"], itrf_xyz=[3822294.825, -153862.275, 5085987.071],
+    name="jb_42ft",
+    aliases=["jb42"],
+    itrf_xyz=[3822294.825, -153862.275, 5085987.071],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="jb_mkii",
@@ -529,25 +838,32 @@ TopoObs(
     tempo_code="h",
     itoa_code="J2",
     itrf_xyz=[3822846.76, -153802.28, 5086285.9],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="jb_mkii_rch",
     aliases=["jbmk2roach"],
     itrf_xyz=[3822846.76, -153802.28, 5086285.9],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="jb_mkii_dfb",
     aliases=["jbmk2dfb"],
     itrf_xyz=[3822846.76, -153802.28, 5086285.9],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="lwa_sv",
     aliases=["lwasv"],
     itoa_code="LS",
     itrf_xyz=[-1531155.54418, -5045324.30517, 3579583.8945],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
-    name="grao", aliases=["grao"], itrf_xyz=[6346273.531, -33779.7127, 634844.9454],
+    name="grao",
+    aliases=["grao"],
+    itrf_xyz=[6346273.531, -33779.7127, 634844.9454],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 TopoObs(
     name="srt",
@@ -555,6 +871,7 @@ TopoObs(
     tempo_code="z",
     itoa_code="SR",
     itrf_xyz=[4865182.766, 791922.689, 4035137.174],
+    origin="""Imported from TEMPO2 observatories.dat 2021 June 7.""",
 )
 
 # From Tempo 2021 June 8
@@ -563,21 +880,25 @@ TopoObs(
     tempo_code="2",
     itoa_code="QU",
     itrf_xyz=[1430913.3496148302, -4495711.383965823, 4278113.974517222],
+    origin="""Imported from TEMPO obsys.dat 2021 June 8.""",
 )
 TopoObs(
     name="vla_site",
     tempo_code="c",
     itoa_code="V2",
     itrf_xyz=[-1601135.5133304405, -5042005.480977412, 3554875.076856462],
+    origin="""Imported from TEMPO obsys.dat 2021 June 8.""",
 )
 TopoObs(
     name="gb_20m_xyz",
     itoa_code="G2",
     itrf_xyz=[883772.7974, -4924385.5975, 3944042.4991],
+    origin="""Imported from TEMPO obsys.dat 2021 June 8.""",
 )
 TopoObs(
     name="northern_cross",
     tempo_code="d",
     itoa_code="BO",
     itrf_xyz=[4461242.882451464, 919559.8351226494, 4449633.220012489],
+    origin="""Imported from TEMPO obsys.dat 2021 June 8.""",
 )

--- a/src/pint/observatory/special_locations.py
+++ b/src/pint/observatory/special_locations.py
@@ -3,6 +3,8 @@
 Special "site" locations (eg, barycenter) which do not need clock
 corrections or much else done.
 """
+import os
+
 import astropy.constants as const
 import astropy.units as u
 from astropy import log
@@ -64,7 +66,9 @@ class SpecialLocation(Observatory):
         self.bipm_version = bipm_version
         self._bipm_clock = None
 
-        super(SpecialLocation, self).__init__(name, aliases=aliases)
+        self.origin = "Built-in special location."
+
+        super().__init__(name, aliases=aliases)
 
     @property
     def gps_fullpath(self):

--- a/tests/test_observatory_metadata.py
+++ b/tests/test_observatory_metadata.py
@@ -43,41 +43,37 @@ class TestObservatoryMetadata(unittest.TestCase):
     def test_observatory_replacement(self):
         from pint.observatory.topo_obs import TopoObs
 
-        gbt = pint.observatory.get_observatory(self.pint_obsname)
-        msg = "Checking that 'test' is in the metadata for '%s': metadata is '%s'" % (
-            self.pint_obsname,
-            gbt.origin,
+        obsname = "nonexistent"
+
+        TopoObs(
+            obsname,
+            itrf_xyz=[882589.65, -4924872.32, 3943729.348],
+            overwrite=True,
+            origin="Inserted for testing purposes",
         )
-        assert "test" in gbt.origin, msg
-        msg = (
-            "This should raise an exception because we are making a replacement observatory for '%s' but overwrite=False"
-            % self.pint_obsname
-        )
+        obs = pint.observatory.get_observatory(obsname)
         self.assertRaises(
             ValueError,
             TopoObs,
-            self.pint_obsname,
-            tempo_code="1",
-            itoa_code="GB",
+            obsname,
             itrf_xyz=[882589.65, -4924872.32, 3943729.348],
             origin="This is a test - replacement",
         )
+        obs = pint.observatory.get_observatory(obsname)
         msg = (
             "Checking that 'replacement' is not in the metadata for '%s': metadata is '%s'"
-            % (self.pint_obsname, gbt.origin)
+            % (obsname, obs.origin)
         )
-        assert not ("replacement" in gbt.origin), msg
+        assert not ("replacement" in obs.origin), msg
         TopoObs(
-            self.pint_obsname,
-            tempo_code="1",
-            itoa_code="GB",
+            obsname,
             itrf_xyz=[882589.65, -4924872.32, 3943729.348],
             origin="This is a test - replacement",
             overwrite=True,
         )
-        gbt = pint.observatory.get_observatory(self.pint_obsname)
+        obs = pint.observatory.get_observatory(obsname)
         msg = (
             "Checking that 'replacement' is now in the metadata for '%s': metadata is '%s'"
-            % (self.pint_obsname, gbt.origin)
+            % (obsname, obs.origin)
         )
-        assert "replacement" in gbt.origin, msg
+        assert "replacement" in obs.origin, msg


### PR DESCRIPTION
This PR also includes a function to check PINT's list of observatories against TEMPO and TEMPO2's and report ones that PINT is missing or thinks are different. With this patch the only differences appear to be errors in TEMPO2 or minor disagreements in position.

One possible warning is that TEMPO expects G1 to mean the GBT 140-foot while PINT previously defined G1 to be the GEO600 site. I removed the latter but left a comment. 

Now includes `origin` strings for most (all?) topographic observatories, describing the origin and/or comparison with TEMPO/TEMPO2 plus any other information that seemed relevant and easy to obtain.

Closes #1049
Closes #1048