### PR TITLE
Clean up and test derivative calculations

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -33,3 +33,4 @@ pygments
 ipython
 pathlib2
 twine
+numdifftools

--- a/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
+++ b/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
@@ -50,8 +50,10 @@ class Orbit:
         try:
             func = getattr(self, "d_orbits_d_" + par)
         except AttributeError:
+
             def func():
                 return np.zeros(len(self.tt0)) * u.Unit("") / par_obj.unit
+
         result = func()
         return result
 
@@ -61,8 +63,10 @@ class Orbit:
         try:
             func = getattr(self, "d_pbprime_d_" + par)
         except AttributeError:
+
             def func():
                 return np.zeros(len(self.tt0)) * u.day / par_obj.unit
+
         result = func()
         return result
 
@@ -90,6 +94,7 @@ class OrbitPB(Orbit):
     subtracted from PBDOT when computing the derivative of orbits with respect
     to T0. It is also not included when computing ``pbdot_orbit``.
     """
+
     def __init__(self, parent, orbit_params=["PB", "PBDOT", "XPBDOT", "T0"]):
         super().__init__("orbitPB", parent, orbit_params)
 
@@ -154,6 +159,7 @@ class OrbitPB(Orbit):
 
 class OrbitFBX(Orbit):
     """Orbits expressed in terms of orbital frequency and its derivatives FB0, FB1, FB2..."""
+
     def __init__(self, parent, orbit_params=["FB0"]):
         super().__init__("orbitFBX", parent, orbit_params)
         # add the rest of FBX parameters.
@@ -164,8 +170,10 @@ class OrbitFBX(Orbit):
                     self.orbit_params += [k]
                     indices.add(int(k[2:]))
         if indices != set(range(len(indices))):
-            raise ValueError(f"Indices must be 0 up to some number k without gaps "
-                             f"but are {indices}.")
+            raise ValueError(
+                f"Indices must be 0 up to some number k without gaps "
+                f"but are {indices}."
+            )
 
     def _FBXs(self):
         FBXs = [0 * u.Unit("")]

--- a/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
+++ b/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
@@ -44,7 +44,7 @@ class Orbit:
         Note
         ----
         This gives the derivative of ``orbit_phase``, that is, it is scaled by 2 pi
-        with respect to the derivative with respect to the derivative of ``orbits``.
+        with respect to the derivative of ``orbits``.
         """
         par_obj = getattr(self, par)
         try:
@@ -88,7 +88,7 @@ class OrbitPB(Orbit):
     XPBDOT is something else, not completely clear what. It is added to PBDOT
     when computing ``orbits`` and its derivative with respect to PB, but it is
     subtracted from PBDOT when computing the derivative of orbits with respect
