### PR TITLE
Adding information/metadata strings to par and tim files

### DIFF
--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -2053,6 +2053,7 @@ class TimingModel:
         self,
         start_order=["astrometry", "spindown", "dispersion"],
         last_order=["jump_delay"],
+        include_info=True,
         comment=None,
     ):
         """Represent the entire model as a parfile string.
@@ -2063,12 +2064,17 @@ class TimingModel:
             Categories to include at the beginning
         last_order : list
             Categories to include at the end
+        include_info : bool, optional
+            Include information string if True
         comment : str, optional
             Additional comment string to include in parfile
         """
         self.validate()
-        info_string = pint.utils.info_string(prefix_string="# ", comment=comment)
-        result_begin = info_string + "\n"
+        if include_info:
+            info_string = pint.utils.info_string(prefix_string="# ", comment=comment)
+            result_begin = info_string + "\n"
+        else:
+            result_begin = ""
         result_end = ""
         result_middle = ""
         cates_comp = self.get_components_by_category()

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -2053,6 +2053,7 @@ class TimingModel:
         self,
         start_order=["astrometry", "spindown", "dispersion"],
         last_order=["jump_delay"],
+        comment=None,
     ):
         """Represent the entire model as a parfile string.
 
@@ -2062,9 +2063,12 @@ class TimingModel:
             Categories to include at the beginning
         last_order : list
             Categories to include at the end
+        comment : str, optional
+            Additional comment string to include in parfile
         """
         self.validate()
-        result_begin = ""
+        info_string = pint.utils.info_string(prefix_string="# ", comment=comment)
+        result_begin = info_string + "\n"
         result_end = ""
         result_middle = ""
         cates_comp = self.get_components_by_category()

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -2053,6 +2053,7 @@ class TimingModel:
         self,
         start_order=["astrometry", "spindown", "dispersion"],
         last_order=["jump_delay"],
+        *,
         include_info=True,
         comment=None,
     ):

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1748,6 +1748,7 @@ class TOAs:
         format="tempo2",
         commentflag=None,
         order_by_index=True,
+        *,
         include_info=True,
         comment=None,
     ):

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -31,6 +31,7 @@ from pint.pulsar_mjd import Time
 from pint.solar_system_ephemerides import objPosVel_wrt_SSB
 from pint.phase import Phase
 from pint.pulsar_ecliptic import PulsarEcliptic
+import pint.utils
 
 __all__ = [
     "TOAs",
@@ -1747,6 +1748,7 @@ class TOAs:
         format="tempo2",
         commentflag=None,
         order_by_index=True,
+        comment=None,
     ):
         """Write this object to a ``.tim`` file.
 
@@ -1785,6 +1787,8 @@ class TOAs:
             handle = True
         if format.upper() in ("TEMPO2", "1"):
             outf.write("FORMAT 1\n")
+        info_string = pint.utils.info_string(prefix_string="C ", comment=comment)
+        outf.write(info_string + "\n")
 
         # Add pulse numbers to flags temporarily if there is a pulse number column
         # FIXME: everywhere else the pulse number column is called pulse_number not pn

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1748,6 +1748,7 @@ class TOAs:
         format="tempo2",
         commentflag=None,
         order_by_index=True,
+        include_info=True,
         comment=None,
     ):
         """Write this object to a ``.tim`` file.
@@ -1776,6 +1777,8 @@ class TOAs:
             if False, write them in the order they occur in the TOAs object
             (which is usually the same as the original file except that all the
             TOAs associated with each observatory have been grouped).
