### PR TITLE
Pintk Residuals Axis Rescales

### DIFF
--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -920,30 +920,18 @@ class PlkWidget(tk.Frame):
             for i in range(len(rs)):
                 self.plkAxes.plot(f_toas_plot, rs[i], "-k", alpha=0.3)
 
-    def determine_yaxis_units(self, maxy, miny):
+    def determine_yaxis_units(self, miny, maxy):
         """Checks range of residuals and converts units if range sufficiently large/small."""
         diff = maxy - miny
-        if diff.unit is u.us:
-            if diff.value > 200000:
-                maxy = maxy.to(u.s)
-                miny = miny.to(u.s)
-            elif diff.value > 2000:
-                maxy = maxy.to(u.ms)
-                miny = miny.to(u.ms)
-        elif diff.unit is u.ms:
-            if diff.value <= 2:
-                maxy = maxy.to(u.us)
-                miny = miny.to(u.us)
-            elif diff.value > 2000:
-                maxy = maxy.to(u.s)
-                miny = miny.to(u.s)
-        else:
-            if diff.value <= 0.002:
-                maxy = maxy.to(u.us)
-                miny = miny.to(u.us)
-            elif diff.value <= 2:
-                maxy = maxy.to(u.ms)
-                miny = miny.to(u.ms)
+        if diff > 200000 * u.us:
+            maxy = maxy.to(u.s)
+            miny = miny.to(u.s)
+        elif diff > 200 * u.us:
+            maxy = maxy.to(u.ms)
+            miny = miny.to(u.ms)
+        elif diff <= 200 * u.us:
+            maxy = maxy.to(u.us)
+            miny = miny.to(u.us)
         return miny, maxy
 
     def print_info(self):

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -889,11 +889,14 @@ class PlkWidget(tk.Frame):
                     if self.yid == "pre-fit" or not self.psr.fitted
                     else self.psr.postfit_resids
                 )
-                f0 = r.get_PSR_freq().to(u.MHz).value
+                if y_unit == u.us:
+                    f0 = r.get_PSR_freq().to(u.MHz).value
+                elif y_unit == u.ms:
+                    f0 = r.get_PSR_freq().to(u.kHz).value
+                else:
+                    f0 = r.get_PSR_freq().to(u.Hz).value
                 self.plkAx2x.set_visible(True)
