### PR TITLE
Parameter simplification

### DIFF
--- a/docs/timingmodels.rst
+++ b/docs/timingmodels.rst
@@ -18,6 +18,8 @@ these PINT raises an exception.
 
 .. componentlist::
 
+.. _`Supported Parameters`:
+
 Supported Parameters
 --------------------
 

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -313,7 +313,7 @@ class Fitter:
                         )
                 elif isinstance(par, boolParameter):
                     s += ("{:" + spacingName + "s} {:>20s} {:28s} {}\n").format(
-                        pn, prefitpar._print_quantity(prefitpar.value), "", par.units
+                        pn, prefitpar.str_quantity(prefitpar.value), "", par.units
                     )
                 else:
                     # Assume a numerical parameter

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -313,7 +313,7 @@ class Fitter:
                         )
                 elif isinstance(par, boolParameter):
                     s += ("{:" + spacingName + "s} {:>20s} {:28s} {}\n").format(
-                        pn, prefitpar.print_quantity(prefitpar.value), "", par.units
+                        pn, prefitpar._print_quantity(prefitpar.value), "", par.units
                     )
                 else:
                     # Assume a numerical parameter

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -178,9 +178,7 @@ class Parameter:
                 and self._quantity is not None
             ):
                 raise ValueError(
-                    "This parameter value is number convertible. "
-                    "Setting .value to None will lost the "
-                    "parameter value."
+                    "Setting .value to None will lose the parameter value."
                 )
             else:
                 self.value = val
@@ -244,14 +242,14 @@ class Parameter:
     def uncertainty(self, val):
         if val is None:
             if hasattr(self, "uncertainty") and self.uncertainty is not None:
-                raise ValueError("Setting an exist uncertainty to None is not allowed.")
+                raise ValueError("Setting an existing uncertainty to None is not allowed.")
             else:
                 self._uncertainty = self._uncertainty_value = None
                 return
         val = self._set_uncertainty(val)
 
         if not val >= 0:
-            raise ValueError(f"Uncertainty cannot be set to negative {val}")
+            raise ValueError(f"Uncertainties cannot be negative but {val} was supplied")
             # self.uncertainty_value = np.abs(self.uncertainty_value)
 
         self._uncertainty = val.to(self.units)
@@ -451,7 +449,7 @@ class Parameter:
     def name_matches(self, name):
         """Whether or not the parameter name matches the provided name"""
         return (name == self.name.upper()) or (
-            name in map(lambda x: x.upper(), self.aliases)
+            name in [x.upper() for x in self.aliases]
         )
 
     def set(self, value):
@@ -500,7 +498,7 @@ class floatParameter(Parameter):
     -------
     >>> from parameter import floatParameter
     >>> test = floatParameter(name='test1', value=100.0, units='second')
-    >>> print test
+    >>> print(test)
     test1 (s) 100.0
     """
 
@@ -1887,9 +1885,7 @@ class pairParameter(floatParameter):
                 and self._quantity is not None
             ):
                 raise ValueError(
-                    "This parameter value is number convertible. "
-                    "Setting .value to None will lose the "
-                    "parameter value."
+                    "Setting .value to None will lose the parameter value."
                 )
             else:
                 self.value = val

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -697,6 +697,7 @@ class strParameter(Parameter):
         """Convert to string."""
         return str(val)
 
+
 class boolParameter(Parameter):
     """Boolean-valued parameter.
 

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -338,7 +338,7 @@ class Parameter:
             value = self.value
         return self.prior.logpdf(value) if logpdf else self.prior.pdf(value)
 
-    def _print_quantity(self, quan):
+    def str_quantity(self, quan):
         """Format the argument in an appropriate way as a string."""
         return str(quan)
 
@@ -355,7 +355,7 @@ class Parameter:
         if self.quantity is None:
             out += "UNSET"
             return out
-        out += "{:17s}".format(self._print_quantity(self.quantity))
+        out += "{:17s}".format(self.str_quantity(self.quantity))
         if self.units is not None:
             out += " (" + str(self.units) + ")"
         if self.uncertainty is not None and isinstance(self.value, numbers.Number):
@@ -380,7 +380,7 @@ class Parameter:
             name = self.name
         else:
             name = self.use_alias