-    to T0. It is also not included when computing ``ppbdot_orbit``.
+    to T0. It is also not included when computing ``pbdot_orbit``.
     """
     def __init__(self, parent, orbit_params=["PB", "PBDOT", "XPBDOT", "T0"]):
         super().__init__("orbitPB", parent, orbit_params)

--- a/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
+++ b/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
@@ -7,8 +7,12 @@ import pint.utils as ut
 from pint.utils import taylor_horner, taylor_horner_deriv
 
 
-class orbits:
-    """This is a base class for implementing different parameterization of pulsar binary orbits."""
+class Orbit:
+    """Base class for implementing different parameterization of pulsar binary orbits.
+
+    It should be constructed with a ``parent`` class, so that parameter lookups can be
+    referred to the parent class by a custom ``__getattr__``.
+    """
 
     def __init__(self, orbit_name, parent, orbit_params=[]):
         self.name = orbit_name
@@ -16,64 +20,81 @@ class orbits:
         self.orbit_params = orbit_params
 
     def orbits(self):
+        """Orbital phase (number of orbits since T0)."""
         raise NotImplementedError
 
     def orbit_phase(self):
+        """Orbital phase (between zero and two pi)."""
         orbits = self.orbits()
         norbits = np.array(np.floor(orbits), dtype=np.compat.long)
         phase = (orbits - norbits) * 2 * np.pi * u.rad
         return phase
 
     def pbprime(self):
+        """Derivative of binary period with respect to time."""
         raise NotImplementedError
 
     def pbdot_orbit(self):
+        """Reported value of PBDOT."""
         raise NotImplementedError
 
     def d_orbits_d_par(self, par):
+        """Derivative of orbital phase with respect to some parameter.
+
+        Note
+        ----
+        This gives the derivative of ``orbit_phase``, that is, it is scaled by 2 pi
+        with respect to the derivative with respect to the derivative of ``orbits``.
+        """
         par_obj = getattr(self, par)
         try:
             func = getattr(self, "d_orbits_d_" + par)
-        except:
-            func = lambda: np.zeros(len(self.tt0)) * u.Unit("") / par_obj.unit
+        except AttributeError:
+            def func():
+                return np.zeros(len(self.tt0)) * u.Unit("") / par_obj.unit
         result = func()
         return result
 
     def d_pbprime_d_par(self, par):
+        """Derivative of binary period with respect to some parameter."""
         par_obj = getattr(self, par)
         try:
             func = getattr(self, "d_pbprime_d_" + par)
-        except:
-            func = lambda: np.zeros(len(self.tt0)) * u.day / par_obj.unit
+        except AttributeError:
+            def func():
+                return np.zeros(len(self.tt0)) * u.day / par_obj.unit
         result = func()
         return result
 
     def __getattr__(self, name):
         try:
-            return super(orbits, self).__getattribute__(name)
+            return super().__getattribute__(name)
         except AttributeError:
-            try:
-                p = super(orbits, self).__getattribute__("_parent")
-                if p is None:
-                    raise AttributeError(
-                        "'%s' object has no attribute '%s'."
-                        % (self.__class__.__name__, name)
-                    )
-                else:
-                    return self._parent.__getattribute__(name)
-            except:
+            p = super().__getattribute__("_parent")
+            if p is None:
                 raise AttributeError(
                     "'%s' object has no attribute '%s'."
                     % (self.__class__.__name__, name)
                 )
+            else:
+                return self._parent.__getattribute__(name)
 
 
-class OrbitPB(orbits):
+class OrbitPB(Orbit):
+    """Orbits using PB, PBDOT, XPBDOT.
+
+    PBDOT is just the conventional derivative of the binary period.
+
+    XPBDOT is something else, not completely clear what. It is added to PBDOT
+    when computing ``orbits`` and its derivative with respect to PB, but it is
+    subtracted from PBDOT when computing the derivative of orbits with respect
+    to T0. It is also not included when computing ``ppbdot_orbit``.
+    """
     def __init__(self, parent, orbit_params=["PB", "PBDOT", "XPBDOT", "T0"]):
-        super(OrbitPB, self).__init__("orbitPB", parent, orbit_params)
+        super().__init__("orbitPB", parent, orbit_params)
 
-    def orbits(self,):
-        """Orbits using PB, PBDOT, XPBDOT"""
+    def orbits(self):
+        """Orbital phase (number of orbits since T0)."""
         PB = self.PB.to("second")
         PBDOT = self.PBDOT
         XPBDOT = self.XPBDOT
@@ -83,13 +104,15 @@ class OrbitPB(orbits):
         return orbits
 
     def pbprime(self):
+        """Derivative of binary period with respect to time."""
         return self.PB + self.PBDOT * self.tt0
 
     def pbdot_orbit(self):
+        """Reported value of PBDOT."""
         return self.PBDOT
 
     def d_orbits_d_T0(self):
-        """The derivitve of orbits respect to T0"""
+        """The derivatve of orbits with respect to T0."""
         PB = self.PB.to("second")
         PBDOT = self.PBDOT
         XPBDOT = self.XPBDOT
@@ -129,47 +152,49 @@ class OrbitPB(orbits):
         return result * u.Unit(self.PBDOT.unit)
 
 
-class OrbitFBX(orbits):
+class OrbitFBX(Orbit):
+    """Orbits expressed in terms of orbital frequency and its derivatives FB0, FB1, FB2..."""
     def __init__(self, parent, orbit_params=["FB0"]):
-        super(OrbitFBX, self).__init__("orbitFBX", parent, orbit_params)
+        super().__init__("orbitFBX", parent, orbit_params)
         # add the rest of FBX parameters.
+        indices = set()
         for k in self.binary_params:
-            if re.match(r"FB\d", k) is not None:
+            if re.match(r"FB\d+", k) is not None:
                 if k not in self.orbit_params:
                     self.orbit_params += [k]
+                    indices.add(int(k[2:]))
+        if indices != set(range(len(indices))):
+            raise ValueError(f"Indices must be 0 up to some number k without gaps "
+                             f"but are {indices}.")
 
-    def orbits(self):
+    def _FBXs(self):
         FBXs = [0 * u.Unit("")]
         ii = 0
         while "FB" + str(ii) in self.orbit_params:
             FBXs.append(getattr(self, "FB" + str(ii)))
             ii += 1
-        orbits = taylor_horner(self.tt0, FBXs)
+        return FBXs
+
+    def orbits(self):
+        """Orbital phase (number of orbits since T0)."""
+        orbits = taylor_horner(self.tt0, self._FBXs())
         return orbits.decompose()
 
     def pbprime(self):
-        FBXs = [0 * u.Unit("")]
-        ii = 0
-        while "FB" + str(ii) in self.orbit_params:
-            FBXs.append(getattr(self, "FB" + str(ii)))
-            ii += 1
-        orbit_freq = taylor_horner_deriv(self.tt0, FBXs, 1)
+        """Derivative of binary period with respect to time."""
+        orbit_freq = taylor_horner_deriv(self.tt0, self._FBXs(), 1)
         return 1.0 / orbit_freq
 
     def pbdot_orbit(self):
-        FBXs = [0 * u.Unit("")]
-        ii = 0
-        while "FB" + str(ii) in self.orbit_params:
-            FBXs.append(getattr(self, "FB" + str(ii)))
-            ii += 1
-        orbit_freq_dot = taylor_horner_deriv(self.tt0, FBXs, 2)
+        """Reported value of PBDOT."""
+        orbit_freq_dot = taylor_horner_deriv(self.tt0, self._FBXs(), 2)
         return -(self.pbprime() ** 2) * orbit_freq_dot
 
     def d_orbits_d_par(self, par):
-        if re.match(r"FB\d", par) is not None:
+        if re.match(r"FB\d+", par) is not None:
             result = self.d_orbits_d_FBX(par)
         else:
-            result = super(OrbitFBX, self).d_orbits_d_par(par)
+            result = super().d_orbits_d_par(par)
         return result
 
     def d_orbits_d_FBX(self, FBX):
@@ -181,6 +206,7 @@ class OrbitFBX(orbits):
                 FBXs.append(0.0 * getattr(self, "FB" + str(ii)).unit)
             else:
                 FBXs.append(1.0 * getattr(self, "FB" + str(ii)).unit)
+                break
             ii += 1
         d_orbits = taylor_horner(self.tt0, FBXs) / par.unit
         return d_orbits.decompose() * 2 * np.pi * u.rad
@@ -194,13 +220,14 @@ class OrbitFBX(orbits):
                 FBXs.append(0.0 * getattr(self, "FB" + str(ii)).unit)
             else:
                 FBXs.append(1.0 * getattr(self, "FB" + str(ii)).unit)
+                break
             ii += 1
         d_FB = taylor_horner_deriv(self.tt0, FBXs, 1) / par.unit
         return -(self.pbprime() ** 2) * d_FB
 
     def d_pbprime_d_par(self, par):
         par_obj = getattr(self, par)
-        if re.match(r"FB\d", par) is not None:
+        if re.match(r"FB\d+", par) is not None:
             result = self.d_pbprime_d_FBX(par)
         else:
             result = np.zeros(len(self.tt0)) * u.second / par_obj.unit

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1597,13 +1597,13 @@ class TimingModel:
         M = np.zeros((ntoas, nparams))
         for ii, param in enumerate(params):
             if param == "Offset":
-                M[:, ii] = 1.0/F0.value
+                M[:, ii] = 1.0 / F0.value
                 units.append(u.s / u.s)
             else:
                 q = -self.d_phase_d_param(toas, delay, param)
                 the_unit = u.Unit("") / getattr(self, param).units
-                M[:, ii] = q.to_value(the_unit)/F0.value
-                units.append(the_unit/F0.unit)
+                M[:, ii] = q.to_value(the_unit) / F0.value
+                units.append(the_unit / F0.unit)
         return M, params, units
 
     def compare(

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1022,18 +1022,18 @@ class TimingModel:
     def delay(self, toas, cutoff_component="", include_last=True):
         """Total delay for the TOAs.
 