-                self.plkAx2x.set_ylabel(
-                    plotlabels[self.yid][1] + " (" + str(y_unit) + ")"
-                )
+                self.plkAx2x.set_ylabel(plotlabels[self.yid][1])
                 self.plkAx2x.set_ylim(ymin * f0, ymax * f0)
                 self.plkAx2x.yaxis.set_major_locator(
                     mpl.ticker.FixedLocator(self.plkAxes.get_yticks() * f0)

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -926,13 +926,13 @@ class PlkWidget(tk.Frame):
     def determine_yaxis_units(self, miny, maxy):
         """Checks range of residuals and converts units if range sufficiently large/small."""
         diff = maxy - miny
-        if diff > 200000 * u.us:
+        if diff > 0.2 * u.s:
             maxy = maxy.to(u.s)
             miny = miny.to(u.s)
-        elif diff > 200 * u.us:
+        elif diff > 0.2 * u.ms:
             maxy = maxy.to(u.ms)
             miny = miny.to(u.ms)
-        elif diff <= 200 * u.us:
+        elif diff <= 0.2 * u.ms:
             maxy = maxy.to(u.us)
             miny = miny.to(u.us)
         return miny, maxy

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1524,7 +1524,7 @@ class TOAs:
         In that case  ``self.table.meta['cluster_gap']``  will be set to the
         `gap_limit`.  If the desired clustering corresponds to that in
         :attr:`pint.toa.TOAs.table` then that column is returned.
-        
+
         Parameters
         ----------
         gap_limit : astropy.units.Quantity, optional
@@ -1655,16 +1655,16 @@ class TOAs:
         else:
             s += f"Number of commands:  {len(self.commands)}\n"
         s += f"Number of observatories: {len(self.observatories)} {list(self.observatories)}\n"
-        s += "MJD span:  {self.first_MJD.mjd:.3f} to {self.last_MJD.mjd:.3f}\n"
-        s += "Date span: {self.first_MJD.iso} to {self.last_MJD.iso}\n"
+        s += f"MJD span:  {self.first_MJD.mjd:.3f} to {self.last_MJD.mjd:.3f}\n"
+        s += f"Date span: {self.first_MJD.iso} to {self.last_MJD.iso}\n"
         for ii, key in enumerate(self.table.groups.keys):
             grp = self.table.groups[ii]
-            s += "{key['obs']} TOAs ({len(grp)}):\n"
-            s += "  Min freq:      {np.min(grp['freq'].to(u.MHz)):.3f}\n"
-            s += "  Max freq:      {np.max(grp['freq'].to(u.MHz)):.3f}\n"
-            s += "  Min error:     {np.min(grp['error'].to(u.us)):.3g}\n"
-            s += "  Max error:     {np.max(grp['error'].to(u.us)):.3g}\n"
-            s += "  Median error:  {np.median(grp['error'].to(u.us)):.3g}\n"
+            s += f"{key['obs']} TOAs ({len(grp)}):\n"
+            s += f"  Min freq:      {np.min(grp['freq'].to(u.MHz)):.3f}\n"
+            s += f"  Max freq:      {np.max(grp['freq'].to(u.MHz)):.3f}\n"
+            s += f"  Min error:     {np.min(grp['error'].to(u.us)):.3g}\n"
+            s += f"  Max error:     {np.max(grp['error'].to(u.us)):.3g}\n"
+            s += f"  Median error:  {np.median(grp['error'].to(u.us)):.3g}\n"
         return s
 
     def print_summary(self):

--- a/tests/test_plk_widget.py
+++ b/tests/test_plk_widget.py
@@ -15,43 +15,15 @@ def widget():
         (0 * u.us, 190 * u.us, 0 * u.us, 190 * u.us),
         (0 * u.us, 201 * u.us, 0 * u.ms, 0.201 * u.ms),
         (0 * u.us, 200001 * u.us, 0 * u.s, 0.200001 * u.s),
-    ],
-)
-def test_determine_yaxis_units_start_with_us(in_min, in_max, out_min, out_max, widget):
-    newmin, newmax = widget.determine_yaxis_units(in_min, in_max)
-
-    assert newmin.value == pytest.approx(out_min.value)
-    assert newmin.unit == out_min.unit
-    assert newmax.value == pytest.approx(out_max.value)
-    assert newmax.unit == out_max.unit
-
-
-@pytest.mark.parametrize(
-    "in_min,in_max,out_min,out_max",
-    [
         (0 * u.ms, 2.1 * u.ms, 0 * u.ms, 2.1 * u.ms),
         (0 * u.ms, 201 * u.ms, 0 * u.s, 0.201 * u.s),
         (0 * u.ms, 0.19 * u.ms, 0 * u.us, 190 * u.us),
-    ],
-)
-def test_determine_yaxis_units_start_with_ms(in_min, in_max, out_min, out_max, widget):
-    newmin, newmax = widget.determine_yaxis_units(in_min, in_max)
-
-    assert newmin.value == pytest.approx(out_min.value)
-    assert newmin.unit == out_min.unit
-    assert newmax.value == pytest.approx(out_max.value)
-    assert newmax.unit == out_max.unit
-
-
-@pytest.mark.parametrize(
-    "in_min,in_max,out_min,out_max",
-    [
         (0 * u.s, 0.21 * u.s, 0 * u.s, 0.21 * u.s),
         (0 * u.s, 0.19 * u.s, 0 * u.ms, 190 * u.ms),
         (0 * u.s, 0.00019 * u.s, 0 * u.us, 190 * u.us),
     ],
 )
-def test_yaxis_units_start_with_s(in_min, in_max, out_min, out_max, widget):
+def test_determine_yaxis_units(in_min, in_max, out_min, out_max, widget):
     newmin, newmax = widget.determine_yaxis_units(in_min, in_max)
 
     assert newmin.value == pytest.approx(out_min.value)