-        line = "%-15s %25s" % (name, self._print_quantity(self.quantity))
+        line = "%-15s %25s" % (name, self.str_quantity(self.quantity))
         if self.uncertainty is not None:
             line += " %d %s" % (
                 0 if self.frozen else 1,
@@ -634,7 +634,7 @@ class floatParameter(Parameter):
     def _set_uncertainty(self, val):
         return self._set_quantity(val)
 
-    def _print_quantity(self, quan):
+    def str_quantity(self, quan):
         """Quantity as a string (for floating-point values)."""
         v = quan.to(self.units).value
         if self._long_double:
@@ -746,7 +746,7 @@ class boolParameter(Parameter):
         self.value_type = bool
         self.paramType = "boolParameter"
 
-    def _print_quantity(self, quan):
+    def str_quantity(self, quan):
         return "Y" if quan else "N"
 
     def _set_quantity(self, val):
@@ -903,7 +903,7 @@ class MJDParameter(Parameter):
         self.paramType = "MJDParameter"
         self.special_arg += ["time_scale"]
 
-    def _print_quantity(self, quan):
+    def str_quantity(self, quan):
         return time_to_mjd_string(quan)
 
     def _get_value(self, quan):
@@ -1096,7 +1096,7 @@ class AngleParameter(Parameter):
             )
         return result
 
-    def _print_quantity(self, quan):
+    def str_quantity(self, quan):
         """This is a function to print out the angle parameter."""
         if ":" in self._str_unit:
             return quan.to_string(sep=":", precision=8)
@@ -1336,8 +1336,8 @@ class prefixParameter:
     def prior_pdf(self, value=None, logpdf=False):
         return self.param_comp.prior_pdf(value, logpdf)
 
-    def _print_quantity(self, quan):
-        return self.param_comp._print_quantity(quan)
+    def str_quantity(self, quan):
+        return self.param_comp.str_quantity(quan)
 
     def _print_uncertainty(self, uncertainty):
         return str(uncertainty.to(self.units).value)
@@ -1529,7 +1529,7 @@ class maskParameter(floatParameter):
             for kv in self.key_value:
                 out += " " + str(kv)
         if self.quantity is not None:
-            out += " " + self._print_quantity(self.quantity)
+            out += " " + self.str_quantity(self.quantity)
         else:
             out += " " + "UNSET"
             return out
@@ -1649,7 +1649,7 @@ class maskParameter(floatParameter):
                 line += f"{kv.value} "
             else:
                 line += f"{kv} "
-        line += "%25s" % self._print_quantity(self.quantity)
+        line += "%25s" % self.str_quantity(self.quantity)
         if self.uncertainty is not None:
             line += " %d %s" % (0 if self.frozen else 1, str(self.uncertainty_value))
         elif not self.frozen:
@@ -1841,8 +1841,8 @@ class pairParameter(floatParameter):
         else:
             name = self.use_alias
         line = "%-15s " % name
-        line += "%25s" % self._print_quantity(quantity[0])
-        line += " %25s" % self._print_quantity(quantity[1])
+        line += "%25s" % self.str_quantity(quantity[0])
+        line += " %25s" % self.str_quantity(quantity[1])
 
         return line + "\n"
 
@@ -1893,11 +1893,11 @@ class pairParameter(floatParameter):
                 self.value = val
         self._quantity = self._set_quantity(val)
 
-    def _print_quantity(self, quan):
+    def str_quantity(self, quan):
         """Return quantity as a string."""
         try:
             # Maybe it's a singleton quantity
-            return floatParameter._print_quantity(self, quan)
+            return floatParameter.str_quantity(self, quan)
         except AttributeError:
             # Not a quantity, let's hope it's a list of length two?
             if len(quan) != 2:

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -242,7 +242,9 @@ class Parameter:
     def uncertainty(self, val):
         if val is None:
             if hasattr(self, "uncertainty") and self.uncertainty is not None:
-                raise ValueError("Setting an existing uncertainty to None is not allowed.")
+                raise ValueError(
+                    "Setting an existing uncertainty to None is not allowed."
+                )
             else:
                 self._uncertainty = self._uncertainty_value = None
                 return

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -23,6 +23,8 @@ data passing between these two parts is carried out by
 To actually create a timing model, you almost certainly want to use
 :func:`~pint.models.model_builder.get_model`.
 
