### PR TITLE
Switch from astropy logging to python logging

### DIFF
--- a/docs/controlling-logging.rst
+++ b/docs/controlling-logging.rst
@@ -1,0 +1,64 @@
+How to Control PINT Logging Output
+==================================
+
+If you have run PINT, you have probably noticed that PINT emits a generous
+amount of information in the form of log messages. These come in two forms:
+warnings emitted through the python :module:`warnings` module, and messages
+sent through the python :module:`logging` mechanism (some of which are also
+warnings). The amount of information emitted can result in the messages of
+interest being lost among routine messages, or one could wish for further
+detail (for example for debugging PINT code). There are tools for managing this
+information flow; although PINT is a library and thus simply emits messages, a
+user with a notebook, script, or GUI application can use these tools to
+manage this output.
+
+Warnings versus logging
+-----------------------
+
+The logging HOWTO_ describes the difference between ``warnings.warn`` and ``logging.warning`` thus:
+
+    - ``warnings.warn()`` in library code if the issue is avoidable and the client application should be modified to eliminate the warning
+    - ``logging.warning()`` if there is nothing the client application can do about the situation, but the event should still be noted
+
+Although PINT does not follow these rules perfectly, it does emit both kinds of
+warning, and users may quite reasonably want to handle them in various ways.
+Notably, users can call :func:`logging.captureWarnings` to arrange for
+``warnings.warn()`` to be logged as ``logging.warning()``, although they are not tagged with
+their module of origin.
+
+Users can control the handling of warnings with "warning filters"; in the simplest arrangements, users can just use ``warnings.simplefilter("ignore")`` or similar to arrange for all warnings to be ignored or treated as exceptions; users can use the more sophisticated :func:`warnings.filterwarnings` to control warnings based on their module of origin and/or the class supplied to the ``warnings.warn()`` call. Of particular note is the confusingly named :func:`warnings.catch_warnings`, which is a context manager that supports temporary changes in how warnings are handled::
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        fitter.fit_toas()
+
+For further details on the management of warnings, see the documentation of the module :module:`warnings`.
+
+.. _HOWTO: https://docs.python.org/3/howto/logging.html
+
+Controlling log messages
+------------------------
+
+Python's :module:`logging` is somewhat complicated and confusing but it does
+support some important features. In PINT's case it is worth explaining a design
+principle: libraries simply emit messages, while applications, notebooks, and
+scripts configure what to do with those messages. If PINT tried to decide what
+to do with the messages, it would inevitably conflict with the needs of one of
+those users (we have seen this in NANOGrav notebooks, where conflicting
+configurations resulted in every message appearing twice). So if you are using
+PINT and the log messages don't look very nice, that's python's default log
+reporting. If you want to. most simply, set the log level that is reported
+globally, you can::
+
+    import logging
+    logging.getLogger().setLevel("DEBUG")
+
+What PINT does do is ensure that every log message is handled based on the
+module that originated it. This uses the fact that python's loggers are
+hierarchical, passing messages up towards a global "root" logger. So to obtain
+debugging information from only :module:`pint.fitter`, you can::
+
+    import logging
+    logging.getLogger("pint.fitter").setLevel("DEBUG")
+
+

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -14,3 +14,4 @@ to use PINT. Please feel free to change this by writing more.
    development-setup
    editing-documentation
    working-with-notebooks
+   controlling-logging

--- a/src/pint/__init__.py
+++ b/src/pint/__init__.py
@@ -11,18 +11,22 @@ These docstrings contain reference documentation; for tutorials, explanations,
 or how-to documentation, please see other sections of the online documentation.
 """
 
+import logging
 import os
-import pkg_resources
-import numpy as np
+
 import astropy
 import astropy.constants as c
 import astropy.time as time
 import astropy.units as u
-from astropy import log
+import numpy as np
+import pkg_resources
 from astropy.units import si
+
 from pint.extern._version import get_versions
-from pint.pulsar_mjd import time_to_longdouble, PulsarMJD  # ensure always loaded
 from pint.pulsar_ecliptic import PulsarEcliptic
+from pint.pulsar_mjd import PulsarMJD, time_to_longdouble  # ensure always loaded
+
+log = logging.getLogger(__name__)
 
 __all__ = [
     "__version__",

--- a/src/pint/erfautils.py
+++ b/src/pint/erfautils.py
@@ -1,30 +1,24 @@
 """Observatory position and velocity calculation."""
+import logging
+
 try:
     import erfa
 except ImportError:
     import astropy._erfa as erfa
 
+import astropy
+import astropy.time
 import astropy.units as u
-from astropy import log
+import astropy.version
 import numpy as np
 from astropy import table
 from astropy.utils.data import clear_download_cache, download_file, is_url_in_cache
-from astropy.utils.iers import IERS_B, IERS_B_URL, IERS_Auto
-import astropy.version
-import astropy
-import astropy.time
-
-if astropy.version.major < 4:
-    log.warning(
-        "Using astropy version {}. To get most recent IERS data, upgrade to astropy >= 4.0".format(
-            astropy.__version__
-        )
-    )
-else:
-    from astropy.utils.iers import earth_orientation_table
+from astropy.utils.iers import IERS_B, IERS_B_URL, IERS_Auto, earth_orientation_table
 
 from pint.pulsar_mjd import Time
 from pint.utils import PosVel
+
+log = logging.getLogger(__name__)
 
 __all__ = ["get_iers_up_to_date", "gcrs_posvel_from_itrf", "old_gcrs_posvel_from_itrf"]
 

--- a/src/pint/event_toas.py
+++ b/src/pint/event_toas.py
@@ -1,11 +1,14 @@
 """Generic function to load TOAs from events files."""
+import logging
 import os
+
 import astropy.io.fits as pyfits
 import numpy as np
-from astropy import log
 
 import pint.toa as toa
 from pint.fits_utils import read_fits_event_mjds_tuples
+
+log = logging.getLogger(__name__)
 
 __all__ = [
     "load_fits_TOAs",

--- a/src/pint/fermi_toas.py
+++ b/src/pint/fermi_toas.py
@@ -1,5 +1,6 @@
 """Work with Fermi TOAs."""
-from astropy import log
+import logging
+
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 import astropy.units as u
@@ -8,6 +9,8 @@ import numpy as np
 import pint.toa as toa
 from pint.fits_utils import read_fits_event_mjds_tuples
 from pint.observatory import get_observatory
+
+log = logging.getLogger(__name__)
 
 __all__ = ["load_Fermi_TOAs"]
 

--- a/src/pint/fits_utils.py
+++ b/src/pint/fits_utils.py
@@ -1,6 +1,7 @@
 """FITS handling functions"""
+import logging
+
 import numpy as np
-from astropy import log
 
 try:
     from erfa import DAYSEC as SECS_PER_DAY
@@ -8,6 +9,8 @@ except ImportError:
     from astropy._erfa import DAYSEC as SECS_PER_DAY
 
 from pint.pulsar_mjd import fortran_float
+
+log = logging.getLogger(__name__)
 
 __all__ = ["read_fits_event_mjds", "read_fits_event_mjds_tuples"]
 

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -55,20 +55,20 @@ Fitters in use::
 """
 import collections
 import copy
