### PR TITLE
Pintk output

### DIFF
--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -243,7 +243,10 @@ class PlkRandomModelSelect(tk.Frame):
             widget.grid_forget()
 
     def changedRMCheckBox(self):
-        log.info("Random Models set to %d" % (self.var.get()))
+        if self.var.get() == 1:
+            log.info("Random Models turned on.")
+        else:
+            log.info("Random Models turned off.")
 
     def getRandomModel(self):
         return self.var.get()
@@ -400,6 +403,9 @@ class PlkActionsWidget(tk.Frame):
         self.writeTim_callback = None
         self.saveFig_callback = None
         self.revert_callback = None
+        self.INFO_callback = None
+
+        self.infoShowing = False  # state of INFO logs
 
         self.initPlkActions()
 
@@ -419,6 +425,11 @@ class PlkActionsWidget(tk.Frame):
         button = tk.Button(self, text="Revert", command=self.revert)
         button.grid(row=0, column=4)
 
+        self.infobutton = tk.Button(
+            self, text="Show INFO", command=self.changeInfoStatus
+        )
+        self.infobutton.grid(row=0, column=5)
+
     def setCallbacks(self, fit, reset, writePar, writeTim, revert):
         """
         Callback functions
@@ -431,6 +442,9 @@ class PlkActionsWidget(tk.Frame):
 
     def setFitButtonText(self, text):
         self.fitbutton.config(text=text)
+
+    def setInfoButtonText(self, text):
+        self.infobutton.config(text=text)
 
     def fit(self):
         if self.fit_callback is not None:
@@ -455,6 +469,21 @@ class PlkActionsWidget(tk.Frame):
         if self.revert_callback is not None:
             self.revert_callback()
         log.info("Revert clicked")
+
+    def changeInfoStatus(self):
+        """
+        Change whether the INFO log statements display in the terminal
+        """
+        self.infoShowing = ~self.infoShowing
+        if self.infoShowing:
+            # INFO statements turned on
+            log.setLevel("INFO")
+            log.info("INFO statements turned on")
+            self.setInfoButtonText("Hide INFO")
+        else:
+            # INFO statements turned off
+            log.setLevel("WARNING")
+            self.setInfoButtonText("Show INFO")
 
 
 class PlkWidget(tk.Frame):

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -403,9 +403,6 @@ class PlkActionsWidget(tk.Frame):
         self.writeTim_callback = None
         self.saveFig_callback = None
         self.revert_callback = None
-        self.INFO_callback = None
-
-        self.infoShowing = False  # state of INFO logs
 
         self.initPlkActions()
 
@@ -425,11 +422,6 @@ class PlkActionsWidget(tk.Frame):
         button = tk.Button(self, text="Revert", command=self.revert)
         button.grid(row=0, column=4)
 
-        self.infobutton = tk.Button(
-            self, text="Show INFO", command=self.changeInfoStatus
-        )
-        self.infobutton.grid(row=0, column=5)
-
     def setCallbacks(self, fit, reset, writePar, writeTim, revert):
         """
         Callback functions
@@ -442,9 +434,6 @@ class PlkActionsWidget(tk.Frame):
 
     def setFitButtonText(self, text):
         self.fitbutton.config(text=text)
-
-    def setInfoButtonText(self, text):
-        self.infobutton.config(text=text)
 
     def fit(self):
         if self.fit_callback is not None:
@@ -469,21 +458,6 @@ class PlkActionsWidget(tk.Frame):
         if self.revert_callback is not None:
             self.revert_callback()
         log.info("Revert clicked")
-
-    def changeInfoStatus(self):
-        """
-        Change whether the INFO log statements display in the terminal
-        """
-        self.infoShowing = ~self.infoShowing
-        if self.infoShowing:
-            # INFO statements turned on
-            log.setLevel("INFO")
-            log.info("INFO statements turned on")
-            self.setInfoButtonText("Hide INFO")
-        else:
-            # INFO statements turned off
-            log.setLevel("WARNING")
-            self.setInfoButtonText("Show INFO")
 
 
 class PlkWidget(tk.Frame):

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -245,9 +245,9 @@ class PlkRandomModelSelect(tk.Frame):
 
     def changedRMCheckBox(self):
         if self.var.get() == 1:
-            log.info("Random Models turned on.")
+            log.debug("Random Models turned on.")
         else:
-            log.info("Random Models turned off.")
+            log.debug("Random Models turned off.")
 
     def getRandomModel(self):
         return self.var.get()

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -24,6 +24,7 @@ except ImportError:
     import tkinter as tk
     import tkinter.filedialog as tkFileDialog
     import tkinter.messagebox as tkMessageBox
+    from tkinter import ttk
 
 log.setLevel("INFO")
 log.debug("This should show up")
@@ -250,6 +251,29 @@ class PlkRandomModelSelect(tk.Frame):
 
     def getRandomModel(self):
         return self.var.get()