+See :ref:`Timing Models` for more details on how PINT's timing models work.
+
 """
 import abc
 import copy

--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -199,7 +199,7 @@ class Pulsar:
         if self.fitted:
             chi2 = self.postfit_resids.chi2
             wrms = self.postfit_resids.rms_weighted()
-            print("Post-Fit Chi2:\t\t%.8g us^2" % chi2)
+            print("Post-Fit Chi2:\t\t%.8g" % chi2)
             print("Post-Fit Weighted RMS:\t%.8g us" % wrms.to(u.us).value)
             print(
                 "%19s  %24s\t%24s\t%16s  %16s  %16s"
@@ -224,8 +224,8 @@ class Pulsar:
                 post = getattr(self.postfit_model, key)
                 line += "%10s  " % ("" if post.units is None else str(post.units))
                 if post.quantity is not None:
-                    line += "%24s\t" % pre.print_quantity(pre.quantity)
-                    line += "%24s\t" % post.print_quantity(post.quantity)
+                    line += "%24s\t" % pre.str_quantity(pre.quantity)
+                    line += "%24s\t" % post.str_quantity(post.quantity)
                     try:
                         line += "%16.8g  " % post.uncertainty.value
                     except:
@@ -432,7 +432,7 @@ class Pulsar:
             fitter = pint.fitter.GLSFitter(self.selected_toas, self.prefit_model)
         chi2 = self.prefit_resids.chi2
         wrms = self.prefit_resids.rms_weighted()
-        print("Pre-Fit Chi2:\t\t%.8g us^2" % chi2)
+        print("Pre-Fit Chi2:\t\t%.8g" % chi2)
         print("Pre-Fit Weighted RMS:\t%.8g us" % wrms.to(u.us).value)
 
         fitter.fit_toas(maxiter=1)

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1621,16 +1621,16 @@ class TOAs:
         else:
             s += f"Number of commands:  {len(self.commands)}\n"
         s += f"Number of observatories: {len(self.observatories)} {list(self.observatories)}\n"
-        s += "MJD span:  {self.first_MJD.mjd:.3f} to {self.last_MJD.mjd:.3f}\n"
-        s += "Date span: {self.first_MJD.iso} to {self.last_MJD.iso}\n"
+        s += f"MJD span:  {self.first_MJD.mjd:.3f} to {self.last_MJD.mjd:.3f}\n"
+        s += f"Date span: {self.first_MJD.iso} to {self.last_MJD.iso}\n"
         for ii, key in enumerate(self.table.groups.keys):
             grp = self.table.groups[ii]
-            s += "{key['obs']} TOAs ({len(grp)}):\n"
-            s += "  Min freq:      {np.min(grp['freq'].to(u.MHz)):.3f}\n"
-            s += "  Max freq:      {np.max(grp['freq'].to(u.MHz)):.3f}\n"
-            s += "  Min error:     {np.min(grp['error'].to(u.us)):.3g}\n"
-            s += "  Max error:     {np.max(grp['error'].to(u.us)):.3g}\n"
-            s += "  Median error:  {np.median(grp['error'].to(u.us)):.3g}\n"
+            s += f"{key['obs']} TOAs ({len(grp)}):\n"
+            s += f"  Min freq:      {np.min(grp['freq'].to(u.MHz)):.3f}\n"
+            s += f"  Max freq:      {np.max(grp['freq'].to(u.MHz)):.3f}\n"
+            s += f"  Min error:     {np.min(grp['error'].to(u.us)):.3g}\n"
+            s += f"  Max error:     {np.max(grp['error'].to(u.us)):.3g}\n"
+            s += f"  Median error:  {np.median(grp['error'].to(u.us)):.3g}\n"
         return s
 
     def print_summary(self):

--- a/tests/datafile/test_par_read.par
+++ b/tests/datafile/test_par_read.par
@@ -11,20 +11,20 @@ F2           1.2083172450962419925e-23
 F3           0   0
 F4           0   0.001
 F5           0   0 0.001
-F6           0   1 -0.001
-F7           0   -3
+F6           0   1 0.001
+F7           0   3
 F8           0   10
 JUMP  MJD  52742  52745 0.2
 JUMP  FREQ  1400.0 2000.0 0.1 0
 JUMP  FREQ  2001.0 2025.0 0.1 0 10
-JUMP  FREQ  2001.0 2025.0 0.1 1 -10
+JUMP  FREQ  2001.0 2025.0 0.1 1 +10
 JUMP  FREQ  2001.0 2025.0 0.1 10
-JUMP  FREQ  2001.0 2025.0 0.1 -10
+JUMP  FREQ  2001.0 2025.0 0.1 +10
 JUMP  FREQ  2001.0 2025.0 0.1 10.5
 JUMP  -testflag flagvalue 0.1
 JUMP  -testflag flagvalue 0.1 1
 JUMP  -testflag flagvalue 0.1 0
 JUMP  -testflag flagvalue 0.1 1 10
-JUMP  -testflag flagvalue 0.1 1 -2
+JUMP  -testflag flagvalue 0.1 1 +2
 JUMP  -testflag flagvalue 0.1 10
 JUMP  -testflag flagvalue 0.1 10.5

--- a/tests/test_parametercovariancematrix.py
+++ b/tests/test_parametercovariancematrix.py
@@ -49,12 +49,7 @@ def test_wls_covmatrix(wls):
         matrix_uncertainty = np.sqrt(
             wls.parameter_covariance_matrix.get_label_matrix([param]).matrix[0, 0]
         )
-        if param in ["RAJ", "DECJ"]:
-            # then uncertainties are in arcsec, need to convert
-            factor = 3600
-        else:
-            factor = 1
-        assert np.isclose(uncertainties[param] / factor, matrix_uncertainty)
+        assert np.isclose(uncertainties[param], matrix_uncertainty)
 
 
 def test_gls_covmatrix(wls):
@@ -71,12 +66,7 @@ def test_gls_covmatrix(wls):
         matrix_uncertainty = np.sqrt(
             gls.parameter_covariance_matrix.get_label_matrix([param]).matrix[0, 0]
         )
-        if param in ["RAJ", "DECJ"]:
-            # then uncertainties are in arcsec, need to convert
-            factor = 3600
-        else:
-            factor = 1
-        assert np.isclose(uncertainties[param] / factor, matrix_uncertainty)
+        assert np.isclose(uncertainties[param], matrix_uncertainty)
 
 
 def test_downhillwls_covmatrix(wls):
@@ -94,12 +84,7 @@ def test_downhillwls_covmatrix(wls):
         matrix_uncertainty = np.sqrt(
             dh_wls.parameter_covariance_matrix.get_label_matrix([param]).matrix[0, 0]
         )
-        if param in ["RAJ", "DECJ"]:
-            # then uncertainties are in arcsec, need to convert
-            factor = 3600
-        else:
-            factor = 1
-        assert np.isclose(uncertainties[param] / factor, matrix_uncertainty)
+        assert np.isclose(uncertainties[param], matrix_uncertainty)
 
 
 def test_downhillgls_covmatrix(wls):
@@ -117,12 +102,7 @@ def test_downhillgls_covmatrix(wls):
         matrix_uncertainty = np.sqrt(
             dh_gls.parameter_covariance_matrix.get_label_matrix([param]).matrix[0, 0]
         )
-        if param in ["RAJ", "DECJ"]:
-            # then uncertainties are in arcsec, need to convert
-            factor = 3600
-        else:
-            factor = 1
-        assert np.isclose(uncertainties[param] / factor, matrix_uncertainty)
+        assert np.isclose(uncertainties[param], matrix_uncertainty)
 
 
 def test_wb_covmatrix(wb):
@@ -132,12 +112,7 @@ def test_wb_covmatrix(wb):
         matrix_uncertainty = np.sqrt(
             wb.parameter_covariance_matrix.get_label_matrix([param]).matrix[0, 0]
         )
-        if param in ["RAJ", "DECJ"]:
-            # then uncertainties are in arcsec, need to convert
-            factor = 3600
-        else:
-            factor = 1
-        assert np.isclose(uncertainties[param] / factor, matrix_uncertainty)
+        assert np.isclose(uncertainties[param], matrix_uncertainty)
 
 
 def test_downhillwb_covmatrix(wb):
@@ -154,9 +129,4 @@ def test_downhillwb_covmatrix(wb):
         matrix_uncertainty = np.sqrt(
             dwb.parameter_covariance_matrix.get_label_matrix([param]).matrix[0, 0]
         )
-        if param in ["RAJ", "DECJ"]:
-            # then uncertainties are in arcsec, need to convert
-            factor = 3600
-        else:
-            factor = 1
-        assert np.isclose(uncertainties[param] / factor, matrix_uncertainty)
+        assert np.isclose(uncertainties[param], matrix_uncertainty)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,22 +1,27 @@
 import copy
 import os
+import pickle
 import unittest
 
 import astropy.time as time
 import astropy.units as u
 import numpy as np
 import pytest
-from pinttestdata import datadir
 from numpy.testing import assert_allclose
+from pinttestdata import datadir
 
 import pint.fitter
 from pint import pint_units
 from pint.models.model_builder import get_model
 from pint.models.parameter import (
+    AngleParameter,
     MJDParameter,
     boolParameter,
     floatParameter,
     intParameter,
+    maskParameter,
+    pairParameter,
+    prefixParameter,
     strParameter,
 )
 from pint.toa import get_TOAs
@@ -511,3 +516,27 @@ def test_parameter_setting(type_, set_value, value):
 def test_set_uncertainty_bogus_raises(p):
     with pytest.raises(NotImplementedError):
         p.uncertainty = 7.0
+
+
+@pytest.mark.parametrize(
+    "p",
+    [
+        boolParameter(name="FISH"),
+        intParameter(name="FISH"),
+        strParameter(name="FISH"),
+        pytest.param(
+            maskParameter(name="JUMP"),
+            marks=pytest.mark.xfail(reason="maskParameter uses lambdas internally."),
+        ),
+        pytest.param(
+            prefixParameter(name="F0"),
+            marks=pytest.mark.xfail(
+                reason="prefixParameter uses lambda functions for formatting help and defining units"
+            ),
+        ),
+        pairParameter(name="WEAVE"),
+        AngleParameter(name="BEND"),
+    ],
+)
+def test_parameter_can_be_pickled(p):
+    pickle.dumps(p)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from pinttestdata import datadir
+from numpy.testing import assert_allclose
 
 import pint.fitter
 from pint import pint_units
@@ -20,6 +21,7 @@ from pint.models.parameter import (
 )
 from pint.toa import get_TOAs
 
+# FIXME: this should be in the docs!
 """
 The behavior we want for numerical Parameter variables (p):
 