+        include_info : bool, optional
+            Include information string if True
         comment : str, optional
             Additional string to include in TOA file
         """
@@ -1789,8 +1792,9 @@ class TOAs:
             handle = True
         if format.upper() in ("TEMPO2", "1"):
             outf.write("FORMAT 1\n")
-        info_string = pint.utils.info_string(prefix_string="C ", comment=comment)
-        outf.write(info_string + "\n")
+        if include_info:
+            info_string = pint.utils.info_string(prefix_string="C ", comment=comment)
+            outf.write(info_string + "\n")
 
         # Add pulse numbers to flags temporarily if there is a pulse number column
         # FIXME: everywhere else the pulse number column is called pulse_number not pn

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1776,6 +1776,8 @@ class TOAs:
             if False, write them in the order they occur in the TOAs object
             (which is usually the same as the original file except that all the
             TOAs associated with each observatory have been grouped).
+        comment : str, optional
+            Additional string to include in TOA file
         """
         try:
             # FIXME: file must be closed even if an exception occurs!

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1700,15 +1700,11 @@ def info_string(prefix_string="# ", comment=None):
     Adds:
 
     - Creation date
-
     - PINT version
-
-    - Username (given by the `gitpython`_ global configuration ``user.name`` if available, in addition to :func:`getpass.getuser`).
-
+    - Username (given by the `gitpython`_ global configuration ``user.name``
+      if available, in addition to :func:`getpass.getuser`).
     - Host (given by :func:`platform.node`)
-
     - OS (given by :func:`platform.platform`)
-
     - plus a user-supplied comment (if present).
 
     Parameters

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1707,7 +1707,7 @@ def info_string(prefix_string="# ", comment=None):
         # user-level git config
         c = git.GitConfigParser()
         username = c.get_value("user", option="name") + f" ({getpass.getuser()})"
-    except configparser.NoOptionError, ImportError:
+    except (configparser.NoOptionError, ImportError):
         username = getpass.getuser()
 
     s = f"""

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1675,9 +1675,9 @@ def info_string(prefix_string="# ", comment=None):
     import platform
     import datetime
 
-    s = f"Created at: {datetime.datetime.now().isoformat()}\nPINT version: {pint.__version__}\nUser: {getpass.getuser()}\nHost: {platform.node()}\nOS: {platform.platform()}"
+    s = f"Created: {datetime.datetime.now().isoformat()}\nPINT_version: {pint.__version__}\nUser: {getpass.getuser()}\nHost: {platform.node()}\nOS: {platform.platform()}"
     if comment is not None:
-        s += f"\n{comment}"
+        s += f"\nComment: {comment}"
     if (prefix_string is not None) and (len(prefix_string) > 0):
         s = "\n".join([prefix_string + x for x in s.split("\n")])
     return s

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -56,6 +56,7 @@ __all__ = [
     "FTest",
     "add_dummy_distance",
     "remove_dummy_distance",
+    "info_string",
 ]
 
 
@@ -1697,20 +1698,27 @@ def info_string(prefix_string="# ", comment=None):
     """Returns an informative string about the current state of PINT.
 
     Adds:
-    Creation date
-    PINT version
-    Username
-    Host
-    OS
-    plus a user-supplied comment (if present).
+    
+    * Creation date
 
-    Username is given by the `gitpython` global configuration `user.name` (if available),
-    otherwise `getpass.getuser()`.
+    * PINT version
+
+    * Username
+
+    * Host
+
+    * OS
+
+    * plus a user-supplied comment (if present).
+
+    Username is given by the ``gitpython`` global configuration ``user.name``
+    (if available), otherwise ``getpass.getuser()``.
 
     Parameters
     ----------
     prefix_string: str, default='# '
-        a string to be prefixed to the output (often to designate as a comment or similar)
+        a string to be prefixed to the output (often to designate as a
+        comment or similar)
     comment: str, optional
         a free-form comment string to be included if present
     
@@ -1719,13 +1727,10 @@ def info_string(prefix_string="# ", comment=None):
     s : str
         informative string
 
-
     Examples
-    -------
-
+    --------
     >>> import pint.utils
     >>> print(pint.utils.info_string(prefix_string="# ",comment="Example comment"))