+        Return the total delay which will be subtracted from the given
+        TOA to get time of emission at the pulsar.
+
         Parameters
         ----------
-        toas: toa.table
+        toas: pint.toa.TOAs
             The toas for analysis delays.
         cutoff_component: str
             The delay component name that a user wants the calculation to stop
             at.
         include_last: bool
             If the cutoff delay component is included.
-
-        Return the total delay which will be subtracted from the given
-        TOA to get time of emission at the pulsar.
         """
         delay = np.zeros(toas.ntoas) * u.second
         if cutoff_component == "":
@@ -1057,7 +1057,7 @@ class TimingModel:
         """Return the model-predicted pulse phase for the given TOAs.
 
         This is the phase as observed at the observatory at the exact moment
-        specified in each TOA. The result is a `~pint.phase.Phase` object.
+        specified in each TOA. The result is a :class:`pint.phase.Phase` object.
         """
         # First compute the delays to "pulsar time"
         delay = self.delay(toas)
@@ -1141,7 +1141,7 @@ class TimingModel:
 
         Parameters
         ----------
-        toas: `pint.toa.TOAs` object
+        toas: pint.toa.TOAs
             The input data object for TOAs uncertainty.
         """
         ntoa = toas.ntoas
@@ -1164,7 +1164,7 @@ class TimingModel:
 
         Parameters
         ----------
-        toas: `pint.toa.TOAs` object
+        toas: pint.toa.TOAs
             The input data object for DM uncertainty.
         """
         dm_error, valid = toas.get_flag_value("pp_dme")
@@ -1335,7 +1335,7 @@ class TimingModel:
 
         Return
         ------
-        astropy.Quantity
+        astropy.units.Quantity
             Barycentered TOAs.
         """
         tbl = toas.table
@@ -1352,12 +1352,11 @@ class TimingModel:
 
         Parameters
         ----------
-        toas : PINT TOAs class
+        toas : pint.toa.TOAs
             The toas when the derivative of phase will be evaluated at.
-        sample_step : float optional
+        sample_step : float, optional
             Finite difference steps. If not specified, it will take 1000 times the
             spin period.
-
         """
         copy_toas = copy.deepcopy(toas)
         if sample_step is None:
@@ -1394,7 +1393,7 @@ class TimingModel:
         respect to each parameter. This is closely related to the derivative
         of residuals with respect to each parameter, differing only by a
         factor of the spin frequency and possibly a minus sign. See
-        `~pint.models.timing_model.TimingModel.designmatrix` for a way
+        :meth:`pint.models.timing_model.TimingModel.designmatrix` for a way
         of evaluating many derivatives at once.
 
         The calculation is done by combining the analytical derivatives
@@ -1402,7 +1401,7 @@ class TimingModel:
 
         Parameters
         ----------
-        toas : pint.toas.TOAs
+        toas : pint.toa.TOAs
             The TOAs at which the derivative should be evaluated.
         delay : astropy.units.Quantity or None
             The delay at the TOAs where the derivatives should be evaluated.
@@ -1543,18 +1542,18 @@ class TimingModel:
     def designmatrix(self, toas, acc_delay=None, incfrozen=False, incoffset=True):
         """Return the design matrix.
 
-        The design matrix is the matrix with columns of d_phase_d_param/F0
-        or d_toa_d_param; it is used in fitting and calculating parameter
+        The design matrix is the matrix with columns of ``d_phase_d_param/F0``
+        or ``d_toa_d_param``; it is used in fitting and calculating parameter
         covariances.
 
-        The value of F0 used here is the parameter value in the model.
+        The value of ``F0`` used here is the parameter value in the model.
 
         The order of parameters that are included is that returned by
-        self.params.
+        ``self.params``.
 
         Parameters
         ----------
-        toas : pint.toas.TOAs
+        toas : pint.toa.TOAs
             The TOAs at which to compute the design matrix.
         acc_delay
             ???

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1,6 +1,28 @@
 """Timing model objects.
 
 Defines the basic timing model interface classes.
+
+A PINT timing model will be an instance of
+:class:`pint.models.timing_model.TimingModel`. It will have a number of
+"components", each an instance of a subclass of
+:class:`pint.models.timing_model.Component`. These components each
+implement some part of the timing model, whether astrometry (for
+example :class:`pint.models.astrometry.AstrometryEcliptic`), noise
+modelling (for example :class:`pint.models.noise_model.ScaleToaError`),
+interstellar dispersion (for example
+:class:`pint.models.dispersion_model.DispersionDM`), or pulsar binary orbits.
+This last category is somewhat unusual in that the code for each model is
+divided into a PINT-facing side (for example
+:class:`pint.models.binary_bt.BinaryBT`) and an internal model that does the
+actual computation (for example
+:class:`pint.models.stand_alone_psr_binaries.BT_model.BTmodel`); the management of
+data passing between these two parts is carried out by
+:class:`pint.models.pulsar_binary.PulsarBinary` and
+:class:`pint.models.stand_alone_psr_binaries.binary_generic.PSR_BINARY`.
+
+To actually create a timing model, you almost certainly want to use
+:func:`pint.models.model_builder.get_model`.
+
 """
 import abc
 import copy