@@ -48,6 +50,78 @@ The behavior we want for numerical Parameter variables (p):
 
 """
 
+def test_read_par_line_expected_values():
+    test_m = get_model(os.path.join(datadir, "test_par_read.par"))
+    assert test_m.F2.frozen
+    assert test_m.F3.frozen
+    assert_allclose(test_m.F3.value, 0.0)
+    assert_allclose(test_m.F3.uncertainty_value, 0.0)
+    assert test_m.F4.frozen
+    assert_allclose(test_m.F4.value, 0.0)
+    assert_allclose(test_m.F4.uncertainty_value, 0.001)
+    assert test_m.F5.frozen
+    assert_allclose(test_m.F5.value, 0.0)
+    assert_allclose(test_m.F5.uncertainty_value, 0.001)
+    assert not test_m.F6.frozen
+    assert_allclose(test_m.F6.value, 0.0)
+    assert_allclose(test_m.F6.uncertainty_value, 0.001)
+    assert test_m.F7.frozen
+    assert_allclose(test_m.F7.value, 0.0)
+    assert_allclose(test_m.F7.uncertainty_value, 3.0)
+    assert test_m.F8.frozen
+    assert_allclose(test_m.F8.value, 0.0)
+    assert_allclose(test_m.F8.uncertainty_value, 10)
+    assert test_m.JUMP1.frozen
+    assert test_m.JUMP1.key == "MJD"
+    assert_allclose(test_m.JUMP1.key_value[0], 52742.0, atol=1e-10)
+    assert_allclose(test_m.JUMP1.key_value[1], 52745.0, atol=1e-10)
+    assert_allclose(test_m.JUMP1.value, 0.2)
+
+    assert test_m.JUMP2.frozen
+    assert_allclose(test_m.JUMP2.value, 0.1)
+    assert_allclose(test_m.JUMP2.uncertainty_value, 0.0)
+    assert_allclose(test_m.JUMP7.value, 0.1)
+    assert_allclose(test_m.JUMP7.uncertainty_value, 10.5)
+    assert_allclose(test_m.JUMP6.value, 0.1)
+    assert_allclose(test_m.JUMP6.uncertainty_value, 10.0)
+    assert test_m.JUMP12.key == "-testflag"
+    assert not test_m.JUMP12.frozen
+    assert test_m.JUMP12.key_value[0] == "flagvalue"
+    assert_allclose(test_m.JUMP12.value, 0.1)
+    assert_allclose(test_m.JUMP12.uncertainty_value, 2.0)
+    assert_allclose(test_m.RAJ.uncertainty, 476.94611148516092061223*pint_units["hourangle_second"])
+
+    assert_allclose(
+            test_m.DECJ.uncertainty,
+            190996312986311097848351.00000000000000000000*u.arcsecond,
+        )
+
+
+@pytest.mark.xfail(reason="For some reason AngleParameters should have different units for their uncertainties")
+def test_read_par_line_raj_units():
+    test_m = get_model(os.path.join(datadir, "test_par_read.par"))
+    assert test_m.RAJ.uncertainty.unit == pint_units["hourangle_second"]
+    assert test_m.DECJ.uncertainty.unit == u.arcsecond
+
+
+@pytest.mark.xfail(reason="For some reason AngleParameters should have different units for their uncertainties")
+def test_read_par_line_decj_units():
+    test_m = get_model(os.path.join(datadir, "test_par_read.par"))
+    assert test_m.DECJ.uncertainty.unit == u.arcsecond
+
+def test_units_consistent():
+    m = get_model(os.path.join(datadir, "test_par_read.par"))
+    for p in m.params:
+        pm = getattr(m, p)
+        if not hasattr(pm.quantity, "unit"):
+            continue
+        assert pm.quantity.unit == pm.units
+        assert pm.quantity == pm.value*pm.units
+        if pm.uncertainty is None:
+            continue
+        assert pm.uncertainty.unit == pm.units
+        assert pm.uncertainty_value * pm.units == pm.uncertainty
+
 
 class TestParameters(unittest.TestCase):
     @classmethod
@@ -55,58 +129,6 @@ class TestParameters(unittest.TestCase):
         os.chdir(datadir)
         cls.m = get_model("B1855+09_NANOGrav_dfg+12_modified.par")
         cls.mp = get_model("prefixtest.par")
-
-    def test_read_par_line(self):
-        test_m = get_model("test_par_read.par")
-        self.assertEqual(test_m.F2.frozen, True)
-        self.assertEqual(test_m.F3.frozen, True)
-        self.assertTrue(np.isclose(test_m.F3.value, 0.0))
-        self.assertTrue(np.isclose(test_m.F3.uncertainty_value, 0.0))
-        self.assertEqual(test_m.F4.frozen, True)
-        self.assertTrue(np.isclose(test_m.F4.value, 0.0))
-        self.assertTrue(np.isclose(test_m.F4.uncertainty_value, 0.001))
-        self.assertEqual(test_m.F5.frozen, True)
-        self.assertTrue(np.isclose(test_m.F5.value, 0.0))
-        self.assertTrue(np.isclose(test_m.F5.uncertainty_value, 0.001))
-        self.assertEqual(test_m.F6.frozen, False)
-        self.assertTrue(np.isclose(test_m.F6.value, 0.0))
-        self.assertTrue(np.isclose(test_m.F6.uncertainty_value, 0.001))
-        self.assertEqual(test_m.F7.frozen, True)
-        self.assertTrue(np.isclose(test_m.F7.value, 0.0))
-        self.assertTrue(np.isclose(test_m.F7.uncertainty_value, 3.0))
-        self.assertEqual(test_m.F8.frozen, True)
-        self.assertTrue(np.isclose(test_m.F8.value, 0.0))
-        self.assertTrue(np.isclose(test_m.F8.uncertainty_value, 10))
-        self.assertEqual(test_m.JUMP1.frozen, True)
-        self.assertEqual(test_m.JUMP1.key, "MJD")
-        self.assertTrue(np.isclose(test_m.JUMP1.key_value[0], 52742.0, atol=1e-10))
-        self.assertTrue(np.isclose(test_m.JUMP1.key_value[1], 52745.0, atol=1e-10))
-        self.assertTrue(np.isclose(test_m.JUMP1.value, 0.2))
-
-        self.assertEqual(test_m.JUMP2.frozen, True)
-        self.assertTrue(np.isclose(test_m.JUMP2.value, 0.1))
-        self.assertTrue(np.isclose(test_m.JUMP2.uncertainty_value, 0.0))
-        self.assertTrue(np.isclose(test_m.JUMP7.value, 0.1))
-        self.assertTrue(np.isclose(test_m.JUMP7.uncertainty_value, 10.5))
-        self.assertTrue(np.isclose(test_m.JUMP6.value, 0.1))
-        self.assertTrue(np.isclose(test_m.JUMP6.uncertainty_value, 10.0))
-        self.assertEqual(test_m.JUMP12.key, "-testflag")
-        self.assertEqual(test_m.JUMP12.frozen, False)
-        self.assertEqual(test_m.JUMP12.key_value[0], "flagvalue")
-        self.assertTrue(np.isclose(test_m.JUMP12.value, 0.1))
-        self.assertTrue(np.isclose(test_m.JUMP12.uncertainty_value, 2.0))
-        self.assertTrue(
-            np.isclose(test_m.RAJ.uncertainty_value, 476.94611148516092061223)
-        )
-
-        self.assertTrue(
-            np.isclose(
-                test_m.DECJ.uncertainty_value,
-                190996312986311097848351.00000000000000000000,
-            )
-        )
-        self.assertTrue(test_m.RAJ.uncertainty.unit, pint_units["hourangle_second"])
-        self.assertTrue(test_m.RAJ.uncertainty.unit, u.arcsecond)
 
     def test_RAJ(self):
         """Check whether the value and units of RAJ parameter are ok"""
@@ -471,3 +493,12 @@ def test_parameter_setting(type_, set_value, value):
     else:
         p.value = set_value
         assert p.value == value
+
+
+@pytest.mark.parametrize(
+    "p",
+    [boolParameter(name="FISH"), intParameter(name="FISH"), strParameter(name="FISH")],
+)
+def test_set_uncertainty_bogus_raises(p):
+    with pytest.raises(NotImplementedError):
+        p.uncertainty = 7.0

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -50,6 +50,7 @@ The behavior we want for numerical Parameter variables (p):
 
 """
 
