### PR TITLE
improving docstrings in `utils.py`

### DIFF
--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1109,7 +1109,7 @@ def p_to_f(p, pd, pdd=None):
     p : astropy.units.Quantity
         pulsar period (or frequency)
     pd : astropy.units.Quantity
-        period derivative (or frequency derivative)        
+        period derivative (or frequency derivative)
     pdd : astropy.units.Quantity, optional
         period second derivative (or frequency second derivative)
 
@@ -1120,7 +1120,7 @@ def p_to_f(p, pd, pdd=None):
     fd : astropy.units.Quantity
         pulsar frequency derivative (or period derivative)
     fdd : astropy.units.Quantity
-        frequency second derivative (or period second derivative) if pdd is supplied        
+        frequency second derivative (or period second derivative) if pdd is supplied
     """
     f = 1.0 / p
     fd = -pd / (p * p)
@@ -1146,10 +1146,14 @@ def pferrs(porf, porferr, pdorfd=None, pdorfderr=None):
         pulsar period (or frequency)
     porferr : astropy.units.Quantity
         pulsar period uncertainty (or frequency uncertainty)
+        :math:`\sigma_P` or :math:`\sigma_f`
     pdorfd : astropy.units.Quantity, optional
         pulsar period derivative (or frequency derivative)
+        :math:`\dot P` or :math:`\dot f`
     pdorfderr : astropy.units.Quantity, optional
-        pulsar period derivative uncertainty (or frequency derivative uncertainty)
+        pulsar period derivative uncertainty
+        (or frequency derivative uncertainty)  :math:`\sigma_{\dot P}`
+        or :math:`\sigma_{\dot f}`
 
     Returns
     -------
@@ -1157,10 +1161,14 @@ def pferrs(porf, porferr, pdorfd=None, pdorfderr=None):
         pulsar frequency (or period)
     forperr : astropy.units.Quantity
         pulsar frequency uncertainty (or period uncertainty)
+        :math:`\sigma_f` or :math:`\sigma_P`
     fdorpd : astropy.units.Quantity
         pulsar frequency derivative (or period derivative) if pdorfd supplied
+        :math:`\dot f` or :math:`\dot P`
     fdorpderr : astropy.units.Quantity if pdorfd supplied
-        pulsar frequency derivative uncertainty (or period derivative uncertainty)
+        pulsar frequency derivative uncertainty
+        (or period derivative uncertainty)
+        :math:`\sigma_{\dot f}` or :math:`\sigma_{\dot P}`
     """
     if pdorfd is None:
         return [1.0 / porf, porferr / porf ** 2.0]
@@ -1200,7 +1208,7 @@ def pulsar_age(f, fdot, n=3, fo=1e99 * u.Hz):
 
     Notes
     -----
-    Calculates :math:`(f/(n-1)\dot f) (1-(f/f_0)^{n-1})`    
+    Calculates :math:`(f/(n-1)\dot f) (1-(f/f_0)^{n-1})`
     """
     return (-f / ((n - 1.0) * fdot) * (1.0 - (f / fo) ** (n - 1.0))).to(u.yr)
 
@@ -1217,7 +1225,7 @@ def pulsar_edot(f, fdot, I=1.0e45 * u.g * u.cm ** 2):
     f : astropy.units.Quantity
         pulsar frequency
     fdot : astropy.units.Quantity
-        frequency derivative
+        frequency derivative :math:`\dot f`
     I : astropy.units.Quantity, optional
         pulsar moment of inertia, default of 1e45 g*cm**2
 
@@ -1244,7 +1252,7 @@ def pulsar_B(f, fdot):
     f : astropy.units.Quantity
         pulsar frequency
     fdot : astropy.units.Quantity
-        frequency derivative
+        frequency derivative :math:`\dot f`
 
     Returns
     -------
@@ -1272,7 +1280,7 @@ def pulsar_B_lightcyl(f, fdot):
     f : :class:`astropy.units.Quantity`
         pulsar frequency
     fdot : :class:`astropy.units.Quantity`
-        frequency derivative
+        frequency derivative :math:`\dot f`
 
     Returns
     -------
@@ -1860,7 +1868,8 @@ def calculate_random_models(fitter, toas, Nmodels=100, keep_models=True, params=
     Note
     ----
     To calculate new TOAs, you can do:
-        ``tnew = :func:~pint.toa.make_fake_toas(MJDmin, MJDmax, Ntoa, model=fitter.model)``
+        ``tnew =`` :func:`~pint.toa.make_fake_toas` ``(MJDmin, MJDmax, Ntoa, model=fitter.model)``
+
     or similar
     """
     Nmjd = len(toas)

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1304,7 +1304,7 @@ def pulsar_B_lightcyl(f, fdot):
 
     Returns
     -------
