### PR TITLE
Automatically generate table of parameters

### DIFF
--- a/docs/_ext/componentlist.py
+++ b/docs/_ext/componentlist.py
@@ -1,0 +1,46 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst.directives.tables import Table
+from docutils.parsers.rst.directives import unchanged_required
+from docutils.statemachine import ViewList
+import pint.utils
+
+
+class ComponentList(Directive):
+    has_content = False
+
+    def run(self):
+        content = ViewList()
+        source = "bogus.rst"
+        content.append("Components supported by PINT:", source)
+        content.append("", source)
+
+        import pint.models.timing_model
+        d = pint.models.timing_model.Component.component_types.copy()
+        for k in sorted(d.keys()):
+            class_ = d[k]
+            full_name = f"{class_.__module__}.{class_.__name__}"
+            if hasattr(class_, "__doc__") and class_.__doc__ is not None:
+                doc = class_.__doc__.split("\n")[0].strip()
+            else:
+                doc = ""
+            content.append(f"* :class:`~{full_name}` - {doc}", source)
+        para = nodes.paragraph()
+        self.state.nested_parse(
+            content,
+            self.content_offset,
+            para,
+        )
+
+        return [para]
+
+
+def setup(app):
+
+    app.add_directive("componentlist", ComponentList)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/_ext/componentlist.py
+++ b/docs/_ext/componentlist.py
@@ -24,7 +24,11 @@ class ComponentList(Directive):
                 doc = class_.__doc__.split("\n")[0].strip()
             else:
                 doc = ""
-            content.append(f"* :class:`~{full_name}` - {doc}", source)
+            msg = f"* :class:`~{full_name}` - {doc}"
+            inst = class_()
+            if hasattr(inst, "binary_model_name"):
+                msg += f" (``BINARY {inst.binary_model_name}``)"
+            content.append(msg, source)
         para = nodes.paragraph()
         self.state.nested_parse(
             content,

--- a/docs/_ext/paramtable.py
+++ b/docs/_ext/paramtable.py
@@ -1,0 +1,77 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst.directives.tables import Table
+from docutils.parsers.rst.directives import unchanged_required
+from docutils.statemachine import ViewList
+import pint.utils
+
+
+class ParamTable(Table):
+    option_spec = {"class": unchanged_required}
+    has_content = False
+
+    def run(self):
+        columns = [
+            ("Name", "name", 10),
+            ("Description", "description", 30),
+            ("Kind", "kind", 10),
+            ("Aliases", "aliases", 20),
+        ]
+        if "class" in self.options:
+            class_ = eval(self.options["class"])
+        else:
+            class_ = None
+            columns.append(("Classes", "classes", 30))
+
+        table = nodes.table()
+        tgroup = nodes.tgroup(len(columns))
+        table += tgroup
+
+        thead = nodes.thead()
+        row = nodes.row()
+        for label, _, w in columns:
+            tgroup += nodes.colspec(colwidth=w)
+            entry = nodes.entry()
+            row += entry
+            entry += nodes.paragraph(text=label)
+        thead += row
+        tgroup += thead
+
+        tbody = nodes.tbody()
+        for d in pint.utils.list_parameters(class_):
+            row = nodes.row()
+            for _, c, _ in columns:
+                entry = nodes.entry()
+                row += entry
+                if c not in d:
+                    continue
+                if c == "classes":
+                    para = nodes.paragraph()
+                    for cl in d[c]:
+                        self.state.nested_parse(
+                            ViewList([f":class:`~{cl}` "], "bogus.rst"), self.content_offset, para
+                        )
+                    entry += para
+                elif isinstance(d[c], str):
+                    entry += nodes.paragraph(text=d[c])
+                elif isinstance(d[c], list):
+                    entry += nodes.paragraph(text=", ".join(d[c]))
+                elif d[c] is None:
+                    pass
+                else:
+                    entry += nodes.paragraph(text=str(d[c]))
+            tbody += row
+        tgroup += tbody
+
+        return [table]
+
+
+def setup(app):
+
+    app.add_directive("paramtable", ParamTable)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/_ext/paramtable.py
+++ b/docs/_ext/paramtable.py
@@ -12,7 +12,7 @@ class ParamTable(Table):
 
     def run(self):
         columns = [
-            ("Name", "name", 10),
+            ("Name / Aliases", "name", 10),
             ("Description", "description", 30),
             ("Kind", "kind", 10),
         ]
@@ -20,7 +20,7 @@ class ParamTable(Table):
             class_ = eval(self.options["class"])
         else:
             class_ = None
-            columns.append(("Classes", "classes", 30))
+            columns.append(("Components", "classes", 30))
 
         table = nodes.table()
         tgroup = nodes.tgroup(len(columns))

--- a/docs/_ext/paramtable.py
+++ b/docs/_ext/paramtable.py
@@ -49,7 +49,9 @@ class ParamTable(Table):
                     para = nodes.paragraph()
                     for cl in d[c]:
                         self.state.nested_parse(
-                            ViewList([f":class:`~{cl}` "], "bogus.rst"), self.content_offset, para
+                            ViewList([f":class:`~{cl}` "], "bogus.rst"),
+                            self.content_offset,
+                            para,
                         )
                     entry += para
                 elif isinstance(d[c], str):

--- a/docs/_ext/paramtable.py
+++ b/docs/_ext/paramtable.py
@@ -15,7 +15,6 @@ class ParamTable(Table):
             ("Name", "name", 10),
             ("Description", "description", 30),
             ("Kind", "kind", 10),
-            ("Aliases", "aliases", 20),
         ]
         if "class" in self.options:
             class_ = eval(self.options["class"])
@@ -54,6 +53,12 @@ class ParamTable(Table):
                             para,
                         )
                     entry += para
+                elif c == "name":
+                    text = d[c]
+                    alias_list = d.get("aliases", [])
+                    if alias_list:
+                        text += " / " + ", ".join(d["aliases"])
+                    entry += nodes.paragraph(text=text)
                 elif isinstance(d[c], str):
                     entry += nodes.paragraph(text=d[c])
                 elif isinstance(d[c], list):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ extensions = [
     "sphinx.ext.napoleon",  # get docstring formatting
     "nbsphinx",
     "paramtable",
+    "componentlist",
 ]
 #                            'astropy_helpers.sphinx.ext.numpydoc',
 #                            'astropy_helpers.sphinx.ext.automodapi',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ project_root = os.path.join(cwd, "../src")  # parent directory of wherever this 
 # This lets us ensure that the source package is imported, and that its
 # version is used.
 sys.path.insert(0, project_root)
+sys.path.append(os.path.join(os.path.dirname(__file__), "_ext"))
 import pint
 
 # -- General configuration ---------------------------------------------
@@ -53,6 +54,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",  # get docstring formatting
     "nbsphinx",
+    "paramtable",
 ]
 #                            'astropy_helpers.sphinx.ext.numpydoc',
 #                            'astropy_helpers.sphinx.ext.automodapi',

--- a/docs/timingmodels.rst
+++ b/docs/timingmodels.rst
@@ -16,6 +16,8 @@ if ``ELAT`` is present, :class:`~pint.models.astrometry.AstrometryEcliptic` is
 selected). Ambiguous or contradictory parameter files are possible, and for
 these PINT raises an exception.
 