+
 def test_read_par_line_expected_values():
     test_m = get_model(os.path.join(datadir, "test_par_read.par"))
     assert test_m.F2.frozen
@@ -89,25 +90,33 @@ def test_read_par_line_expected_values():
     assert test_m.JUMP12.key_value[0] == "flagvalue"
     assert_allclose(test_m.JUMP12.value, 0.1)
     assert_allclose(test_m.JUMP12.uncertainty_value, 2.0)
-    assert_allclose(test_m.RAJ.uncertainty, 476.94611148516092061223*pint_units["hourangle_second"])
+    assert_allclose(
+        test_m.RAJ.uncertainty,
+        476.94611148516092061223 * pint_units["hourangle_second"],
+    )
 
     assert_allclose(
-            test_m.DECJ.uncertainty,
-            190996312986311097848351.00000000000000000000*u.arcsecond,
-        )
+        test_m.DECJ.uncertainty,
+        190996312986311097848351.00000000000000000000 * u.arcsecond,
+    )
 
 
-@pytest.mark.xfail(reason="For some reason AngleParameters should have different units for their uncertainties")
+@pytest.mark.xfail(
+    reason="For some reason AngleParameters should have different units for their uncertainties"
+)
 def test_read_par_line_raj_units():
     test_m = get_model(os.path.join(datadir, "test_par_read.par"))
     assert test_m.RAJ.uncertainty.unit == pint_units["hourangle_second"]
     assert test_m.DECJ.uncertainty.unit == u.arcsecond
 
 
