### PR TITLE
Make `change_binary_epoch` more cautious and also not broken

### DIFF
--- a/tests/test_change_epoch.py
+++ b/tests/test_change_epoch.py
@@ -199,9 +199,8 @@ def test_change_binary_epoch(binary_model):
     # new_epoch is within a single binary period of t0
     assert start_time < t0 < end_time
 
-    t1 = new_epoch + PB/3
+    t1 = new_epoch + PB / 3
     model_2 = copy.deepcopy(model)
     model_2.change_binary_epoch(t1)
     for p in model.params:
         assert getattr(model, p).quantity == getattr(model_2, p).quantity
-

--- a/tests/test_change_epoch.py
+++ b/tests/test_change_epoch.py
@@ -198,3 +198,10 @@ def test_change_binary_epoch(binary_model):
 
     # new_epoch is within a single binary period of t0
     assert start_time < t0 < end_time
+
+    t1 = new_epoch + PB/3
+    model_2 = copy.deepcopy(model)
+    model_2.change_binary_epoch(t1)
+    for p in model.params:
+        assert getattr(model, p).quantity == getattr(model_2, p).quantity
+


### PR DESCRIPTION
Use the correct integer number of orbits to update `FBn` parameters. Also if not moving TASC/T0 make absolutely no changes (bail out early). 

Incidentally only warn about approximate TASC/T0 computation (FB2 etc are not used) if the epoch is actually changed.

Includes tests.

Fixes #1119