-    Blc : :class:`astropy.units.Quantity`
+    Blc : astropy.units.Quantity
         pulsar dipole magnetic field at the light cylinder in ``u.G``
 
     Notes
@@ -1327,9 +1327,9 @@ def mass_funct(pb, x):
 
     Parameters
     ----------
-    pb : :class:`astropy.units.Quantity`
+    pb : astropy.units.Quantity
         Binary period
-    x : :class:`astropy.units.Quantity` in ``pint.ls``
+    x : astropy.units.Quantity in ``pint.ls``
         Semi-major axis, A1SINI, in units of ls
 
     Returns

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1180,18 +1180,18 @@ def pulsar_age(f, fdot, n=3, fo=1e99 * u.Hz):
     Return the age of a pulsar given the spin frequency
     and frequency derivative.  By default, the characteristic age
     is returned (assuming a braking index `n` =3 and an initial
-    spin frequency `fo` >> `f`).  But `n` and `fo` can be set.
+    spin frequency :math:`f_0 \gg f`).  But `n` and `fo` can be set.
 
     Parameters
     ----------
     f : astropy.units.Quantity
         pulsar frequency
     fdot : astropy.units.Quantity
-        frequency derivative
+        frequency derivative :math:`\dot f`
     n : int, optional
         braking index (default = 3)
     fo : astropy.units.Quantity, optional
-        initial frequency
+        initial frequency :math:`f_0`
 
     Returns
     -------
@@ -1200,7 +1200,7 @@ def pulsar_age(f, fdot, n=3, fo=1e99 * u.Hz):
 
     Notes
     -----
-    Calculates ``(-f/(n-1)/fdot) * (1 - (f/fo)**(n-1))``
+    Calculates :math:`(f/(n-1)\dot f) (1-(f/f_0)^{n-1})`    
     """
     return (-f / ((n - 1.0) * fdot) * (1.0 - (f / fo) ** (n - 1.0))).to(u.yr)
 
@@ -1228,7 +1228,7 @@ def pulsar_edot(f, fdot, I=1.0e45 * u.g * u.cm ** 2):
 
     Notes
     -----
-    Calculates ``-4 * np.pi**2 * I * f * fdot``
+    Calculates :math:`-4\pi^2  I  f  \dot f`
     """
     return (-4.0 * np.pi ** 2 * I * f * fdot).to(u.erg / u.s)
 
@@ -1253,7 +1253,7 @@ def pulsar_B(f, fdot):
 
     Notes
     -----