-@pytest.mark.xfail(reason="For some reason AngleParameters should have different units for their uncertainties")
+@pytest.mark.xfail(
+    reason="For some reason AngleParameters should have different units for their uncertainties"
+)
 def test_read_par_line_decj_units():
     test_m = get_model(os.path.join(datadir, "test_par_read.par"))
     assert test_m.DECJ.uncertainty.unit == u.arcsecond
+
 
 def test_units_consistent():
     m = get_model(os.path.join(datadir, "test_par_read.par"))
@@ -116,7 +125,7 @@ def test_units_consistent():
         if not hasattr(pm.quantity, "unit"):
             continue
         assert pm.quantity.unit == pm.units
-        assert pm.quantity == pm.value*pm.units
+        assert pm.quantity == pm.value * pm.units
         if pm.uncertainty is None:
             continue
         assert pm.uncertainty.unit == pm.units

--- a/tests/test_pintk_pulsar.py
+++ b/tests/test_pintk_pulsar.py
@@ -1,0 +1,70 @@
+import re
+from io import StringIO
+
+import numpy as np
+import pytest
+
+import pint.pintk.pulsar
+
+tim = """
+FORMAT 1
+unk 999999.000000 57000.0000000078830324 1.000 gbt  -pn -2273593021.0
+unk 999999.000000 57052.6315789538116088 1.000 gbt  -pn -124285.0
+unk 999999.000000 57105.2631578955917593 1.000 gbt  -pn 2273470219.0
+unk 999999.000000 57157.8947368420341204 1.000 gbt  -pn 4547256435.0
+JUMP
+unk 999999.000000 57210.5263157897339815 1.000 gbt  -pn 6821152750.0
+unk 999999.000000 57263.1578947318551852 1.000 gbt  -pn 9095000767.0
+unk 999999.000000 57315.7894736865498264 1.000 gbt  -pn 11368677703.0
+unk 999999.000000 57368.4210526391189699 1.000 gbt  -pn 13642183645.0
+JUMP
+unk 999999.000000 57421.0526315687085764 1.000 gbt  -pn 15915655534.0
+unk 999999.000000 57473.6842105144226621 1.000 gbt  -pn 18189261252.0
+unk 999999.000000 57526.3157894708454977 1.000 gbt  -pn 20463057581.0
+unk 999999.000000 57578.9473684237653588 1.000 gbt  -pn 22736955090.0
+JUMP
+unk 999999.000000 57631.5789473769360416 1.000 gbt  -pn 25010795383.0
+unk 999999.000000 57684.2105263208505671 1.000 gbt  -pn 27284460486.0
+unk 999999.000000 57736.8421052672976158 1.000 gbt  -pn 29557959408.0
+unk 999999.000000 57789.4736842041808449 1.000 gbt  -pn 31831435551.0
+JUMP
+JUMP
+unk 999999.000000 57842.1052631637698032 1.000 gbt  -pn 34105052652.0
+unk 999999.000000 57894.7368420936182176 1.000 gbt  -pn 36378858766.0
+unk 999999.000000 57947.3684210606924768 1.000 gbt  -pn 38652757406.0
+unk 999999.000000 57999.9999999883338542 1.000 gbt  -pn 40926589498.0
+JUMP
+"""
+
+par = """
+PSR J1234+5678
+ELAT 0
+ELONG 0
+PEPOCH 57000
+POSEPOCH 57000
+F0 500
+JUMP mjd 58000 60000 0
+JUMP mjd 59000 60000 0
+"""
+
+
+def test_fit_summary(tmp_path, capsys):
+    # Pulsar can't cope with file-like objects in place of filenames - I think?
+    par_file = tmp_path / "file.par"
+    with open(par_file, "wt") as f:
+        f.write(par)
+    tim_file = tmp_path / "file.tim"
+    with open(tim_file, "wt") as f:
+        f.write(tim)
+    p = pint.pintk.pulsar.Pulsar(parfile=str(par_file), timfile=str(tim_file))
+    p.fit(np.ones(len(p.all_toas), dtype=bool))
+
+    capsys.readouterr()
+    p.write_fit_summary()
+    captured_fit_summary = capsys.readouterr()
+
+    assert re.search(r"Post-Fit Chi2:\s*[0-9.]+", captured_fit_summary.out)
+    assert not re.search(r"Post-Fit Chi2:\s*[0-9.]+ +us", captured_fit_summary.out)
+    assert re.search(r"Post-Fit Weighted RMS:\s*[0-9.]+ +us", captured_fit_summary.out)
+    assert re.search(r"\s*JUMP", captured_fit_summary.out)
+

