### PR TITLE
Fix for improper arguments in fitter.get_summary()

### DIFF
--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -476,14 +476,14 @@ class Fitter:
                     mcmed = pint.derived_quantities.companion_mass(
                         self.model.PB.quantity,
                         self.model.A1.quantity,
-                        inc=60.0 * u.deg,
-                        mpsr=1.4 * u.solMass,
+                        i=60.0 * u.deg,
+                        mp=1.4 * u.solMass,
                     )
                     mcmin = pint.derived_quantities.companion_mass(
                         self.model.PB.quantity,
                         self.model.A1.quantity,
-                        inc=90.0 * u.deg,
-                        mpsr=1.4 * u.solMass,
+                        i=90.0 * u.deg,
+                        mp=1.4 * u.solMass,
                     )
                     s += "Companion mass min, median (assuming Mpsr = 1.4 Msun) = {:.4f}, {:.4f} Msun\n".format(
                         mcmin, mcmed

--- a/tests/test_fitter.py
+++ b/tests/test_fitter.py
@@ -13,6 +13,7 @@ from pint import fitter, toa
 from pinttestdata import datadir
 import pint.models.parameter as param
 from pint import ls
+from pint.models import get_model, get_model_and_toas
 
 
 @pytest.mark.xfail
@@ -195,3 +196,16 @@ def test_ftest_wb():
     # Test removing parallax
     Ftest_dict = wb_f.ftest(PX, PX_Component, remove=True, full_output=True)
     assert isinstance(Ftest_dict["ft"], float) or isinstance(Ftest_dict["ft"], bool)
+
+
+def test_fitsummary_binary():
+    """Test fitter print_summary() when an ELL1 binary is fit"""
+    par = os.path.join(datadir, "B1855+09_NANOGrav_12yv3.wb.gls.par")
+    tim = os.path.join(datadir, "B1855+09_NANOGrav_dfg+12.tim")
+
+    m, t = get_model_and_toas(par, tim)
+
+    f = fitter.WLSFitter(t, m)
+    f.model.free_params = ["PB", "A1", "SINI"]
+    f.fit_toas()
+    f.print_summary()


### PR DESCRIPTION
The signature for `companion_mass` changed and it didn't change in `fitter.get_summary()`.  This wasn't caught by testing since the summary was only printed for a non-binary pulsar, and the companion/pulsar mass lines are only called for binaries (need to be `ELL1` and have certain parameters free).

This has been fixed, and a new test (`test_fitsummary_binary()`) has been added to `tests/test_fitter.py` to check for it.