-    # 
     # Created: 2021-07-21T09:39:45.606894
     # PINT_version: 0.8.2+311.ge351099d
     # User: David Kaplan (dlk)
@@ -1733,12 +1738,11 @@ def info_string(prefix_string="# ", comment=None):
     # OS: macOS-10.14.6-x86_64-i386-64bit
     # Comment: Example comment
     
-
     Multi-line comments are allowed:
 
     >>> import pint.utils
-    >>> print(pint.utils.info_string(prefix_string="C ",comment="Example multi-line comment\nAlso using a different comment character"))
-    C 
+    >>> print(pint.utils.info_string(prefix_string="C ",
+    ...                              comment="Example multi-line comment\\nAlso using a different comment character"))
     C Created: 2021-07-21T09:40:34.172333
     C PINT_version: 0.8.2+311.ge351099d
     C User: David Kaplan (dlk)
@@ -1747,7 +1751,6 @@ def info_string(prefix_string="# ", comment=None):
     C Comment: Example multi-line comment
     C Comment: Also using a different comment character    
     """
-
     # try to get the git user.name
     # if defined
     try:
@@ -1772,9 +1775,11 @@ def info_string(prefix_string="# ", comment=None):
     s = os.linesep.join([x for x in s.splitlines() if x])
     if comment is not None:
         if os.linesep in comment:
-            s += os.linesep.join([f"Comment: {x}" for x in comment.splitlines()])
+            s += os.linesep + os.linesep.join(
+                [f"Comment: {x}" for x in comment.splitlines()]
+            )
         else:
-            s += f"Comment: {comment}"
+            s += f"{os.linesep}Comment: {comment}"
 
     if (prefix_string is not None) and (len(prefix_string) > 0):
         s = os.linesep.join([prefix_string + x for x in s.splitlines()])

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1667,3 +1667,17 @@ def remove_dummy_distance(c):
             "Do not know coordinate frame for %r: returning coordinates unchanged" % c
         )
         return c
+
+
+def info_string(prefix_string="# ", comment=None):
+    import pint
+    import getpass
+    import platform
+    import datetime
+
+    s = f"Created at: {datetime.datetime.now().isoformat()}\nPINT version: {pint.__version__}\nUser: {getpass.getuser()}\nHost: {platform.node()}\nOS: {platform.platform()}"
+    if comment is not None:
+        s += f"\n{comment}"
+    if (prefix_string is not None) and (len(prefix_string) > 0):
+        s = "\n".join([prefix_string + x for x in s.split("\n")])
+    return s

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -2,13 +2,14 @@
 import configparser
 import datetime
 import getpass
+import os
 import platform
 import re
 import textwrap
+from collections import OrderedDict
 from contextlib import contextmanager
 from copy import deepcopy
 from io import StringIO
-from collections import OrderedDict
 
 import astropy.constants as const
 import astropy.coordinates as coords
@@ -1693,8 +1694,7 @@ def remove_dummy_distance(c):
 
 
 def info_string(prefix_string="# ", comment=None):
-    """
-    Returns an informative string about the current state of PINT.
+    """Returns an informative string about the current state of PINT.
 
     Adds:
     Creation date
@@ -1768,15 +1768,18 @@ def info_string(prefix_string="# ", comment=None):
     """
 
     s = textwrap.dedent(s)
+    # remove blank lines
+    s = os.linesep.join([x for x in s.splitlines() if x])
     if comment is not None:
-        if "\n" in comment:
-            s += "\n".join([f"Comment: {x}" for x in comment.split("\n")])
+        if os.linesep in comment:
+            s += os.linesep.join([f"Comment: {x}" for x in comment.splitlines()])
         else:
             s += f"Comment: {comment}"
 
     if (prefix_string is not None) and (len(prefix_string) > 0):
-        s = "\n".join([prefix_string + x for x in s.split("\n")])
+        s = os.linesep.join([prefix_string + x for x in s.splitlines()])
     return s