+.. componentlist::
+
 Supported Parameters
 --------------------
 

--- a/docs/timingmodels.rst
+++ b/docs/timingmodels.rst
@@ -23,3 +23,4 @@ The following table lists all the parameters that PINT can understand (along wit
 
 .. paramtable::
 
+For comparison, there is a `table of parameters that TEMPO supports <http://tempo.sourceforge.net/ref_man_sections/binary.txt>`_.

--- a/docs/timingmodels.rst
+++ b/docs/timingmodels.rst
@@ -15,4 +15,7 @@ storage and managing.
 Supported Parameters
 --------------------
 
-.. include:: parametertable.rst
+.. paramtable::
+
+.. paramtable::
+    :class: pint.models.spindown.Spindown

--- a/docs/timingmodels.rst
+++ b/docs/timingmodels.rst
@@ -3,19 +3,23 @@
 Timing Models
 =============
 
-This section is to explain the bulit-in timing models.
-
-PINT built-in timing models are located at the directory `PINT/src/pint/models`_.
-Timing model is structured as model components which implement difference pieces
-of timing model, and the parent :class:`pint.models.timing_model.TimingModel` object for overall model components
-storage and managing.
-
-.. _PINT/src/pint/models: https://github.com/nanograv/PINT/tree/master/src/pint/models
+PINT, like TEMPO and TEMPO2, support many different ways of calculating pulse
+arrival times. The key tool for doing this is a
+:class:`~pint.models.timing_model.TimingModel` object, through which a whole
+range of :class:`~pint.models.parameter.Parameter` are accessible. The actual
+computation is done by pieces of code that live in
+:class:`~pint.models.timing_model.Component`; during the parsing of a parameter
+file, these are selected based on the parameters present. Binary models are
+selected explicitly using the ``BINARY`` parameter, while each non-binary
+component is selected if some parameter unique to it is included (for example
+if ``ELAT`` is present, :class:`~pint.models.astrometry.AstrometryEcliptic` is
+selected). Ambiguous or contradictory parameter files are possible, and for
+these PINT raises an exception.
 
 Supported Parameters
 --------------------
 
-.. paramtable::
+The following table lists all the parameters that PINT can understand (along with their aliases). The model components that use them (linked below) should give more information about how they are interpreted.
 
 .. paramtable::
-    :class: pint.models.spindown.Spindown
+

--- a/docs/timingmodels.rst
+++ b/docs/timingmodels.rst
@@ -19,7 +19,34 @@ these PINT raises an exception.
 Supported Parameters
 --------------------
 
-The following table lists all the parameters that PINT can understand (along with their aliases). The model components that use them (linked below) should give more information about how they are interpreted.
+The following table lists all the parameters that PINT can understand (along
+with their aliases). The model components that use them (linked below) should
+give more information about how they are interpreted.
+
+Some parameters PINT understands have aliases - for example, the parameter PINT
+calls "ECC" may also be written as "E" in parameter files. PINT will understand
+these parameter files, but will always refer to this parameter internally as
+"ECC". By default, though, when PINT reads a parameter file, PINT will remember
+the alias that was used, and PINT will write the model out using the same
+alias. This can be controlled by the ``use_alias`` attribute of
+:class:`~pint.models.parameter.Parameter` objects.
+
+PINT support for families of parameters, either specified by prefix (``F0``,
+``F1``, ``F2``, ... or ``DMX_0017``, ``DMX_0123``, ...) or selecting subsets of
+parameters based on flags (``JUMP -tel AO``). These are indicated in the table
+with square brackets. Note that like the frequency derivatives, these families
+may have units that vary in a systematic way.
+
+Parameters can also have different types. Most are long double floating point,
+with or without units; these can be specified in the usual ``1.234e5`` format,
+although they also support ``1.234d5`` as well as capitalized versions for
+compatibility. One or two parameters - notably ``A1DOT`` - can accept a value
+scaled by ``1e12``, automatically rescaling upon read; although this is
+confusing, it is necessary because TEMPO does this and so there are parameter
+files "in the wild" that use this feature. Other data types allow input of
+different formats, for example ``RAJ 10:23:47.67``; boolean parameters allow
+``1``/``0``, ``Y``/``N``, ``T/F``, ``YES``/``NO``, ``TRUE``/``FALSE``, or
+lower-case versions of these.
 
 .. paramtable::
 

--- a/src/pint/models/__init__.py
+++ b/src/pint/models/__init__.py
@@ -1,19 +1,19 @@
-"""Implementations of pulsar timing models.
+"""Pulsar timing models and tools for working with them.
 
 The primary object for representing a timing model is
-:class:`pint.models.timing_model.TimingModel`. This contains a collection of
-components (subclasses of ``pint.models.timing_model.Component``), each of
+:class:`~pint.models.timing_model.TimingModel`. This contains a collection of
+components (subclasses of :class:`~pint.models.timing_model.Component`), each of
 which should have a collection of parameters (subclasses of
-:class:`pint.models.parameter.Parameter`). These parameters carry values
+:class:`~pint.models.parameter.Parameter`). These parameters carry values
 uncertainties and units and can be "frozen" or "free" to indicate whether
-fitters (subclasses of :class:`pint.fitter.Fitter`) should be allowed to modify
+fitters (subclasses of :class:`~pint.fitter.Fitter`) should be allowed to modify
 them. Normally timing models are created using
-:func:`pint.models.model_builder.get_model` but it is possible to construct and
+:func:`~pint.models.model_builder.get_model` but it is possible to construct and
 modify them as python objects.
 
 Binary models are implemented as Components, but they have somewhat special
 handling; they are implemented by deriving from
-:class:`pint.models.stand_alone_psr_binaries.binary_generic.PSR_BINARY`, which
+:class:`~pint.models.stand_alone_psr_binaries.binary_generic.PSR_BINARY`, which
 provides some of the infrastructure needed to implement them conveniently.
 """
 from pint.models.absolute_phase import AbsPhase

--- a/src/pint/models/absolute_phase.py
+++ b/src/pint/models/absolute_phase.py
@@ -12,6 +12,11 @@ class AbsPhase(PhaseComponent):
 
     The model defines the absolute phase's reference time and observatory.
 
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.absolute_phase.AbsPhase
+
     Note
     ----
     Although this class is condisder as a phase component, it does not

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -29,7 +29,7 @@ class Astrometry(DelayComponent):
     category = "astrometry"
 
     def __init__(self):
-        super(Astrometry, self).__init__()
+        super().__init__()
         self.add_param(
             MJDParameter(
                 name="POSEPOCH",
@@ -214,10 +214,17 @@ class Astrometry(DelayComponent):
 
 
 class AstrometryEquatorial(Astrometry):
+    """Astrometry in equatorial coordinates.
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.astrometry.AstrometryEquatorial
+    """
     register = True
 
     def __init__(self):
-        super(AstrometryEquatorial, self).__init__()
+        super().__init__()
         self.add_param(
             AngleParameter(
                 name="RAJ",
@@ -259,13 +266,9 @@ class AstrometryEquatorial(Astrometry):
             func = getattr(self, deriv_func_name)
             self.register_deriv_funcs(func, param)
 
-    def setup(self):
-        super(AstrometryEquatorial, self).setup()
-
     def validate(self):
-        """ Validate the input parameter.
-        """
-        super(AstrometryEquatorial, self).validate()
+        """Validate the input parameter."""
+        super().validate()
         # RA/DEC are required
         for p in ("RAJ", "DECJ"):
             if getattr(self, p).value is None:
@@ -354,9 +357,7 @@ class AstrometryEquatorial(Astrometry):
         return pos_icrs.transform_to(PulsarEcliptic(ecl=ecl))
 
     def coords_as_GAL(self, epoch=None):
-        """Return the pulsar's galactic coordinates as an astropy coordinate object.
-
-        """
+        """Return the pulsar's galactic coordinates as an astropy coordinate object."""
         pos_icrs = self.get_psr_coords(epoch=epoch)
         return pos_icrs.transform_to(coords.Galactic)
 