@@ -147,6 +169,11 @@ class TimingModel:
     TimingModel objects also support a number of functions for computing
     various things like orbital phase, and barycentric versions of TOAs,
     as well as the various derivatives and matrices needed to support fitting.
+
+    TimingModel objects forward attribute lookups to their components, so
+    that you can access any method or attribute (in particular Parameters)
+    of any Component directly on the TimingModel object, for example as
+    ``model.F0``.
 
     TimingModel objects can be written out to ``.par`` files using
     :func:`pint.models.timing_model.TimingModel.as_parfile`.

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -304,16 +304,30 @@ def taylor_horner(x, coeffs):
         In [1]: taylor_horner(2.0, [10, 3, 4, 12])
         Out[1]: 40.0
 
+    Parameters
+    ----------
+    x: astropy.units.Quantity
+        Input value; may be an array.
+    coeffs: list of astropy.units.Quantity
+        Coefficient array; must have length at least one. The coefficient in
+        position ``i`` is multiplied by ``x**i``. Each coefficient should
+        just be a number, not an array. The units should be compatible once
+        multiplied by an appropriate power of x.
+
+    Returns
+    -------
+    astropy.units.Quantity
+        Output value; same shape as input. Units as inferred from inputs.
     """
     result = 0.0
     if hasattr(coeffs[-1], "unit"):
         if not hasattr(x, "unit"):
             x = x * u.Unit("")
         result *= coeffs[-1].unit / x.unit
-    fact = float(len(coeffs))
+    fact = len(coeffs)
     for coeff in coeffs[::-1]:
         result = result * x / fact + coeff
-        fact -= 1.0
+        fact -= 1
     return result
 
 
@@ -326,6 +340,22 @@ def taylor_horner_deriv(x, coeffs, deriv_order=1):
         In [1]: taylor_horner_deriv(2.0, [10, 3, 4, 12], 1)
         Out[1]: 15.0
 
+    Parameters
+    ----------
+    x: astropy.units.Quantity
+        Input value; may be an array.
+    coeffs: list of astropy.units.Quantity
+        Coefficient array; must have length at least one. The coefficient in
+        position ``i`` is multiplied by ``x**i``. Each coefficient should
+        just be a number, not an array. The units should be compatible once
+        multiplied by an appropriate power of x.
+    deriv_order: int
+        The order of the derivative to take (that is, how many times to differentiate).
+
+    Returns
+    -------
+    astropy.units.Quantity
+        Output value; same shape as input. Units as inferred from inputs.
     """
     result = 0.0
     if hasattr(coeffs[-1], "unit"):
@@ -333,7 +363,7 @@ def taylor_horner_deriv(x, coeffs, deriv_order=1):
             x = x * u.Unit("")
         result *= coeffs[-1].unit / x.unit
     der_coeffs = coeffs[deriv_order::]
-    fact = float(len(der_coeffs))
+    fact = len(der_coeffs)
     for coeff in der_coeffs[::-1]:
         result = result * x / fact + coeff
         fact -= 1.0
@@ -1247,10 +1277,10 @@ def pulsar_mass(pb, x, mc, inc):
     mass : Quantity in `u.solMass`
 
     Notes
-    -------    
+    -------
     This forms a quadratic equation of the form:
     ca*Mp**2 + cb*Mp + cc = 0
-    
+
     with:
     ca = massfunct
     cb = 2 * massfunct * mc
@@ -1258,7 +1288,7 @@ def pulsar_mass(pb, x, mc, inc):
 
     except the discriminant simplifies to:
     4 * massfunct * mc**3 * sini**3
-    
+
     solve it directly
     this has to be the positive branch of the quadratic
     because the vertex is at -mc, so the negative branch will always be < 0
@@ -1320,7 +1350,7 @@ def companion_mass(pb, x, inc=60.0 * u.deg, mpsr=1.4 * u.solMass):
 
     It's useful to look at the discriminant to understand the nature of the roots
     and make sure we get the right one