+
 
 def calculate_random_models(fitter, toas, Nmodels=100, keep_models=True, params="all"):
     """
@@ -1893,10 +1896,10 @@ def list_parameters(class_=None):
     if class_ is not None:
         from pint.models.parameter import (
             boolParameter,
-            strParameter,
             intParameter,
-            prefixParameter,
             maskParameter,
+            prefixParameter,
+            strParameter,
         )
 
         result = []

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1699,13 +1699,13 @@ def info_string(prefix_string="# ", comment=None):
 
     Adds:
 
-    - Creation date
-    - PINT version
-    - Username (given by the `gitpython`_ global configuration ``user.name``
+    * Creation date
+    * PINT version
+    * Username (given by the `gitpython`_ global configuration ``user.name``
       if available, in addition to :func:`getpass.getuser`).
-    - Host (given by :func:`platform.node`)
-    - OS (given by :func:`platform.platform`)
-    - plus a user-supplied comment (if present).
+    * Host (given by :func:`platform.node`)
+    * OS (given by :func:`platform.platform`)
+    * plus a user-supplied comment (if present).
 
     Parameters
     ----------

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1699,17 +1699,17 @@ def info_string(prefix_string="# ", comment=None):
 
     Adds:
     
-    * Creation date
+    - Creation date
 
-    * PINT version
+    - PINT version
 
-    * Username
+    - Username
 
-    * Host
+    - Host
 
-    * OS
+    - OS
 
-    * plus a user-supplied comment (if present).
+    - plus a user-supplied comment (if present).
 
     Username is given by the ``gitpython`` global configuration ``user.name``
     (if available), otherwise ``getpass.getuser()``.
@@ -1724,7 +1724,7 @@ def info_string(prefix_string="# ", comment=None):
     
     Returns
     -------
-    s : str
+    str
         informative string
 
     Examples
@@ -1753,7 +1753,7 @@ def info_string(prefix_string="# ", comment=None):
 
     Notes
     -----
-    This can be called via ``t.write_TOA_file("combined.tim",comment="trying combination")``
+    This can be called via ``t.TOAs.write_TOA_file>("combined.tim",comment="trying combination")``
     for a tim file, or ``m.as_parfile(comment="test parfile writing")`` for par file    
     """
     # try to get the git user.name

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1,24 +1,24 @@
 """Miscellaneous potentially-helpful functions."""
+import configparser
+import datetime
+import getpass
+import platform
 import re
+import textwrap
 from contextlib import contextmanager
 from copy import deepcopy
 from io import StringIO
-import getpass
-import platform
-import datetime
-import textwrap
-import configparser
 
 import astropy.constants as const
 import astropy.coordinates as coords
-import astropy.units as u
 import astropy.coordinates.angles as angles
+import astropy.units as u
 import numpy as np
 import scipy.optimize.zeros as zeros
 from astropy import log
 from scipy.special import fdtrc
-import pint
 
