### PR TITLE
Fix #1060

### DIFF
--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1121,6 +1121,7 @@ class DownhillFitter(Fitter):
         for i in range(maxiter):
             step = current_state.step
             lambda_ = 1
+            chi2_decrease = 0
             while True:
                 try:
                     new_state = current_state.take_step(step, lambda_)


### PR DESCRIPTION
Resolve name referenced before use.

It's not so simple to trigger this for a test as it needs a Fitter that cannot make any step at all.

Closes #1060 