### PR TITLE
Make fit_NGC6440E into documentation

### DIFF
--- a/docs/examples/fit_NGC6440E.py
+++ b/docs/examples/fit_NGC6440E.py
@@ -1,46 +1,95 @@
 #! /usr/bin/env python
-"""Demonstrate use of pint in a script."""
-from __future__ import print_function, division
-import pint.toa
-import pint.fitter
-import pint.residuals
-import pint.models as mm
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     formats: ipynb,py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
 
+# %% [markdown]
+# # Demonstrate the use of PINT in a script
+#
+# This notebook is primarily designed to operate as a plain `.py` script.
+# You should be able to run the `.py` script that occurs in the
+# `docs/examples/` directory in order to carry out a simple fit of a
+# timing model to some data. You should also be able to run the notebook
+# version as it is here (it may be necessary to `make notebooks` to
+# produce a `.ipynb` version using `jupyext`).
+
+# %%
+import os
+
+import astropy.units as u
+
+# This will change which output method matplotlib uses and may behave better on some machines
 # import matplotlib
 # matplotlib.use('TKAgg')
 import matplotlib.pyplot as plt
+import pint.fitter
+import pint.residuals
+import pint.toa
+from pint.models import get_model, get_model_and_toas
 
-import astropy.units as u
-import os
-
-datadir = os.path.dirname(os.path.abspath(str(__file__)))
+# %%
+try:
+    datadir = os.path.dirname(os.path.abspath(str(__file__)))
+except NameError:
+    datadir = os.getcwd()
 parfile = os.path.join(datadir, "NGC6440E.par")
 timfile = os.path.join(datadir, "NGC6440E.tim")
+assert os.path.exists(parfile)
+assert os.path.exists(timfile)
 
+# %%
 # Read the timing model and the TOAs
-m, t = mm.get_model_and_toas(parfile, timfile)
+m, t = get_model_and_toas(parfile, timfile)
 
+# %% [markdown]
 # If we wanted to do things separately we could do
-# Define the timing model
-# m = mm.get_model(parfile)
-# Read in the TOAs, overriding some things from the model
+# ```python
+# # Define the timing model
+# m = get_model(parfile)
+# # Read in the TOAs, using the solar system epemeris and other things from the model
 # t = pint.toa.get_TOAs(timfile, model=m)
+# ```
 
-# Examples of how to select some subsets of TOAs
-# These can be un-done using t.unselect()
-#
+# %% [markdown]
+# If we wanted to select some subset of the TOAs, there are tools to do that. Most easily
+# you make a new TOAs object containing the subset you care about (we will make but not use
+# them):
+
+# %% [markdown]
 # Use every other TOA
-# t.select(np.where(np.arange(t.ntoas) % 2))
 
+# %%
+t_every_other = t[::2]
+
+# %% [markdown]
 # Use only TOAs with errors < 30 us
-# t.select(t.get_errors() < 30 * u.us)
 
+# %%
+t_small_errors = t[t.get_errors() < 30 * u.us]
+
+# %% [markdown]
 # Use only TOAs from the GBT (although this is all of them for this example)
-# t.select(t.get_obss() == 'gbt')
 
+# %%
+t_gbt = t[t.get_obss() == "gbt"]
+
+# %%
 # Print a summary of the TOAs that we have
-t.print_summary()
+print(t.get_summary())
 
+# %%
 # These are pre-fit residuals
 rs = pint.residuals.Residuals(t, m).phase_resids
 xt = t.get_mjds()
@@ -51,28 +100,32 @@ plt.ylabel("Residual (phase)")
 plt.grid()
 plt.show()
 
+# %%
 # Now do the fit
 print("Fitting.")
-f = pint.fitter.WLSFitter(t, m)
-# f = pint.fitter.PowellFitter(t, m)
+f = pint.fitter.DownhillWLSFitter(t, m)
 f.fit_toas()
-# f = pint.fitter.GLSFitter(t, m)
+# f = pint.fitter.DownhillGLSFitter(t, m)
 # f.fit_toas(full_cov=True)
 
+# %%
 # Print some basic params
 print("Best fit has reduced chi^2 of", f.resids.reduced_chi2)
 print("RMS in phase is", f.resids.phase_resids.std())
 print("RMS in time is", f.resids.time_resids.std().to(u.us))
 
+# %%
 # Show the parameter correlation matrix
 corm = f.get_parameter_correlation_matrix(pretty_print=True)
 
-f.print_summary()
+# %%
+print(f.get_summary())
 
+# %%
 plt.errorbar(
     xt.value,
-    f.resids.time_resids.to(u.us).value,
-    t.get_errors().to(u.us).value,
+    f.resids.time_resids.to_value(u.us),
+    t.get_errors().to_value(u.us),
     fmt="x",
 )
 plt.title("%s Post-Fit Timing Residuals" % m.PSR.value)
@@ -80,3 +133,5 @@ plt.xlabel("MJD")
 plt.ylabel("Residual (us)")
 plt.grid()
 plt.show()
+
+# %%

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -12,6 +12,7 @@ We don't really have any proper tutorials yet. But for the moment, we have a few
    basic-installation
    examples/time_a_pulsar.ipynb
    examples/PINT_walkthrough.ipynb
+   examples/fit_NGC6440E.ipynb
    examples/understanding_timing_models.ipynb
    examples/understanding_parameters.ipynb
    examples/build_model_from_scratch.ipynb


### PR DESCRIPTION
In #1071 we had some problems where changes broke `fit_NCG6440E.py` but it was never tested as part of CI. This change makes it part of our documentation - as a tutorial, rendered as a notebook - and as a result failures to run will result in CI failures. This can still be run as a `.py` file (and is downloadable from the tutorial page) but will also be visible in our documentation.

I also updated certain code to more modern approaches.