+import pint
 import pint.pulsar_ecliptic
 
 __all__ = [

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1698,7 +1698,7 @@ def info_string(prefix_string="# ", comment=None):
     """Returns an informative string about the current state of PINT.
 
     Adds:
-    
+
     - Creation date
 
     - PINT version
@@ -1721,7 +1721,7 @@ def info_string(prefix_string="# ", comment=None):
         comment or similar)
     comment: str, optional
         a free-form comment string to be included if present
-    
+
     Returns
     -------
     str
@@ -1737,7 +1737,7 @@ def info_string(prefix_string="# ", comment=None):
     # Host: margle-2.local
     # OS: macOS-10.14.6-x86_64-i386-64bit
     # Comment: Example comment
-    
+
     Multi-line comments are allowed:
 
     >>> import pint.utils
@@ -1749,12 +1749,12 @@ def info_string(prefix_string="# ", comment=None):
     C Host: margle-2.local
     C OS: macOS-10.14.6-x86_64-i386-64bit
     C Comment: Example multi-line comment
-    C Comment: Also using a different comment character    
+    C Comment: Also using a different comment character
 
     Notes
     -----
-    This can be called via ``t.TOAs.write_TOA_file>("combined.tim",comment="trying combination")``
-    for a tim file, or ``m.as_parfile(comment="test parfile writing")`` for par file    
+    This can be called via ``t.`` :func:`~pint.toa.TOAs.write_TOA_file` ``("combined.tim",comment="trying combination")``
+    for a tim file, or ``m.`` :func:`:func:`~pint.models.timing_model.TimingModel.as_parfile` ``(comment="test parfile writing")`` for par file
     """
     # try to get the git user.name
     # if defined

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -7,7 +7,6 @@ import getpass
 import platform
 import datetime
 import textwrap
-import git
 import configparser
 
 import astropy.constants as const
@@ -1704,10 +1703,11 @@ def info_string(prefix_string="# ", comment=None):
     # try to get the git username
     # if defined
     try:
+        import git
         # user-level git config
         c = git.GitConfigParser()
         username = c.get_value("user", option="name") + f" ({getpass.getuser()})"
-    except configparser.NoOptionError:
+    except configparser.NoOptionError, ImportError:
         username = getpass.getuser()
 
     s = f"""

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1703,16 +1703,13 @@ def info_string(prefix_string="# ", comment=None):
 
     - PINT version
 
-    - Username
+    - Username (given by the `gitpython`_ global configuration ``user.name`` if available, in addition to :func:`getpass.getuser`).
 
-    - Host
+    - Host (given by :func:`platform.node`)
 
-    - OS
+    - OS (given by :func:`platform.platform`)
 
     - plus a user-supplied comment (if present).
-
-    Username is given by the ``gitpython`` global configuration ``user.name``
-    (if available), otherwise ``getpass.getuser()``.
 
     Parameters
     ----------
@@ -1751,13 +1748,57 @@ def info_string(prefix_string="# ", comment=None):
     C Comment: Example multi-line comment
     C Comment: Also using a different comment character
 
+    Full example of writing a par and tim file:
+
+    >>> from pint.models import get_model_and_toas
+    >>> # the locations of these may vary
+    >>> timfile = "tests/datafile/NGC6440E.tim"
+    >>> parfile = "tests/datafile/NGC6440E.par"
+    >>> m, t = get_model_and_toas(parfile, timfile)
+    >>> print(m.as_parfile(comment="Here is a comment on the par file"))
+    # Created: 2021-07-22T08:24:27.101479
+    # PINT_version: 0.8.2+439.ge81c9b11.dirty
+    # User: David Kaplan (dlk)
+    # Host: margle-2.local
+    # OS: macOS-10.14.6-x86_64-i386-64bit
+    # Comment: Here is a comment on the par file
+    PSR                            1748-2021E
+    EPHEM                               DE421
+    CLK                             UTC(NIST)
+    ...
+
+    >>> from pint.models import get_model_and_toas
+    >>> import io
+    >>> # the locations of these may vary
+    >>> timfile = "tests/datafile/NGC6440E.tim"
+    >>> parfile = "tests/datafile/NGC6440E.par"
+    >>> m, t = get_model_and_toas(parfile, timfile)
+    >>> f = io.StringIO(parfile)
+    >>> t.write_TOA_file(f, comment="Here is a comment on the tim file")
+    >>> f.seek(0)
+    >>> print(f.getvalue())
+    FORMAT 1
+    C Created: 2021-07-22T08:24:27.213529
+    C PINT_version: 0.8.2+439.ge81c9b11.dirty
+    C User: David Kaplan (dlk)
+    C Host: margle-2.local
+    C OS: macOS-10.14.6-x86_64-i386-64bit
+    C Comment: Here is a comment on the tim file
+    unk 1949.609000 53478.2858714192189005 21.710 gbt  -format Princeton -ddm 0.0
+    unk 1949.609000 53483.2767051885165973 21.950 gbt  -format Princeton -ddm 0.0
+    unk 1949.609000 53489.4683897879295023 29.950 gbt  -format Princeton -ddm 0.0
+    ....
+
+
     Notes
     -----
-    This can be called via ``t.`` :func:`~pint.toa.TOAs.write_TOA_file` ``("combined.tim",comment="trying combination")``
-    for a tim file, or ``m.`` :func:`:func:`~pint.models.timing_model.TimingModel.as_parfile` ``(comment="test parfile writing")`` for par file
+    This can be called via  :func:`~pint.toa.TOAs.write_TOA_file` on a :class:`~~pint.toa.TOAs` object,
+    or :func:`~pint.models.timing_model.TimingModel.as_parfile` on a
+    :class:`~pint.models.timing_model.TimingModel` object.
+
+    .. _gitpython: https://gitpython.readthedocs.io/en/stable/
     """
-    # try to get the git user.name
-    # if defined
+    # try to get the git user if defined
     try:
         import git
 

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1704,6 +1704,7 @@ def info_string(prefix_string="# ", comment=None):
     # if defined
     try:
         import git
+
         # user-level git config
         c = git.GitConfigParser()
         username = c.get_value("user", option="name") + f" ({getpass.getuser()})"

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1679,6 +1679,17 @@ def info_string(prefix_string="# ", comment=None):
     """
     Returns an informative string about the current state of PINT.
 
+    Adds:
+    Creation date
+    PINT version
+    Username
+    Host
+    OS
+    plus a user-supplied comment (if present).
+
+    Username is given by the `gitpython` global configuration `user.name` (if available),
+    otherwise `getpass.getuser()`.
+
     Parameters
     ----------
     prefix_string: str, default='# '
@@ -1688,19 +1699,32 @@ def info_string(prefix_string="# ", comment=None):
     
     Returns
     -------
-    s
+    s : str
         informative string
 
-    example:
+
+    Notes
+    -------
+
+    Example:
     # Created: 2021-07-09T13:52:43.873908
     # PINT_version: 0.8.2+297.g5ddf3207.dirty
     # User: dlk
     # Host: margle-2.local
     # OS: macOS-10.14.6-x86_64-i386-64bit
     # Comment: trying combination
+
+    Multi-line comments are allowed:
+    # Created: 2021-07-09T13:52:43.873908
+    # PINT_version: 0.8.2+297.g5ddf3207.dirty
+    # User: dlk
+    # Host: margle-2.local
+    # OS: macOS-10.14.6-x86_64-i386-64bit
+    # Comment: trying combination
+    # Comment: will it work?
     """
 
-    # try to get the git username
+    # try to get the git user.name
     # if defined
     try:
         import git
@@ -1719,10 +1743,13 @@ def info_string(prefix_string="# ", comment=None):
     OS: {platform.platform()}
     """
 
-    if comment is not None:
-        comment = comment.replace("\n", "\\n")
-        s += f"Comment: {comment}"
     s = textwrap.dedent(s)
+    if comment is not None:
+        if "\n" in comment:
+            s += "\n".join([f"Comment: {x}" for x in comment.split("\n")])
+        else:
+            s += f"Comment: {comment}"
+
     if (prefix_string is not None) and (len(prefix_string) > 0):
         s = "\n".join([prefix_string + x for x in s.split("\n")])
     return s

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1703,25 +1703,32 @@ def info_string(prefix_string="# ", comment=None):
         informative string
 
 
-    Notes
+    Examples
     -------
 
-    Example:
-    # Created: 2021-07-09T13:52:43.873908
-    # PINT_version: 0.8.2+297.g5ddf3207.dirty
-    # User: dlk
+    >>> import pint.utils
+    >>> print(pint.utils.info_string(prefix_string="# ",comment="Example comment"))
+    # 
+    # Created: 2021-07-21T09:39:45.606894
+    # PINT_version: 0.8.2+311.ge351099d
+    # User: David Kaplan (dlk)
     # Host: margle-2.local
     # OS: macOS-10.14.6-x86_64-i386-64bit
-    # Comment: trying combination
+    # Comment: Example comment
+    
 
     Multi-line comments are allowed:
-    # Created: 2021-07-09T13:52:43.873908
-    # PINT_version: 0.8.2+297.g5ddf3207.dirty
-    # User: dlk
-    # Host: margle-2.local
-    # OS: macOS-10.14.6-x86_64-i386-64bit
-    # Comment: trying combination
-    # Comment: will it work?
+
+    >>> import pint.utils
+    >>> print(pint.utils.info_string(prefix_string="C ",comment="Example multi-line comment\nAlso using a different comment character"))
+    C 
+    C Created: 2021-07-21T09:40:34.172333
+    C PINT_version: 0.8.2+311.ge351099d
+    C User: David Kaplan (dlk)
+    C Host: margle-2.local
+    C OS: macOS-10.14.6-x86_64-i386-64bit
+    C Comment: Example multi-line comment
+    C Comment: Also using a different comment character    
     """
 
     # try to get the git user.name

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1750,6 +1750,11 @@ def info_string(prefix_string="# ", comment=None):
     C OS: macOS-10.14.6-x86_64-i386-64bit
     C Comment: Example multi-line comment
     C Comment: Also using a different comment character    
+
+    Notes
+    -----
+    This can be called via ``t.write_TOA_file("combined.tim",comment="trying combination")``
+    for a tim file, or ``m.as_parfile(comment="test parfile writing")`` for par file    
     """
     # try to get the git user.name
     # if defined

--- a/tests/test_infostrings.py
+++ b/tests/test_infostrings.py
@@ -1,0 +1,86 @@
+"""Tests for adding info strings to parfiles and tim files"""
+import logging
+import os
+import unittest
+import pytest
+import copy
+import io
+import platform
+
+import astropy.units as u
+import numpy as np
+
+import pint.models.model_builder as mb
+import pint.toa as toa
+from pint.residuals import Residuals
+from pinttestdata import datadir
+import pint
+
+
+class SimpleSetup:
+    def __init__(self, par, tim):
+        self.par = par
+        self.tim = tim
+        self.m = mb.get_model(self.par)
+        self.t = toa.get_TOAs(
+            self.tim, ephem="DE405", planets=False, include_bipm=False
+        )
+
+
+@pytest.fixture
+def setup_NGC6440E():
+    os.chdir(datadir)
+    return SimpleSetup("NGC6440E.par", "NGC6440E.tim")
+
+
+def test_infostring_in_parfile(setup_NGC6440E):
+    parfile = setup_NGC6440E.m.as_parfile(comment="test parfile writing")
+    f = io.StringIO(parfile)
+    newmodel = mb.get_model(f)
+    for p in setup_NGC6440E.m.params:
+        assert (
+            getattr(newmodel, p).value == getattr(setup_NGC6440E.m, p).value
+        ), f"Value of {p} does not match in new par file: ({getattr(newmodel, p).value} vs. {getattr(setup_NGC6440E.m, p).value})"
+
+
+def test_contents_of_infostring_parfile(setup_NGC6440E):
+    parfile = setup_NGC6440E.m.as_parfile(comment="test parfile writing")
+    f = io.StringIO(parfile)
+    lines = f.readlines()
+    info = {}
+    for line in lines:
+        if line.startswith("# ") and ":" in line:
+            data = line[2:].split(":")
+            k = data[0]
+            v = ":".join(data[1:])
+            info[k] = v.strip()
+    assert info["Comment"] == "test parfile writing"
+    assert info["PINT_version"] == pint.__version__
+    assert info["Host"] == platform.node()
+    assert info["OS"] == platform.platform()
+
+
+def test_infostring_in_timfile(setup_NGC6440E):
+    f = io.StringIO()
+    setup_NGC6440E.t.write_TOA_file(f, comment="test timfile writing")
+    f.seek(0)
+    newtoas = toa.get_TOAs(f)
+    assert (setup_NGC6440E.t.get_mjds() == newtoas.get_mjds()).all()
+
+
+def test_contents_of_infostring_timfile(setup_NGC6440E):
+    f = io.StringIO()
+    setup_NGC6440E.t.write_TOA_file(f, comment="test timfile writing")
+    f.seek(0)
+    lines = f.readlines()
+    info = {}
+    for line in lines:
+        if line.startswith("C ") and ":" in line:
+            data = line[2:].split(":")
+            k = data[0]
+            v = ":".join(data[1:])
+            info[k] = v.strip()
+    assert info["Comment"] == "test timfile writing"
+    assert info["PINT_version"] == pint.__version__
+    assert info["Host"] == platform.node()
+    assert info["OS"] == platform.platform()

--- a/tests/test_toa_writer.py
+++ b/tests/test_toa_writer.py
@@ -153,12 +153,20 @@ def test_tim_writing_order():
 
     o = StringIO()
     toas.write_TOA_file(o, order_by_index=False)
-    toas.write_TOA_file('test.tim', order_by_index=False)
-    obs = [ln.split()[4] for ln in o.getvalue().split("\n")[1:] if (ln and not ln.startswith('C '))]
+    toas.write_TOA_file("test.tim", order_by_index=False)
+    obs = [
+        ln.split()[4]
+        for ln in o.getvalue().split("\n")[1:]
+        if (ln and not ln.startswith("C "))
+    ]
     assert obs[0] == obs[1] == obs[2] == obs[3]
 
     o = StringIO()
     toas.write_TOA_file(o, order_by_index=True)
-    obs = [ln.split()[4] for ln in o.getvalue().split("\n")[1:] if (ln and not ln.startswith('C '))]
+    obs = [
+        ln.split()[4]
+        for ln in o.getvalue().split("\n")[1:]
+        if (ln and not ln.startswith("C "))
+    ]
     assert obs[0] == obs[3] == obs[6] == obs[9]
     assert obs[0] != obs[1]

--- a/tests/test_toa_writer.py
+++ b/tests/test_toa_writer.py
@@ -153,11 +153,12 @@ def test_tim_writing_order():
 
     o = StringIO()
     toas.write_TOA_file(o, order_by_index=False)
-    obs = [ln.split()[4] for ln in o.getvalue().split("\n")[1:] if ln]
+    toas.write_TOA_file('test.tim', order_by_index=False)
+    obs = [ln.split()[4] for ln in o.getvalue().split("\n")[1:] if (ln and not ln.startswith('C '))]
     assert obs[0] == obs[1] == obs[2] == obs[3]
 
     o = StringIO()
     toas.write_TOA_file(o, order_by_index=True)
-    obs = [ln.split()[4] for ln in o.getvalue().split("\n")[1:] if ln]
+    obs = [ln.split()[4] for ln in o.getvalue().split("\n")[1:] if (ln and not ln.startswith('C '))]
     assert obs[0] == obs[3] == obs[6] == obs[9]
     assert obs[0] != obs[1]


### PR DESCRIPTION
Adds information like:
```
C Created: 2021-07-09T13:52:43.873908
C PINT_version: 0.8.2+297.g5ddf3207.dirty
C User: dlk
C Host: margle-2.local
C OS: macOS-10.14.6-x86_64-i386-64bit
C Comment: trying combination
```
to par and tim files via their writers.  At the moment this is just discarded on reading although that could change.  You can supply the last (optional) comment via:
```
t.write_TOA_file("combined.tim",comment="trying combination")
```