--- a/tests/test_plk_widget.py
+++ b/tests/test_plk_widget.py
@@ -1,0 +1,85 @@
+import astropy.units as u
+import unittest
+from pint.pintk.plk import PlkWidget
+
+
+class TestPlkWidget(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.widget = PlkWidget()
+
+    def test_determine_yaxis_units(self):
+        # test interval where no unit conversion happens
+        miny = 5 * u.us
+        maxy = 10 * u.us
+        newmin, newmax = self.widget.determine_yaxis_units(maxy, miny)
+
+        self.assertAlmostEqual(newmin.value, miny.value)
+        self.assertEqual(newmin.unit, miny.unit)
+        self.assertAlmostEqual(newmax.value, maxy.value)
+        self.assertEqual(newmax.unit, maxy.unit)
+
+        # test interval where u.us converted to u.ms
+        maxy = 10000 * u.us
+        newmin, newmax = self.widget.determine_yaxis_units(maxy, miny)
+
+        self.assertAlmostEqual(newmin.value, 0.005)
+        self.assertEqual(newmin.unit, u.ms)
+        self.assertAlmostEqual(newmax.value, 10)
+        self.assertEqual(newmax.unit, u.ms)
+
+        # test interval where u.us converted to u.s
+        maxy = 210000 * u.us
+        newmin, newmax = self.widget.determine_yaxis_units(maxy, miny)
+
+        self.assertAlmostEqual(newmin.value, 0.000005)
+        self.assertEqual(newmin.unit, u.s)
+        self.assertAlmostEqual(newmax.value, 0.21)
+        self.assertEqual(newmax.unit, u.s)
+
+        # test u.ms to u.ms
+        miny = 5 * u.ms
+        maxy = 10 * u.ms
+        newmin, newmax = self.widget.determine_yaxis_units(maxy, miny)
+
+        self.assertAlmostEqual(newmin.value, miny.value)
+        self.assertEqual(newmin.unit, miny.unit)
+        self.assertAlmostEqual(newmax.value, maxy.value)
+        self.assertEqual(newmax.unit, maxy.unit)
+
+        # test u.ms to u.s
+        maxy = 10000 * u.ms
+        newmin, newmax = self.widget.determine_yaxis_units(maxy, miny)
+
+        self.assertAlmostEqual(newmin.value, 0.005)
+        self.assertEqual(newmin.unit, u.s)
+        self.assertAlmostEqual(newmax.value, 10)
+        self.assertEqual(newmax.unit, u.s)
+
+        # test u.ms to u.us
+        maxy = 6 * u.ms
+        newmin, newmax = self.widget.determine_yaxis_units(maxy, miny)
+
+        self.assertAlmostEqual(newmin.value, 5000)
+        self.assertEqual(newmin.unit, u.us)
+        self.assertAlmostEqual(newmax.value, 6000)
+        self.assertEqual(newmax.unit, u.us)
+
+        # test u.s to u.s
+        miny = 5 * u.s
+        maxy = 10 * u.s
+        newmin, newmax = self.widget.determine_yaxis_units(maxy, miny)
+
+        self.assertAlmostEqual(newmin.value, miny.value)
+        self.assertEqual(newmin.unit, miny.unit)
+        self.assertAlmostEqual(newmax.value, maxy.value)
+        self.assertEqual(newmax.unit, maxy.unit)
+
+        # test u.s to u.ms
+        maxy = 5.5 * u.us
+        newmin, newmax = self.widget.determine_yaxis_units(maxy, miny)
+
+        self.assertAlmostEqual(newmin.value, miny.value)
+        self.assertEqual(newmin.unit, miny.unit)
+        self.assertAlmostEqual(newmax.value, maxy.value)
+        self.assertEqual(newmax.unit, maxy.unit)

--- a/tests/test_plk_widget.py
+++ b/tests/test_plk_widget.py
@@ -4,6 +4,11 @@ from pint.pintk.plk import PlkWidget
 from tkinter import Frame
 
 
+@pytest.fixture
+def widget():
+    return Frame.__new__(PlkWidget)
+
+
 @pytest.mark.parametrize(
     "in_min,in_max,out_min,out_max",
     [
@@ -12,8 +17,7 @@ from tkinter import Frame
         (0 * u.us, 200001 * u.us, 0 * u.s, 0.200001 * u.s),
     ],
 )
-def test_determine_yaxis_units_start_with_us(in_min, in_max, out_min, out_max):
-    widget = Frame.__new__(PlkWidget)
+def test_determine_yaxis_units_start_with_us(in_min, in_max, out_min, out_max, widget):
     newmin, newmax = widget.determine_yaxis_units(in_min, in_max)
 
     assert newmin.value == pytest.approx(out_min.value)
@@ -30,8 +34,7 @@ def test_determine_yaxis_units_start_with_us(in_min, in_max, out_min, out_max):
         (0 * u.ms, 0.19 * u.ms, 0 * u.us, 190 * u.us),
     ],
 )