+
+
+class PlkLogLevelSelect(tk.Frame):
+    """
+    Allows one to select the log output level in the terminal
+    """
+
+    def __init__(self, master):
+        tk.Frame.__init__(self, master)
+        self.logLabel = tk.Label(self, text="Minimum Log Level: ")
+        self.logLabel.pack()
+        self.logLevelSelect = ttk.Combobox(self)
+        self.logLevelSelect.pack()
+        self.logLevelSelect["values"] = ["DEBUG", "INFO", "WARNING", "ERROR"]
+        self.logLevelSelect["state"] = "readonly"  # user can't enter an option
+        self.logLevelSelect.current(2)  # automatically on WARNING level
+        # bind user log level selection to function changing log level
+        self.logLevelSelect.bind("<<ComboboxSelected>>", self.changeLogLevel)
+
+    def changeLogLevel(self, event):
+        newLevel = self.logLevelSelect.get()  # get current value
+        log.setLevel(str(newLevel))
+        log.info("Log level changed to " + str(newLevel))
 
 
 class PlkColorModeBoxes(tk.Frame):
@@ -489,6 +513,7 @@ class PlkWidget(tk.Frame):
         self.xyChoiceWidget = PlkXYChoiceWidget(master=self)
         self.actionsWidget = PlkActionsWidget(master=self)
         self.randomboxWidget = PlkRandomModelSelect(master=self)
+        self.logLevelWidget = PlkLogLevelSelect(master=self)
         self.colorModeWidget = PlkColorModeBoxes(master=self)
 
         self.plkDpi = 100
@@ -521,6 +546,7 @@ class PlkWidget(tk.Frame):
         self.xyChoiceWidget.grid(row=2, column=0, sticky="nw")
         self.plkCanvas.get_tk_widget().grid(row=2, column=1, sticky="nesw")
         self.actionsWidget.grid(row=3, column=0, columnspan=2, sticky="W")
+        self.logLevelWidget.grid(row=3, column=1, sticky="E")
 
         self.grid_columnconfigure(1, weight=10)
         self.grid_columnconfigure(0, weight=1)

--- a/src/pint/scripts/pintk.py
+++ b/src/pint/scripts/pintk.py
@@ -100,6 +100,11 @@ class PINTk:
             command=lambda: self.changeLogLevel("ERROR"),
             variable=self.log_levels["ERROR"],
         )
+        self.logMenu.add_checkbutton(
+            label="NOTSET",
+            command=lambda: self.changeLogLevel("NOTSET"),
+            variable=self.log_levels["NOTSET"],
+        )
         self.menuBar.add_cascade(label="Log Levels", menu=self.logMenu)
 
         # Key bindings
@@ -123,6 +128,7 @@ class PINTk:
             "INFO": tk.IntVar(),
             "WARNING": tk.IntVar(),
             "ERROR": tk.IntVar(),
+            "NOTSET": tk.IntVar(),
         }
         self.log_levels["WARNING"].set(1)
 

--- a/src/pint/scripts/pintk.py
+++ b/src/pint/scripts/pintk.py
@@ -160,7 +160,6 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     log.setLevel("WARNING")  # only display warnings and higher in the terminal
-
     root = tk.Tk()
     root.minsize(800, 600)
     if not args.test:

--- a/src/pint/scripts/pintk.py
+++ b/src/pint/scripts/pintk.py
@@ -10,6 +10,7 @@ import numpy as np
 import tkinter as tk
 import tkinter.filedialog as tkFileDialog
 import tkinter.messagebox as tkMessageBox
+from tkinter import ttk
 from astropy import log
 
 from pint.pintk.paredit import ParWidget
@@ -79,34 +80,6 @@ class PINTk:
         self.helpMenu.add_command(label="Plk Help", command=lambda: print(helpstring))
         self.menuBar.add_cascade(label="Help", menu=self.helpMenu)
 
-        self.logMenu = tk.Menu(self.menuBar)
-        self.logMenu.add_checkbutton(
-            label="DEBUG",
-            command=lambda: self.changeLogLevel("DEBUG"),
-            variable=self.log_levels["DEBUG"],
-        )
-        self.logMenu.add_checkbutton(
-            label="INFO",
-            command=lambda: self.changeLogLevel("INFO"),
-            variable=self.log_levels["INFO"],
-        )
-        self.logMenu.add_checkbutton(
-            label="WARNING",
-            command=lambda: self.changeLogLevel("WARNING"),
-            variable=self.log_levels["WARNING"],
-        )
-        self.logMenu.add_checkbutton(
-            label="ERROR",
-            command=lambda: self.changeLogLevel("ERROR"),
-            variable=self.log_levels["ERROR"],
-        )
-        self.logMenu.add_checkbutton(
-            label="NOTSET",
-            command=lambda: self.changeLogLevel("NOTSET"),
-            variable=self.log_levels["NOTSET"],
-        )
-        self.menuBar.add_cascade(label="Log Levels", menu=self.logMenu)
-
         # Key bindings
         top.bind("<Control-p>", lambda e: self.toggle("plk"))
         top.bind("<Control-m>", lambda e: self.toggle("par"))
