### PR TITLE
Unbreak codecov

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -85,8 +85,8 @@ jobs:
       if: "endsWith(matrix.tox_env, '-cov')"
       uses: codecov/codecov-action@v2
       with:
-          fail_ci_if_error: true # reset this to False once debugged
-#        files: ./coverage.xml
+        fail_ci_if_error: true # reset this to False once debugged
+        files: coverage.xml
 #    - name: Publish docs as an artifact
 #      if: "endsWith(matrix.tox_env, 'docs')"
 #      uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -84,7 +84,8 @@ jobs:
     - name: Upload coverage to codecov
       if: "endsWith(matrix.tox_env, '-cov')"
       uses: codecov/codecov-action@v2
-#      with:
+      with:
+          fail_ci_if_error: true # reset this to False once debugged
 #        files: ./coverage.xml
 #    - name: Publish docs as an artifact
 #      if: "endsWith(matrix.tox_env, 'docs')"

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -85,9 +85,7 @@ jobs:
       if: "endsWith(matrix.tox_env, '-cov')"
       uses: codecov/codecov-action@v2
       with:
-        fail_ci_if_error: true # reset this to False once debugged
         files: coverage.xml
-        verbose: true
 #    - name: Publish docs as an artifact
 #      if: "endsWith(matrix.tox_env, 'docs')"
 #      uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -85,7 +85,7 @@ jobs:
       if: "endsWith(matrix.tox_env, '-cov')"
       uses: codecov/codecov-action@v2
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
 #    - name: Publish docs as an artifact
 #      if: "endsWith(matrix.tox_env, 'docs')"
 #      uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -84,8 +84,8 @@ jobs:
     - name: Upload coverage to codecov
       if: "endsWith(matrix.tox_env, '-cov')"
       uses: codecov/codecov-action@v2
-      with:
-        files: ./coverage.xml
+#      with:
+#        files: ./coverage.xml
 #    - name: Publish docs as an artifact
 #      if: "endsWith(matrix.tox_env, 'docs')"
 #      uses: actions/upload-artifact@v2

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -87,6 +87,7 @@ jobs:
       with:
         fail_ci_if_error: true # reset this to False once debugged
         files: coverage.xml
+        verbose: true
 #    - name: Publish docs as an artifact
 #      if: "endsWith(matrix.tox_env, 'docs')"
 #      uses: actions/upload-artifact@v2


### PR DESCRIPTION
There was a typo in the codecov settings file, and the error was not obviously reported. This should fix it, though it's worth checking the CI results in detail to make sure that the "upload results to codecov" block is being run for the CI jobs that end in `-cov`. 