+import logging
 from warnings import warn
 
 import astropy.units as u
 import numpy as np
 import scipy.linalg
 import scipy.optimize as opt
-from astropy import log
 
 import pint.utils
 import pint.derived_quantities
 from pint.models.parameter import AngleParameter, boolParameter, strParameter
 from pint.pint_matrix import (
-    CovarianceMatrix,
     CorrelationMatrix,
+    CovarianceMatrix,
     CovarianceMatrixMaker,
     DesignMatrixMaker,
     combine_covariance_matrix,
@@ -78,6 +78,8 @@ from pint.pint_matrix import (
 from pint.residuals import Residuals, WidebandTOAResiduals
 from pint.toa import TOAs
 from pint.utils import FTest
+
+log = logging.getLogger(__name__)
 
 __all__ = [
     "Fitter",

--- a/src/pint/gridutils.py
+++ b/src/pint/gridutils.py
@@ -1,12 +1,13 @@
-import os
+"""Tools for building chi-squared grids."""
 import copy
 import multiprocessing
+import os
 from multiprocessing import Process, Queue
 
+import astropy.constants as const
 import astropy.units as u
 import numpy as np
-from astropy import log
-import astropy.constants as const
+
 import pint.utils
 
 __all__ = ["grid_chisq", "grid_chisq_mp", "plot_grid_chisq"]

--- a/src/pint/ltinterface.py
+++ b/src/pint/ltinterface.py
@@ -1,5 +1,6 @@
 """An interface for pint compatible to the interface of libstempo."""
 import collections
+import logging
 import time
 from collections import OrderedDict
 
@@ -7,13 +8,14 @@ import astropy.constants as ac
 import astropy.coordinates.angles as ang
 import astropy.units as u
 import numpy as np
-from astropy import log
 
 import pint.models as pm
 import pint.toa as pt
 from pint import fitter
 from pint.utils import has_astropy_unit
 from pint.residuals import Residuals
+
+log = logging.getLogger(__name__)
 
 __all__ = ["PINTPar", "PINTPulsar"]
 
@@ -177,9 +179,9 @@ class PINTPulsar:
             Whether or not we are using the 'units' interface of libstempo
         """
         if warnings:
-            log.setLevel("INFO")
+            logging.getLogger().setLevel("INFO")
         else:
-            log.setLevel("ERROR")
+            logging.getLogger().setLevel("ERROR")
 
         self.loadparfile(parfile)
 

--- a/src/pint/mcmc_fitter.py
+++ b/src/pint/mcmc_fitter.py
@@ -1,9 +1,11 @@
+"""Markov Chain Monte Carlo fitting."""
+
 import copy
+import logging
 
 import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
-from astropy import log
 from astropy.table import vstack
 from scipy.stats import norm, uniform
 
@@ -13,6 +15,8 @@ from pint.fitter import Fitter
 from pint.models.priors import Prior
 from pint.residuals import Residuals
 from pint.templates.lctemplate import LCTemplate
+
+log = logging.getLogger(__name__)
 
 __all__ = [
     "MCMCFitter",

--- a/src/pint/models/absolute_phase.py
+++ b/src/pint/models/absolute_phase.py
@@ -1,10 +1,13 @@
 """Timing model absolute phase (TZRMJD, TZRSITE ...)"""
+import logging
+
 import astropy.units as u
-from astropy import log
 
 import pint.toa as toa
 from pint.models.parameter import MJDParameter, floatParameter, strParameter
 from pint.models.timing_model import MissingParameter, PhaseComponent
+
+log = logging.getLogger(__name__)
 
 
 class AbsPhase(PhaseComponent):

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -1,13 +1,11 @@
 """Astrometric models for describing pulsar sky positions."""
-# astrometry.py
-# Defines Astrometry timing model class
+import logging
 import sys
 
 import astropy.constants as const
 import astropy.coordinates as coords
 import astropy.units as u
 import numpy as np
-from astropy import log
 from astropy.time import Time
 
 from pint import ls
@@ -20,6 +18,8 @@ from pint.models.parameter import (
 from pint.models.timing_model import DelayComponent, MissingParameter
 from pint.pulsar_ecliptic import OBL, PulsarEcliptic
 from pint.utils import add_dummy_distance, remove_dummy_distance
+
+log = logging.getLogger(__name__)
 
 astropy_version = sys.modules["astropy"].__version__
 mas_yr = u.mas / u.yr

--- a/src/pint/models/binary_ddk.py
+++ b/src/pint/models/binary_ddk.py
@@ -1,6 +1,4 @@
 """The DDK model - Damour and Deruelle with kinematics."""
-from astropy import log
-
 from pint.models.binary_dd import BinaryDD
 from pint.models.parameter import boolParameter, floatParameter
 from pint.models.stand_alone_psr_binaries.DDK_model import DDKmodel

--- a/src/pint/models/binary_ell1.py
+++ b/src/pint/models/binary_ell1.py
@@ -1,8 +1,9 @@
 """Approximate binary model for small eccentricity."""
+import logging
 from warnings import warn
 
+import astropy.units as u
 import numpy as np
-from astropy import log, units as u
 from astropy.time import Time
 
 from pint.models.parameter import MJDParameter, floatParameter, intParameter
@@ -12,6 +13,8 @@ from pint.models.stand_alone_psr_binaries.ELL1_model import ELL1model
 from pint.models.stand_alone_psr_binaries.ELL1H_model import ELL1Hmodel
 from pint.models.timing_model import MissingParameter, TimingModelError
 from pint.utils import taylor_horner_deriv
+
+log = logging.getLogger(__name__)
 
 
 class BinaryELL1(PulsarBinary):

--- a/src/pint/models/glitch.py
+++ b/src/pint/models/glitch.py
@@ -1,11 +1,14 @@
 """Pulsar timing glitches."""
+import logging
+
 import astropy.units as u
 import numpy as np
-from astropy import log
 
-from pint.models.parameter import prefixParameter, MJDParameter
+from pint.models.parameter import MJDParameter, prefixParameter
 from pint.models.timing_model import MissingParameter, PhaseComponent
 from pint.utils import split_prefixed_name
+
+log = logging.getLogger(__name__)
 
 
 class Glitch(PhaseComponent):
@@ -195,7 +198,7 @@ class Glitch(PhaseComponent):
             else:
                 decayterm = 0.0 * u.Unit("")
 
-            log.info("{} {} ".format(dphs, dphs.unit))
+            log.info("Glitch phase {} {} ".format(dphs, dphs.unit))
             phs[affected] += (
                 dphs
                 + dt[affected]

--- a/src/pint/models/jump.py
+++ b/src/pint/models/jump.py
@@ -1,12 +1,13 @@
 """Phase jumps. """
-# phase_jump.py
-# Defines PhaseJump timing model class
+import logging
+
 import astropy.units as u
 import numpy
 
 from pint.models.parameter import maskParameter
 from pint.models.timing_model import DelayComponent, MissingParameter, PhaseComponent
-from astropy import log
+
+log = logging.getLogger(__name__)
 
 
 class DelayJump(DelayComponent):

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -1,20 +1,19 @@
-# model_builder.py
-# Defines the automatic timing model generator interface
+import logging
 import os
 import tempfile
 from collections import Counter, defaultdict
 
-from astropy import log
-
+from pint.models.parameter import maskParameter
 from pint.models.timing_model import (
+    DEFAULT_ORDER,
     Component,
     TimingModel,
     ignore_prefix,
-    DEFAULT_ORDER,
 )
-from pint.models.parameter import maskParameter
-from pint.utils import PrefixError, interesting_lines, lines_of, split_prefixed_name
 from pint.toa import get_TOAs
+from pint.utils import PrefixError, interesting_lines, lines_of, split_prefixed_name
+
+log = logging.getLogger(__name__)
 
 __all__ = ["get_model"]
 

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -1,14 +1,16 @@
 """Pulsar timing noise models."""
 
 import copy
+import logging
 import warnings
 
 import astropy.units as u
 import numpy as np
-from astropy import log
 
 from pint.models.parameter import floatParameter, maskParameter
 from pint.models.timing_model import Component
+
+log = logging.getLogger(__name__)
 
 
 class NoiseComponent(Component):
@@ -118,7 +120,7 @@ class ScaleToaError(NoiseComponent):
                     EQUAD_par.quantity = tneq_par.quantity.to(u.us)
                 else:
                     self.add_param(
-                        p.maskParameter(
+                        maskParameter(
                             name="EQUAD",
                             units="us",
                             index=tneq_par.index,

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -21,13 +21,13 @@ See :ref:`Supported Parameters` for an overview, including a table of all the
 parameters PINT understands.
 
 """
+import logging
 import numbers
 from warnings import warn
 
 import astropy.time as time
 import astropy.units as u
 import numpy as np
-from astropy import log
 from astropy.coordinates.angles import Angle
 
 from pint import pint_units
@@ -44,6 +44,8 @@ from pint.pulsar_mjd import (
 )
 from pint.toa_select import TOASelect
 from pint.utils import split_prefixed_name
+
+log = logging.getLogger(__name__)
 
 
 class Parameter:

--- a/src/pint/models/piecewise.py
+++ b/src/pint/models/piecewise.py
@@ -1,9 +1,6 @@
 """Pulsar timing piecewise spin-down solution."""
-# piecewise.py
-# Defines piecewise spindown timing model class
 import astropy.units as u
 import numpy as np
-from astropy import log
 
 from pint.models.parameter import prefixParameter, MJDParameter
 from pint.models.timing_model import MissingParameter, PhaseComponent

--- a/src/pint/models/priors.py
+++ b/src/pint/models/priors.py
@@ -8,7 +8,6 @@ such as total proper motion, 2-d sky location, etc.
 """
 import numpy as np
 import scipy.stats
-from astropy import log
 from scipy.stats import norm, rv_continuous, rv_discrete, uniform
 
 

--- a/src/pint/models/pulsar_binary.py
+++ b/src/pint/models/pulsar_binary.py
@@ -3,15 +3,19 @@
 This module if for wrapping standalone binary models so that they work
 as PINT timing models.
 """
+import logging
+
 import astropy.units as u
 import numpy as np
-from astropy import log
 from astropy.time import Time
+
 from pint import ls
 from pint.models.parameter import MJDParameter, floatParameter, prefixParameter
 from pint.models.stand_alone_psr_binaries import binary_orbits as bo
 from pint.models.timing_model import DelayComponent, MissingParameter
 from pint.utils import taylor_horner_deriv
+
+log = logging.getLogger(__name__)
 
 
 class PulsarBinary(DelayComponent):

--- a/src/pint/models/solar_system_shapiro.py
+++ b/src/pint/models/solar_system_shapiro.py
@@ -1,8 +1,9 @@
 """Solar system Shapiro delay."""
+import logging
+
 import astropy.constants as const
 import astropy.units as u
 import numpy
-from astropy import log
 
 from pint import (
     Tearth,
@@ -17,6 +18,8 @@ from pint import (
 )
 from pint.models.parameter import boolParameter
 from pint.models.timing_model import DelayComponent
+
+log = logging.getLogger(__name__)
 
 
 class SolarSystemShapiro(DelayComponent):

--- a/src/pint/models/stand_alone_psr_binaries/DDK_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/DDK_model.py
@@ -1,11 +1,15 @@
 """Kopeikin corrected DD model."""
+import logging
+
 import astropy.constants as c
 import astropy.units as u
 import numpy as np
-from astropy import log
+
 from pint import GMsun, Tsun, ls
 
 from .DD_model import DDmodel
+
+log = logging.getLogger(__name__)
 
 
 class DDKmodel(DDmodel):

--- a/src/pint/models/stand_alone_psr_binaries/binary_generic.py
+++ b/src/pint/models/stand_alone_psr_binaries/binary_generic.py
@@ -1,8 +1,9 @@
-# This file is a prototype of independent psr binary model class
+"""Parent class for internal binary models."""
+import logging
+
 import astropy.constants as c
 import astropy.units as u
 import numpy as np
-from astropy import log
 
 try:
     from erfa import DAYSEC as SECS_PER_DAY
@@ -11,6 +12,8 @@ except ImportError:
 
 from pint import Tsun, ls
 from pint.models.stand_alone_psr_binaries.binary_orbits import OrbitPB
+
+log = logging.getLogger(__name__)
 
 SECS_PER_JUL_YEAR = SECS_PER_DAY * 365.25
 

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -29,6 +29,7 @@ See :ref:`Timing Models` for more details on how PINT's timing models work.
 import abc
 import copy
 import inspect
+import logging
 from collections import OrderedDict, defaultdict
 from functools import wraps
 from warnings import warn
@@ -36,7 +37,6 @@ from warnings import warn
 import astropy.time as time
 import astropy.units as u
 import numpy as np
-from astropy import log
 from scipy.optimize import brentq
 
 import pint
@@ -53,6 +53,8 @@ from pint.models.parameter import (
 from pint.phase import Phase
 from pint.toa import TOAs
 from pint.utils import PrefixError, interesting_lines, lines_of, split_prefixed_name
+
+log = logging.getLogger(__name__)
 
 __all__ = [
     "DEFAULT_ORDER",
@@ -1664,7 +1666,7 @@ class TimingModel:
                 "max"     - print all lines from both models whether they are fit or not (note that nodmx will override this); DEFAULT
                 "med"     - only print lines for parameters that are fit
                 "min"     - only print lines for fit parameters for which diff_sigma > threshold
-                "check"   - only print significant changes with astropy.log.warning, not as string (note that all other modes will still print this)
+                "check"   - only print significant changes with logging.warning, not as string (note that all other modes will still print this)
 
         Returns
         -------
@@ -1682,7 +1684,7 @@ class TimingModel:
 
         Note
         ----
-            Prints astropy.log warnings for parameters that have changed significantly
+            Prints logging warnings for parameters that have changed significantly
             and/or have increased in uncertainty.
         """
         import sys
@@ -1851,7 +1853,6 @@ class TimingModel:
                         except (ValueError, AttributeError):
                             newstr += " {:28f}".format(otherpar.value)
                         if otherpar.value != par.value:
-                            sys.stdout.flush()
                             if par.name in ["START", "FINISH", "CHI2", "NTOA"]:
                                 if verbosity == "max":
                                     log.info(
@@ -1873,7 +1874,6 @@ class TimingModel:
                                     % par.name
                                 )
                                 newstr += " !"
-                            log.handlers[0].flush()
                         if (
                             par.uncertainty is not None
                             and otherpar.uncertainty is not None
@@ -1943,26 +1943,20 @@ class TimingModel:
 
             if "!" in newstr and not par.frozen:
                 try:
-                    sys.stdout.flush()
                     log.warning(
                         "Parameter %s has changed significantly (%f sigma)"
                         % (newstr.split()[0], float(newstr.split()[-2]))
                     )
-                    log.handlers[0].flush()
                 except ValueError:
-                    sys.stdout.flush()
                     log.warning(
                         "Parameter %s has changed significantly (%f sigma)"
                         % (newstr.split()[0], float(newstr.split()[-3]))
                     )
-                    log.handlers[0].flush()
             if "*" in newstr:
-                sys.stdout.flush()
                 log.warning(
                     "Uncertainty on parameter %s has increased (unc2/unc1 = %2.2f)"
                     % (newstr.split()[0], float(otherpar.uncertainty / par.uncertainty))
                 )
-                log.handlers[0].flush()
 
             if verbosity == "max":
                 s += newstr

--- a/src/pint/models/troposphere_delay.py
+++ b/src/pint/models/troposphere_delay.py
@@ -1,18 +1,21 @@
 """Delay due to Earth's troposphere"""
+import logging
 from warnings import warn
 
 import astropy.constants as const
 import astropy.units as u
 import numpy as np
-import pint.utils as ut
 import scipy.interpolate
-from astropy import log
 from astropy.coordinates import AltAz, SkyCoord
+
+import pint.utils as ut
 from pint.models.parameter import boolParameter
 from pint.models.timing_model import DelayComponent
 from pint.observatory import get_observatory
 from pint.observatory.topo_obs import TopoObs
 from pint.toa_select import TOASelect
+
+log = logging.getLogger(__name__)
 
 
 class TroposphereDelay(DelayComponent):

--- a/src/pint/modelutils.py
+++ b/src/pint/modelutils.py
@@ -1,5 +1,9 @@
-from astropy import log
+import logging
 from pint.models.astrometry import AstrometryEquatorial, AstrometryEcliptic
+
+log = logging.getLogger(__name__)
+
+# FIXME: shouldn't this be in the AstrometryEquatorial and AstrometryEcliptic classes?
 
 
 def model_ecliptic_to_equatorial(model, force=False):

--- a/src/pint/observatory/__init__.py
+++ b/src/pint/observatory/__init__.py
@@ -1,3 +1,6 @@
+"""Machinery to support PINT's list of observatories."""
+
+import logging
 import os
 import textwrap
 from collections import defaultdict
@@ -7,12 +10,13 @@ import astropy.constants as const
 import astropy.coordinates
 import astropy.units as u
 import numpy as np
-from astropy import log
 from astropy.coordinates import EarthLocation
 
 import pint.solar_system_ephemerides as sse
 from pint.pulsar_mjd import Time
 from pint.utils import interesting_lines
+
+log = logging.getLogger(__name__)
 
 # Include any files that define observatories here.  This will start
 # with the standard distribution files, then will read any system- or

--- a/src/pint/observatory/clock_file.py
+++ b/src/pint/observatory/clock_file.py
@@ -1,12 +1,11 @@
-# clock_file.py
+"""Routines for reading various formats of clock file."""
 
-# Routines for reading various formats of clock file.
+import logging
 import os
 import warnings
 
 import astropy.units as u
 import numpy as np
-from astropy import log
 
 try:
     from erfa import ErfaWarning
@@ -14,6 +13,8 @@ except ImportError:
     from astropy._erfa import ErfaWarning
 
 from pint.pulsar_mjd import Time
+
+log = logging.getLogger(__name__)
 
 
 class ClockFileMeta(type):

--- a/src/pint/observatory/satellite_obs.py
+++ b/src/pint/observatory/satellite_obs.py
@@ -1,8 +1,10 @@
-# special_locations.py
+"""Observatories at special (non-Earth) locations."""
+
+import logging
+
 import astropy.io.fits as pyfits
 import astropy.units as u
 import astropy.constants as const
-from astropy import log
 from astropy.coordinates import EarthLocation
 from astropy.table import Table, vstack
 from scipy.interpolate import InterpolatedUnivariateSpline
@@ -12,6 +14,8 @@ from pint.fits_utils import read_fits_event_mjds
 from pint.observatory.special_locations import SpecialLocation
 from pint.solar_system_ephemerides import objPosVel_wrt_SSB
 from pint.utils import PosVel
+
+log = logging.getLogger(__name__)
 
 
 def load_Fermi_FT2(ft2_filename):

--- a/src/pint/observatory/special_locations.py
+++ b/src/pint/observatory/special_locations.py
@@ -3,11 +3,11 @@
 Special "site" locations (eg, barycenter) which do not need clock
 corrections or much else done.
 """
+import logging
 import os
 
 import astropy.constants as const
 import astropy.units as u
-from astropy import log
 from astropy.coordinates import EarthLocation
 import numpy as np
 
@@ -17,6 +17,8 @@ from pint.observatory.clock_file import ClockFile
 from pint.solar_system_ephemerides import objPosVel_wrt_SSB
 from pint.utils import PosVel
 from . import Observatory
+
+log = logging.getLogger(__name__)
 
 
 class SpecialLocation(Observatory):

--- a/src/pint/observatory/topo_obs.py
+++ b/src/pint/observatory/topo_obs.py
@@ -1,12 +1,10 @@
 """Ground-based fixed observatories."""
-# topo_obs.py
-# Code for dealing with "standard" ground-based observatories.
+import logging
 import os
 
 import astropy.constants as c
 import astropy.units as u
 import numpy
-from astropy import log
 from astropy.coordinates import EarthLocation
 
 from pint import JD_MJD
@@ -17,6 +15,8 @@ from pint.observatory.clock_file import ClockFile
 from pint.pulsar_mjd import Time
 from pint.solar_system_ephemerides import get_tdb_tt_ephem_geocenter, objPosVel_wrt_SSB
 from pint.utils import has_astropy_unit
+
+log = logging.getLogger(__name__)
 
 
 class TopoObs(Observatory):

--- a/src/pint/pintk/colormodes.py
+++ b/src/pint/pintk/colormodes.py
@@ -1,7 +1,10 @@
 """ Color modes for graphed pintk TOAs. """
-from astropy import log
+import logging
+
 import numpy as np
 import matplotlib
+
+log = logging.getLogger(__name__)
 
 
 class ColorMode:

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -2,32 +2,28 @@
 Interactive emulator of tempo2 plk
 """
 import copy
+import logging
 import os
 import sys
 
 import astropy.units as u
 import matplotlib as mpl
 import numpy as np
-from astropy import log
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 
 import pint.pintk.pulsar as pulsar
 import pint.pintk.colormodes as cm
 
-try:
-    # Python2
-    import Tkinter as tk
-    import tkFileDialog
-    import tkMessageBox
-except ImportError:
-    # Python3
-    import tkinter as tk
-    import tkinter.filedialog as tkFileDialog
-    import tkinter.messagebox as tkMessageBox
-    from tkinter import ttk
+import tkinter as tk
+import tkinter.filedialog as tkFileDialog
+import tkinter.messagebox as tkMessageBox
+from tkinter import ttk
 
-log.setLevel("INFO")
-log.debug("This should show up")
+log = logging.getLogger(__name__)
+
+# FIXME: do not set logging in an importable module. Why is this here? settings should go in the scripts/
+# log.setLevel("INFO")
+# log.debug("This should show up")
 
 try:
     from matplotlib.backends.backend_tkagg import NavigationToolbar2Tk
@@ -37,9 +33,10 @@ except ImportError:
     )
 
 
-log.debug(
-    "This should also show up. test click revert, turn params on and off, and prefit model"
-)
+# Where is this meant for? Maybe it belongs in application creation?
+# log.debug(
+#    "This should also show up. test click revert, turn params on and off, and prefit model"
+# )
 
 plotlabels = {
     "pre-fit": [
@@ -272,7 +269,9 @@ class PlkLogLevelSelect(tk.Frame):
 
     def changeLogLevel(self, event):
         newLevel = self.logLevelSelect.get()  # get current value
-        log.setLevel(str(newLevel))
+        # FIXME: this adjusts the level for all logging
+        # we might want to make it PINT-specific, or even narrower
+        logging.getLogger().setLevel(str(newLevel))
         log.info("Log level changed to " + str(newLevel))
 
 

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -21,10 +21,6 @@ from tkinter import ttk
 
 log = logging.getLogger(__name__)
 
-# FIXME: do not set logging in an importable module. Why is this here? settings should go in the scripts/
-# log.setLevel("INFO")
-# log.debug("This should show up")
-
 try:
     from matplotlib.backends.backend_tkagg import NavigationToolbar2Tk
 except ImportError:

--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -6,11 +6,11 @@ pre/post fit residuals, and other useful information.
 self.selected_toas = selected toas, self.all_toas = all toas in tim file
 """
 import copy
+import logging
 from enum import Enum
 
 import astropy.units as u
 import numpy as np
-from astropy import log
 
 import pint.fitter
 import pint.models
@@ -18,6 +18,8 @@ from pint.pulsar_mjd import Time
 from pint.random_models import random_models
 from pint.residuals import Residuals
 from pint.toa import get_TOAs
+
+log = logging.getLogger(__name__)
 
 plot_labels = [
     "pre-fit",

--- a/src/pint/random_models.py
+++ b/src/pint/random_models.py
@@ -1,12 +1,15 @@
-"""Generate random models distributed like the results of a fit"""
+"""Generate random models distributed like the results of a fit."""
+
+import logging
 from collections import OrderedDict
 from copy import deepcopy
 
 import numpy as np
-from astropy import log
 
 import pint.toa as toa
 from pint.phase import Phase
+
+log = logging.getLogger(__name__)
 
 __all__ = ["random_models"]
 # log.setLevel("INFO")

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -8,16 +8,18 @@ dispersion measures (:class:`pint.residuals.WidebandTOAResiduals`).
 """
 import collections
 import copy
+import logging
 import warnings
 
 import astropy.units as u
 import numpy as np
-from astropy import log
 from scipy.linalg import LinAlgError
 
 from pint.models.dispersion_model import Dispersion
 from pint.phase import Phase
 from pint.utils import weighted_mean
+
+log = logging.getLogger(__name__)
 
 __all__ = [
     "Residuals",

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python -W ignore::FutureWarning -W ignore::UserWarning -W ignore::DeprecationWarning
 import argparse
+import logging
 import os
 import sys
 
@@ -8,7 +9,6 @@ import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.optimize as op
-from astropy import log
 from astropy.coordinates import SkyCoord
 from scipy.stats import norm, uniform
 
@@ -25,6 +25,8 @@ from pint.models.priors import (
     UniformUnboundedRV,
 )
 from pint.observatory.satellite_obs import get_satellite_observatory
+
+log = logging.getLogger(__name__)
 
 __all__ = ["read_gaussfitfile", "marginalize_over_phase", "main"]
 # log.setLevel('DEBUG')

--- a/src/pint/scripts/event_optimize_MCMCFitter.py
+++ b/src/pint/scripts/event_optimize_MCMCFitter.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python -W ignore::FutureWarning -W ignore::UserWarning -W ignore::DeprecationWarning
 import argparse
+import logging
 import os
 import sys
 
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.optimize as op
-from astropy import log
 from astropy.coordinates import SkyCoord
 
 import pint.fermi_toas as fermi
@@ -16,6 +16,8 @@ from pint.mcmc_fitter import MCMCFitterBinnedTemplate
 from pint.observatory.satellite_obs import get_satellite_observatory
 from pint.sampler import EmceeSampler
 from pint.scripts.event_optimize import marginalize_over_phase, read_gaussfitfile
+
+log = logging.getLogger(__name__)
 
 __all__ = ["main"]
 # log.setLevel('DEBUG')

--- a/src/pint/scripts/event_optimize_multiple.py
+++ b/src/pint/scripts/event_optimize_multiple.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python -W ignore::FutureWarning -W ignore::UserWarning -W ignore::DeprecationWarning
 import argparse
+import logging
 import sys
 
 import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
-from astropy import log
 from astropy.coordinates import SkyCoord
 
 import pint.fermi_toas as fermi
@@ -15,6 +15,8 @@ from pint.mcmc_fitter import CompositeMCMCFitter
 from pint.observatory.satellite_obs import get_satellite_observatory
 from pint.sampler import EmceeSampler
 from pint.scripts.event_optimize import read_gaussfitfile
+
+log = logging.getLogger(__name__)
 
 __all__ = ["main"]
 # log.setLevel('DEBUG')

--- a/src/pint/scripts/fermiphase.py
+++ b/src/pint/scripts/fermiphase.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 import argparse
+import logging
 
 import astropy.io.fits as pyfits
 import astropy.units as u
 import numpy as np
-from astropy import log
 from astropy.coordinates import SkyCoord
 
 import pint.models
@@ -16,6 +16,8 @@ from pint.fits_utils import read_fits_event_mjds_tuples
 from pint.observatory.satellite_obs import get_satellite_observatory
 from pint.plot_utils import phaseogram
 from pint.pulsar_mjd import Time
+
+log = logging.getLogger(__name__)
 
 __all__ = ["main"]
 

--- a/src/pint/scripts/photonphase.py
+++ b/src/pint/scripts/photonphase.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
+import logging
 import sys
 
 import astropy.io.fits as pyfits
 import astropy.units as u
 import numpy as np
-from astropy import log
 
 import pint.models
 import pint.residuals
@@ -15,6 +15,8 @@ from pint.fits_utils import read_fits_event_mjds
 from pint.observatory.satellite_obs import get_satellite_observatory
 from pint.plot_utils import phaseogram_binned
 from pint.pulsar_mjd import Time
+
+log = logging.getLogger(__name__)
 
 __all__ = ["main"]
 

--- a/src/pint/scripts/pintbary.py
+++ b/src/pint/scripts/pintbary.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python -W ignore::FutureWarning -W ignore::UserWarning -W ignore::DeprecationWarning
 import argparse
+import logging
 
 import astropy.units as u
 import numpy as np
-from astropy import log
 from astropy.coordinates import Angle
 
 import pint.models
 import pint.toa as toa
 from pint.pulsar_mjd import Time
+
+log = logging.getLogger(__name__)
 
 __all__ = ["main"]
 

--- a/src/pint/scripts/pintempo.py
+++ b/src/pint/scripts/pintempo.py
@@ -8,6 +8,7 @@ specify '-f parfile' to those codes -- I mean, who runs TEMPO without a timing m
 This is currently just a stub and should be added to and expanded, as desired.
 """
 import argparse
+import logging
 import sys
 
 import astropy.units as u
@@ -16,6 +17,8 @@ from astropy import log
 import pint.fitter
 import pint.models
 import pint.residuals
+
+log = logging.getLogger(__name__)
 
 __all__ = ["main"]
 

--- a/src/pint/scripts/pintk.py
+++ b/src/pint/scripts/pintk.py
@@ -158,7 +158,7 @@ def main(argv=None):
     )
     args = parser.parse_args(argv)
 
-    logging.getLogger().setLevel("INFO")
+    logging.getLogger().setLevel("DEBUG")
     root = tk.Tk()
     root.minsize(800, 600)
     if not args.test:

--- a/src/pint/scripts/pintk.py
+++ b/src/pint/scripts/pintk.py
@@ -158,7 +158,7 @@ def main(argv=None):
     )
     args = parser.parse_args(argv)
 
-    logging.getLogger().setLevel("DEBUG")
+    logging.getLogger().setLevel("WARNING")
     root = tk.Tk()
     root.minsize(800, 600)
     if not args.test:

--- a/src/pint/scripts/pintk.py
+++ b/src/pint/scripts/pintk.py
@@ -2,6 +2,7 @@
 """Tkinter interactive interface for PINT pulsar timing tool"""
 import argparse
 import code
+import logging
 import os
 import sys
 
@@ -11,7 +12,6 @@ import tkinter as tk
 import tkinter.filedialog as tkFileDialog
 import tkinter.messagebox as tkMessageBox
 from tkinter import ttk
-from astropy import log
 
 from pint.pintk.paredit import ParWidget
 from pint.pintk.plk import PlkWidget, helpstring
@@ -19,8 +19,6 @@ from pint.pintk.pulsar import Pulsar
 from pint.pintk.timedit import TimWidget
 
 __all__ = ["main"]
-
-# log.setLevel("WARNING")
 
 
 class PINTk:
@@ -160,7 +158,7 @@ def main(argv=None):
     )
     args = parser.parse_args(argv)
 
-    log.setLevel("WARNING")  # only display warnings and higher in the terminal
+    logging.getLogger().setLevel("INFO")
     root = tk.Tk()
     root.minsize(800, 600)
     if not args.test:

--- a/src/pint/scripts/zima.py
+++ b/src/pint/scripts/zima.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python -W ignore::FutureWarning -W ignore::UserWarning -W ignore::DeprecationWarning
 """PINT-based tool for making simulated TOAs."""
+import logging
+
 import astropy.units as u
 import numpy as np
-from astropy import log
 from astropy.time import TimeDelta
 
 import pint.fitter
 import pint.models
 import pint.toa as toa
 from pint.observatory import get_observatory
+
+log = logging.getLogger(__name__)
 
 __all__ = ["main"]
 

--- a/src/pint/solar_system_ephemerides.py
+++ b/src/pint/solar_system_ephemerides.py
@@ -1,15 +1,18 @@
+"""Solar system ephemeris downloading and setting support."""
+import logging
 import os
 
 from astropy.utils.data import download_file
 import astropy.coordinates
 import astropy.units as u
 import numpy as np
-from astropy import log
 from astropy.utils.data import download_file
 from urllib.parse import urljoin
 
 import pint.config
 from pint.utils import PosVel
+
+log = logging.getLogger(__name__)
 
 __all__ = ["objPosVel_wrt_SSB", "get_tdb_tt_ephem_geocenter"]
 

--- a/src/pint/templates/lctemplate.py
+++ b/src/pint/templates/lctemplate.py
@@ -5,14 +5,16 @@ Implements a mixture model of LCPrimitives to form a normalized template represe
 author: M. Kerr <matthew.kerr@gmail.com>
 
 """
+import logging
 from collections import defaultdict
 from copy import deepcopy
 
 import numpy as np
-from astropy import log
 
 from .lcnorm import NormAngles
 from .lcprimitives import *
+
+log = logging.getLogger(__name__)
 
 
 class LCTemplate:

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -8,6 +8,7 @@ as this makes certain operations much more convenient. You probably want to load
 import copy
 import gzip
 import hashlib
+import logging
 import os
 import pickle
 import re
@@ -20,7 +21,6 @@ import astropy.time as time
 import astropy.units as u
 import numpy as np
 import numpy.ma
-from astropy import log
 from astropy.coordinates import (
     ICRS,
     CartesianDifferential,
@@ -38,6 +38,8 @@ from pint.pulsar_ecliptic import PulsarEcliptic
 from pint.pulsar_mjd import Time
 from pint.solar_system_ephemerides import objPosVel_wrt_SSB
 
+
+log = logging.getLogger(__name__)
 
 __all__ = [
     "TOAs",
@@ -1753,7 +1755,7 @@ class TOAs:
         In that case  ``self.table.meta['cluster_gap']``  will be set to the
         `gap_limit`.  If the desired clustering corresponds to that in
         :attr:`pint.toa.TOAs.table` then that column is returned.
-        
+
         Parameters
         ----------
         gap_limit : astropy.units.Quantity, optional

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -26,6 +26,7 @@ have moved to :mod:`pint.derived_quantities`.
 import configparser
 import datetime
 import getpass
+import logging
 import os
 import platform
 import re
@@ -41,11 +42,12 @@ import astropy.coordinates.angles as angles
 import astropy.units as u
 import numpy as np
 import scipy.optimize.zeros as zeros
-from astropy import log
 from scipy.special import fdtrc
 
 import pint
 import pint.pulsar_ecliptic
+
+log = logging.getLogger(__name__)
 
 __all__ = [
     "PosVel",


### PR DESCRIPTION
Astropy has clarified that their logging system is meant only for code that is part of astropy itself. This PR switches to plain python logging, using per-module loggers so that users can select the log level on a per-module level.

Closes #1075 