@@ -121,23 +94,6 @@ class PINTk:
         }
         self.active = {"plk": tk.IntVar(), "par": tk.IntVar(), "tim": tk.IntVar()}
         self.active["plk"].set(1)
-
-    def createLogLevels(self):
-        self.log_levels = {
-            "DEBUG": tk.IntVar(),
-            "INFO": tk.IntVar(),
-            "WARNING": tk.IntVar(),
-            "ERROR": tk.IntVar(),
-            "NOTSET": tk.IntVar(),
-        }
-        self.log_levels["WARNING"].set(1)
-
-    def changeLogLevel(self, newLevel):
-        log.setLevel(str(newLevel))
-        log.info("Log level changed to " + str(newLevel))
-        for key in self.log_levels.keys():
-            if self.log_levels[key].get() and key != newLevel:
-                self.log_levels[key].set(0)  # toggle old level off
 
     def updateLayout(self):
         for widget in self.mainFrame.winfo_children():

--- a/src/pint/scripts/pintk.py
+++ b/src/pint/scripts/pintk.py
@@ -40,6 +40,8 @@ class PINTk:
         if parfile is not None and timfile is not None:
             self.openPulsar(parfile=parfile, timfile=timfile, ephem=ephem)
 
+        self.createLogLevels()
+
         self.initUI()
         self.updateLayout()
 
@@ -77,6 +79,29 @@ class PINTk:
         self.helpMenu.add_command(label="Plk Help", command=lambda: print(helpstring))
         self.menuBar.add_cascade(label="Help", menu=self.helpMenu)
 
+        self.logMenu = tk.Menu(self.menuBar)
+        self.logMenu.add_checkbutton(
+            label="DEBUG",
+            command=lambda: self.changeLogLevel("DEBUG"),
+            variable=self.log_levels["DEBUG"],
+        )
+        self.logMenu.add_checkbutton(
+            label="INFO",
+            command=lambda: self.changeLogLevel("INFO"),
+            variable=self.log_levels["INFO"],
+        )
+        self.logMenu.add_checkbutton(
+            label="WARNING",
+            command=lambda: self.changeLogLevel("WARNING"),
+            variable=self.log_levels["WARNING"],
+        )
+        self.logMenu.add_checkbutton(
+            label="ERROR",
+            command=lambda: self.changeLogLevel("ERROR"),
+            variable=self.log_levels["ERROR"],
+        )
+        self.menuBar.add_cascade(label="Log Levels", menu=self.logMenu)
+
         # Key bindings
         top.bind("<Control-p>", lambda e: self.toggle("plk"))
         top.bind("<Control-m>", lambda e: self.toggle("par"))
@@ -91,6 +116,22 @@ class PINTk:
         }
         self.active = {"plk": tk.IntVar(), "par": tk.IntVar(), "tim": tk.IntVar()}
         self.active["plk"].set(1)
+
+    def createLogLevels(self):
+        self.log_levels = {
+            "DEBUG": tk.IntVar(),
+            "INFO": tk.IntVar(),
+            "WARNING": tk.IntVar(),
+            "ERROR": tk.IntVar(),
+        }
+        self.log_levels["WARNING"].set(1)
+
+    def changeLogLevel(self, newLevel):
+        log.setLevel(str(newLevel))
+        log.info("Log level changed to " + str(newLevel))
+        for key in self.log_levels.keys():
+            if self.log_levels[key].get() and key != newLevel:
+                self.log_levels[key].set(0)  # toggle old level off
 
     def updateLayout(self):
         for widget in self.mainFrame.winfo_children():

--- a/src/pint/scripts/pintk.py
+++ b/src/pint/scripts/pintk.py
@@ -41,8 +41,6 @@ class PINTk:
         if parfile is not None and timfile is not None:
             self.openPulsar(parfile=parfile, timfile=timfile, ephem=ephem)
 
-        self.createLogLevels()
-
         self.initUI()
         self.updateLayout()
 

--- a/src/pint/scripts/pintk.py
+++ b/src/pint/scripts/pintk.py
@@ -159,6 +159,8 @@ def main(argv=None):
     )
     args = parser.parse_args(argv)
 
+    log.setLevel("WARNING")  # only display warnings and higher in the terminal
+
     root = tk.Tk()
     root.minsize(800, 600)
     if not args.test:


### PR DESCRIPTION
Set pintk's default operation to hide INFO log statements from the terminal and added a button to the pintk interface to turn these INFO statements on and off. Addresses issue #1038 .