--- a/tests/test_pintk_pulsar.py
+++ b/tests/test_pintk_pulsar.py
@@ -67,4 +67,3 @@ def test_fit_summary(tmp_path, capsys):
     assert not re.search(r"Post-Fit Chi2:\s*[0-9.]+ +us", captured_fit_summary.out)
     assert re.search(r"Post-Fit Weighted RMS:\s*[0-9.]+ +us", captured_fit_summary.out)
     assert re.search(r"\s*JUMP", captured_fit_summary.out)
-

--- a/tests/test_toa.py
+++ b/tests/test_toa.py
@@ -1,8 +1,15 @@
+import os
+import re
 import unittest
+from io import StringIO
+
 import astropy.units as u
 from astropy.time import Time
-from pint.toa import TOA, TOAs
+from pinttestdata import datadir
+
+from pint.models import get_model
 from pint.observatory import get_observatory
+from pint.toa import TOA, TOAs, make_fake_toas
 
 
 class TestTOA(unittest.TestCase):
@@ -94,3 +101,21 @@ class TestTOAs(unittest.TestCase):
         assert toas.table["mjd"][0].location == site2.earth_location_itrf()
         assert toas.table["mjd"][1].location == site3.earth_location_itrf()
         assert toas.table["mjd"][2].location == site1.earth_location_itrf()