@@ -373,14 +374,14 @@ class AstrometryEquatorial(Astrometry):
         """Calculate the derivative wrt RAJ
 
         For the RAJ and DEC derivatives, use the following approximate model for
-        the pulse delay. (Inner-product between two Cartesian vectors)
+        the pulse delay. (Inner-product between two Cartesian vectors):
 
-        de = Earth declination (wrt SSB)
-        ae = Earth right ascension
-        dp = pulsar declination
-        aa = pulsar right ascension
-        r = distance from SSB to Earh
-        c = speed of light
+            - de = Earth declination (wrt SSB)
+            - ae = Earth right ascension
+            - dp = pulsar declination
+            - aa = pulsar right ascension
+            - r = distance from SSB to Earh
+            - c = speed of light
 
         delay = r*[cos(de)*cos(dp)*cos(ae-aa)+sin(de)*sin(dp)]/c
         """
@@ -476,10 +477,17 @@ class AstrometryEquatorial(Astrometry):
 
 
 class AstrometryEcliptic(Astrometry):
+    """Astrometry in ecliptic coordinates.
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.astrometry.AstrometryEcliptic
+    """
     register = True
 
     def __init__(self):
-        super(AstrometryEcliptic, self).__init__()
+        super().__init__()
         self.add_param(
             AngleParameter(
                 name="ELONG",
@@ -532,13 +540,10 @@ class AstrometryEcliptic(Astrometry):
             func = getattr(self, deriv_func_name)
             self.register_deriv_funcs(func, param)
 
-    def setup(self):
-        super(AstrometryEcliptic, self).setup()
-
     def validate(self):
         """ Validate Ecliptic coordinate parameter inputs.
         """
-        super(AstrometryEcliptic, self).validate()
+        super().validate()
         # ELONG/ELAT are required
         for p in ("ELONG", "ELAT"):
             if getattr(self, p).value is None:

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -1,3 +1,4 @@
+"""Astrometric models for describing pulsar sky positions."""
 # astrometry.py
 # Defines Astrometry timing model class
 import sys
@@ -23,8 +24,12 @@ from pint.utils import add_dummy_distance, remove_dummy_distance
 astropy_version = sys.modules["astropy"].__version__
 mas_yr = u.mas / u.yr
 
+__all__ = ["AstrometryEquatorial", "AstrometryEcliptic", "Astrometry"]
+
 
 class Astrometry(DelayComponent):
+    """Common tools for astrometric calculations."""
+
     register = False
     category = "astrometry"
 

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -221,6 +221,7 @@ class AstrometryEquatorial(Astrometry):
     .. paramtable::
         :class: pint.models.astrometry.AstrometryEquatorial
     """
+
     register = True
 
     def __init__(self):
@@ -484,6 +485,7 @@ class AstrometryEcliptic(Astrometry):
     .. paramtable::
         :class: pint.models.astrometry.AstrometryEcliptic
     """
+
     register = True
 
     def __init__(self):

--- a/src/pint/models/binary_bt.py
+++ b/src/pint/models/binary_bt.py
@@ -21,6 +21,11 @@ class BinaryBT(PulsarBinary):
     The aim for this class is to connect the stand alone binary model with PINT platform
     BTmodel special parameters:
     GAMMA Binary Einsten delay coeeficient
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.binary_bt.BinaryBT
     """
 
     register = True

--- a/src/pint/models/binary_dd.py
+++ b/src/pint/models/binary_dd.py
@@ -16,6 +16,11 @@ class BinaryDD(PulsarBinary):
     GAMMA Binary Einsten delay coeeficient
     DR Relativistic deformation of the orbit
     DTH Relativistic deformation of the orbit
+
+   Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.binary_dd.BinaryDD
     """
 
     register = True

--- a/src/pint/models/binary_ddk.py
+++ b/src/pint/models/binary_ddk.py
@@ -19,6 +19,11 @@ class BinaryDDK(BinaryDD):
     KIN inclination angle
     KOM the longitude of the ascending node, Kopeikin (1995) Eq 9. OMEGA
 
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.binary_ddk.BinaryDDK
+
     References
     ----------
     KOPEIKIN. 1995, 1996

--- a/src/pint/models/binary_ell1.py
+++ b/src/pint/models/binary_ell1.py
@@ -1,3 +1,4 @@
+"""Approximate binary model for small eccentricity."""
 from warnings import warn
 
 import numpy as np

--- a/src/pint/models/binary_ell1.py
+++ b/src/pint/models/binary_ell1.py
@@ -29,6 +29,10 @@ class BinaryELL1Base(PulsarBinary):
         - EPS1DOT First derivative of first Laplace-Lagrange parameter
         - EPS2DOT Second derivative of second Laplace-Lagrange parameter
 
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.binary_ell1.BinaryELL1
     """
 
     def __init__(self):
@@ -207,6 +211,11 @@ class BinaryELL1H(BinaryELL1Base):
     This is modified version of ELL1 model. a new parameter H3 is
     introduced to model the shapiro delay.
 
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.binary_ell1.BinaryELL1H
+
     Note
     ----
     Ref:  Freire and Wex 2010; Only the Medium-inclination case model is implemented.
@@ -244,6 +253,7 @@ class BinaryELL1H(BinaryELL1Base):
                 units="",
                 description="Shapiro delay parameter STIGMA as in Freire and Wex 2010 Eq(12)",
                 long_double=True,
+                aliases=["VARSIGMA"],
             )
         )
         self.add_param(

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -130,6 +130,10 @@ class DispersionDM(Dispersion):
     This model uses Taylor expansion to model DM variation over time. It
     can also be used for a constant DM.
 
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.dispersion_model.DispersionDM
     """
 
     register = True
@@ -312,6 +316,11 @@ class DispersionDMX(Dispersion):
 
     This model lets the user specify time ranges and fit for a different
     DM value in each time range.
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.dispersion_model.DispersionDMX
     """
 
     register = True
@@ -571,6 +580,11 @@ class DispersionDMX(Dispersion):
 
 class DispersionJump(Dispersion):
     """This class provides the contant offsets to the DM values.
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.dispersion_model.DispersionDMX
 
     Notes
     -----

--- a/src/pint/models/frequency_dependent.py
+++ b/src/pint/models/frequency_dependent.py
@@ -9,18 +9,25 @@ from pint.models.timing_model import DelayComponent, MissingParameter
 
 
 class FD(DelayComponent):
-    """A timing model for frequency evolution of pulsar profiles."""
+    """A timing model for frequency evolution of pulsar profiles.
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.frequency_dependent.FD
+    """
 
     register = True
     category = "frequency_dependent"
 
     def __init__(self):
-        super(FD, self).__init__()
+        super().__init__()
         self.add_param(
             prefixParameter(
                 name="FD1",
                 units="second",
                 value=0.0,
+                description="Coefficient of delay as a polynomial function of log-frequency",
                 descriptionTplt=lambda x: (
                     "%d term of frequency" " dependent  coefficients" % x
                 ),
@@ -32,7 +39,7 @@ class FD(DelayComponent):
         self.delay_funcs_component += [self.FD_delay]
 
     def setup(self):
-        super(FD, self).setup()
+        super().setup()
         # Check if FD terms are in order.
         FD_mapping = self.get_prefix_mapping_component("FD")
         self.num_FD_terms = len(FD_mapping)
@@ -41,7 +48,7 @@ class FD(DelayComponent):
             self.register_deriv_funcs(self.d_delay_FD_d_FDX, val)
 
     def validate(self):
-        super(FD, self).validate()
+        super().validate()
         FD_terms = list(self.get_prefix_mapping_component("FD").keys())
         FD_terms.sort()
         FD_in_order = list(range(1, max(FD_terms) + 1))

--- a/src/pint/models/frequency_dependent.py
+++ b/src/pint/models/frequency_dependent.py
@@ -1,4 +1,4 @@
-"""A frequency evolution of pulsar profiles model"""
+"""Frequency-dependent delays to model profile evolution."""
 from warnings import warn
 
 import astropy.units as u
@@ -10,6 +10,11 @@ from pint.models.timing_model import DelayComponent, MissingParameter
 
 class FD(DelayComponent):
     """A timing model for frequency evolution of pulsar profiles.
+
+    This model expresses the delay as a polynomial function of the
+    logarithm of observing frequency. This is intended to compensate
+    for the delays introduced by frequency-dependent profile structure
+    when a frequency-independent template profile is used.
 
     Parameters supported:
 

--- a/src/pint/models/glitch.py
+++ b/src/pint/models/glitch.py
@@ -9,13 +9,19 @@ from pint.utils import split_prefixed_name
 
 
 class Glitch(PhaseComponent):
-    """Pulsar spin-down glitches."""
+    """Pulsar spin-down glitches.
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.glitch.Glitch
+    """
 
     register = True
     category = "glitch"
 
     def __init__(self):
-        super(Glitch, self).__init__()
+        super().__init__()
 
         self.add_param(
             prefixParameter(
@@ -96,7 +102,7 @@ class Glitch(PhaseComponent):
         self.phase_funcs_component += [self.glitch_phase]
 
     def setup(self):
-        super(Glitch, self).setup()
+        super().setup()
         # Check for required glitch epochs, set not specified parameters to 0
         self.glitch_prop = [
             "GLEP_",
@@ -126,7 +132,7 @@ class Glitch(PhaseComponent):
     def validate(self):
         """ Validate parameters input.
         """
-        super(Glitch, self).validate()
+        super().validate()
         for idx in set(self.glitch_indices):
             if not hasattr(self, "GLEP_%d" % idx):
                 msg = "Glitch Epoch is needed for Glitch %d." % idx

--- a/src/pint/models/ifunc.py
+++ b/src/pint/models/ifunc.py
@@ -1,3 +1,4 @@
+"""Tabulated extra delays."""
 import astropy.units as u
 import numpy as np
 
@@ -16,7 +17,7 @@ class IFunc(PhaseComponent):
     they are converted to phase simply by multiplication with F0, therefore
     changing PEPOCH should be done with care.
 
-    The format of IFuncs in an ephemeris is:
+    The format of IFuncs in an ephemeris is::
 
         SIFUNC X 0
         IFUNC1 MJD1 DT1 0.0
@@ -26,7 +27,7 @@ class IFunc(PhaseComponent):
 
     X indicates the type of interpolation:
 
-        - 0 == piecewise (no interpolation)
+        - 0 == piecewise constant (no interpolation)
         - 1 == sinc (not supported)
         - 2 == linear
 
@@ -61,7 +62,7 @@ class IFunc(PhaseComponent):
             prefixParameter(
                 name="IFUNC1",
                 units="s",
-                description="Interpolation Components (MJD+delay)",
+                description="Interpolation control point pair (MJD, delay)",
                 type_match="pair",
                 long_double=True,
                 parameter_type="pair",

--- a/src/pint/models/ifunc.py
+++ b/src/pint/models/ifunc.py
@@ -17,16 +17,18 @@ class IFunc(PhaseComponent):
     changing PEPOCH should be done with care.
 
     The format of IFuncs in an ephemeris is:
-    SIFUNC X 0
-    IFUNC1 MJD1 DT1 0.0
-    IFUNC2 MJD2 DT2 0.0
-    ...
-    IFUNCN MJDN DTN 0.0
+
+        SIFUNC X 0
+        IFUNC1 MJD1 DT1 0.0
+        IFUNC2 MJD2 DT2 0.0
+        ...
+        IFUNCN MJDN DTN 0.0
 
     X indicates the type of interpolation:
-    0 == piecewise (no interpolation)
-    1 == sinc (not supported)
-    2 == linear
+
+        - 0 == piecewise (no interpolation)
+        - 1 == sinc (not supported)
+        - 2 == linear
 
     NB that the trailing 0.0s are necessary for accurate tempo2 parsing.
     NB also that tempo2 has a static setting MAX_IFUNC whose default value
@@ -39,13 +41,18 @@ class IFunc(PhaseComponent):
     of the interpolated signal.  Because the interpolant spacing is
     typically large (days to weeks), the difference between SAT and BAT of
     a few minutes should make little difference.
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.ifunc.IFunc
     """
 
     register = True
     category = "ifunc"
 
     def __init__(self):
-        super(IFunc, self).__init__()
+        super().__init__()
 
         self.add_param(
             floatParameter(name="SIFUNC", description="Type of interpolation", units="")
@@ -63,12 +70,12 @@ class IFunc(PhaseComponent):
         self.phase_funcs_component += [self.ifunc_phase]
 
     def setup(self):
-        super(IFunc, self).setup()
+        super().setup()
         self.terms = list(self.get_prefix_mapping_component("IFUNC").keys())
         self.num_terms = len(self.terms)
 
     def validate(self):
-        super(IFunc, self).validate()
+        super().validate()
         if self.SIFUNC.quantity is None:
             raise MissingParameter(
                 "IFunc", "SIFUNC", "SIFUNC is required if IFUNC entries are present."
@@ -128,7 +135,7 @@ class IFunc(PhaseComponent):
             times[idx == 0] = y[0]
             times[idx == len(x)] = y[-1]
         else:
-            raise ValueError("Interpolation type %d not supported.".format(itype))
+            raise ValueError(f"Interpolation type {itype} not supported.")
 
         phase = ((times * u.s) * self._parent.F0.quantity).to(u.dimensionless_unscaled)
         return phase

--- a/src/pint/models/jump.py
+++ b/src/pint/models/jump.py
@@ -88,7 +88,13 @@ class PhaseJump(PhaseComponent):
 
     def __init__(self):
         super().__init__()
-        self.add_param(maskParameter(name="JUMP", units="second", description="Amount to jump the selected TOAs by."))
+        self.add_param(
+            maskParameter(
+                name="JUMP",
+                units="second",
+                description="Amount to jump the selected TOAs by.",
+            )
+        )
         self.phase_funcs_component += [self.jump_phase]
 
     def setup(self):

--- a/src/pint/models/jump.py
+++ b/src/pint/models/jump.py
@@ -12,6 +12,11 @@ from astropy import log
 class DelayJump(DelayComponent):
     """Phase jumps
 
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.jump.DelayJump
+
     Note
     ----
     This component is disabled for now, since we don't have any method
@@ -22,21 +27,18 @@ class DelayJump(DelayComponent):
     category = "delay_jump"
 
     def __init__(self):
-        super(DelayJump, self).__init__()
+        super().__init__()
         self.add_param(maskParameter(name="JUMP", units="second"))
         self.delay_funcs_component += [self.jump_delay]
 
     def setup(self):
-        super(DelayJump, self).setup()
+        super().setup()
         self.jumps = []
         for mask_par in self.get_params_of_type("maskParameter"):
             if mask_par.startswith("JUMP"):
                 self.jumps.append(mask_par)
         for j in self.jumps:
             self.register_deriv_funcs(self.d_delay_d_jump, j)
-
-    def validate(self):
-        super(DelayJump, self).validate()
 
     def jump_delay(self, toas, acc_delay=None):
         """This method returns the jump delays for each toas section collected by
@@ -70,18 +72,27 @@ class DelayJump(DelayComponent):
 
 
 class PhaseJump(PhaseComponent):
-    """A class to implement phase jumps."""
+    """Arbitrary jumps in pulse phase.
+
+    In spite of the name, the amounts here are specified in seconds and
+    converted to phase using F0.
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.jump.PhaseJump
+    """
 
     register = True
     category = "phase_jump"
 
     def __init__(self):
-        super(PhaseJump, self).__init__()
-        self.add_param(maskParameter(name="JUMP", units="second"))
+        super().__init__()
+        self.add_param(maskParameter(name="JUMP", units="second", description="Amount to jump the selected TOAs by."))
         self.phase_funcs_component += [self.jump_phase]
 
     def setup(self):
-        super(PhaseJump, self).setup()
+        super().setup()
         self.jumps = []
         for mask_par in self.get_params_of_type("maskParameter"):
             if mask_par.startswith("JUMP"):
@@ -91,9 +102,6 @@ class PhaseJump(PhaseComponent):
             if j in self.deriv_funcs.keys():
                 del self.deriv_funcs[j]
             self.register_deriv_funcs(self.d_phase_d_jump, j)
-
-    def validate(self):
-        super(PhaseJump, self).validate()
 
     def jump_phase(self, toas, delay):
         """This method returns the jump phase for each toas section collected by

--- a/src/pint/models/jump.py
+++ b/src/pint/models/jump.py
@@ -208,7 +208,6 @@ class PhaseJump(PhaseComponent):
                 value=0.0,
                 units="second",
                 frozen=False,
-                aliases=["JUMP"],
             )
             self.add_param(param)
             ind = 1
@@ -230,7 +229,6 @@ class PhaseJump(PhaseComponent):
                 value=0.0,
                 units="second",
                 frozen=False,
-                aliases=["JUMP"],
             )
             self.add_param(param)
             ind = param.index

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -13,7 +13,7 @@ from pint.models.timing_model import Component
 
 class NoiseComponent(Component):
     def __init__(self,):
-        super(NoiseComponent, self).__init__()
+        super().__init__()
         self.covariance_matrix_funcs = []
         self.scaled_toa_sigma_funcs = []  # Need to move this to a speical place.
         self.scaled_dm_sigma_funcs = []
@@ -25,12 +25,14 @@ class NoiseComponent(Component):
         self.dm_covariance_matrix_funcs_component = []
         self.basis_funcs = []
 
-    def validate(self,):
-        super(NoiseComponent, self).validate()
-
 
 class ScaleToaError(NoiseComponent):
     """Correct reported template fitting uncertainties.
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.noise_model.ScaleToaError
 
     Note
     ----
@@ -42,7 +44,7 @@ class ScaleToaError(NoiseComponent):
     category = "scale_toa_error"
 
     def __init__(self,):
-        super(ScaleToaError, self).__init__()
+        super().__init__()
         self.introduces_correlated_errors = False
         self.add_param(
             maskParameter(
@@ -79,7 +81,7 @@ class ScaleToaError(NoiseComponent):
         self.scaled_toa_sigma_funcs += [self.scale_toa_sigma]
 
     def setup(self):
-        super(ScaleToaError, self).setup()
+        super().setup()
         # Get all the EFAC parameters and EQUAD
         self.EFACs = {}
         self.EQUADs = {}
@@ -136,7 +138,7 @@ class ScaleToaError(NoiseComponent):
                 self.EQUADs[pp] = (par.key, par.key_value)
 
     def validate(self):
-        super(ScaleToaError, self).validate()
+        super().validate()
         # check duplicate
         for el in ["EFACs", "EQUADs"]:
             l = list(getattr(self, el).values())
@@ -171,6 +173,11 @@ class ScaleToaError(NoiseComponent):
 class ScaleDmError(NoiseComponent):
     """Correction for estimated wideband DM measurement uncertainty.
 
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.noise_model.ScaleDmError
+
     Note
     ----
     Ref: NanoGrav 12.5 yrs wideband data
@@ -180,7 +187,7 @@ class ScaleDmError(NoiseComponent):
     category = "scale_dm_error"
 
     def __init__(self,):
-        super(ScaleDmError, self).__init__()
+        super().__init__()
         self.introduces_correlated_errors = False
         self.add_param(
             maskParameter(
@@ -206,7 +213,7 @@ class ScaleDmError(NoiseComponent):
         self._paired_DMEFAC_DMEQUAD = None
 
     def setup(self):
-        super(ScaleDmError, self).setup()
+        super().setup()
         # Get all the EFAC parameters and EQUAD
         self.DMEFACs = {}
         self.DMEQUADs = {}
@@ -228,7 +235,7 @@ class ScaleDmError(NoiseComponent):
         #     self._paired_DMEFAC_DMEQUAD = self.pair_DMEFAC_DMEQUAD()
 
     def validate(self):
-        super(ScaleDmError, self).validate()
+        super().validate()
         # check duplicate
         for el in ["DMEFACs", "DMEQUADs"]:
             l = list(getattr(self, el).values())
@@ -272,6 +279,11 @@ class EcorrNoise(NoiseComponent):
     and forth within the average profile, and this effect is the same
     for all frequencies. Thus these TOAs have correlated errors.
 
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.noise_model.EcorrNoise
+
     Note
     ----
     Ref: NanoGrav 11 yrs data
@@ -282,7 +294,7 @@ class EcorrNoise(NoiseComponent):
     category = "ecorr_noise"
 
     def __init__(self,):
-        super(EcorrNoise, self).__init__()
+        super().__init__()
         self.introduces_correlated_errors = True
         self.add_param(
             maskParameter(
@@ -299,7 +311,7 @@ class EcorrNoise(NoiseComponent):
         self.basis_funcs += [self.ecorr_basis_weight_pair]
 
     def setup(self):
-        super(EcorrNoise, self).setup()
+        super().setup()
         # Get all the EFAC parameters and EQUAD
         self.ECORRs = {}
         for mask_par in self.get_params_of_type("maskParameter"):
@@ -310,7 +322,7 @@ class EcorrNoise(NoiseComponent):
                 continue
 
     def validate(self):
-        super(EcorrNoise, self).validate()
+        super().validate()
 
         # check duplicate
         for el in ["ECORRs"]:
@@ -370,6 +382,11 @@ class PLRedNoise(NoiseComponent):
     is noise dominated by the lowest frequency. This results in errors
     that are correlated between TOAs over fairly long time spans.
 
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.noise_model.PLRedNoise
+
     Note
     ----
     Ref: NanoGrav 11 yrs data
@@ -380,7 +397,7 @@ class PLRedNoise(NoiseComponent):
     category = "pl_red_noise"
 
     def __init__(self,):
-        super(PLRedNoise, self).__init__()
+        super().__init__()
         self.introduces_correlated_errors = True
         self.add_param(
             floatParameter(
@@ -426,12 +443,6 @@ class PLRedNoise(NoiseComponent):
 
         self.covariance_matrix_funcs += [self.pl_rn_cov_matrix]
         self.basis_funcs += [self.pl_rn_basis_weight_pair]
-
-    def setup(self):
-        super(PLRedNoise, self).setup()
-
-    def validate(self):
-        super(PLRedNoise, self).validate()
 
     def get_pl_vals(self):
         nf = int(self.TNRedC.value) if self.TNRedC.value is not None else 30

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -668,7 +668,7 @@ class strParameter(Parameter):
         super().__init__(
             name=name,
             value=value,
-            description=None,
+            description=description,
             frozen=True,
             aliases=aliases,
             print_quantity=print_quantity,
@@ -730,7 +730,7 @@ class boolParameter(Parameter):
         super().__init__(
             name=name,
             value=value,
-            description=None,
+            description=description,
             frozen=True,
             aliases=aliases,
             print_quantity=print_quantity,
@@ -806,7 +806,7 @@ class intParameter(Parameter):
         super().__init__(
             name=name,
             value=value,
-            description=None,
+            description=description,
             frozen=True,
             aliases=aliases,
             print_quantity=print_quantity,

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -41,20 +41,24 @@ from pint.observatory import get_observatory
 
 
 class Parameter:
-    """A base PINT class describing a single timing model parameter.
+    """A single timing model parameter.
 
-    A ``Parameter`` object can be created with one of the subclasses provided by
-    ``PINT`` depending on the parameter usage.
+    Subclasses of this class can represent parameters of various types. They
+    can record units, a description of the parameter's meaning, a default value
+    in some cases, whether the parameter has ever been set, and they can
+    keep track of whether a parameter is to be fit or not.
 
-    Current Parameter types:
-    [``floatParameter``, ``strParameter``, ``boolParameter``, ``MDJParameter``,
-    ``AngleParameter``, ``prefixParameter``, ``maskParameter``]
+    Parameters can also come in families, either in the form of numbered
+    :class:`~pint.models.parameter.prefixParameter` or with associated
+    selection criteria in the form of
+    :class:`~pint.models.parameter.maskParameter`.
 
     Parameter current value information will be stored at ``.quantity`` property
-    which can be a flexible format, for example `astropy.quantity.Quantity` in
-    ``floatParameter`` and string in ``strParameter``, (For more detail see Parameter
+    which can be a flexible format, for example :class:`astropy.quantity.Quantity` in
+    :class:`~pint.models.parameter.floatParameter` and string in
+    :class:`~pint.models.parameter.strParameter`, (for more detail see Parameter
     subclasses docstrings). If applicable, Parameter default unit is
-    stored at ``.units`` property which is an ``astropy.units.Unit``. Property
+    stored at ``.units`` property which is an :class:`astropy.units.Unit`. Property
     ``.value`` always returns a pure value associated with ``.units`` from
     ``.quantity``. ``.uncertainty`` provides the storage for parameter uncertainty
     and ``.uncertainty_value`` for pure uncertainty value. Like ``.value``,
@@ -64,14 +68,14 @@ class Parameter:
     ----------
     name : str, optional
         The name of the parameter.
-    value : number, str, `astropy.units.Quantity` object, or other data type or object
+    value : number, str, astropy.units.Quantity, or other data type or object
         The input parameter value.
     units : str or astropy.units.Unit, optional
         Parameter default unit. Parameter .value and .uncertainty_value attribute
         will associate with the default units.
     description : str, optional
         A short description of what this parameter means.
-    uncertainty : number
+    uncertainty : float
         Current uncertainty of the value.
     frozen : bool, optional
         A flag specifying whether "fitters" should adjust the value of this

--- a/src/pint/models/piecewise.py
+++ b/src/pint/models/piecewise.py
@@ -1,4 +1,4 @@
-"""Pulsar timing piecewise solution."""
+"""Pulsar timing piecewise spin-down solution."""
 # piecewise.py
 # Defines piecewise spindown timing model class
 import astropy.units as u
@@ -11,13 +11,19 @@ from pint.utils import split_prefixed_name, taylor_horner, taylor_horner_deriv
 
 
 class PiecewiseSpindown(PhaseComponent):
-    """Pulsar spin-down piecewise solution."""
+    """Pulsar spin-down piecewise solution.
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.piecewise.PiecewiseSpindown
+    """
 
     register = True
     category = "piecewise"
 
     def __init__(self):
-        super(PiecewiseSpindown, self).__init__()
+        super().__init__()
 
         self.add_param(
             prefixParameter(
@@ -98,7 +104,7 @@ class PiecewiseSpindown(PhaseComponent):
         # self.phase_derivs_wrt_delay += [self.d_piecewise_phase_d_delay]
 
     def setup(self):
-        super(PiecewiseSpindown, self).setup()
+        super().setup()
         self.pwsol_prop = [
             "PWEP_",
             "PWSTART_",
@@ -130,7 +136,7 @@ class PiecewiseSpindown(PhaseComponent):
 
     def validate(self):
         """Validate parameters input."""
-        super(PiecewiseSpindown, self).validate()
+        super().validate()
         for idx in set(self.pwsol_indices):
             if not hasattr(self, "PWEP_%d" % idx):
                 msg = "Piecewise solution Epoch is needed for Piece %d." % idx

--- a/src/pint/models/pulsar_binary.py
+++ b/src/pint/models/pulsar_binary.py
@@ -29,6 +29,10 @@ class PulsarBinary(DelayComponent):
         - Longitude of periastron:         omega
         - Projected semi-major axis of orbit:   a1
 
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.pulsar_binary.PulsarBinary
     """
 
     category = "pulsar_system"

--- a/src/pint/models/solar_system_shapiro.py
+++ b/src/pint/models/solar_system_shapiro.py
@@ -20,7 +20,13 @@ from pint.models.timing_model import DelayComponent
 
 
 class SolarSystemShapiro(DelayComponent):
-    """Shapiro delay due to light bending near Solar System objects."""
+    """Shapiro delay due to light bending near Solar System objects.
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.solar_system_shapiro.SolarSystemShapiro
+    """
 
     register = True
     category = "solar_system_shapiro"
@@ -31,7 +37,7 @@ class SolarSystemShapiro(DelayComponent):
             boolParameter(
                 name="PLANET_SHAPIRO",
                 value=False,
-                description="Include planetary Shapiro delays (Y/N)",
+                description="Include planetary Shapiro delays",
             )
         )
         self.delay_funcs_component += [self.solar_system_shapiro_delay]

--- a/src/pint/models/solar_wind_dispersion.py
+++ b/src/pint/models/solar_wind_dispersion.py
@@ -14,8 +14,13 @@ from pint.toa_select import TOASelect
 class SolarWindDispersion(Dispersion):
     """Dispersion due to the solar wind (basic model).
 
-    The model is a simple spherically-symmetric model that varies
-    only in its amplitude.
+    The model is a simple spherically-symmetric model that is fit
+    only in its constant amplitude.
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.solar_wind_dispersion.SolarWindDispersion
 
     References
     ----------

--- a/src/pint/models/spindown.py
+++ b/src/pint/models/spindown.py
@@ -12,13 +12,26 @@ from pint.utils import split_prefixed_name, taylor_horner, taylor_horner_deriv
 
 
 class Spindown(PhaseComponent):
-    """A simple timing model for an isolated pulsar."""
+    """A simple timing model for an isolated pulsar.
+
+    This represents the pulsar's spin as a Taylor series,
+    given its derivatives at time PEPOCH. Using more than
+    about twelve derivatives leads to hopeless numerical
+    instability, and probably has no physical significance.
+    It is probably worth investigating timing noise models
+    if this many derivatives are needed.
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.spindown.Spindown
+    """
 
     register = True
     category = "spindown"
 
     def __init__(self):
-        super(Spindown, self).__init__()
+        super().__init__()
         self.add_param(
             floatParameter(
                 name="F0",
@@ -52,14 +65,14 @@ class Spindown(PhaseComponent):
         self.phase_derivs_wrt_delay += [self.d_spindown_phase_d_delay]
 
     def setup(self):
-        super(Spindown, self).setup()
+        super().setup()
         self.num_spin_terms = len(self.F_terms) + 1
         # Add derivative functions
         for fp in list(self.get_prefix_mapping_component("F").values()) + ["F0"]:
             self.register_deriv_funcs(self.d_phase_d_F, fp)
 
     def validate(self):
-        super(Spindown, self).validate()
+        super().validate()
         # Check for required params
         for p in ("F0",):
             if getattr(self, p).value is None:

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -3,25 +3,25 @@
 Defines the basic timing model interface classes.
 
 A PINT timing model will be an instance of
-:class:`pint.models.timing_model.TimingModel`. It will have a number of
+:class:`~pint.models.timing_model.TimingModel`. It will have a number of
 "components", each an instance of a subclass of
-:class:`pint.models.timing_model.Component`. These components each
+:class:`~pint.models.timing_model.Component`. These components each
 implement some part of the timing model, whether astrometry (for
-example :class:`pint.models.astrometry.AstrometryEcliptic`), noise
-modelling (for example :class:`pint.models.noise_model.ScaleToaError`),
+example :class:`~pint.models.astrometry.AstrometryEcliptic`), noise
+modelling (for example :class:`~pint.models.noise_model.ScaleToaError`),
 interstellar dispersion (for example
-:class:`pint.models.dispersion_model.DispersionDM`), or pulsar binary orbits.
+:class:`~pint.models.dispersion_model.DispersionDM`), or pulsar binary orbits.
 This last category is somewhat unusual in that the code for each model is
 divided into a PINT-facing side (for example
-:class:`pint.models.binary_bt.BinaryBT`) and an internal model that does the
+:class:`~pint.models.binary_bt.BinaryBT`) and an internal model that does the
 actual computation (for example
-:class:`pint.models.stand_alone_psr_binaries.BT_model.BTmodel`); the management of
+:class:`~pint.models.stand_alone_psr_binaries.BT_model.BTmodel`); the management of
 data passing between these two parts is carried out by
-:class:`pint.models.pulsar_binary.PulsarBinary` and
-:class:`pint.models.stand_alone_psr_binaries.binary_generic.PSR_BINARY`.
+:class:`~pint.models.pulsar_binary.PulsarBinary` and
+:class:`~pint.models.stand_alone_psr_binaries.binary_generic.PSR_BINARY`.
 
 To actually create a timing model, you almost certainly want to use
-:func:`pint.models.model_builder.get_model`.
+:func:`~pint.models.model_builder.get_model`.
 
 """
 import abc
@@ -52,7 +52,14 @@ from pint.phase import Phase
 from pint.toa import TOAs
 from pint.utils import PrefixError, interesting_lines, lines_of, split_prefixed_name
 
-__all__ = ["DEFAULT_ORDER", "TimingModel"]
+__all__ = [
+    "DEFAULT_ORDER",
+    "TimingModel",
+    "Component",
+    "TimingModelError",
+    "MissingParameter",
+    "MissingTOAs",
+]
 # Parameters or lines in parfiles we don't understand but shouldn't
 # complain about. These are still passed to components so that they
 # can use them if they want to.
@@ -98,6 +105,8 @@ DEFAULT_ORDER = [
 
 
 class MissingTOAs(ValueError):
+    """Some parameter does not describe any TOAs."""
+
     def __init__(self, parameter_names):
         if isinstance(parameter_names, str):
             parameter_names = [parameter_names]
@@ -205,7 +214,7 @@ class TimingModel:
         - Derivatives of delay and phase respect to parameter for fitting toas.
 
     Each timing parameters are stored as TimingModel attribute in the type of
-    :class:`pint.models.parameter.Parameter` delay or phase and its derivatives are implemented
+    :class:`~pint.models.parameter.Parameter` delay or phase and its derivatives are implemented
     as TimingModel Methods.
 
     Attributes
@@ -2273,16 +2282,23 @@ class ModelMeta(abc.ABCMeta):
 
 
 class Component(object, metaclass=ModelMeta):
-    """A base class for timing model components."""
+    """Timing model components.
 
-    component_types = {}
-    """An index of all registered subtypes.
-
+    When such a class is defined, it registers itself in
+    ``Component.component_types`` so that it can be found and used
+    when parsing par files.
     Note that classes are registered when their modules are imported,
     so ensure all classes of interest are imported before this list
     is checked.
 
+    These objects can be constructed with no particular values, but
+    their `.setup()` and `.validate()` methods should be called
+    before using them to compute anything. These should check
+    parameter values for validity, raising an exception if
+    invalid parameter values are chosen.
     """
+
+    component_types = {}
 
     def __init__(self):
         self.params = []

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -144,11 +144,12 @@ class TimingModel:
     """Timing model object built from Components.
 
     This object is the primary object to represent a timing model in PINT.  It
-    is normally constructed with :func:`pint.models.model_builder.get_model`,
-    and it contains a variety of Component objects, each representing a
+    is normally constructed with :func:`~pint.models.model_builder.get_model`,
+    and it contains a variety of :class:`~pint.models.timing_model.Component`
+    objects, each representing a
     physical process that either introduces delays in the pulse arrival time or
     introduces shifts in the pulse arrival phase.  These components have
-    parameters, described by :class:`pint.models.parameter.Parameter` objects,
+    parameters, described by :class:`~pint.models.parameter.Parameter` objects,
     and methods. Both the parameters and the methods are accessible through
     this object using attribute access, for example as ``model.F0`` or
     ``model.coords_as_GAL()``.
@@ -177,6 +178,11 @@ class TimingModel:
 
     TimingModel objects can be written out to ``.par`` files using
     :func:`pint.models.timing_model.TimingModel.as_parfile`.
+
+    PINT Parameters supported (here, rather than in any Component):
+
+    .. paramtable::
+        :class: pint.models.timing_model.TimingModel
 
     Parameters
     ----------

--- a/src/pint/models/troposphere_delay.py
+++ b/src/pint/models/troposphere_delay.py
@@ -16,9 +16,7 @@ from pint.toa_select import TOASelect
 
 
 class TroposphereDelay(DelayComponent):
-    """
-
-    Model for accounting for the troposphere delay for topocentric TOAs.
+    """Model for accounting for the troposphere delay for topocentric TOAs.
 
     Based on Davis zenith hydrostatic delay (Davis et al., 1985, Appendix A)
     Niell Mapping Functions (Niell, 1996, Eq 4)
@@ -35,6 +33,10 @@ class TroposphereDelay(DelayComponent):
     The wet delay represents changes due to dynamical variation in the
     atmosphere (ie changing water vapor) and is ususally around 10% of the hydrostatic delay
 
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.troposphere_delay.TroposphereDelay
     """
 
     register = True
@@ -97,7 +99,7 @@ class TroposphereDelay(DelayComponent):
         )
 
     def __init__(self):
-        super(TroposphereDelay, self).__init__()
+        super().__init__()
         self.add_param(
             boolParameter(
                 name="CORRECT_TROPOSPHERE",
@@ -123,12 +125,6 @@ class TroposphereDelay(DelayComponent):
         ]:
             array[0] = array[1]
             array[-1] = array[-2]
-
-    def setup(self):
-        super(TroposphereDelay, self).setup()
-
-    def validate(self):
-        super(TroposphereDelay, self).validate()
 
     def _get_target_altitude(self, obs, grp, radec):
         """convert the sky coordinates of the target to the angular altitude at each TOA

--- a/src/pint/models/wave.py
+++ b/src/pint/models/wave.py
@@ -1,3 +1,4 @@
+"""Delays expressed as a sum of sinusoids."""
 import astropy.units as u
 import numpy as np
 
@@ -6,7 +7,7 @@ from pint.models.timing_model import PhaseComponent, MissingParameter
 
 
 class Wave(PhaseComponent):
-    """This class provides harmonic signals.
+    """Delays expressed as a sum of sinusoids.
 
     Historically, used for decomposition of timing noise into a series of
     sine/cosine components.

--- a/src/pint/models/wave.py
+++ b/src/pint/models/wave.py
@@ -15,6 +15,11 @@ class Wave(PhaseComponent):
     as a time series, but trivially converted into phase by multiplication by
     F0, which could makes changes to PEPOCH fragile if there is strong spin
     frequency evolution.
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.wave.Wave
     """
 
     register = True

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1829,9 +1829,9 @@ def list_parameters(class_=None):
             elif isinstance(pm, intParameter):
                 d["kind"] = "integer"
             if isinstance(pm, prefixParameter):
-                d["name"] += " [and other numbers]"
+                d["name"] = pm.prefix + "{number}"
             if isinstance(pm, maskParameter):
-                d["name"] += " [flag] [value]"
+                d["name"] = pm.origin_name + " {flag} {value}"
             result.append(d)
         return result
     else:

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1817,7 +1817,7 @@ def list_parameters(class_=None):
                 description=pm.description,
             )
             if pm.aliases:
-                d["aliases"] = pm.aliases
+                d["aliases"] = [a for a in pm.aliases if a != pm.name]
             if pm.units:
                 d["kind"] = pm.units.to_string()
                 if not d["kind"]:
@@ -1830,8 +1830,12 @@ def list_parameters(class_=None):
                 d["kind"] = "integer"
             if isinstance(pm, prefixParameter):
                 d["name"] = pm.prefix + "{number}"
+                d["aliases"] = [a + "{number}" for a in pm.prefix_aliases]
             if isinstance(pm, maskParameter):
                 d["name"] = pm.origin_name + " {flag} {value}"
+                d["aliases"] = [a + " {flag} {value}" for a in pm.prefix_aliases]
+            if "aliases" in d and not d["aliases"]:
+                del d["aliases"]
             result.append(d)
         return result
     else:

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1838,7 +1838,9 @@ def list_parameters(class_=None):
         import pint.models.timing_model
 
         results = {}
-        for k, v in pint.models.timing_model.Component.component_types.items():
+        ct = pint.models.timing_model.Component.component_types.copy()
+        ct["TimingModel"] = pint.models.timing_model.TimingModel
+        for v in ct.values():
             for d in list_parameters(v):
                 n = d["name"]
                 class_ = d.pop("class_")

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1781,3 +1781,76 @@ def calculate_random_models(fitter, toas, Nmodels=100, keep_models=True, params=
         return dphase, random_models
     else:
         return dphase
+
+
+def list_parameters(class_=None):
+    """List parameters understood by PINT.
+
+    Parameters
+    ----------
+    class_: type, optional
+        If provided, produce a list of parameters understood by the Component type; if None,
+        return a list of parameters understood by all Components known to PINT.
+
+    Returns
+    -------
+    list of dict
+        Each entry is a dictionary describing one parameter. Dictionary values are all strings
+        or lists of strings, and will include at least "name", "classes", and "description".
+    """
+    if class_ is not None:
+        from pint.models.parameter import (
+            boolParameter,
+            strParameter,
+            intParameter,
+            prefixParameter,
+            maskParameter,
+        )
+
+        result = []
+        inst = class_()
+        for p in inst.params:
+            pm = getattr(inst, p)
+            d = dict(
+                name=pm.name,
+                class_=f"{class_.__module__}.{class_.__name__}",
+                description=pm.description,
+            )
+            if pm.aliases:
+                d["aliases"] = pm.aliases
+            if pm.units:
+                d["kind"] = pm.units.to_string()
+                if not d["kind"]:
+                    d["kind"] = "number"
+            elif isinstance(pm, boolParameter):
+                d["kind"] = "boolean"
+            elif isinstance(pm, strParameter):
+                d["kind"] = "string"
+            elif isinstance(pm, intParameter):
+                d["kind"] = "integer"
+            if isinstance(pm, prefixParameter):
+                d["name"] += " [and other numbers]"
+            if isinstance(pm, maskParameter):
+                d["name"] += " [flag] [value]"
+            result.append(d)
+        return result
+    else:
+        import pint.models.timing_model
+
+        results = {}
+        for k, v in pint.models.timing_model.Component.component_types.items():
+            for d in list_parameters(v):
+                n = d["name"]
+                class_ = d.pop("class_")
+                if n not in results:
+                    d["classes"] = [class_]
+                    results[n] = d
+                else:
+                    r = results[n].copy()
+                    r.pop("classes")
+                    if r != d:
+                        raise ValueError(
+                            f"Parameter {d} in class {class_} does not match {results[n]}"
+                        )
+                    results[n]["classes"].append(class_)
+        return sorted(results.values(), key=lambda d: d["name"])


### PR DESCRIPTION
We now generate a table of all the parameters PINT supports every time the docs are built. Each model component now also lists all the parameters it understands.

Also greatly flesh out documentation of models and their components, and incidentally modernize many uses of `super()`.

Closes #1064 
Will have some conflicts with #1062 because that updates some of the same documentation.