### PR TITLE
Model Editor Pintk

### DIFF
--- a/src/pint/pintk/paredit.py
+++ b/src/pint/pintk/paredit.py
@@ -200,7 +200,10 @@ class ParWidget(tk.Frame):
         self.set_model()
         self.call_updates()
 
-    def set_model(self):
+    def set_model(self, newpsr=None):
+        # if the pulsar was updated in pintk, update here
+        if newpsr != None:
+            self.psr = newpsr
         choice = self.choiceWidget.choice.get()
         if choice == "postfit":
             if self.psr.fitted:

--- a/src/pint/pintk/paredit.py
+++ b/src/pint/pintk/paredit.py
@@ -221,6 +221,9 @@ class ParWidget(tk.Frame):
         pfile = open(pfilename, "w")
         pfile.write(self.editor.get("1.0", "end-1c"))
         pfile.close()
+        if self.psr.fitted:
+            # if pulsar already fitted, add changes to postfit model as well
+            self.psr.postfit_model = pint.models.get_model(pfilename)
         self.psr.prefit_model = pint.models.get_model(pfilename)
         os.remove(pfilename)
         self.call_updates()

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -583,10 +583,13 @@ class PlkWidget(tk.Frame):
         self.updatePlot(keepAxes=False)
         self.plkToolbar.update()
 
-    def call_updates(self):
+    def call_updates(self, psr_update=False):
         if not self.update_callbacks is None:
             for ucb in self.update_callbacks:
-                ucb()
+                if psr_update:
+                    ucb(self.psr)
+                else:
+                    ucb()
 
     def updateGraphColors(self, color_mode):
         self.current_mode = color_mode
@@ -681,7 +684,7 @@ class PlkWidget(tk.Frame):
         self.plkToolbar.update()
         self.current_state = State()
         self.state_stack = [self.base_state]
-        self.call_updates()
+        self.call_updates(psr_update=True)
 
     def writePar(self):
         """

--- a/src/pint/pintk/timedit.py
+++ b/src/pint/pintk/timedit.py
@@ -109,7 +109,11 @@ class TimWidget(tk.Frame):
         self.set_toas()
         self.call_updates()
 
-    def set_toas(self):
+    def set_toas(self, newpsr=None):
+        # if pulsar updated in pintk, update here
+        if newpsr != None:
+            self.psr = newpsr
+
         self.editor.delete("1.0", tk.END)
 
         # Pretty much copying TOAs.write_TOA_file here but without creating an

--- a/src/pint/random_models.py
+++ b/src/pint/random_models.py
@@ -45,7 +45,7 @@ def random_models(
     params = fitter.model.get_params_dict("free", "num")
     mean_vector = params.values()
     # remove the first column and row (absolute phase)
-    cov_matrix = (((fitter.covariance_matrix[1:]).T)[1:]).T
+    cov_matrix = (((fitter.covariance_matrix.matrix[1:]).T)[1:]).T
     fac = fitter.fac[1:]
     f_rand = deepcopy(fitter)
     mrand = f_rand.model


### PR DESCRIPTION
This is a fix to issue #1037 in which adding parameters through the model editor after a fit didn't work. This was fixed by updating the postfit model in the pulsar object if it had been fitted (before only the prefit model was added to). Since the prefit model is set equal to the postfit model before a fitting after the first fit, it was erasing the modifications made through the model editor; the above resolves this.

Additionally, I noticed that the pulsar pointed to by the PlkWidget changed after pressing the "Reset" button, whereas the model editor pulsar did not. This essentially disconnected the model editor from the rest of pintk (and the TOA editor). I included a fix for this in this PR, where the new pulsar created in the PlkWidget is returned to the model editor and TOA editor when updates are called.

Finally, there is one small bug fix in random_models.py - the file was attempting to access the covariance matrix directly, which apparently is no longer supported. It now uses the 'matrix' attribute instead.