-    Calculates ``B=3.2e19 G * np.sqrt(-f/fdot**3)``
+    Calculates :math:`B=3.2\\times 10^{19}\\,{\\rm  G}\\sqrt{ f \dot f^{-3}}`
     """
     # This is a hack to use the traditional formula by stripping the units.
     # It would be nice to improve this to a  proper formula with units
@@ -1312,7 +1312,7 @@ def mass_funct(pb, x):
 
     Notes
     -----
-    Calculates ``4*np.pi**2 * x**3 / G / Pb**2``
+    Calculates :math:`4\pi^2 x^3 / G / P_b^2`
     """
     if not isinstance(x, u.quantity.Quantity):
         raise ValueError(
@@ -1351,7 +1351,7 @@ def mass_funct2(mp, mc, i):
     Inclination is such that edge on is ``i = 90*u.deg``
     An 'average' orbit has cos(i) = 0.5, or ``i = 60*u.deg``
 
-    Calculates ``(mc*sin(i))**3 / (mc + mp)**2``
+    Calculates :math:`m_c\sin^3 i / (m_c + m_p)^2`
     """
     if not (isinstance(i, angles.Angle) or isinstance(i, u.quantity.Quantity)):
         raise ValueError(f"The inclination should be an Angle but is {i}.")

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1106,20 +1106,20 @@ def p_to_f(p, pd, pdd=None):
 
     Parameters
     ----------
-    p : :class:`astropy.units.Quantity`
+    p : astropy.units.Quantity
         pulsar period (or frequency)
-    pd : :class:`astropy.units.Quantity`
+    pd : astropy.units.Quantity
         period derivative (or frequency derivative)        
-    pdd : :class:`astropy.units.Quantity`, optional
+    pdd : astropy.units.Quantity, optional
         period second derivative (or frequency second derivative)
 
     Returns
     -------
-    f : :class:`astropy.units.Quantity`
+    f : astropy.units.Quantity
         pulsar frequency (or period)
-    fd : :class:`astropy.units.Quantity`
+    fd : astropy.units.Quantity
         pulsar frequency derivative (or period derivative)
-    fdd : :class:`astropy.units.Quantity`
+    fdd : astropy.units.Quantity
         frequency second derivative (or period second derivative) if pdd is supplied        
     """
     f = 1.0 / p
@@ -1142,24 +1142,24 @@ def pferrs(porf, porferr, pdorfd=None, pdorfderr=None):
 
     Parameters
     ----------
-    porf : :class:`astropy.units.Quantity`
+    porf : astropy.units.Quantity
         pulsar period (or frequency)
-    porferr : :class:`astropy.units.Quantity`
+    porferr : astropy.units.Quantity
         pulsar period uncertainty (or frequency uncertainty)
-    pdorfd : :class:`astropy.units.Quantity`, optional
+    pdorfd : astropy.units.Quantity, optional
         pulsar period derivative (or frequency derivative)
-    pdorfderr : :class:`astropy.units.Quantity`, optional
+    pdorfderr : astropy.units.Quantity, optional
         pulsar period derivative uncertainty (or frequency derivative uncertainty)
 
     Returns
     -------
-    forp : :class:`astropy.units.Quantity`
+    forp : astropy.units.Quantity
         pulsar frequency (or period)
-    forperr : :class:`astropy.units.Quantity`
+    forperr : astropy.units.Quantity
         pulsar frequency uncertainty (or period uncertainty)
-    fdorpd : :class:`astropy.units.Quantity`
+    fdorpd : astropy.units.Quantity
         pulsar frequency derivative (or period derivative) if pdorfd supplied
-    fdorpderr : :class:`astropy.units.Quantity` if pdorfd supplied
+    fdorpderr : astropy.units.Quantity if pdorfd supplied
         pulsar frequency derivative uncertainty (or period derivative uncertainty)
     """
     if pdorfd is None:
@@ -1184,18 +1184,18 @@ def pulsar_age(f, fdot, n=3, fo=1e99 * u.Hz):
 
     Parameters
     ----------
-    f : :class:`astropy.units.Quantity`
+    f : astropy.units.Quantity
         pulsar frequency
-    fdot : :class:`astropy.units.Quantity`
+    fdot : astropy.units.Quantity
         frequency derivative
     n : int, optional
         braking index (default = 3)
-    fo : :class:`astropy.units.Quantity`, optional
+    fo : astropy.units.Quantity, optional
         initial frequency
 
     Returns
     -------
-    age : :class:`astropy.units.Quantity`
+    age : astropy.units.Quantity
         pulsar age in ``u.yr``
 
     Notes
@@ -1214,16 +1214,16 @@ def pulsar_edot(f, fdot, I=1.0e45 * u.g * u.cm ** 2):
 
     Parameters
     ----------
-    f : :class:`astropy.units.Quantity`
+    f : astropy.units.Quantity
         pulsar frequency
-    fdot : :class:`astropy.units.Quantity`
+    fdot : astropy.units.Quantity
         frequency derivative
-    I : :class:`astropy.units.Quantity`, optional
+    I : astropy.units.Quantity, optional
         pulsar moment of inertia, default of 1e45 g*cm**2
 
     Returns
     -------
-    Edot : :class:`astropy.units.Quantity`
+    Edot : astropy.units.Quantity
         pulsar spin-down luminosity in ``u.erg/u.s``
 
     Notes
@@ -1241,14 +1241,14 @@ def pulsar_B(f, fdot):
 
     Parameters
     ----------
-    f : :class:`astropy.units.Quantity`
+    f : astropy.units.Quantity
         pulsar frequency
-    fdot : :class:`astropy.units.Quantity`
+    fdot : astropy.units.Quantity
         frequency derivative
 
     Returns
     -------
-    B : :class:`astropy.units.Quantity`
+    B : astropy.units.Quantity
         pulsar dipole magnetic field in ``u.G``
 
     Notes
@@ -1329,16 +1329,16 @@ def mass_funct2(mp, mc, i):
 
     Parameters
     ----------
-    mp : :class:`astropy.units.Quantity`
+    mp : astropy.units.Quantity
         Pulsar mass, typically in ``u.solMass``
-    mc : :class:`astropy.units.Quantity`
+    mc : astropy.units.Quantity
         Companion mass, typically in ``u.solMass``
-    i : :class:`astropy.coordinates.Angle`
+    i : astropy.coordinates.Angle
         Inclination angle, in ``u.deg`` or ``u.rad``
 
     Returns
     -------
-    f_m : :class:`astropy.units.Quantity`
+    f_m : astropy.units.Quantity
         Mass function in ``u.solMass``
 
     Raises
@@ -1370,23 +1370,32 @@ def pulsar_mass(pb, x, mc, inc):
 
     Parameters
     ----------
-    pb : :class:`astropy.units.Quantity`
+    pb : astropy.units.Quantity
         Binary orbital period
-    x : :class:`astropy.units.Quantity`
-        Projected semi-major axis (aka ASINI) in ``pint.ls``
-    mc : :class:`astropy.units.Quantity`
+    x : astropy.units.Quantity
+        Projected pulsar semi-major axis (aka ASINI) in ``pint.ls``
+    mc : astropy.units.Quantity
         Companion mass in ``u.solMass``
-    inc : :class:`astropy.coordinates.Angle`
+    inc : astropy.coordinates.Angle
         Inclination angle, in ``u.deg`` or ``u.rad``
 
     Returns
     -------
-    mass : :class:`astropy.units.Quantity` in ``u.solMass``
+    mass : astropy.units.Quantity in ``u.solMass``
 
     Raises
     ------
     ValueError
         If the input data are not appropriate quantities
+
+    Example
+    -------
+    >>> import pint
+    >>> import pint.utils
+    >>> from astropy import units as u
+    >>> print(pint.utils.pulsar_mass(2*u.hr, .2*pint.ls, 0.5*u.Msun, 60*u.deg))
+    7.6018341985817885 solMass
+
 
     Notes
     -------
@@ -1434,24 +1443,32 @@ def companion_mass(pb, x, inc=60.0 * u.deg, mpsr=1.4 * u.solMass):
 
     Parameters
     ----------
-    pb : :class:`astropy.units.Quantity`
+    pb : astropy.units.Quantity
         Binary orbital period
-    x : :class:`astropy.units.Quantity`
-        Projected semi-major axis (aka ASINI) in ``pint.ls``
-    inc : :class:`astropy.coordinates.Angle`, optional
+    x : astropy.units.Quantity`
+        Projected pulsar semi-major axis (aka ASINI) in ``pint.ls``
+    inc : astropy.coordinates.Angle, optional
         Inclination angle, in ``u.deg`` or ``u.rad.`` Default is 60 deg.
-    mpsr : :class:`astropy.units.Quantity`, optional
+    mpsr : astropy.units.Quantity, optional
         Pulsar mass in ``u.solMass``. Default is 1.4 Msun
 
     Returns
     -------
-    mass : :class:`astropy.units.Quantity`
+    mass : astropy.units.Quantity
         In ``u.solMass``
 
     Raises
     ------
     ValueError
         If the input data are not appropriate quantities
+
+    Example
+    -------
+    >>> import pint
+    >>> import pint.utils
+    >>> from astropy import units as u
+    >>> print(pint.utils.companion_mass(1*u.d, 2*pint.ls, inc=30*u.deg, mpsr=1.3*u.Msun))
+    0.6363138973397279 solMass
 
     Notes
     -----
@@ -1662,14 +1679,14 @@ def add_dummy_distance(c, distance=1 * u.kpc):
 
     Parameters
     ----------
-    c: :class:`astropy.coordinates.sky_coordinate.SkyCoord` 
+    c: astropy.coordinates.sky_coordinate.SkyCoord
         current SkyCoord object without distance but with proper motion and obstime
-    distance: :class:`astropy.units.Quantity`, optional
+    distance: astropy.units.Quantity, optional
         distance to supply
 
     Returns
     -------
-    cnew : :class:`astropy.coordinates.sky_coordinate.SkyCoord` 
+    cnew : astropy.coordinates.sky_coordinate.SkyCoord
         new SkyCoord object with a distance attached
     """
 
@@ -1743,12 +1760,12 @@ def remove_dummy_distance(c):
 
     Parameters
     ----------
-    c: :class:`astropy.coordinates.sky_coordinate.SkyCoord` 
+    c: astropy.coordinates.sky_coordinate.SkyCoord
         current SkyCoord object with distance and with proper motion and obstime
 
     Returns
     -------
-    cnew : :class:`astropy.coordinates.sky_coordinate.SkyCoord` 
+    cnew : astropy.coordinates.sky_coordinate.SkyCoord
         new SkyCoord object with a distance removed
     """
 
@@ -1822,9 +1839,9 @@ def calculate_random_models(fitter, toas, Nmodels=100, keep_models=True, params=
 
     Parameters
     ----------
-    fitter: :class:`pint.fitter` 
+    fitter: pint.fitter.Fitter
         current fitter object containing a model and parameter covariance matrix
-    toas: :class:`pint.toa.TOAs` 
+    toas: pint.toa.TOAs
         TOAs to calculate models
     Nmodels: int, optional
         number of random models to calculate
@@ -1835,7 +1852,7 @@ def calculate_random_models(fitter, toas, Nmodels=100, keep_models=True, params=
 
     Returns
     -------
-    dphase : :class:`np.ndarray`
+    dphase : np.ndarray
         phase difference with respect to input model, size is [Nmodels, len(toas)]
     random_models : list, optional
         list of random models (each is a :class:`pint.models.timing_model.TimingModel`)
@@ -1843,7 +1860,7 @@ def calculate_random_models(fitter, toas, Nmodels=100, keep_models=True, params=
     Note
     ----
     To calculate new TOAs, you can do:
-        ``tnew = pint.toa.make_fake_toas(MJDmin, MJDmax, Ntoa, model=fitter.model)``
+        ``tnew = :func:~pint.toa.make_fake_toas(MJDmin, MJDmax, Ntoa, model=fitter.model)``
     or similar
     """
     Nmjd = len(toas)

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -30,6 +30,7 @@ __all__ = [
     "lines_of",
     "interesting_lines",
     "show_param_cov_matrix",
+    "pmtot",
     "dmxparse",
     "dmxstats",
     "dmx_ranges_old",
@@ -432,9 +433,11 @@ def show_param_cov_matrix(matrix, params, name="Covariance Matrix", switchRD=Fal
     :param name: title to be printed above, default Covariance Matrix
     :param switchRD: if True, switch the positions of RA and DEC to match setup of TEMPO cov. matrices
 
-    :return string to be printed
+    :return: string to be printed
 
-    DEPRECATED
+    Warning
+    -------
+    **DEPRECATED**.  Use :meth:`pint.pint_matrix.CovarianceMatrix.prettyprint` instead of :func:`show_param_cov_matrix`
     """
 
     warn(
@@ -503,14 +506,19 @@ def pmtot(model):
     so PMRA = (d(RAJ)/dt)*cos(DECJ). This is different from the astrometry community where mu_alpha = d(alpha)/dt.
     Thus, we don't need to include cos(DECJ) or cos(ELAT) in our calculation.
 
+    Parameters
+    ----------
+    model: pint.models.timing_model.TimingModel
+
     Returns
     -------
-    pmtot : Quantity
-        Returns total proper motion with units of u.mas/u.yr
+    pmtot : astropy.units.Quantity
+        Returns total proper motion with units of ``u.mas/u.yr``
 
     Raises
     ------
-        AttributeError if no Astrometry component is found in the model
+    AttributeError
+        If no Astrometry component is found in the model
     """
 
     if "AstrometryEcliptic" in model.components.keys():
@@ -1101,26 +1109,30 @@ def p_to_f(p, pd, pdd=None):
     """Converts P, Pdot to F, Fdot (or vice versa)
 
     Convert period, period derivative and period second
-    derivative to the equivalent frequency counterparts.
-    Will also convert from f to p.
+    derivative (if supplied) to the equivalent frequency counterparts.
+    Will also convert from F to P.
 
     Parameters
     ----------
     p : astropy.units.Quantity
-        pulsar period (or frequency)
+        pulsar period (or frequency), :math:`P` (or :math:`f`)
     pd : astropy.units.Quantity
-        period derivative (or frequency derivative)
+        period derivative (or frequency derivative),
+        :math:`\dot P` (or :math:`\dot f`)
     pdd : astropy.units.Quantity, optional
-        period second derivative (or frequency second derivative)
+        period second derivative (or frequency second derivative),
+        :math:`\ddot P` (or :math:`\ddot f`)
 
     Returns
     -------
     f : astropy.units.Quantity
-        pulsar frequency (or period)
+        pulsar frequency (or period), :math:`f` (or :math:`P`)
     fd : astropy.units.Quantity
-        pulsar frequency derivative (or period derivative)
+        pulsar frequency derivative (or period derivative),
+        :math:`\dot f` (or :math:`\dot P`)
     fdd : astropy.units.Quantity
-        frequency second derivative (or period second derivative) if pdd is supplied
+        if `pdd` is supplied, then frequency second derivative
+        (or period second derivative), :math:`\ddot f` (or :math:`\ddot P`)
     """
     f = 1.0 / p
     fd = -pd / (p * p)
@@ -1135,20 +1147,20 @@ def p_to_f(p, pd, pdd=None):
 
 
 def pferrs(porf, porferr, pdorfd=None, pdorfderr=None):
-    """Convert P, Pdot to F, Fdot with uncertainties.
+    """Convert P, Pdot to F, Fdot with uncertainties (or vice versa).
 
     Calculate the period or frequency errors and
-    the pdot or fdot errors from the opposite one.
+    the Pdot or fdot errors from the opposite ones.
 
     Parameters
     ----------
     porf : astropy.units.Quantity
-        pulsar period (or frequency)
+        pulsar period (or frequency), :math:`P` or :math:`f`
     porferr : astropy.units.Quantity
-        pulsar period uncertainty (or frequency uncertainty)
+        pulsar period uncertainty (or frequency uncertainty),
         :math:`\sigma_P` or :math:`\sigma_f`
     pdorfd : astropy.units.Quantity, optional
-        pulsar period derivative (or frequency derivative)
+        pulsar period derivative (or frequency derivative),
         :math:`\dot P` or :math:`\dot f`
     pdorfderr : astropy.units.Quantity, optional
         pulsar period derivative uncertainty
@@ -1158,16 +1170,16 @@ def pferrs(porf, porferr, pdorfd=None, pdorfderr=None):
     Returns
     -------
     forp : astropy.units.Quantity
-        pulsar frequency (or period)
+        pulsar frequency (or period) :math:`f` or :math:`P`
     forperr : astropy.units.Quantity
         pulsar frequency uncertainty (or period uncertainty)
         :math:`\sigma_f` or :math:`\sigma_P`
     fdorpd : astropy.units.Quantity
         pulsar frequency derivative (or period derivative) if pdorfd supplied
         :math:`\dot f` or :math:`\dot P`
-    fdorpderr : astropy.units.Quantity if pdorfd supplied
-        pulsar frequency derivative uncertainty
-        (or period derivative uncertainty)
+    fdorpderr : astropy.units.Quantity
+        if `pdorfd` supplied, then pulsar frequency derivative uncertainty
+        (or period derivative uncertainty),
         :math:`\sigma_{\dot f}` or :math:`\sigma_{\dot P}`
     """
     if pdorfd is None:
@@ -1277,15 +1289,19 @@ def pulsar_B_lightcyl(f, fdot):
 
     Parameters
     ----------
-    f : :class:`astropy.units.Quantity`
+    f : astropy.units.Quantity
         pulsar frequency
-    fdot : :class:`astropy.units.Quantity`
+    fdot : astropy.units.Quantity
         frequency derivative :math:`\dot f`
 
     Returns
     -------
     Blc : :class:`astropy.units.Quantity`
         pulsar dipole magnetic field at the light cylinder in ``u.G``
+
+    Notes
+    -----
+    Calculates :math:`B_{LC} = 2.9\\times 10^8\\,{\\rm G} P^{-5/2} \dot P^{1/2}`
     """
     p, pd = p_to_f(f, fdot)
     # This is a hack to use the traditional formula by stripping the units.
@@ -1310,8 +1326,8 @@ def mass_funct(pb, x):
 
     Returns
     -------
-    f_m : Quantity
-        Mass function in `u.solMass`
+    f_m : astropy.units.Quantity
+        Mass function in ``u.solMass``
 
     Raises
     ------
@@ -1389,7 +1405,8 @@ def pulsar_mass(pb, x, mc, inc):
 
     Returns
     -------
-    mass : astropy.units.Quantity in ``u.solMass``
+    mass : astropy.units.Quantity
+        In ``u.solMass``
 
     Raises
     ------
@@ -1646,18 +1663,18 @@ def FTest(chi2_1, dof_1, chi2_2, dof_2):
 
     Parameters
     -----------
-    chi2_1 : Float
+    chi2_1 : float
         Chi-squared value of model with fewer parameters
-    dof_1 : Int
+    dof_1 : int
         Degrees of freedom of model with fewer parameters
-    chi2_2 : Float
+    chi2_2 : float
         Chi-squared value of model with more parameters
-    dof_2 : Int
+    dof_2 : int
         Degrees of freedom of model with more parameters
 
     Returns
     --------
-    ft : Float
+    ft : float
         F-test significance value for the model with the larger number of
         components over the other.
     """
@@ -1687,14 +1704,14 @@ def add_dummy_distance(c, distance=1 * u.kpc):
 
     Parameters
     ----------
-    c: astropy.coordinates.sky_coordinate.SkyCoord
+    c: astropy.coordinates.SkyCoord
         current SkyCoord object without distance but with proper motion and obstime
     distance: astropy.units.Quantity, optional
         distance to supply
 
     Returns
     -------
-    cnew : astropy.coordinates.sky_coordinate.SkyCoord
+    cnew : astropy.coordinates.SkyCoord
         new SkyCoord object with a distance attached
     """
 
@@ -1768,12 +1785,12 @@ def remove_dummy_distance(c):
 
     Parameters
     ----------
-    c: astropy.coordinates.sky_coordinate.SkyCoord
+    c: astropy.coordinates.SkyCoord
         current SkyCoord object with distance and with proper motion and obstime
 
     Returns
     -------
-    cnew : astropy.coordinates.sky_coordinate.SkyCoord
+    cnew : astropy.coordinates.SkyCoord
         new SkyCoord object with a distance removed
     """
 
@@ -1865,10 +1882,32 @@ def calculate_random_models(fitter, toas, Nmodels=100, keep_models=True, params=
     random_models : list, optional
         list of random models (each is a :class:`pint.models.timing_model.TimingModel`)
 
+    Example
+    -------
+    >>> from pint.models import get_model_and_toas
+    >>> from pint import fitter, toa
+    >>> import pint.utils
+    >>> import io
+    >>> 
+    >>> # the locations of these may vary
+    >>> timfile = "tests/datafile/NGC6440E.tim"
+    >>> parfile = "tests/datafile/NGC6440E.par"
+    >>> m, t = get_model_and_toas(parfile, timfile)
+    >>> # fit the model to the data
+    >>> f = fitter.WLSFitter(toas=t, model=m)
+    >>> f.fit_toas()
+    >>> 
+    >>> # make fake TOAs starting at the end of the
+    >>> # current data and going out 100 days
+    >>> tnew = toa.make_fake_toas(t.get_mjds().max().value,
+    >>>                           t.get_mjds().max().value+100, 50, model=f.model)
+    >>> # now make random models
+    >>> dphase, mrand = pint.utils.calculate_random_models(f, tnew, Nmodels=100)
+    
+
     Note
     ----
-    To calculate new TOAs, you can do:
-        ``tnew =`` :func:`~pint.toa.make_fake_toas` ``(MJDmin, MJDmax, Ntoa, model=fitter.model)``
+    To calculate new TOAs, you can use :func:`~pint.toa.make_fake_toas` 
 
     or similar
     """


### PR DESCRIPTION
I went through and retroactively improved the docstrings for functions I wrote in `utils.py`.  I also improved docstrings for some functions I didn't write but which were very similar (for computing characteristic age, Edot, B, ...).

A couple of very minor changes to the functions themselves, mostly moving from `.to(...).value` to `.to_value(...)`