-def test_determine_yaxis_units_start_with_ms(in_min, in_max, out_min, out_max):
-    widget = Frame.__new__(PlkWidget)
+def test_determine_yaxis_units_start_with_ms(in_min, in_max, out_min, out_max, widget):
     newmin, newmax = widget.determine_yaxis_units(in_min, in_max)
 
     assert newmin.value == pytest.approx(out_min.value)
@@ -48,8 +51,7 @@ def test_determine_yaxis_units_start_with_ms(in_min, in_max, out_min, out_max):
         (0 * u.s, 0.00019 * u.s, 0 * u.us, 190 * u.us),
     ],
 )
-def test_yaxis_units_start_with_s(in_min, in_max, out_min, out_max):
-    widget = Frame.__new__(PlkWidget)
+def test_yaxis_units_start_with_s(in_min, in_max, out_min, out_max, widget):
     newmin, newmax = widget.determine_yaxis_units(in_min, in_max)
 
     assert newmin.value == pytest.approx(out_min.value)

--- a/tests/test_plk_widget.py
+++ b/tests/test_plk_widget.py
@@ -1,87 +1,58 @@
 import astropy.units as u
-import unittest
+import pytest
 from pint.pintk.plk import PlkWidget
 from tkinter import Frame
 
 
-class TestPlkWidget(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        # use __new__ to prevent an actual tkinter window from popping up
-        cls.widget = Frame.__new__(PlkWidget)
+@pytest.mark.parametrize(
+    "in_min,in_max,out_min,out_max",
+    [
+        (0 * u.us, 190 * u.us, 0 * u.us, 190 * u.us),
+        (0 * u.us, 201 * u.us, 0 * u.ms, 0.201 * u.ms),
+        (0 * u.us, 200001 * u.us, 0 * u.s, 0.200001 * u.s),
+    ],
+)
+def test_determine_yaxis_units_start_with_us(in_min, in_max, out_min, out_max):
+    widget = Frame.__new__(PlkWidget)
+    newmin, newmax = widget.determine_yaxis_units(in_min, in_max)
 
-    def test_determine_yaxis_units(self):
-        # test interval where no unit conversion happens
-        miny = 5 * u.us
-        maxy = 10 * u.us
-        newmin, newmax = self.widget.determine_yaxis_units(maxy, miny)
+    assert newmin.value == pytest.approx(out_min.value)
+    assert newmin.unit == out_min.unit
+    assert newmax.value == pytest.approx(out_max.value)
+    assert newmax.unit == out_max.unit
 
-        self.assertAlmostEqual(newmin.value, miny.value)
-        self.assertEqual(newmin.unit, miny.unit)
-        self.assertAlmostEqual(newmax.value, maxy.value)
-        self.assertEqual(newmax.unit, maxy.unit)
 
-        # test interval where u.us converted to u.ms
-        maxy = 10000 * u.us
-        newmin, newmax = self.widget.determine_yaxis_units(maxy, miny)
+@pytest.mark.parametrize(
+    "in_min,in_max,out_min,out_max",
+    [
+        (0 * u.ms, 2.1 * u.ms, 0 * u.ms, 2.1 * u.ms),
+        (0 * u.ms, 201 * u.ms, 0 * u.s, 0.201 * u.s),
+        (0 * u.ms, 0.19 * u.ms, 0 * u.us, 190 * u.us),
+    ],
+)
+def test_determine_yaxis_units_start_with_ms(in_min, in_max, out_min, out_max):
+    widget = Frame.__new__(PlkWidget)
+    newmin, newmax = widget.determine_yaxis_units(in_min, in_max)
 
-        self.assertAlmostEqual(newmin.value, 0.005)
-        self.assertEqual(newmin.unit, u.ms)
-        self.assertAlmostEqual(newmax.value, 10)
-        self.assertEqual(newmax.unit, u.ms)
+    assert newmin.value == pytest.approx(out_min.value)
+    assert newmin.unit == out_min.unit
+    assert newmax.value == pytest.approx(out_max.value)
+    assert newmax.unit == out_max.unit
 
-        # test interval where u.us converted to u.s
-        maxy = 210000 * u.us
-        newmin, newmax = self.widget.determine_yaxis_units(maxy, miny)
 
-        self.assertAlmostEqual(newmin.value, 0.000005)
-        self.assertEqual(newmin.unit, u.s)
-        self.assertAlmostEqual(newmax.value, 0.21)
-        self.assertEqual(newmax.unit, u.s)
+@pytest.mark.parametrize(
+    "in_min,in_max,out_min,out_max",
+    [
+        (0 * u.s, 0.21 * u.s, 0 * u.s, 0.21 * u.s),
+        (0 * u.s, 0.19 * u.s, 0 * u.ms, 190 * u.ms),
+        (0 * u.s, 0.00019 * u.s, 0 * u.us, 190 * u.us),
+    ],
+)
+def test_yaxis_units_start_with_s(in_min, in_max, out_min, out_max):
+    widget = Frame.__new__(PlkWidget)
+    newmin, newmax = widget.determine_yaxis_units(in_min, in_max)
 
-        # test u.ms to u.ms
-        miny = 5 * u.ms
-        maxy = 10 * u.ms
-        newmin, newmax = self.widget.determine_yaxis_units(maxy, miny)
-
-        self.assertAlmostEqual(newmin.value, miny.value)
-        self.assertEqual(newmin.unit, miny.unit)
-        self.assertAlmostEqual(newmax.value, maxy.value)
-        self.assertEqual(newmax.unit, maxy.unit)
-
-        # test u.ms to u.s
-        maxy = 10000 * u.ms
-        newmin, newmax = self.widget.determine_yaxis_units(maxy, miny)
-
-        self.assertAlmostEqual(newmin.value, 0.005)
-        self.assertEqual(newmin.unit, u.s)
-        self.assertAlmostEqual(newmax.value, 10)
-        self.assertEqual(newmax.unit, u.s)
-
-        # test u.ms to u.us
-        maxy = 6 * u.ms
-        newmin, newmax = self.widget.determine_yaxis_units(maxy, miny)
-
-        self.assertAlmostEqual(newmin.value, 5000)
-        self.assertEqual(newmin.unit, u.us)
-        self.assertAlmostEqual(newmax.value, 6000)
-        self.assertEqual(newmax.unit, u.us)
-
-        # test u.s to u.s
-        miny = 5 * u.s
-        maxy = 10 * u.s
-        newmin, newmax = self.widget.determine_yaxis_units(maxy, miny)
-
-        self.assertAlmostEqual(newmin.value, miny.value)
-        self.assertEqual(newmin.unit, miny.unit)
-        self.assertAlmostEqual(newmax.value, maxy.value)
-        self.assertEqual(newmax.unit, maxy.unit)
-
-        # test u.s to u.ms
-        maxy = 5.5 * u.us
-        newmin, newmax = self.widget.determine_yaxis_units(maxy, miny)
-
-        self.assertAlmostEqual(newmin.value, miny.value)
-        self.assertEqual(newmin.unit, miny.unit)
-        self.assertAlmostEqual(newmax.value, maxy.value)
-        self.assertEqual(newmax.unit, maxy.unit)
+    assert newmin.value == pytest.approx(out_min.value)
+    assert newmin.unit == out_min.unit
+    assert newmax.value == pytest.approx(out_max.value)
+    assert newmax.unit == out_max.unit

--- a/tests/test_plk_widget.py
+++ b/tests/test_plk_widget.py
@@ -1,12 +1,14 @@
 import astropy.units as u
 import unittest
 from pint.pintk.plk import PlkWidget
+from tkinter import Frame
 
 
 class TestPlkWidget(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.widget = PlkWidget()
+        # use __new__ to prevent an actual tkinter window from popping up
+        cls.widget = Frame.__new__(PlkWidget)
 
     def test_determine_yaxis_units(self):
         # test interval where no unit conversion happens


### PR DESCRIPTION
Addresses issue #1081 and converts the units for residuals in pintk when a sufficiently large/small range is met. us, ms, and s are supported. A test file for the PlkWidget was added with a test for the scaling function; this could be a starting point for adding more tests for plk.py in general. Additionally, a minor bug fix to toa.py was made, where print statements with special formatting were missing the special formatting indicator.