+
+
+def test_toa_summary():
+    m = get_model(os.path.join(datadir, "NGC6440E.par"))
+    toas = make_fake_toas(57000,58000,10,m, obs="ao", freq=2000*u.MHz)
+    s = toas.get_summary()
+
+    assert re.search(r"Number of commands: *0", s)
+    assert re.search(r"Number of observatories: *1 *\['arecibo'\]", s)
+    assert re.search(r"MJD span: *57000\.000 to 58000\.000", s)
+    assert re.search(r"Date span: *20\d\d-\d\d-\d\d \d\d:\d\d:\d\d\.\d+ to 20\d\d-\d\d-\d\d \d\d:\d\d:\d\d\.\d+", s)
+    assert re.search(r"arecibo TOAs *\(10\):", s)
+    assert re.search(r" *Min freq: *2000.000 MHz", s)
+    assert re.search(r" *Max freq: *2000.000 MHz", s)
+    assert re.search(r" *Min error: *1 us", s)
+    assert re.search(r" *Max error: *1 us", s)
+    assert re.search(r" *Median error: *1 us", s)
+

--- a/tests/test_toa.py
+++ b/tests/test_toa.py
@@ -105,17 +105,19 @@ class TestTOAs(unittest.TestCase):
 
 def test_toa_summary():
     m = get_model(os.path.join(datadir, "NGC6440E.par"))
-    toas = make_fake_toas(57000,58000,10,m, obs="ao", freq=2000*u.MHz)
+    toas = make_fake_toas(57000, 58000, 10, m, obs="ao", freq=2000 * u.MHz)
     s = toas.get_summary()
 
     assert re.search(r"Number of commands: *0", s)
     assert re.search(r"Number of observatories: *1 *\['arecibo'\]", s)
     assert re.search(r"MJD span: *57000\.000 to 58000\.000", s)
-    assert re.search(r"Date span: *20\d\d-\d\d-\d\d \d\d:\d\d:\d\d\.\d+ to 20\d\d-\d\d-\d\d \d\d:\d\d:\d\d\.\d+", s)
+    assert re.search(
+        r"Date span: *20\d\d-\d\d-\d\d \d\d:\d\d:\d\d\.\d+ to 20\d\d-\d\d-\d\d \d\d:\d\d:\d\d\.\d+",
+        s,
+    )
     assert re.search(r"arecibo TOAs *\(10\):", s)
     assert re.search(r" *Min freq: *2000.000 MHz", s)
     assert re.search(r" *Max freq: *2000.000 MHz", s)
     assert re.search(r" *Min error: *1 us", s)
     assert re.search(r" *Max error: *1 us", s)
     assert re.search(r" *Median error: *1 us", s)
-


### PR DESCRIPTION
This is meant to clean up Parameter objects, making better use of inheritance and improving their documentation. User-visible changes are minor, mostly involving more strict input type validation for parameters. Implementation is much simplified and the documentation is better. There are also tests of pickle-ability, though these are currently marked as expected failures for prefix and mask parameters.

We have many more suggestions in the discussion for improving Parameter objects but these are probably best deferred to later PRs so that this can go in and be used by (for example) #1072, which made substantial changes to maskParameters.