-    
+
     https://en.wikipedia.org/wiki/Discriminant#Degree_3
     delta = (
         cb ** 2 * cc ** 2
@@ -1333,7 +1363,7 @@ def companion_mass(pb, x, inc=60.0 * u.deg, mpsr=1.4 * u.solMass):
     and this should be < 0
     since this reduces to -27 * sin(i)**6 * massfunct**2 * mp**4 -4 * sin(i)**3 * massfunct**3 * mp**3
     so there is just 1 real root and we compute it below
-    
+
     """
     if not (isinstance(inc, angles.Angle) or isinstance(inc, u.quantity.Quantity)):
         raise ValueError(f"The inclination should be an Angle but is {inc}.")
@@ -1492,7 +1522,7 @@ def FTest(chi2_1, dof_1, chi2_2, dof_2):
     if delta_chi2 > 0 and dof_1 != dof_2:
         delta_dof = dof_1 - dof_2
         new_redchi2 = chi2_2 / dof_2
-        F = np.float64(
+        F = float(
             (delta_chi2 / delta_dof) / new_redchi2
         )  # fdtr doesn't like float128
         ft = fdtrc(delta_dof, dof_2, F)

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -319,16 +319,7 @@ def taylor_horner(x, coeffs):
     astropy.units.Quantity
         Output value; same shape as input. Units as inferred from inputs.
     """
-    result = 0.0
-    if hasattr(coeffs[-1], "unit"):
-        if not hasattr(x, "unit"):
-            x = x * u.Unit("")
-        result *= coeffs[-1].unit / x.unit
-    fact = len(coeffs)
-    for coeff in coeffs[::-1]:
-        result = result * x / fact + coeff
-        fact -= 1
-    return result
+    return taylor_horner_deriv(x, coeffs, deriv_order=0)
 
 
 def taylor_horner_deriv(x, coeffs, deriv_order=1):
@@ -351,6 +342,7 @@ def taylor_horner_deriv(x, coeffs, deriv_order=1):
         multiplied by an appropriate power of x.
     deriv_order: int
         The order of the derivative to take (that is, how many times to differentiate).
+        Must be non-negative.
 
     Returns
     -------

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1514,9 +1514,7 @@ def FTest(chi2_1, dof_1, chi2_2, dof_2):
     if delta_chi2 > 0 and dof_1 != dof_2:
         delta_dof = dof_1 - dof_2
         new_redchi2 = chi2_2 / dof_2
-        F = float(
-            (delta_chi2 / delta_dof) / new_redchi2
-        )  # fdtr doesn't like float128
+        F = float((delta_chi2 / delta_dof) / new_redchi2)  # fdtr doesn't like float128
         ft = fdtrc(delta_dof, dof_2, F)
     elif dof_1 == dof_2:
         log.warning("Models have equal degrees of freedom, cannot perform F-test.")

--- a/tests/test_d_phase_d_toa.py
+++ b/tests/test_d_phase_d_toa.py
@@ -28,7 +28,7 @@ class TestD_phase_d_toa(unittest.TestCase):
         self.plc = Polycos()
         self.plc.read_polyco_file("B1855_polyco.dat", "tempo")
 
-    def TestD_phase_d_toa(self):
+    def testD_phase_d_toa(self):
         pint_d_phase_d_toa = self.modelB1855.d_phase_d_toa(self.toasB1855)
         mjd = np.array(
             [
@@ -39,7 +39,7 @@ class TestD_phase_d_toa(unittest.TestCase):
         tempo_d_phase_d_toa = self.plc.eval_spin_freq(mjd)
         diff = pint_d_phase_d_toa.value - tempo_d_phase_d_toa
         relative_diff = diff / tempo_d_phase_d_toa
-        assert np.all(relative_diff < 1e-8), "d_phae_d_toa test filed."
+        assert np.all(relative_diff < 1e-20), "d_phae_d_toa test filed."
 
 
 if __name__ == "__main__":

--- a/tests/test_ddk.py
+++ b/tests/test_ddk.py
@@ -1,4 +1,5 @@
 """Various tests to assess the performance of the DD model."""
+import copy
 import logging
 import os
 from io import StringIO
@@ -89,20 +90,22 @@ class TestDDK(unittest.TestCase):
                 continue
 
     def test_K96(self):
+        modelJ1713 = copy.deepcopy(self.modelJ1713)
         log = logging.getLogger("TestJ1713 Switch of K96")
-        self.modelJ1713.K96.value = False
+        modelJ1713.K96.value = False
         res = Residuals(
-            self.toasJ1713, self.modelJ1713, use_weighted_mean=False
+            self.toasJ1713, modelJ1713, use_weighted_mean=False
         ).time_resids.to(u.s)
         delay = self.modelJ1713.delay(self.toasJ1713)
-        testp = tdu.get_derivative_params(self.modelJ1713)
+        testp = tdu.get_derivative_params(modelJ1713)
         for p in testp.keys():
-            adf = self.modelJ1713.d_phase_d_param(self.toasJ1713, delay, p)
+            self.modelJ1713.d_phase_d_param(self.toasJ1713, delay, p)
 
     def test_sini_from_value(self):
-        self.modelJ1713.SINI.value = 0.9
+        modelJ1713 = copy.deepcopy(self.modelJ1713)
+        modelJ1713.SINI.value = 0.9
         with pytest.raises(ValueError):
-            self.modelJ1713.validate()
+            modelJ1713.validate()
 
     def test_sini_from_par(self):
         temp_par_str = """PSR  J1713+0747

--- a/tests/test_model_derivatives.py
+++ b/tests/test_model_derivatives.py
@@ -33,83 +33,6 @@ class Values:
         return f"{os.path.basename(self.parfile)}::{self.param}"
 
 
-models = {}
-bad_models = set()
-
-
-@composite
-def model_and_free_param(draw):
-    known_bad = set()
-    parfiles = sorted(
-        set(
-            glob(os.path.join(os.path.dirname(__file__), "datafile", "*.par"))
-        ).difference(known_bad)
-    )
-    parfile = draw(sampled_from(parfiles))
-    try:
-        m = models[parfile]
-    except KeyError:
-        assume(parfile not in bad_models)
-        with quiet():
-            try:
-                m = get_model(parfile)
-            except (ValueError, AttributeError):
-                bad_models.add(parfile)
-                assume(False)
-            else:
-                models[parfile] = m
-    assume(m.free_params)
-    v = Values()
-    v.parfile = parfile
-    v.model = m
-    v.param = draw(sampled_from(m.free_params))
-    return v
-
-
-# @settings(suppress_health_check=[HealthCheck.too_slow], verbosity=Verbosity.verbose)
-# @given(model_and_free_param())
-# def test_load_ok(model_and_param):
-#    pass
-
-
-# For some reason this is extremely slow
-@settings(suppress_health_check=[HealthCheck.too_slow], verbosity=Verbosity.verbose)
-# @settings(suppress_health_check=[HealthCheck.too_slow])
-@given(model_and_free_param(), floats(50000, 60000))
-def disabled_test_derivative_equals_numerical(model_and_param, start):
-    _, model, param = (
-        model_and_param.parfile,
-        model_and_param.model,
-        model_and_param.param,
-    )
-    with quiet():
-        toas = pint.toa.make_fake_toas(
-            model=model, startMJD=start, endMJD=start + 1, ntoas=2
-        )
-        phase = model.phase(toas)
-    units = getattr(model, param).units
-
-    def f(value):
-        m = copy.deepcopy(model)
-        getattr(m, param).value = value
-        with quiet():
-            warnings.simplefilter("ignore")
-            try:
-                dphase = m.phase(toas) - phase
-            except ValueError:
-                return np.nan * np.zeros_like(phase.frac)
-        return dphase.int + dphase.frac
-
-    df = numdifftools.Derivative(f)
-
-    assert_allclose(
-        model.d_phase_d_param(toas, delay=None, param=param).to_value(1 / units),
-        df(getattr(model, param).value),
-        atol=1e-3,
-        rtol=1e-3,
-    )
-
-
 _cached_models = {}
 
 
@@ -127,9 +50,13 @@ def get_model_and_toas(parfile):
     if parfile not in _cached_toas:
         model = get_model_cached(parfile)
         with quiet():
-            toas = pint.toa.make_fake_toas(
-                model=model, startMJD=57000, endMJD=58000, ntoas=5
+            toas1 = pint.toa.make_fake_toas(
+                model=model, startMJD=57000, endMJD=58000, ntoas=5, freq=1400, obs='gbt'
             )
+            toas2 = pint.toa.make_fake_toas(
+                model=model, startMJD=57100, endMJD=58000, ntoas=5, freq=2000, obs='ao'
+            )
+            toas = pint.toa.merge_TOAs([toas1, toas2])
             phase = model.phase(toas)
         _cached_toas[parfile] = model, toas, phase
     return copy.deepcopy(_cached_toas[parfile])
@@ -174,7 +101,7 @@ def get_model_and_toas(parfile):
     + [("B1855+09_NANOGrav_12yv3.wb.gls.par", param) for param in ["M2", "SINI",]]
     + [
         ("J0023+0923_NANOGrav_11yv0.gls.par", param)
-        for param in ["FB0", "FB1", "FB2", "FB3",]
+        for param in ["FB0", "FB1", "FB2", "FB3", "FD1", "JUMP1"]
     ]
     + [("J0613-0200_NANOGrav_9yv1_ELL1H.gls.par", param) for param in ["H3", "H4",]]
     + [
@@ -186,7 +113,7 @@ def get_model_and_toas(parfile):
         for param in ["PB", "A1", "ECC", "T0", "M2", "KIN", "KOM", "PX",]
     ],
 )
-def test_derivative_equals_numerical_multi(parfile, param):
+def test_derivative_equals_numerical(parfile, param):
     model, toas, phase = get_model_and_toas(
         os.path.join(os.path.dirname(__file__), "datafile", parfile)
     )
@@ -203,7 +130,12 @@ def test_derivative_equals_numerical_multi(parfile, param):
                 return np.nan * np.zeros_like(phase.frac)
         return dphase.int + dphase.frac
 
-    df = numdifftools.Derivative(f)
+    if param == 'ECC':
+        e = model.ECC.value
+        stepgen = numdifftools.MaxStepGenerator(min(e, 1-e))
+    else:
+        stepgen = None
+    df = numdifftools.Derivative(f, step=stepgen)
 
     assert_allclose(
         model.d_phase_d_param(toas, delay=None, param=param).to_value(1 / units),

--- a/tests/test_model_derivatives.py
+++ b/tests/test_model_derivatives.py
@@ -1,0 +1,213 @@
+import copy
+import logging
+import os.path
+import warnings
+from contextlib import contextmanager
+from glob import glob
+
+import numdifftools
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, Verbosity, assume, given, settings
+from hypothesis.strategies import composite, floats, integers, sampled_from
+from numpy.testing import assert_allclose
+
+import pint.toa
+from pint.models import get_model
+
+
+@contextmanager
+def quiet():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        previous_level = logging.root.manager.disable
+        logging.disable(logging.CRITICAL)
+        try:
+            yield
+        finally:
+            logging.disable(previous_level)
+
+
+class Values:
+    def __repr__(self):
+        return f"{os.path.basename(self.parfile)}::{self.param}"
+
+
+models = {}
+bad_models = set()
+
+
+@composite
+def model_and_free_param(draw):
+    known_bad = set()
+    parfiles = sorted(
+        set(
+            glob(os.path.join(os.path.dirname(__file__), "datafile", "*.par"))
+        ).difference(known_bad)
+    )
+    parfile = draw(sampled_from(parfiles))
+    try:
+        m = models[parfile]
+    except KeyError:
+        assume(parfile not in bad_models)
+        with quiet():
+            try:
+                m = get_model(parfile)
+            except (ValueError, AttributeError):
+                bad_models.add(parfile)
+                assume(False)
+            else:
+                models[parfile] = m
+    assume(m.free_params)
+    v = Values()
+    v.parfile = parfile
+    v.model = m
+    v.param = draw(sampled_from(m.free_params))
+    return v
+
+
+# @settings(suppress_health_check=[HealthCheck.too_slow], verbosity=Verbosity.verbose)
+# @given(model_and_free_param())
+# def test_load_ok(model_and_param):
+#    pass
+
+
+# For some reason this is extremely slow
+@settings(suppress_health_check=[HealthCheck.too_slow], verbosity=Verbosity.verbose)
+# @settings(suppress_health_check=[HealthCheck.too_slow])
+@given(model_and_free_param(), floats(50000, 60000))
+def disabled_test_derivative_equals_numerical(model_and_param, start):
+    _, model, param = (
+        model_and_param.parfile,
+        model_and_param.model,
+        model_and_param.param,
+    )
+    with quiet():
+        toas = pint.toa.make_fake_toas(
+            model=model, startMJD=start, endMJD=start + 1, ntoas=2
+        )
+        phase = model.phase(toas)
+    units = getattr(model, param).units
+
+    def f(value):
+        m = copy.deepcopy(model)
+        getattr(m, param).value = value
+        with quiet():
+            warnings.simplefilter("ignore")
+            try:
+                dphase = m.phase(toas) - phase
+            except ValueError:
+                return np.nan * np.zeros_like(phase.frac)
+        return dphase.int + dphase.frac
+
+    df = numdifftools.Derivative(f)
+
+    assert_allclose(
+        model.d_phase_d_param(toas, delay=None, param=param).to_value(1 / units),
+        df(getattr(model, param).value),
+        atol=1e-3,
+        rtol=1e-3,
+    )
+
+
+_cached_models = {}
+
+
+def get_model_cached(parfile):
+    if parfile not in _cached_models:
+        with quiet():
+            _cached_models[parfile] = get_model(parfile)
+    return copy.deepcopy(_cached_models[parfile])
+
+
+_cached_toas = {}
+
+
+def get_model_and_toas(parfile):
+    if parfile not in _cached_toas:
+        model = get_model_cached(parfile)
+        with quiet():
+            toas = pint.toa.make_fake_toas(
+                model=model, startMJD=57000, endMJD=58000, ntoas=5
+            )
+            phase = model.phase(toas)
+        _cached_toas[parfile] = model, toas, phase
+    return copy.deepcopy(_cached_toas[parfile])
+
+
+@pytest.mark.parametrize(
+    "parfile, param",
+    [
+        ("J1955dd.par", param)
+        for param in [
+            "PX",
+            "RAJ",
+            "DECJ",
+            "PMRA",
+            "PMDEC",
+            "F0",
+            "F1",
+            "PB",
+            "A1",
+            "ECC",  # NaNs for some reason
+            "T0",
+            "OM",
+        ]
+    ]
+    + [
+        ("J1853+1303_NANOGrav_11yv0.gls.par", param)  # ELL1H (?)
+        for param in [
+            "ELONG",
+            "ELAT",
+            "PMELONG",
+            "PMELAT",
+            "DMX_0027",
+            "TASC",
+            "EPS1",
+            "EPS2",
+            "H3",
+            "PB",
+            "A1",
+            "A1DOT",  # Scaling weirdness
+        ]
+    ]
+    + [("B1855+09_NANOGrav_12yv3.wb.gls.par", param) for param in ["M2", "SINI",]]
+    + [
+        ("J0023+0923_NANOGrav_11yv0.gls.par", param)
+        for param in ["FB0", "FB1", "FB2", "FB3",]
+    ]
+    + [("J0613-0200_NANOGrav_9yv1_ELL1H.gls.par", param) for param in ["H3", "H4",]]
+    + [
+        ("J0613-0200_NANOGrav_9yv1_ELL1H_STIG.gls.par", param)
+        for param in ["H3", "STIGMA",]
+    ]
+    + [
+        ("J1713+0747_NANOGrav_11yv0.gls.par", param)  # DDK
+        for param in ["PB", "A1", "ECC", "T0", "M2", "KIN", "KOM", "PX",]
+    ],
+)
+def test_derivative_equals_numerical_multi(parfile, param):
+    model, toas, phase = get_model_and_toas(
+        os.path.join(os.path.dirname(__file__), "datafile", parfile)
+    )
+    units = getattr(model, param).units
+
+    def f(value):
+        m = copy.deepcopy(model)
+        getattr(m, param).value = value
+        with quiet():
+            warnings.simplefilter("ignore")
+            try:
+                dphase = m.phase(toas) - phase
+            except ValueError:
+                return np.nan * np.zeros_like(phase.frac)
+        return dphase.int + dphase.frac
+
+    df = numdifftools.Derivative(f)
+
+    assert_allclose(
+        model.d_phase_d_param(toas, delay=None, param=param).to_value(1 / units),
+        df(getattr(model, param).value),
+        atol=1e-3,
+        rtol=1e-3,
+    )

--- a/tests/test_toa_selection.py
+++ b/tests/test_toa_selection.py
@@ -91,9 +91,9 @@ class TestTOAselection(unittest.TestCase):
         assert np.allclose(dmx_old, dmx_new)
 
     def test_hash(self):
-        self.model.dmx_toas_selector.use_hash = True
         dmx_old = self.get_dmx_old(self.toas).value
         dmx_new = self.model.dmx_dm(self.toas).value
+        self.model.dmx_toas_selector.use_hash = True
         assert np.allclose(dmx_old, dmx_new)
         assert self.model.dmx_toas_selector.use_hash
         dmx_old = self.get_dmx_old(self.sort_toas).value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -968,6 +968,7 @@ def test_taylor_horner_deriv(x, coeffs, order):
     df = Derivative(f, n=order)
     assert_allclose(df(x), taylor_horner_deriv(x, coeffs, order), atol=1e-11)
 
+
 @pytest.mark.parametrize(
     "x, coeffs",
     [
@@ -981,16 +982,13 @@ def test_taylor_horner_deriv(x, coeffs, order):
     ],
 )
 def test_taylor_horner_equals_deriv(x, coeffs):
-    assert_allclose(taylor_horner(x, coeffs),
-                    taylor_horner_deriv(x, coeffs, 0))
+    assert_allclose(taylor_horner(x, coeffs), taylor_horner_deriv(x, coeffs, 0))
+
 
 @pytest.mark.parametrize(
     "x, result, n",
-    [
-        (1*u.s, 1*u.m, 5),
-        (1*u.s, 1*u.m, 1),
-        (1*u.km**2, 1*u.m, 3),
-    ])
+    [(1 * u.s, 1 * u.m, 5), (1 * u.s, 1 * u.m, 1), (1 * u.km ** 2, 1 * u.m, 3),],
+)
 def test_taylor_horner_units_ok(x, result, n):
-    coeffs = [result/x**i for i in range(n+1)]
+    coeffs = [result / x ** i for i in range(n + 1)]
     taylor_horner(x, coeffs) + result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,8 @@ import os
 from itertools import product
 from tempfile import NamedTemporaryFile
 
-import astropy.units as u
 import astropy.constants as c
+import astropy.units as u
 import numpy as np
 import pytest
 import scipy.stats
@@ -20,7 +20,8 @@ from hypothesis.strategies import (
     sampled_from,
     slices,
 )
-from numpy.testing import assert_array_equal
+from numdifftools import Derivative
+from numpy.testing import assert_allclose, assert_array_equal
 from pinttestdata import datadir
 
 import pint
@@ -39,19 +40,20 @@ from pint.pulsar_mjd import (
 from pint.utils import (
     FTest,
     PosVel,
+    companion_mass,
     dmxparse,
     interesting_lines,
     lines_of,
-    open_or_use,
-    taylor_horner,
-    companion_mass,
     mass_funct,
     mass_funct2,
+    open_or_use,
     pulsar_age,
     pulsar_B,
     pulsar_B_lightcyl,
     pulsar_edot,
     pulsar_mass,
+    taylor_horner,
+    taylor_horner_deriv,
 )
 
 
@@ -752,10 +754,10 @@ def test_companion_mass(Mpsr, Mc, Pb, incl):
 
 
 @given(
-    arrays(np.float, 10, elements=floats(0.5, 3)),
-    arrays(np.float, 10, elements=floats(0.01, 10)),
-    arrays(np.float, 10, elements=floats(0.04, 1000)),
-    arrays(np.float, 10, elements=floats(0.1, 90)),
+    arrays(float, 10, elements=floats(0.5, 3)),
+    arrays(float, 10, elements=floats(0.01, 10)),
+    arrays(float, 10, elements=floats(0.04, 1000)),
+    arrays(float, 10, elements=floats(0.1, 90)),
 )
 def test_companion_mass_array(Mpsr, Mc, Pb, incl):
     """
@@ -804,10 +806,10 @@ def test_pulsar_mass(Mpsr, Mc, Pb, incl):
 
 
 @given(
-    arrays(np.float, 10, elements=floats(0.5, 3)),
-    arrays(np.float, 10, elements=floats(0.01, 10)),
-    arrays(np.float, 10, elements=floats(0.04, 1000)),
-    arrays(np.float, 10, elements=floats(0.1, 90)),
+    arrays(float, 10, elements=floats(0.5, 3)),
+    arrays(float, 10, elements=floats(0.01, 10)),
+    arrays(float, 10, elements=floats(0.04, 1000)),
+    arrays(float, 10, elements=floats(0.1, 90)),
 )
 def test_pulsar_mass_array(Mpsr, Mc, Pb, incl):
     """
@@ -943,3 +945,52 @@ def test_Ftest_chi2_increase():
 
 def test_Ftest_dof_same():
     assert np.isnan(FTest(100, 100, 100, 100))
+
+
+@pytest.mark.parametrize(
+    "x, coeffs, order",
+    [
+        (1.2, [2], 1),
+        (0.1, [2, 3], 1),
+        (-1, [2, 3, 5], 1),
+        (1.1, [2], 2),
+        (1.3, [2, 3, 4, 5], 2),
+        (1.3, [2, 3, 4, 5], 4),
+        (1.3, [2, 3, 4, 5, 6], 4),
+        (1.5, [2], 10),
+        (1.7, [2, 3, 4], 0),
+    ],
+)
+def test_taylor_horner_deriv(x, coeffs, order):
+    def f(x):
+        return taylor_horner(x, coeffs)
+
+    df = Derivative(f, n=order)
+    assert_allclose(df(x), taylor_horner_deriv(x, coeffs, order), atol=1e-11)
+
+@pytest.mark.parametrize(
+    "x, coeffs",
+    [
+        (1.2, [2]),
+        (0.1, [2, 3]),
+        (-1, [2, 3, 5]),
+        (1.1, [2]),
+        (1.3, [2, 3, 4, 5]),
+        (1.5, [2]),
+        (1.7, [2, 3, 4]),
+    ],
+)
+def test_taylor_horner_equals_deriv(x, coeffs):
+    assert_allclose(taylor_horner(x, coeffs),
+                    taylor_horner_deriv(x, coeffs, 0))
+
+@pytest.mark.parametrize(
+    "x, result, n",
+    [
+        (1*u.s, 1*u.m, 5),
+        (1*u.s, 1*u.m, 1),
+        (1*u.km**2, 1*u.m, 3),
+    ])
+def test_taylor_horner_units_ok(x, result, n):
+    coeffs = [result/x**i for i in range(n+1)]
+    taylor_horner(x, coeffs) + result

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,7 @@ deps =
     pytest
     coverage
     hypothesis
+    numdifftools
 
 [testenv:report]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ deps =
     cov: pytest-cov
     cov: pytest-remotedata
     hypothesis
+    numdifftools
 commands =
     pip freeze
     !cov: pytest 


### PR DESCRIPTION
The goal is to document and fix problems in PINT's derivative calculations. This includes using numdifftools to check the analytical derivatives against finite differences computed from the model.

Closes #1053 
Closes #1054 (now you can use pytest-xdist to run the test suite faster!)