### PR TITLE
Fix allow_local for nicer and others

### DIFF
--- a/src/pint/event_toas.py
+++ b/src/pint/event_toas.py
@@ -83,7 +83,14 @@ def create_mission_config():
 
     # Allow local TOAs for those missions that have a load_<MISSION>_TOAs method
     for mission in ["nustar", "nicer", "xte"]:
-        mission_config[mission]["allow_local"] = True
+        try:
+            # If mission was read from HEASARC, just update allow_local
+            mission_config[mission]["allow_local"] = True
+        except KeyError:
+            # If mission was not read from HEASARC, then create full new entry
+            mission_config[mission] = {}
+            mission_config[mission].update(mission_config["generic"])
+            mission_config[mission]["allow_local"] = True
 
     # Fix xte
     mission_config["xte"]["fits_columns"] = {"ecol": "PHA"}

--- a/src/pint/event_toas.py
+++ b/src/pint/event_toas.py
@@ -68,12 +68,6 @@ def create_mission_config():
         }
     }
 
-    # Allow local TOAs for those missions that have a load_<MISSION>_TOAs method
-    for mission in ["nustar", "nicer", "xte"]:
-        mission_config[mission] = {}
-        mission_config[mission].update(mission_config["generic"])
-        mission_config["allow_local"] = True
-
     # Read the relevant information from $HEADAS/bin/xselect.mdb, if present
     for mission, data in read_mission_info_from_heasoft().items():
         mission_config[mission] = {"allow_local": False}
@@ -86,6 +80,10 @@ def create_mission_config():
             cols = {"ecol": str(ecol)}
         mission_config[mission]["fits_extension"] = ext
         mission_config[mission]["fits_columns"] = cols
+
+    # Allow local TOAs for those missions that have a load_<MISSION>_TOAs method
+    for mission in ["nustar", "nicer", "xte"]:
+        mission_config[mission]["allow_local"] = True
 
     # Fix xte
     mission_config["xte"]["fits_columns"] = {"ecol": "PHA"}

--- a/src/pint/eventstats.py
+++ b/src/pint/eventstats.py
@@ -87,7 +87,7 @@ def sig2sigma(sig, two_tailed=True, logprob=False):
         if np.any(logsig > 0):
             raise ValueError("Probability must be between 0 and 1.")
     else:
-        if np.any((sig > 1) | (sig < 0)):
+        if np.any((sig > 1) | (sig <= 0)):
             raise ValueError("Probability must be between 0 and 1.")
 
     if not two_tailed:

--- a/src/pint/eventstats.py
+++ b/src/pint/eventstats.py
@@ -87,7 +87,7 @@ def sig2sigma(sig, two_tailed=True, logprob=False):
         if np.any(logsig > 0):
             raise ValueError("Probability must be between 0 and 1.")
     else:
-        if np.any((sig > 1) | (sig <= 0)):
+        if np.any((sig > 1) | (sig < 0)):
             raise ValueError("Probability must be between 0 and 1.")
 
     if not two_tailed:


### PR DESCRIPTION
This fixes what I believe is a bug in event_toas.py.
It is supposed to set allow_local to True for the missions that have their own TOA loading method, but it was not working and was generating and ERROR message saying that NICER didn't support spacecraft local TOAs, which is not true.