### PR TITLE
Fix fake toas

### DIFF
--- a/docs/examples/Simulate_and_make_MassMass.py
+++ b/docs/examples/Simulate_and_make_MassMass.py
@@ -33,6 +33,7 @@ import io
 import pint.fitter
 from pint.models import get_model
 import pint.derived_quantities
+import pint.simulation
 
 
 # %% [markdown]
@@ -208,7 +209,7 @@ error = 5 * u.us
 Ntoa = 1000
 # make the new TOAs.  Note that even though `error` is passed, the TOAs
 # start out perfect
-tnew = pint.toa.make_fake_toas(
+tnew = pint.simulation.make_fake_toas_uniform(
     tstart.mjd * u.d, tstop.mjd * u.s, Ntoa, model=m, obs="ARECIBO", error=error
 )
 # So we have to still add in some noise

--- a/docs/examples/Simulate_and_make_MassMass.py
+++ b/docs/examples/Simulate_and_make_MassMass.py
@@ -210,7 +210,7 @@ Ntoa = 1000
 # make the new TOAs.  Note that even though `error` is passed, the TOAs
 # start out perfect
 tnew = pint.simulation.make_fake_toas_uniform(
-    tstart.mjd * u.d, tstop.mjd * u.s, Ntoa, model=m, obs="ARECIBO", error=error
+    tstart.mjd * u.d, tstop.mjd * u.d, Ntoa, model=m, obs="ARECIBO", error=error
 )
 # So we have to still add in some noise
 tnew.adjust_TOAs(astropy.time.TimeDelta(np.random.normal(size=len(tnew)) * error))

--- a/docs/examples/check_phase_connection.py
+++ b/docs/examples/check_phase_connection.py
@@ -25,7 +25,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import astropy.units as u
 
-import pint.fitter, pint.toa
+import pint.fitter, pint.toa, pint.simulation
 from pint.models import get_model_and_toas
 from pint import utils
 import pint.config
@@ -53,7 +53,7 @@ print("Current last TOA: MJD {}".format(f.model.FINISH.quantity))
 # so make fake TOAs to cover the gap
 MJDmax = 59000
 # the number of TOAs is arbitrary since it's mostly for visualization
-tnew = pint.toa.make_fake_toas(f.model.FINISH.value, MJDmax, 50, f.model)
+tnew = pint.simulation.make_fake_toas_uniform(f.model.FINISH.value, MJDmax, 50, f.model)
 
 
 # %%

--- a/docs/examples/check_phase_connection.py
+++ b/docs/examples/check_phase_connection.py
@@ -18,7 +18,7 @@
 #
 # This notebook is meant to answer a common type of question: when I have a solution for a pulsar that goes from ${\rm MJD}_1$ to ${\rm MJD}_2$, can I confidently phase connect it to other data starting at ${\rm MJD}_3$?  What is the phase uncertainty bridging the gap from $\Delta t={\rm MJD}_3-{\rm MJD}_2$?
 #
-# This notebook will start with standard pulsar timing.  It will then use the `utils/calculate_random_models` function to propagate the phase uncertainties forward and examine what happens.
+# This notebook will start with standard pulsar timing.  It will then use the `simulation/calculate_random_models` function to propagate the phase uncertainties forward and examine what happens.
 
 # %%
 import matplotlib.pyplot as plt
@@ -27,7 +27,7 @@ import astropy.units as u
 
 import pint.fitter, pint.toa, pint.simulation
 from pint.models import get_model_and_toas
-from pint import utils
+from pint import utils, simulation
 import pint.config
 
 # %%
@@ -58,7 +58,7 @@ tnew = pint.simulation.make_fake_toas_uniform(f.model.FINISH.value, MJDmax, 50, 
 
 # %%
 # make fake models crossing from the last existing TOA to the start of new observations
-dphase, mrand = utils.calculate_random_models(f, tnew, Nmodels=100)
+dphase, mrand = simulation.calculate_random_models(f, tnew, Nmodels=100)
 # this is the difference in time across the gap
 dt = tnew.get_mjds() - f.model.PEPOCH.value * u.d
 

--- a/src/pint/models/pulsar_binary.py
+++ b/src/pint/models/pulsar_binary.py
@@ -361,7 +361,7 @@ class PulsarBinary(DelayComponent):
         (FB2, FB3, etc.) are ignored in computing the new T0, even if present in
         the model. If high-precision results are necessary, especially for models
         containing higher derivatives of orbital frequency, consider re-fitting
-        the model to a set of TOAs. The use of :func:`pint.toa.make_fake_toas`
+        the model to a set of TOAs. The use of :func:`pint.simulation.make_fake_toas`
         and the :class:`pint.fitter.Fitter` option ``track_mode="use_pulse_number"``
         can make this extremely simple.
 

--- a/src/pint/random_models.py
+++ b/src/pint/random_models.py
@@ -6,6 +6,7 @@ import numpy as np
 from astropy import log
 
 import pint.toa as toa
+import pint.simulation as simulation
 from pint.phase import Phase
 
 __all__ = ["random_models"]
@@ -61,13 +62,13 @@ def random_models(
     spanMJDs = maxMJD - minMJD
     # ledge and redge _multiplier control how far the fake toas extend
     # in either direction of the selected points
-    x = toa.make_fake_toas(
+    x = simulation.make_fake_toas_uniform(
         minMJD - spanMJDs * ledge_multiplier,
         maxMJD + spanMJDs * redge_multiplier,
         npoints,
         mrand,
     )
-    x2 = toa.make_fake_toas(minMJD, maxMJD, npoints, mrand)
+    x2 = simulation.make_fake_toas_uniform(minMJD, maxMJD, npoints, mrand)
 
     rss = []
     random_models = []

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -244,7 +244,7 @@ class Residuals:
 
         Parameters
         ----------
-        calctype : str, optional
+        calctype : {'modelF0', 'numerical', 'taylor'}
             Type of calculation.  If `calctype` == "modelF0", then simply the ``F0``
             parameter from the model.
             If `calctype` == "numerical", then try a numerical derivative
@@ -354,7 +354,7 @@ class Residuals:
 
         Parameters
         ----------
-        calctype : str, optional
+        calctype : {'modelF0', 'numerical', 'taylor'}
             Type of calculation.  If `calctype` == "modelF0", then simply the ``F0``
             parameter from the model.
             If `calctype` == "numerical", then try a numerical derivative

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -346,7 +346,7 @@ class Residuals:
             mean, err = weighted_mean(full, w)
         return full - mean
 
-    def calc_time_resids(self, calctype="modelF0"):
+    def calc_time_resids(self, calctype="taylor"):
         """Compute timing model residuals in time (seconds).
 
         Converts from phase residuals to time residuals using several possible ways
@@ -354,7 +354,7 @@ class Residuals:
 
         Parameters
         ----------
-        calctype : {'modelF0', 'numerical', 'taylor'}
+        calctype : {'taylor', 'modelF0', 'numerical'}
             Type of calculation.  If `calctype` == "modelF0", then simply the ``F0``
             parameter from the model.
             If `calctype` == "numerical", then try a numerical derivative

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -17,7 +17,7 @@ from scipy.linalg import LinAlgError
 
 from pint.models.dispersion_model import Dispersion
 from pint.phase import Phase
-from pint.utils import weighted_mean
+from pint.utils import weighted_mean, taylor_horner_deriv
 
 __all__ = [
     "Residuals",
@@ -239,21 +239,24 @@ class Residuals:
         wmean, werr, wsdev = weighted_mean(self.time_resids, w, sdev=True)
         return wsdev.to(u.us)
 
-    def get_PSR_freq(self, modelF0=True):
+    def get_PSR_freq(self, calctype="modelF0"):
         """Return pulsar rotational frequency in Hz.
 
         Parameters
         ----------
-        modelF0 : bool, optional
-            If True, simply read the ``F0`` parameter from the model. If False,
-            query the model for the spin period at the time of each TOA.
+        calctype : str, optional
+            Type of calculation.  If `calctype` == "modelF0", then simply the ``F0``
+            parameter from the model.
+            If `calctype` == "numerical", then try a numerical derivative
+            If `calctype` == "taylor", evaluate the frequency with a Taylor series
 
         Returns
         -------
-        freq : Quantity
+        freq : astropy.units.Quantity
             Either the single ``F0`` in the model or the spin frequency at the moment of each TOA.
         """
-        if modelF0:
+        assert calctype in ["modelF0", "taylor", "numerical"]
+        if calctype == "modelF0":
             # TODO this function will be re-write and move to timing model soon.
             # The following is a temproary patch.
             if "Spindown" in self.model.components:
@@ -265,7 +268,12 @@ class Residuals:
                     "No pulsar spin parameter(e.g., 'F0'," " 'P0') found."
                 )
             return F0.to(u.Hz)
-        else:
+        elif calctype == "taylor":
+            # see Spindown.spindown_phase
+            dt = self.model.get_dt(self.toas, 0)
+            fterms = [0.0 * u.dimensionless_unscaled] + self.model.get_spin_terms()
+            return taylor_horner_deriv(dt, fterms, deriv_order=1).to(u.Hz)
+        elif calctype == "numerical":
             return self.model.d_phase_d_toa(self.toas)
 
     def calc_phase_resids(self):
@@ -338,11 +346,32 @@ class Residuals:
             mean, err = weighted_mean(full, w)
         return full - mean
 
-    def calc_time_resids(self):
-        """Compute timing model residuals in time (seconds)."""
+    def calc_time_resids(self, calctype="modelF0"):
+        """Compute timing model residuals in time (seconds).
+
+        Converts from phase residuals to time residuals using several possible ways
+        to calculate the frequency.
+
+        Parameters
+        ----------
+        calctype : str, optional
+            Type of calculation.  If `calctype` == "modelF0", then simply the ``F0``
+            parameter from the model.
+            If `calctype` == "numerical", then try a numerical derivative
+            If `calctype` == "taylor", evaluate the frequency with a Taylor series
+
+        Returns
+        -------
+        residuals : astropy.units.Quantity
+
+        See Also
+        --------
+        :meth:`pint.residuals.get_PSR_freq`
+        """
+        assert calctype in ["modelF0", "taylor", "numerical"]
         if self.phase_resids is None:
             self.phase_resids = self.calc_phase_resids()
-        return (self.phase_resids / self.get_PSR_freq()).to(u.s)
+        return (self.phase_resids / self.get_PSR_freq(calctype=calctype)).to(u.s)
 
     def calc_chi2(self, full_cov=False):
         """Return the weighted chi-squared for the model and toas.

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -255,7 +255,7 @@ class Residuals:
         freq : astropy.units.Quantity
             Either the single ``F0`` in the model or the spin frequency at the moment of each TOA.
         """
-        assert calctype.lower() in ["modelF0", "taylor", "numerical"]
+        assert calctype.lower() in ["modelf0", "taylor", "numerical"]
         if calctype.lower() == "modelf0":
             # TODO this function will be re-write and move to timing model soon.
             # The following is a temproary patch.

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -255,8 +255,8 @@ class Residuals:
         freq : astropy.units.Quantity
             Either the single ``F0`` in the model or the spin frequency at the moment of each TOA.
         """
-        assert calctype in ["modelF0", "taylor", "numerical"]
-        if calctype == "modelF0":
+        assert calctype.lower() in ["modelF0", "taylor", "numerical"]
+        if calctype.lower() == "modelf0":
             # TODO this function will be re-write and move to timing model soon.
             # The following is a temproary patch.
             if "Spindown" in self.model.components:
@@ -268,12 +268,12 @@ class Residuals:
                     "No pulsar spin parameter(e.g., 'F0'," " 'P0') found."
                 )
             return F0.to(u.Hz)
-        elif calctype == "taylor":
+        elif calctype.lower() == "taylor":
             # see Spindown.spindown_phase
             dt = self.model.get_dt(self.toas, 0)
             fterms = [0.0 * u.dimensionless_unscaled] + self.model.get_spin_terms()
             return taylor_horner_deriv(dt, fterms, deriv_order=1).to(u.Hz)
-        elif calctype == "numerical":
+        elif calctype.lower() == "numerical":
             return self.model.d_phase_d_toa(self.toas)
 
     def calc_phase_resids(self):
@@ -368,7 +368,7 @@ class Residuals:
         --------
         :meth:`pint.residuals.get_PSR_freq`
         """
-        assert calctype in ["modelF0", "taylor", "numerical"]
+        assert calctype.lower() in ["modelf0", "taylor", "numerical"]
         if self.phase_resids is None:
             self.phase_resids = self.calc_phase_resids()
         return (self.phase_resids / self.get_PSR_freq(calctype=calctype)).to(u.s)

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -271,7 +271,18 @@ class Residuals:
         elif calctype.lower() == "taylor":
             # see Spindown.spindown_phase
             dt = self.model.get_dt(self.toas, 0)
-            fterms = [0.0 * u.dimensionless_unscaled] + self.model.get_spin_terms()
+            # if the model is defined through F0, F1, ...
+            if "F0" in self.model.params:
+                fterms = [0.0 * u.dimensionless_unscaled] + self.model.get_spin_terms()
+
+            # otherwise assume P0, PDOT
+            else:
+                F0 = 1.0 / self.model.P0.quantity
+                if "PDOT" in self.model.params:
+                    F1 = -self.model.PDOT.quantity / self.model.P0.quantity ** 2
+                else:
+                    F1 = 0 * u.Hz / u.s
+                fterms = [0.0 * u.dimensionless_unscaled, F0, F1]
             return taylor_horner_deriv(dt, fterms, deriv_order=1).to(u.Hz)
         elif calctype.lower() == "numerical":
             return self.model.d_phase_d_toa(self.toas)

--- a/src/pint/scripts/zima.py
+++ b/src/pint/scripts/zima.py
@@ -8,22 +8,12 @@ from astropy.time import TimeDelta
 import pint.fitter
 import pint.models
 import pint.toa as toa
-from pint.observatory import get_observatory
+import pint.simulation
+import pint.residuals
 
 __all__ = ["main"]
 
 # log.setLevel("INFO")
-
-
-def get_freq_array(base_freq_values, ntoas):
-    """Right now it is a very simple frequency array simulation.
-       It just simulates an alternating frequency arrays
-    """
-    freq = np.zeros(ntoas)
-    num_freqs = len(base_freq_values)
-    for ii, fv in enumerate(base_freq_values):
-        freq[ii::num_freqs] = fv
-    return freq
 
 
 def main(argv=None):
@@ -65,6 +55,12 @@ def main(argv=None):
         default=1.0,
     )
     parser.add_argument(
+        "--addnoise",
+        action="store_true",
+        default=False,
+        help="Actually add in random noise, or just populate the column",
+    )
+    parser.add_argument(
         "--fuzzdays",
         help="Standard deviation of 'fuzz' distribution (jd) (default: 0.0)",
         type=float,
@@ -72,13 +68,6 @@ def main(argv=None):
     )
     parser.add_argument(
         "--plot", help="Plot residuals", action="store_true", default=False
-    )
-    parser.add_argument("--ephem", help="Ephemeris to use", default="DE421")
-    parser.add_argument(
-        "--planets",
-        help="Use planetary Shapiro delay",
-        action="store_true",
-        default=False,
     )
     parser.add_argument(
         "--format", help="The format of out put .tim file.", default="TEMPO2"
@@ -93,59 +82,28 @@ def main(argv=None):
 
     if args.inputtim is None:
         log.info("Generating uniformly spaced TOAs")
-        duration = args.duration * u.day
-        # start = Time(args.startMJD,scale='utc',format='pulsar_mjd',precision=9)
-        start = np.longdouble(args.startMJD) * u.day
-        freq = np.atleast_1d(args.freq) * u.MHz
-        site = get_observatory(args.obs)
-        scale = site.timescale
-
-        times = np.linspace(0, duration.to(u.day).value, args.ntoa) * u.day + start
-
-        # 'Fuzz' out times
-        if args.fuzzdays > 0.0:
-            fuzz = np.random.normal(scale=args.fuzzdays, size=len(times)) * u.day
-            times += fuzz
-
-        # Add mulitple frequency
-        freq_array = get_freq_array(freq, len(times))
-        tl = [
-            toa.TOA(t.value, error=error, obs=args.obs, freq=f, scale=scale)
-            for t, f in zip(times, freq_array)
-        ]
-        ts = toa.TOAs(toalist=tl)
+        ts = pint.simulation.make_fake_toas_uniform(
+            startMJD=args.startMJD,
+            endMJD=args.startMJD + args.duration,
+            ntoas=args.ntoa,
+            model=m,
+            obs=args.obs,
+            error=error,
+            freq=np.atleast_1d(args.freq) * u.MHz,
+            fuzz=args.fuzzdays * u.d,
+            add_noise=args.addnoise,
+        )
     else:
         log.info("Reading initial TOAs from {0}".format(args.inputtim))
-        ts = toa.TOAs(toafile=args.inputtim)
-        ts.table["error"][:] = error
-
-    # WARNING! I'm not sure how clock corrections should be handled here!
-    # Do we apply them, or not?
-    if not any(["clkcorr" in f for f in ts.table["flags"]]):
-        log.info("Applying clock corrections.")
-        ts.apply_clock_corrections()
-    if "tdb" not in ts.table.colnames:
-        log.info("Getting IERS params and computing TDBs.")
-        ts.compute_TDBs(ephem=args.ephem)
-    if "ssb_obs_pos" not in ts.table.colnames:
-        log.info("Computing observatory positions and velocities.")
-        ts.compute_posvels(args.ephem, args.planets)
-
-    log.info("Creating TOAs")
-    F_local = m.d_phase_d_toa(ts)
-    rs = m.phase(ts).frac / F_local
-
-    # Adjust the TOA times to put them where their residuals will be 0.0
-    ts.adjust_TOAs(TimeDelta(-1.0 * rs))
-    rspost = m.phase(ts).frac / F_local
-
-    log.info("Second iteration")
-    # Do a second iteration
-    ts.adjust_TOAs(TimeDelta(-1.0 * rspost))
-
-    err = np.random.randn(len(ts.table)) * error
-    # Add the actual error fuzzing
-    ts.adjust_TOAs(TimeDelta(err))
+        ts = pint.simulation.make_fake_toas_fromtim(
+            args.inputtim,
+            model=m,
+            obs=args.obs,
+            error=error,
+            freq=np.atleast_1d(args.freq) * u.MHz,
+            fuzz=args.fuzzdays * u.d,
+            add_noise=args.addnoise,
+        )
 
     # Write TOAs to a file
     ts.write_TOA_file(args.timfile, name="fake", format=out_format)
@@ -157,16 +115,13 @@ def main(argv=None):
 
         quantity_support()
 
-        rspost2 = m.phase(ts).frac / F_local
+        r = pint.residuals.Residuals(ts, m)
         plt.errorbar(
-            ts.get_mjds(), rspost2.to(u.us), yerr=ts.get_errors().to(u.us), fmt="."
+            ts.get_mjds(),
+            r.calc_time_resids().to(u.us),
+            yerr=ts.get_errors().to(u.us),
+            fmt=".",
         )
-        newts = pint.toa.get_TOAs(args.timfile, ephem=args.ephem, planets=args.planets)
-        rsnew = m.phase(newts).frac / F_local
-        plt.errorbar(
-            newts.get_mjds(), rsnew.to(u.us), yerr=newts.get_errors().to(u.us), fmt="."
-        )
-        # plt.plot(ts.get_mjds(),rspost.to(u.us),'x')
         plt.xlabel("MJD")
         plt.ylabel("Residual (us)")
         plt.grid(True)

--- a/src/pint/scripts/zima.py
+++ b/src/pint/scripts/zima.py
@@ -118,7 +118,7 @@ def main(argv=None):
         r = pint.residuals.Residuals(ts, m)
         plt.errorbar(
             ts.get_mjds(),
-            r.calc_time_resids().to(u.us),
+            r.calc_time_resids(calctype='taylor').to(u.us),
             yerr=ts.get_errors().to(u.us),
             fmt=".",
         )

--- a/src/pint/scripts/zima.py
+++ b/src/pint/scripts/zima.py
@@ -118,7 +118,7 @@ def main(argv=None):
         r = pint.residuals.Residuals(ts, m)
         plt.errorbar(
             ts.get_mjds(),
-            r.calc_time_resids(calctype='taylor').to(u.us),
+            r.calc_time_resids(calctype="taylor").to(u.us),
             yerr=ts.get_errors().to(u.us),
             fmt=".",
         )

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -60,9 +60,15 @@ def zero_residuals(ts, model, maxiter=10, tolerance=1 * u.ns):
         maximum allowed absolute deviation of residuals from 0
     """
     ts.compute_pulse_numbers(model)
+    maxresid = None
     for i in range(maxiter):
         r = pint.residuals.Residuals(ts, model, track_mode="use_pulse_numbers")
         resids = r.calc_time_resids(calctype="taylor")
+        if maxresid is not None and (np.abs(resids).max() > maxresid):
+            log.warning(
+                f"Residual increasing at iteration {i} while attempting to simulate TOAs"
+            )
+        maxresid = np.abs(resids).max()
         if abs(resids).max() < tolerance:
             break
         ts.adjust_TOAs(-time.TimeDelta(resids))

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -1,3 +1,5 @@
+"""Functions related to simulating TOAs and models
+"""
 from collections import OrderedDict
 from copy import deepcopy
 import numpy as np

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -44,10 +44,7 @@ def get_freq_array(base_frequencies, ntoas):
 
 
 def make_fake_toas(
-    ts,
-    model,
-    add_noise=False,
-    name="fake",
+    ts, model, add_noise=False, name="fake",
 ):
     """Make toas from an array of times
 
@@ -217,10 +214,7 @@ def make_fake_toas_uniform(
 
 
 def make_fake_toas_fromtim(
-    timfile,
-    model,
-    add_noise=False,
-    name="fake",
+    timfile, model, add_noise=False, name="fake",
 ):
     """Make fake toas with the same times as an input tim file
 

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -1,0 +1,392 @@
+import numpy as np
+import astropy.units as u
+import pint.residuals
+import pint.toa
+from pint.observatory import Observatory, bipm_default, get_observatory
+from astropy import log
+from astropy import time
+
+__all__ = [
+    "make_fake_toas",
+    "make_fake_toas_uniform",
+    "make_fake_toas_fromtim",
+    "calculate_random_models",
+]
+
+
+def get_freq_array(base_frequencies, ntoas):
+    """Make frequency array out of one or more frequencies
+
+    If >1 frequency is specified, will alternate
+
+    Parameters
+    ----------
+    base_frequencies : astropy.units.Quantity
+       array of frequencies
+    ntoas : int
+       number of TOAs
+
+    Returns
+    -------
+    astropy.units.Quantity
+        array of (potentially alternating) frequencies
+    """
+    freq = np.zeros(ntoas) * base_frequencies[0].unit
+    num_freqs = len(base_frequencies)
+    for ii, fv in enumerate(base_frequencies):
+        freq[ii::num_freqs] = fv
+    return freq
+
+
+def make_fake_toas(
+    times,
+    model,
+    fuzz=0,
+    freq=1400 * u.MHz,
+    obs="GBT",
+    error=1 * u.us,
+    add_noise=False,
+    dm=None,
+    dm_error=1e-4 * pint.dmu,
+):
+    """Make toas from an array of times
+
+    Can include alternating frequencies if fed an array of frequencies,
+    only works with one observatory at a time
+
+    Parameters
+    ----------
+    times : astropy.units.Quantity
+        MJD times for new TOAs
+    model : pint.models.timing_model.TimingModel
+        current model
+    freq : astropy.units.Quantity, optional
+        frequency of the fake toas, default 1400 MHz
+    obs : str, optional
+        observatory for fake toas, default GBT
+    error : astropy.units.Quantity
+        uncertainty to attach to each TOA
+    add_noise : bool, optional
+        Add noise to the TOAs (otherwise `error` just populates the column)
+    dm : astropy.units.Quantity, optional
+        DM value to include with each TOA; default is not to include any DM information
+    dm_error : astropy.units.Quantity
+        uncertainty to attach to each DM measurement
+        
+    Returns
+    -------
+    TOAs : pint.toa.TOAs
+        object with toas matching input times array with optional errors
+    """
+
+    freq_array = get_freq_array(np.atleast_1d(freq), len(times))
+    t1 = [
+        pint.toa.TOA(t.value, obs=obs, freq=f, scale=get_observatory(obs).timescale)
+        for t, f in zip(times, freq_array)
+    ]
+    ts = pint.toa.TOAs(toalist=t1)
+    ts.planets = model["PLANET_SHAPIRO"].value
+    ts.ephem = model["EPHEM"].value
+    include_bipm = False
+    bipm_version = bipm_default
+    include_gps = True
+    if model["CLOCK"].value is not None:
+        if model["CLOCK"].value == "TT(TAI)":
+            include_bipm = False
+            log.info("Using CLOCK = TT(TAI), so setting include_bipm = False")
+        elif "BIPM" in model["CLOCK"].value:
+            clk = model["CLOCK"].value.strip(")").split("(")
+            if len(clk) == 2:
+                ctype, cvers = clk
+                if ctype == "TT" and cvers.startswith("BIPM"):
+                    include_bipm = True
+                    if bipm_version is None:
+                        bipm_version = cvers
+                        log.info(f"Using CLOCK = {bipm_version} from the given model")
+                else:
+                    log.warning(
+                        f'CLOCK = {model["CLOCK"].value} is not implemented. '
+                        f"Using TT({bipm_default}) instead."
+                    )
+        else:
+            log.warning(
+                f'CLOCK = {model["CLOCK"].value} is not implemented. '
+                f"Using TT({bipm_default}) instead."
+            )
+
+    ts.clock_corr_info.update(
+        {
+            "include_bipm": include_bipm,
+            "bipm_version": bipm_version,
+            "include_gps": include_gps,
+        }
+    )
+    ts.table["error"] = error
+    if dm is not None:
+        for f in ts.table["flags"]:
+            f["pp_dm"] = str(dm.to_value(pint.dmu))
+            f["pp_dme"] = str(dm_error.to_value(pint.dmu))
+    ts.compute_TDBs()
+    ts.compute_posvels()
+    ts.compute_pulse_numbers(model)
+    for i in range(10):
+        r = pint.residuals.Residuals(ts, model, track_mode="use_pulse_numbers")
+        if abs(r.time_resids).max() < 1 * u.ns:
+            break
+        ts.adjust_TOAs(time.TimeDelta(-r.time_resids))
+    else:
+        raise ValueError(
+            "Unable to make fake residuals - left over errors are {}".format(
+                abs(r.time_resids).max()
+            )
+        )
+    if add_noise:
+        err = np.random.randn(len(ts.table)) * error
+        # Add the actual error fuzzing
+        ts.adjust_TOAs(time.TimeDelta(err))
+
+    return ts
+
+
+def make_fake_toas_uniform(
+    startMJD,
+    endMJD,
+    ntoas,
+    model,
+    fuzz=0,
+    freq=1400 * u.MHz,
+    obs="GBT",
+    error=1 * u.us,
+    add_noise=False,
+    dm=None,
+    dm_error=1e-4 * pint.dmu,
+):
+    """Make evenly spaced toas 
+
+    Can include alternating frequencies if fed an array of frequencies,
+    only works with one observatory at a time
+
+    Parameters
+    ----------
+    startMJD : float
+        starting MJD for fake toas
+    endMJD : float
+        ending MJD for fake toas
+    ntoas : int
+        number of fake toas to create between startMJD and endMJD
+    model : pint.models.timing_model.TimingModel
+        current model
+    fuzz : astropy.units.Quantity, optional
+        Standard deviation of 'fuzz' distribution to be applied to TOAs
+    freq : astropy.units.Quantity, optional
+        frequency of the fake toas, default 1400 MHz
+    obs : str, optional
+        observatory for fake toas, default GBT
+    error : astropy.units.Quantity
+        uncertainty to attach to each TOA
+    add_noise : bool, optional
+        Add noise to the TOAs (otherwise `error` just populates the column)
+    dm : astropy.units.Quantity, optional
+        DM value to include with each TOA; default is not to include any DM information
+    dm_error : astropy.units.Quantity
+        uncertainty to attach to each DM measurement
+        
+    Returns
+    -------
+    TOAs : pint.toa.TOAs
+        object with evenly spaced toas spanning given start and end MJD with
+        ntoas toas, with optional errors
+    """
+
+    times = np.linspace(startMJD, endMJD, ntoas, dtype=np.longdouble) * u.d
+    if fuzz > 0:
+        # apply some fuzz to the dates
+        fuzz = np.random.normal(scale=fuzz.to_value(u.d), size=len(times)) * u.d
+        times += fuzz
+    return make_fake_toas(
+        times,
+        model=model,
+        fuzz=fuzz,
+        freq=freq,
+        obs=obs,
+        error=error,
+        add_noise=add_noise,
+        dm=dm,
+        dm_error=dm_error,
+    )
+
+
+def make_fake_toas_fromtim(
+    timfile,
+    model,
+    fuzz=0,
+    freq=1400 * u.MHz,
+    obs="GBT",
+    error=1 * u.us,
+    add_noise=False,
+    dm=None,
+    dm_error=1e-4 * pint.dmu,
+):
+    """Make fake toas with the same times as an input tim file
+
+    Can include alternating frequencies if fed an array of frequencies,
+    only works with one observatory at a time
+
+    Parameters
+    ----------
+    timfile : str or list of strings or file-like
+        Filename, list of filenames, or file-like object containing the TOA data.
+    model : pint.models.timing_model.TimingModel
+        current model
+    fuzz : astropy.units.Quantity, optional
+        Standard deviation of 'fuzz' distribution to be applied to TOAs
+    freq : astropy.units.Quantity, optional
+        frequency of the fake toas, default 1400 MHz
+    obs : str, optional
+        observatory for fake toas, default GBT
+    error : astropy.units.Quantity
+        uncertainty to attach to each TOA
+    add_noise : bool, optional
+        Add noise to the TOAs (otherwise `error` just populates the column)
+    dm : astropy.units.Quantity, optional
+        DM value to include with each TOA; default is not to include any DM information
+    dm_error : astropy.units.Quantity
+        uncertainty to attach to each DM measurement
+        
+    Returns
+    -------
+    TOAs : pint.toa.TOAs
+        object with evenly spaced toas spanning given start and end MJD with
+        ntoas toas, with optional errors
+    """
+    input_ts = pint.toa.get_TOAs(timfile)
+    return make_fake_toas(
+        input_ts.get_mjds(),
+        model=model,
+        fuzz=fuzz,
+        freq=freq,
+        obs=obs,
+        error=error,
+        add_noise=add_noise,
+        dm=dm,
+        dm_error=dm_error,
+    )
+
+
+def calculate_random_models(fitter, toas, Nmodels=100, keep_models=True, params="all"):
+    """
+    Calculates random models based on the covariance matrix of the `fitter` object.
+
+    returns the new phase differences compared to the original model
+    optionally returns all of the random models
+
+    Parameters
+    ----------
+    fitter: pint.fitter.Fitter
+        current fitter object containing a model and parameter covariance matrix
+    toas: pint.toa.TOAs
+        TOAs to calculate models
+    Nmodels: int, optional
+        number of random models to calculate
+    keep_models: bool, optional
+        whether to keep and return the individual random models (slower)
+    params: list, optional
+        if specified, selects only those parameters to vary.  Default ('all') is to use all parameters other than Offset
+
+    Returns
+    -------
+    dphase : np.ndarray
+        phase difference with respect to input model, size is [Nmodels, len(toas)]
+    random_models : list, optional
+        list of random models (each is a :class:`pint.models.timing_model.TimingModel`)
+
+    Example
+    -------
+    >>> from pint.models import get_model_and_toas
+    >>> from pint import fitter, toa
+    >>> import pint.utils
+    >>> import io
+    >>>
+    >>> # the locations of these may vary
+    >>> timfile = "tests/datafile/NGC6440E.tim"
+    >>> parfile = "tests/datafile/NGC6440E.par"
+    >>> m, t = get_model_and_toas(parfile, timfile)
+    >>> # fit the model to the data
+    >>> f = fitter.WLSFitter(toas=t, model=m)
+    >>> f.fit_toas()
+    >>>
+    >>> # make fake TOAs starting at the end of the
+    >>> # current data and going out 100 days
+    >>> tnew = toa.make_fake_toas(t.get_mjds().max().value,
+    >>>                           t.get_mjds().max().value+100, 50, model=f.model)
+    >>> # now make random models
+    >>> dphase, mrand = pint.utils.calculate_random_models(f, tnew, Nmodels=100)
+
+
+    Note
+    ----
+    To calculate new TOAs, you can use :func:`~pint.toa.make_fake_toas`
+
+    or similar
+    """
+    Nmjd = len(toas)
+    phases_i = np.zeros((Nmodels, Nmjd))
+    phases_f = np.zeros((Nmodels, Nmjd))
+
+    cov_matrix = fitter.parameter_covariance_matrix
+    # this is a list of the parameter names in the order they appear in the coviarance matrix
+    param_names = cov_matrix.get_label_names(axis=0)
+    # this is a dictionary with the parameter values, but it might not be in the same order
+    # and it leaves out the Offset parameter
+    param_values = fitter.model.get_params_dict("free", "value")
+    mean_vector = np.array([param_values[x] for x in param_names if not x == "Offset"])
+    if params == "all":
+        # remove the first column and row (absolute phase)
+        if param_names[0] == "Offset":
+            cov_matrix = cov_matrix.get_label_matrix(param_names[1:])
+            fac = fitter.fac[1:]
+            param_names = param_names[1:]
+        else:
+            fac = fitter.fac
+    else:
+        # only select some parameters
+        # need to also select from the fac array and the mean_vector array
+        idx, labels = cov_matrix.get_label_slice(params)
+        cov_matrix = cov_matrix.get_label_matrix(params)
+        index = idx[0].flatten()
+        fac = fitter.fac[index]
+        # except mean_vector does not have the 'Offset' entry
+        # so may need to subtract 1
+        if param_names[0] == "Offset":
+            mean_vector = mean_vector[index - 1]
+        else:
+            mean_vector = mean_vector[index]
+        param_names = cov_matrix.get_label_names(axis=0)
+
+    f_rand = deepcopy(fitter)
+
+    # scale by fac
+    mean_vector = mean_vector * fac
+    scaled_cov_matrix = ((cov_matrix.matrix * fac).T * fac).T
+    random_models = []
+    for imodel in range(Nmodels):
+        # create a set of randomized parameters based on mean vector and covariance matrix
+        rparams_num = np.random.multivariate_normal(mean_vector, scaled_cov_matrix)
+        # scale params back to real units
+        for j in range(len(mean_vector)):
+            rparams_num[j] /= fac[j]
+        rparams = OrderedDict(zip(param_names, rparams_num))
+        f_rand.set_params(rparams)
+        phase = f_rand.model.phase(toas, abs_phase=True)
+        phases_i[imodel] = phase.int
+        phases_f[imodel] = phase.frac
+        if keep_models:
+            random_models.append(f_rand.model)
+            f_rand = deepcopy(fitter)
+    phases = phases_i + phases_f
+    phases0 = fitter.model.phase(toas, abs_phase=True)
+    dphase = phases - (phases0.int + phases0.frac)
+    if keep_models:
+        return dphase, random_models
+    else:
+        return dphase

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -75,10 +75,7 @@ def zero_residuals(ts, model, maxiter=10, tolerance=1 * u.ns):
 
 
 def update_fake_toa_clock(
-    ts,
-    model,
-    include_bipm=False,
-    include_gps=True,
+    ts, model, include_bipm=False, include_gps=True,
 ):
     """Update the clock settings (corrections, etc) for fake TOAs
 
@@ -130,10 +127,7 @@ def update_fake_toa_clock(
 
 
 def make_fake_toas(
-    ts,
-    model,
-    add_noise=False,
-    name="fake",
+    ts, model, add_noise=False, name="fake",
 ):
     """Make toas from an array of times
 
@@ -354,10 +348,7 @@ def make_fake_toas_fromMJDs(
 
 
 def make_fake_toas_fromtim(
-    timfile,
-    model,
-    add_noise=False,
-    name="fake",
+    timfile, model, add_noise=False, name="fake",
 ):
     """Make fake toas with the same times as an input tim file
 

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -77,6 +77,7 @@ def update_fake_toa_clock(
     ts, model, include_bipm=False, include_gps=True,
 ):
     """Update the clock settings (corrections, etc) for fake TOAs
+
     Parameters
     ----------
     ts : pint.toa.TOAs
@@ -85,10 +86,10 @@ def update_fake_toa_clock(
         current model
     include_bipm : bool, optional
         Whether or not to disable UTC-> TT BIPM clock
-        correction (see :class:`pint.observatory.TopoObs`)
+        correction (see :class:`pint.observatory.topo_obs.TopoObs`)
     include_gps : bool, optional
         Whether or not to disable UTC(GPS)->UTC clock correction
-        (see :class:`pint.observatory.TopoObs`)
+        (see :class:`pint.observatory.topo_obs.TopoObs`)
     """
     bipm_version = bipm_default
     if model["CLOCK"].value is not None:
@@ -216,10 +217,10 @@ def make_fake_toas_uniform(
         Name for the TOAs (goes into the flags)
     include_bipm : bool, optional
         Whether or not to disable UTC-> TT BIPM clock
-        correction (see :class:`pint.observatory.TopoObs`)
+        correction (see :class:`pint.observatory.topo_obs.TopoObs`)
     include_gps : bool, optional
         Whether or not to disable UTC(GPS)->UTC clock correction
-        (see :class:`pint.observatory.TopoObs`)
+        (see :class:`pint.observatory.topo_obs.TopoObs`)
     Returns
     -------
     TOAs : pint.toa.TOAs
@@ -303,10 +304,10 @@ def make_fake_toas_fromMJDs(
         Name for the TOAs (goes into the flags)
     include_bipm : bool, optional
         Whether or not to disable UTC-> TT BIPM clock
-        correction (see :class:`pint.observatory.TopoObs`)
+        correction (see :class:`pint.observatory.topo_obs.TopoObs`)
     include_gps : bool, optional
         Whether or not to disable UTC(GPS)->UTC clock correction
-        (see :class:`pint.observatory.TopoObs`)
+        (see :class:`pint.observatory.topo_obs.TopoObs`)
 
     Returns
     -------

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+from copy import deepcopy
 import numpy as np
 import astropy.units as u
 import pint.residuals
@@ -78,7 +80,8 @@ def make_fake_toas(
     TOAs : pint.toa.TOAs
         object with toas matching input times array with optional errors
     """
-
+    if freq is None or np.isinf(freq):
+        freq = np.inf * u.MHz
     freq_array = get_freq_array(np.atleast_1d(freq), len(times))
     t1 = [
         pint.toa.TOA(t.value, obs=obs, freq=f, scale=get_observatory(obs).timescale)
@@ -304,7 +307,7 @@ def calculate_random_models(fitter, toas, Nmodels=100, keep_models=True, params=
     -------
     >>> from pint.models import get_model_and_toas
     >>> from pint import fitter, toa
-    >>> import pint.utils
+    >>> import pint.simulation
     >>> import io
     >>>
     >>> # the locations of these may vary
@@ -317,15 +320,15 @@ def calculate_random_models(fitter, toas, Nmodels=100, keep_models=True, params=
     >>>
     >>> # make fake TOAs starting at the end of the
     >>> # current data and going out 100 days
-    >>> tnew = toa.make_fake_toas(t.get_mjds().max().value,
+    >>> tnew = simulation.make_fake_toas(t.get_mjds().max().value,
     >>>                           t.get_mjds().max().value+100, 50, model=f.model)
     >>> # now make random models
-    >>> dphase, mrand = pint.utils.calculate_random_models(f, tnew, Nmodels=100)
+    >>> dphase, mrand = pint.simulation.calculate_random_models(f, tnew, Nmodels=100)
 
 
     Note
     ----
-    To calculate new TOAs, you can use :func:`~pint.toa.make_fake_toas`
+    To calculate new TOAs, you can use :func:`~pint.simulation.make_fake_toas`
 
     or similar
     """

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -74,10 +74,7 @@ def zero_residuals(ts, model, maxiter=10, tolerance=1 * u.ns):
 
 
 def update_fake_toa_clock(
-    ts,
-    model,
-    include_bipm=False,
-    include_gps=True,
+    ts, model, include_bipm=False, include_gps=True,
 ):
     """Update the clock settings (corrections, etc) for fake TOAs
     Parameters
@@ -128,10 +125,7 @@ def update_fake_toa_clock(
 
 
 def make_fake_toas(
-    ts,
-    model,
-    add_noise=False,
-    name="fake",
+    ts, model, add_noise=False, name="fake",
 ):
     """Make toas from an array of times
 
@@ -352,10 +346,7 @@ def make_fake_toas_fromMJDs(
 
 
 def make_fake_toas_fromtim(
-    timfile,
-    model,
-    add_noise=False,
-    name="fake",
+    timfile, model, add_noise=False, name="fake",
 ):
     """Make fake toas with the same times as an input tim file
 

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -62,19 +62,23 @@ def zero_residuals(ts, model, maxiter=10, tolerance=1 * u.ns):
     ts.compute_pulse_numbers(model)
     for i in range(maxiter):
         r = pint.residuals.Residuals(ts, model, track_mode="use_pulse_numbers")
-        if abs(r.time_resids).max() < tolerance:
+        resids = r.calc_time_resids(calctype="taylor")
+        if abs(resids).max() < tolerance:
             break
-        ts.adjust_TOAs(time.TimeDelta(-r.time_resids))
+        ts.adjust_TOAs(-time.TimeDelta(resids))
     else:
         raise ValueError(
             "Unable to make fake residuals - left over errors are {}".format(
-                abs(r.time_resids).max()
+                abs(resids).max()
             )
         )
 
 
 def update_fake_toa_clock(
-    ts, model, include_bipm=False, include_gps=True,
+    ts,
+    model,
+    include_bipm=False,
+    include_gps=True,
 ):
     """Update the clock settings (corrections, etc) for fake TOAs
 
@@ -126,7 +130,10 @@ def update_fake_toa_clock(
 
 
 def make_fake_toas(
-    ts, model, add_noise=False, name="fake",
+    ts,
+    model,
+    add_noise=False,
+    name="fake",
 ):
     """Make toas from an array of times
 
@@ -347,7 +354,10 @@ def make_fake_toas_fromMJDs(
 
 
 def make_fake_toas_fromtim(
-    timfile, model, add_noise=False, name="fake",
+    timfile,
+    model,
+    add_noise=False,
+    name="fake",
 ):
     """Make fake toas with the same times as an input tim file
 

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -4,6 +4,14 @@ In particular, single TOAs are represented by :class:`pint.toa.TOA` objects, and
 want to manage a collection of these we recommend you use a :class:`pint.toa.TOAs` object
 as this makes certain operations much more convenient. You probably want to load one with
 :func:`pint.toa.get_TOAs`.
+
+Warning
+-------
+Function:
+
+- :func:`pint.simulation.make_fake_toas`
+
+has moved to :mod:`pint.simulation`.
 """
 import copy
 import gzip
@@ -45,7 +53,6 @@ __all__ = [
     "get_TOAs_list",
     "load_pickle",
     "save_pickle",
-    "make_fake_toas",
     "format_toa_line",
     "TOA",
 ]
@@ -828,130 +835,6 @@ def build_table(toas, filename=None):
         ),
         meta={"filename": filename},
     ).group_by("obs")
-
-
-def make_fake_toas(
-    startMJD,
-    endMJD,
-    ntoas,
-    model,
-    freq=999999,
-    obs="GBT",
-    error=1 * u.us,
-    dm=None,
-    dm_error=1e-4 * pint.dmu,
-):
-    """Make evenly spaced toas with residuals = 0 and without errors.
-
-    Might be able to do different frequencies if fed an array of frequencies,
-    only works with one observatory at a time
-
-    Parameters
-    ----------
-    startMJD
-        starting MJD for fake toas
-    endMJD
-        ending MJD for fake toas
-    ntoas
-        number of fake toas to create between startMJD and endMJD
-    model
-        current model
-    freq : float, optional
-        frequency of the fake toas, default 1400
-    obs : str, optional
-        observatory for fake toas, default GBT
-    error : :class:`astropy.units.Quantity`
-        uncertainty to attach to each TOA
-    dm : float, optional
-        DM value to include with each TOA; default is not to include any DM information
-    dm_error : :class:`astropy.units.Quantity`
-        uncertainty to attach to each DM measurement
-
-    Returns
-    -------
-    TOAs
-        object with evenly spaced toas spanning given start and end MJD with
-        ntoas toas, without errors
-    """
-    # FIXME: this is a sign this is not where this function belongs
-    # residuals depends on models and TOAs so this adds a circular dependency
-    import pint.residuals
-
-    # TODO:make all variables Quantity objects
-    # TODO: freq default to inf
-    def get_freq_array(bfv, ntoas):
-        freq = np.zeros(ntoas)
-        num_freqs = len(bfv)
-        for ii, fv in enumerate(bfv):
-            freq[ii::num_freqs] = fv
-        return freq
-
-    times = (
-        np.linspace(np.longdouble(startMJD) * u.d, np.longdouble(endMJD) * u.d, ntoas)
-        * u.day
-    )
-    freq_array = get_freq_array(np.atleast_1d(freq) * u.MHz, len(times))
-    t1 = [
-        TOA(t.value, obs=obs, freq=f, scale=get_observatory(obs).timescale)
-        for t, f in zip(times, freq_array)
-    ]
-    ts = TOAs(toalist=t1)
-    ts.planets = model["PLANET_SHAPIRO"].value
-    ts.ephem = model["EPHEM"].value
-    include_bipm = False
-    bipm_version = bipm_default
-    include_gps = True
-    if model["CLOCK"].value is not None:
-        if model["CLOCK"].value == "TT(TAI)":
-            include_bipm = False
-            log.info("Using CLOCK = TT(TAI), so setting include_bipm = False")
-        elif "BIPM" in model["CLOCK"].value:
-            clk = model["CLOCK"].value.strip(")").split("(")
-            if len(clk) == 2:
-                ctype, cvers = clk
-                if ctype == "TT" and cvers.startswith("BIPM"):
-                    include_bipm = True
-                    if bipm_version is None:
-                        bipm_version = cvers
-                        log.info(f"Using CLOCK = {bipm_version} from the given model")
-                else:
-                    log.warning(
-                        f'CLOCK = {model["CLOCK"].value} is not implemented. '
-                        f"Using TT({bipm_default}) instead."
-                    )
-        else:
-            log.warning(
-                f'CLOCK = {model["CLOCK"].value} is not implemented. '
-                f"Using TT({bipm_default}) instead."
-            )
-
-    ts.clock_corr_info.update(
-        {
-            "include_bipm": include_bipm,
-            "bipm_version": bipm_version,
-            "include_gps": include_gps,
-        }
-    )
-    ts.table["error"] = error
-    if dm is not None:
-        for f in ts.table["flags"]:
-            f["pp_dm"] = str(dm.to_value(pint.dmu))
-            f["pp_dme"] = str(dm_error.to_value(pint.dmu))
-    ts.compute_TDBs()
-    ts.compute_posvels()
-    ts.compute_pulse_numbers(model)
-    for i in range(10):
-        r = pint.residuals.Residuals(ts, model, track_mode="use_pulse_numbers")
-        if abs(r.time_resids).max() < 1 * u.ns:
-            break
-        ts.adjust_TOAs(time.TimeDelta(-r.time_resids))
-    else:
-        raise ValueError(
-            "Unable to make fake residuals - left over errors are {}".format(
-                abs(r.time_resids).max()
-            )
-        )
-    return ts
 
 
 def _cluster_by_gaps(t, gap):

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -22,6 +22,11 @@ Functions:
 - :func:`~pint.derived_quantities.shklovskii_factor`
 
 have moved to :mod:`pint.derived_quantities`.
+
+- :func:`pint.simulation.calculate_random_models`
+
+has moved to :mod:`pint.simulation`.
+
 """
 import configparser
 import datetime
@@ -71,7 +76,6 @@ __all__ = [
     "FTest",
     "add_dummy_distance",
     "remove_dummy_distance",
-    "calculate_random_models",
     "info_string",
 ]
 
@@ -1522,125 +1526,6 @@ def info_string(prefix_string="# ", comment=None):
     if (prefix_string is not None) and (len(prefix_string) > 0):
         s = os.linesep.join([prefix_string + x for x in s.splitlines()])
     return s
-
-
-def calculate_random_models(fitter, toas, Nmodels=100, keep_models=True, params="all"):
-    """
-    Calculates random models based on the covariance matrix of the `fitter` object.
-
-    returns the new phase differences compared to the original model
-    optionally returns all of the random models
-
-    Parameters
-    ----------
-    fitter: pint.fitter.Fitter
-        current fitter object containing a model and parameter covariance matrix
-    toas: pint.toa.TOAs
-        TOAs to calculate models
-    Nmodels: int, optional
-        number of random models to calculate
-    keep_models: bool, optional
-        whether to keep and return the individual random models (slower)
-    params: list, optional
-        if specified, selects only those parameters to vary.  Default ('all') is to use all parameters other than Offset
-
-    Returns
-    -------
-    dphase : np.ndarray
-        phase difference with respect to input model, size is [Nmodels, len(toas)]
-    random_models : list, optional
-        list of random models (each is a :class:`pint.models.timing_model.TimingModel`)
-
-    Example
-    -------
-    >>> from pint.models import get_model_and_toas
-    >>> from pint import fitter, toa
-    >>> import pint.utils
-    >>> import io
-    >>>
-    >>> # the locations of these may vary
-    >>> timfile = "tests/datafile/NGC6440E.tim"
-    >>> parfile = "tests/datafile/NGC6440E.par"
-    >>> m, t = get_model_and_toas(parfile, timfile)
-    >>> # fit the model to the data
-    >>> f = fitter.WLSFitter(toas=t, model=m)
-    >>> f.fit_toas()
-    >>>
-    >>> # make fake TOAs starting at the end of the
-    >>> # current data and going out 100 days
-    >>> tnew = toa.make_fake_toas(t.get_mjds().max().value,
-    >>>                           t.get_mjds().max().value+100, 50, model=f.model)
-    >>> # now make random models
-    >>> dphase, mrand = pint.utils.calculate_random_models(f, tnew, Nmodels=100)
-
-
-    Note
-    ----
-    To calculate new TOAs, you can use :func:`~pint.toa.make_fake_toas`
-
-    or similar
-    """
-    Nmjd = len(toas)
-    phases_i = np.zeros((Nmodels, Nmjd))
-    phases_f = np.zeros((Nmodels, Nmjd))
-
-    cov_matrix = fitter.parameter_covariance_matrix
-    # this is a list of the parameter names in the order they appear in the coviarance matrix
-    param_names = cov_matrix.get_label_names(axis=0)
-    # this is a dictionary with the parameter values, but it might not be in the same order
-    # and it leaves out the Offset parameter
-    param_values = fitter.model.get_params_dict("free", "value")
-    mean_vector = np.array([param_values[x] for x in param_names if not x == "Offset"])
-    if params == "all":
-        # remove the first column and row (absolute phase)
-        if param_names[0] == "Offset":
-            cov_matrix = cov_matrix.get_label_matrix(param_names[1:])
-            fac = fitter.fac[1:]
-            param_names = param_names[1:]
-        else:
-            fac = fitter.fac
-    else:
-        # only select some parameters
-        # need to also select from the fac array and the mean_vector array
-        idx, labels = cov_matrix.get_label_slice(params)
-        cov_matrix = cov_matrix.get_label_matrix(params)
-        index = idx[0].flatten()
-        fac = fitter.fac[index]
-        # except mean_vector does not have the 'Offset' entry
-        # so may need to subtract 1
-        if param_names[0] == "Offset":
-            mean_vector = mean_vector[index - 1]
-        else:
-            mean_vector = mean_vector[index]
-        param_names = cov_matrix.get_label_names(axis=0)
-
-    f_rand = deepcopy(fitter)
-
-    # scale by fac
-    mean_vector = mean_vector * fac
-    scaled_cov_matrix = ((cov_matrix.matrix * fac).T * fac).T
-    random_models = []
-    for imodel in range(Nmodels):
-        # create a set of randomized parameters based on mean vector and covariance matrix
-        rparams_num = np.random.multivariate_normal(mean_vector, scaled_cov_matrix)
-        # scale params back to real units
-        for j in range(len(mean_vector)):
-            rparams_num[j] /= fac[j]
-        rparams = OrderedDict(zip(param_names, rparams_num))
-        f_rand.set_params(rparams)
-        phase = f_rand.model.phase(toas, abs_phase=True)
-        phases_i[imodel] = phase.int
-        phases_f[imodel] = phase.frac
-        if keep_models:
-            random_models.append(f_rand.model)
-            f_rand = deepcopy(fitter)
-    phases = phases_i + phases_f
-    phases0 = fitter.model.phase(toas, abs_phase=True)
-    dphase = phases - (phases0.int + phases0.frac)
-    if keep_models:
-        return dphase, random_models
-    else:
-        return dphase
 
 
 def list_parameters(class_=None):

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -3,6 +3,7 @@ import astropy.units as u
 from astropy.time import Time
 import matplotlib.pyplot as plt
 import pint.toa as toa
+import pint.simulation as simulation
 from pint.models import get_model
 from pylab import *
 from copy import deepcopy
@@ -22,8 +23,10 @@ def test_get_highest_density_range(ndays):
     SOLARN0 0
     """
     model = get_model(io.StringIO(par_base))
-    toas_1 = toa.make_fake_toas(57000, 58000, 1000, model, obs="@")
-    toas_2 = toa.make_fake_toas(57500, 57500 + ndays.value, 100, model, obs="@")
+    toas_1 = simulation.make_fake_toas_uniform(57000, 58000, 1000, model, obs="@")
+    toas_2 = simulation.make_fake_toas_uniform(
+        57500, 57500 + ndays.value, 100, model, obs="@"
+    )
     merged = toa.merge_TOAs([toas_1, toas_2])
     if ndays == 7 * u.d:
         x1 = merged.get_highest_density_range()

--- a/tests/test_downhill_fitter.py
+++ b/tests/test_downhill_fitter.py
@@ -13,7 +13,8 @@ from scipy.linalg import block_diag, cho_factor, cho_solve, cholesky
 import pint.fitter
 from pint.models import get_model
 from pint.models.timing_model import MissingTOAs
-from pint.toa import make_fake_toas, merge_TOAs
+from pint.toa import merge_TOAs
+from pint.simulation import make_fake_toas_uniform
 
 par_eccentric = """
 PSR J1234+5678
@@ -38,7 +39,9 @@ def model_eccentric_toas():
     g = np.random.default_rng(0)
     model_eccentric = get_model(io.StringIO(par_eccentric))
 
-    toas = make_fake_toas(57000, 57001, 20, model_eccentric, freq=1400, obs="@")
+    toas = make_fake_toas_uniform(
+        57000, 57001, 20, model_eccentric, freq=1400 * u.MHz, obs="@"
+    )
     toas.adjust_TOAs(TimeDelta(g.standard_normal(len(toas)) * toas.table["error"]))
 
     return model_eccentric, toas
@@ -53,8 +56,12 @@ def model_eccentric_toas_ecorr():
 
     toas = merge_TOAs(
         [
-            make_fake_toas(57000, 57001, 20, model_eccentric, freq=1000, obs="@"),
-            make_fake_toas(57000, 57001, 20, model_eccentric, freq=2000, obs="@"),
+            make_fake_toas_uniform(
+                57000, 57001, 20, model_eccentric, freq=1000 * u.MHz, obs="@"
+            ),
+            make_fake_toas_uniform(
+                57000, 57001, 20, model_eccentric, freq=2000 * u.MHz, obs="@"
+            ),
         ]
     )
     toas.adjust_TOAs(TimeDelta(g.standard_normal(len(toas)) * toas.table["error"]))
@@ -71,21 +78,21 @@ def model_eccentric_toas_wb():
 
     toas = merge_TOAs(
         [
-            make_fake_toas(
+            make_fake_toas_uniform(
                 57000,
                 57001,
                 20,
                 model_eccentric,
-                freq=1000,
+                freq=1000 * u.MHz,
                 obs="@",
                 dm=10 * u.pc / u.cm ** 3,
             ),
-            make_fake_toas(
+            make_fake_toas_uniform(
                 57000,
                 57001,
                 20,
                 model_eccentric,
-                freq=2000,
+                freq=2000 * u.MHz,
                 obs="@",
                 dm=10 * u.pc / u.cm ** 3,
             ),

--- a/tests/test_fake_toas.py
+++ b/tests/test_fake_toas.py
@@ -118,5 +118,5 @@ def test_fake_from_timfile():
     r_sim = pint.residuals.Residuals(t_sim, f.model)
     # need a generous rtol because of the small statistics
     assert np.isclose(
-        r.calc_time_resids().std(), r_sim.calc_time_resids().std(), rtol=0.5,
+        r.calc_time_resids().std(), r_sim.calc_time_resids().std(), rtol=2,
     )

--- a/tests/test_fake_toas.py
+++ b/tests/test_fake_toas.py
@@ -184,26 +184,27 @@ def test_fake_highF1():
     r = pint.residuals.Residuals(t, m)
     assert np.isclose(r.calc_time_resids(calctype="taylor").std(), 1 * u.us, rtol=0.2)
 
+
 def test_fake_DMfit():
     """ fit only for DM with fake TOAs
     compare the variance of that result against the uncertainties
     """
     parfile = pint.config.examplefile("NGC6440E.par")
     timfile = pint.config.examplefile("NGC6440E.tim")
-    m,t = get_model_and_toas(parfile, timfile)
-    
+    m, t = get_model_and_toas(parfile, timfile)
+
     # pick only data for a DM fit
-    t=t[-8:]
-    m.RAJ.frozen=True
-    m.DECJ.frozen=True
-    m.F0.frozen=True
-    m.F1.frozen=True
-    f = GLSFitter(t,m)
+    t = t[-8:]
+    m.RAJ.frozen = True
+    m.DECJ.frozen = True
+    m.F0.frozen = True
+    m.F1.frozen = True
+    f = GLSFitter(t, m)
     f.fit_toas()
 
     N = 30
-    
-    DMs = np.zeros(N)*u.pc/u.cm**3
+
+    DMs = np.zeros(N) * u.pc / u.cm ** 3
     for iter in range(N):
         t_fake = pint.simulation.make_fake_toas(t, m, add_noise=True)
         f_fake = GLSFitter(t_fake, m)
@@ -211,4 +212,3 @@ def test_fake_DMfit():
         DMs[iter] = f_fake.model.DM.quantity.astype(np.float64)
 
     assert np.isclose(DMs.std(), f.model.DM.uncertainty, rtol=0.2)
-    

--- a/tests/test_fake_toas.py
+++ b/tests/test_fake_toas.py
@@ -127,11 +127,7 @@ def test_zima():
     t = get_TOAs(outfile.name)
     r = pint.residuals.Residuals(t, m)
     # need a generous rtol because of the small statistics
-    assert np.isclose(
-        r.calc_time_resids().std(),
-        1 * u.us,
-        rtol=0.2,
-    )
+    assert np.isclose(r.calc_time_resids().std(), 1 * u.us, rtol=0.2,)
 
 
 def test_fake_from_timfile():
@@ -149,7 +145,5 @@ def test_fake_from_timfile():
     r_sim = pint.residuals.Residuals(t_sim, f.model)
     # need a generous rtol because of the small statistics
     assert np.isclose(
-        r.calc_time_resids().std(),
-        r_sim.calc_time_resids().std(),
-        rtol=2,
+        r.calc_time_resids().std(), r_sim.calc_time_resids().std(), rtol=2,
     )

--- a/tests/test_fake_toas.py
+++ b/tests/test_fake_toas.py
@@ -127,7 +127,35 @@ def test_zima():
     t = get_TOAs(outfile.name)
     r = pint.residuals.Residuals(t, m)
     # need a generous rtol because of the small statistics
-    assert np.isclose(r.calc_time_resids().std(), 1 * u.us, rtol=0.2,)
+    assert np.isclose(
+        r.calc_time_resids().std(),
+        1 * u.us,
+        rtol=0.5,
+    )
+
+
+def test_fake_fromMJDs():
+    # basic model, no EFAC or EQUAD
+    model = get_model(
+        io.StringIO(
+            """
+        PSRJ J1234+5678
+        ELAT 0
+        ELONG 0
+        DM 10
+        F0 1
+        PEPOCH 58000
+        """
+        )
+    )
+    MJDs = np.linspace(57001, 58000, 200, dtype=np.longdouble) * u.d
+    toas = pint.simulation.make_fake_toas_fromMJDs(
+        MJDs, model=model, error=1 * u.us, add_noise=True
+    )
+    r = pint.residuals.Residuals(toas, model)
+
+    # need a generous rtol because of the small statistics
+    assert np.isclose(r.calc_time_resids().std(), 1 * u.us, rtol=0.2)
 
 
 def test_fake_from_timfile():
@@ -145,5 +173,7 @@ def test_fake_from_timfile():
     r_sim = pint.residuals.Residuals(t_sim, f.model)
     # need a generous rtol because of the small statistics
     assert np.isclose(
-        r.calc_time_resids().std(), r_sim.calc_time_resids().std(), rtol=2,
+        r.calc_time_resids().std(),
+        r_sim.calc_time_resids().std(),
+        rtol=2,
     )

--- a/tests/test_fake_toas.py
+++ b/tests/test_fake_toas.py
@@ -1,0 +1,122 @@
+import astropy.units as u
+import pint.simulation
+from pint.models.model_builder import get_model, get_model_and_toas
+from pint.toa import get_TOAs
+import pint.residuals
+import io
+import numpy as np
+import tempfile
+import os
+import pint.config
+from pint.fitter import GLSFitter
+
+
+def test_noise_addition():
+    # basic model, no EFAC or EQUAD
+    model = get_model(
+        io.StringIO(
+            """
+        PSRJ J1234+5678
+        ELAT 0
+        ELONG 0
+        DM 10
+        F0 1
+        PEPOCH 58000
+        """
+        )
+    )
+    toas = pint.simulation.make_fake_toas_uniform(
+        57001, 58000, 200, model=model, error=1 * u.us, add_noise=True
+    )
+    r = pint.residuals.Residuals(toas, model)
+
+    assert np.allclose(toas.get_errors(), 1 * u.us)
+    # need a generous rtol because of the small statistics
+    assert np.isclose(r.calc_time_resids().std(), 1 * u.us, rtol=0.2)
+
+
+def test_noise_addition_EFAC():
+    # add in EFAC
+    model = get_model(
+        io.StringIO(
+            """
+        PSRJ J1234+5678
+        ELAT 0
+        ELONG 0
+        DM 10
+        F0 1
+        PEPOCH 58000
+        EFAC mjd 57000 58000 2
+        """
+        )
+    )
+    toas = pint.simulation.make_fake_toas_uniform(
+        57001, 58000, 200, model=model, error=1 * u.us, add_noise=True
+    )
+    r = pint.residuals.Residuals(toas, model)
+    # need a generous rtol because of the small statistics
+    assert np.isclose(r.calc_time_resids().std(), 2 * 1 * u.us, rtol=0.2)
+
+
+def test_noise_addition_EQUAD():
+    # add in EFAC
+    model = get_model(
+        io.StringIO(
+            """
+        PSRJ J1234+5678
+        ELAT 0
+        ELONG 0
+        DM 10
+        F0 1
+        PEPOCH 58000
+        EQUAD mjd 57000 58000 5
+        """
+        )
+    )
+    toas = pint.simulation.make_fake_toas_uniform(
+        57001, 58000, 200, model=model, error=1 * u.us, add_noise=True
+    )
+    r = pint.residuals.Residuals(toas, model)
+    # need a generous rtol because of the small statistics
+    assert np.isclose(
+        r.calc_time_resids().std(),
+        np.sqrt((1 * u.us) ** 2 + (5 * u.us) ** 2),
+        rtol=0.2,
+    )
+
+
+def test_zima():
+    parfile = pint.config.examplefile("NGC6440E.par")
+    outfile = tempfile.NamedTemporaryFile(suffix="tim")
+
+    error = 1 * u.us
+
+    m = get_model(parfile)
+
+    zima_command = f"zima --freq 1400 --error {error.to_value(u.us)} --ntoa 100 --startMJD 58000 --duration 1000 --obs GBT --addnoise {parfile} {outfile.name}"
+
+    os.system(zima_command)
+
+    t = get_TOAs(outfile.name)
+    r = pint.residuals.Residuals(t, m)
+    # need a generous rtol because of the small statistics
+    assert np.isclose(r.calc_time_resids().std(), 1 * u.us, rtol=0.2,)
+
+
+def test_fake_from_timfile():
+    m, t = get_model_and_toas(
+        pint.config.examplefile("B1855+09_NANOGrav_9yv1.gls.par"),
+        pint.config.examplefile("B1855+09_NANOGrav_9yv1.tim"),
+    )
+
+    # refit the data to get rid of a trend
+    f = GLSFitter(t, m)
+    f.fit_toas()
+
+    r = pint.residuals.Residuals(t, f.model)
+    t_sim = pint.simulation.make_fake_toas(t, f.model, add_noise=True)
+    r_sim = pint.residuals.Residuals(t_sim, f.model)
+    # need a generous rtol because of the small statistics
+    assert np.isclose(
+        r.calc_time_resids().std(), r_sim.calc_time_resids().std(), rtol=0.5,
+    )

--- a/tests/test_fake_toas.py
+++ b/tests/test_fake_toas.py
@@ -127,11 +127,7 @@ def test_zima():
     t = get_TOAs(outfile.name)
     r = pint.residuals.Residuals(t, m)
     # need a generous rtol because of the small statistics
-    assert np.isclose(
-        r.calc_time_resids().std(),
-        1 * u.us,
-        rtol=0.5,
-    )
+    assert np.isclose(r.calc_time_resids().std(), 1 * u.us, rtol=0.5,)
 
 
 def test_fake_fromMJDs():
@@ -173,7 +169,5 @@ def test_fake_from_timfile():
     r_sim = pint.residuals.Residuals(t_sim, f.model)
     # need a generous rtol because of the small statistics
     assert np.isclose(
-        r.calc_time_resids().std(),
-        r_sim.calc_time_resids().std(),
-        rtol=2,
+        r.calc_time_resids().std(), r_sim.calc_time_resids().std(), rtol=2,
     )

--- a/tests/test_fake_toas.py
+++ b/tests/test_fake_toas.py
@@ -9,6 +9,7 @@ import tempfile
 import os
 import pint.config
 from pint.fitter import GLSFitter
+from pinttestdata import datadir, testdir
 
 
 def test_noise_addition():
@@ -171,3 +172,14 @@ def test_fake_from_timfile():
     assert np.isclose(
         r.calc_time_resids().std(), r_sim.calc_time_resids().std(), rtol=2,
     )
+
+
+def test_fake_highF1():
+    m = get_model(os.path.join(datadir, "ngc300nicer.par"))
+    m.F1.quantity *= 10
+    MJDs = np.linspace(58300, 58400, 100, dtype=np.longdouble) * u.d
+    t = pint.simulation.make_fake_toas_fromMJDs(
+        MJDs, model=m, add_noise=True, error=1 * u.us
+    )
+    r = pint.residuals.Residuals(t, m)
+    assert np.isclose(r.calc_time_resids(calctype="taylor").std(), 1 * u.us, rtol=0.2)

--- a/tests/test_fake_toas.py
+++ b/tests/test_fake_toas.py
@@ -211,4 +211,5 @@ def test_fake_DMfit():
         f_fake.fit_toas()
         DMs[iter] = f_fake.model.DM.quantity.astype(np.float64)
 
-    assert np.isclose(DMs.std(), f.model.DM.uncertainty, rtol=0.2)
+    assert np.isclose(DMs.std(), f.model.DM.uncertainty, rtol=0.5)
+    assert np.abs(DMs.mean() - f.model.DM.quantity) < 5 * f.model.DM.uncertainty

--- a/tests/test_fake_toas.py
+++ b/tests/test_fake_toas.py
@@ -183,3 +183,32 @@ def test_fake_highF1():
     )
     r = pint.residuals.Residuals(t, m)
     assert np.isclose(r.calc_time_resids(calctype="taylor").std(), 1 * u.us, rtol=0.2)
+
+def test_fake_DMfit():
+    """ fit only for DM with fake TOAs
+    compare the variance of that result against the uncertainties
+    """
+    parfile = pint.config.examplefile("NGC6440E.par")
+    timfile = pint.config.examplefile("NGC6440E.tim")
+    m,t = get_model_and_toas(parfile, timfile)
+    
+    # pick only data for a DM fit
+    t=t[-8:]
+    m.RAJ.frozen=True
+    m.DECJ.frozen=True
+    m.F0.frozen=True
+    m.F1.frozen=True
+    f = GLSFitter(t,m)
+    f.fit_toas()
+
+    N = 30
+    
+    DMs = np.zeros(N)*u.pc/u.cm**3
+    for iter in range(N):
+        t_fake = pint.simulation.make_fake_toas(t, m, add_noise=True)
+        f_fake = GLSFitter(t_fake, m)
+        f_fake.fit_toas()
+        DMs[iter] = f_fake.model.DM.quantity.astype(np.float64)
+
+    assert np.isclose(DMs.std(), f.model.DM.uncertainty, rtol=0.2)
+    

--- a/tests/test_fitter.py
+++ b/tests/test_fitter.py
@@ -9,7 +9,7 @@ import pytest
 import astropy.units as u
 
 import pint.models as tm
-from pint import fitter, toa
+from pint import fitter, toa, simulation
 from pinttestdata import datadir
 import pint.models.parameter as param
 from pint import ls
@@ -21,7 +21,7 @@ def test_fitter_basic():
     m = tm.get_model(os.path.join(datadir, "NGC6440E.par"))
     m.fit_params = ["F0", "F1"]
     e = 1 * u.us
-    t = toa.make_fake_toas(56000, 59000, 16, m, error=e)
+    t = simulation.make_fake_toas_uniform(56000, 59000, 16, m, error=e)
 
     T = (t.last_MJD - t.first_MJD).to(u.s)
 
@@ -142,7 +142,9 @@ def test_fitter():
 def test_ftest_nb():
     """Test for narrowband fitter class F-test."""
     m = tm.get_model(os.path.join(datadir, "J0023+0923_ell1_simple.par"))
-    t = toa.make_fake_toas(56000.0, 56001.0, 10, m, freq=1400.0, obs="AO")
+    t = simulation.make_fake_toas_uniform(
+        56000.0, 56001.0, 10, m, freq=1400.0 * u.MHz, obs="AO"
+    )
     f = fitter.WLSFitter(toas=t, model=m)
     f.fit_toas()
     # Test adding parameters
@@ -171,8 +173,8 @@ def test_ftest_nb():
 def test_ftest_wb():
     """Test for wideband fitter class F-test."""
     wb_m = tm.get_model(os.path.join(datadir, "J0023+0923_ell1_simple.par"))
-    wb_t = toa.make_fake_toas(
-        56000.0, 56001.0, 10, wb_m, freq=1400.0, obs="GBT", dm=wb_m.DM.quantity
+    wb_t = simulation.make_fake_toas_uniform(
+        56000.0, 56001.0, 10, wb_m, freq=1400.0 * u.MHz, obs="GBT", dm=wb_m.DM.quantity
     )
     wb_f = fitter.WidebandTOAFitter(wb_t, wb_m)
     wb_f.fit_toas()

--- a/tests/test_fitter_compare.py
+++ b/tests/test_fitter_compare.py
@@ -19,7 +19,8 @@ from pint.fitter import (
     WLSFitter,
 )
 from pint.models.model_builder import get_model
-from pint.toa import get_TOAs, make_fake_toas
+from pint.toa import get_TOAs
+from pint.simulation import make_fake_toas_uniform
 
 
 @pytest.fixture
@@ -36,7 +37,9 @@ def wls():
 @pytest.fixture
 def wb():
     m = get_model(join(datadir, "NGC6440E.par"))
-    t = make_fake_toas(55000, 58000, 20, model=m, freq=1400 * u.MHz, dm=10 * pint.dmu)
+    t = make_fake_toas_uniform(
+        55000, 58000, 20, model=m, freq=1400 * u.MHz, dm=10 * pint.dmu
+    )
 
     wb = WidebandTOAFitter(t, m)
     wb.fit_toas()

--- a/tests/test_model_derivatives.py
+++ b/tests/test_model_derivatives.py
@@ -11,8 +11,10 @@ import pytest
 from hypothesis import HealthCheck, Verbosity, assume, given, settings
 from hypothesis.strategies import composite, floats, integers, sampled_from
 from numpy.testing import assert_allclose
+from astropy import units as u
 
 import pint.toa
+import pint.simulation
 from pint.models import get_model
 
 
@@ -58,20 +60,20 @@ def get_model_and_toas(parfile):
         else:
             start = 57000
         with quiet():
-            toas1 = pint.toa.make_fake_toas(
+            toas1 = pint.simulation.make_fake_toas_uniform(
                 model=model,
                 startMJD=start,
                 endMJD=start + 100,
                 ntoas=5,
-                freq=1400,
+                freq=1400 * u.MHz,
                 obs="gbt",
             )
-            toas2 = pint.toa.make_fake_toas(
+            toas2 = pint.simulation.make_fake_toas_uniform(
                 model=model,
                 startMJD=start + 1,
                 endMJD=start + 102,
                 ntoas=5,
-                freq=2000,
+                freq=2000 * u.MHz,
                 obs="ao",
             )
             toas = pint.toa.merge_TOAs([toas1, toas2])

--- a/tests/test_parametercovariancematrix.py
+++ b/tests/test_parametercovariancematrix.py
@@ -35,7 +35,9 @@ def wls():
 @pytest.fixture
 def wb():
     m = get_model(join(datadir, "NGC6440E.par"))
-    t = make_fake_toas_uniform(55000, 58000, 20, model=m, freq=1400 * u.MHz, dm=10 * pint.dmu)
+    t = make_fake_toas_uniform(
+        55000, 58000, 20, model=m, freq=1400 * u.MHz, dm=10 * pint.dmu
+    )
 
     wb = WidebandTOAFitter(t, m)
     wb.fit_toas()

--- a/tests/test_parametercovariancematrix.py
+++ b/tests/test_parametercovariancematrix.py
@@ -17,7 +17,8 @@ from pint.fitter import (
     WidebandTOAFitter,
 )
 from pint.models.model_builder import get_model
-from pint.toa import get_TOAs, make_fake_toas
+from pint.toa import get_TOAs
+from pint.simulation import make_fake_toas_uniform
 
 
 @pytest.fixture
@@ -34,7 +35,7 @@ def wls():
 @pytest.fixture
 def wb():
     m = get_model(join(datadir, "NGC6440E.par"))
-    t = make_fake_toas(55000, 58000, 20, model=m, freq=1400 * u.MHz, dm=10 * pint.dmu)
+    t = make_fake_toas_uniform(55000, 58000, 20, model=m, freq=1400 * u.MHz, dm=10 * pint.dmu)
 
     wb = WidebandTOAFitter(t, m)
     wb.fit_toas()

--- a/tests/test_pulse_number.py
+++ b/tests/test_pulse_number.py
@@ -12,7 +12,8 @@ from pint.residuals import Residuals
 from pinttestdata import datadir
 import pint.fitter
 from pint.models import get_model
-from pint.toa import get_TOAs, make_fake_toas
+from pint.toa import get_TOAs
+from pint.simulation import make_fake_toas_uniform
 
 parfile = os.path.join(datadir, "withpn.par")
 timfile = os.path.join(datadir, "withpn.tim")
@@ -33,7 +34,7 @@ def toas():
 
 @pytest.fixture
 def fake_toas(model):
-    t = make_fake_toas(56000, 59000, 10, model, obs="@")
+    t = make_fake_toas_uniform(56000, 59000, 10, model, obs="@")
     t.table["error"] = 1 * u.us
     return t
 
@@ -65,14 +66,14 @@ def test_pulse_number(model, toas):
 
 @pytest.mark.parametrize("obs", ["GBT", "AO", "@", "coe"])
 def test_make_fake_toas(obs, model):
-    t = make_fake_toas(56000, 59000, 10, model, obs=obs)
+    t = make_fake_toas_uniform(56000, 59000, 10, model, obs=obs)
     t.table["error"] = 1 * u.us
     r = Residuals(t, model, track_mode="nearest")
     assert np.amax(np.abs(r.phase_resids)) < 1e-6
 
 
 def test_parameter_overrides_model(model):
-    t = make_fake_toas(56000, 59000, 10, model, obs="@")
+    t = make_fake_toas_uniform(56000, 59000, 10, model, obs="@")
     t.table["error"] = 1 * u.us
     delta_f = (1 / (t.last_MJD - t.first_MJD)).to(u.Hz)
 

--- a/tests/test_random_models.py
+++ b/tests/test_random_models.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 import os
 from copy import deepcopy
 
@@ -10,7 +9,7 @@ import numpy as np
 import astropy.units as u
 
 from pint.models import get_model, get_model_and_toas
-from pint import fitter, toa
+from pint import fitter, toa, simulation
 from pinttestdata import datadir
 import pint.models.parameter as param
 from pint import ls
@@ -30,15 +29,15 @@ def test_random_models():
 
     # this contains TOAs up through 54200
     # make new ones starting there
-    tnew = toa.make_fake_toas(54200, 59000, 59000 - 54200, f.model)
-    dphase, mrand = utils.calculate_random_models(f, tnew, Nmodels=100)
+    tnew = simulation.make_fake_toas_uniform(54200, 59000, 59000 - 54200, f.model)
+    dphase, mrand = simulation.calculate_random_models(f, tnew, Nmodels=100)
 
     # this is a bit stochastic, but I see typically < 0.14 cycles
     # for the uncertainty at 59000
     assert np.all(dphase.std(axis=0) < 0.2)
 
     # redo it with only F0 free
-    dphase_F, mrand_F = utils.calculate_random_models(
+    dphase_F, mrand_F = simulation.calculate_random_models(
         f, tnew, Nmodels=100, params=["F0"]
     )
 

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -16,7 +16,8 @@ from pint.fitter import GLSFitter, WidebandTOAFitter, WLSFitter
 from pint.models import get_model
 from pint.models.dispersion_model import Dispersion
 from pint.residuals import CombinedResiduals, Residuals, WidebandTOAResiduals
-from pint.toa import get_TOAs, make_fake_toas
+from pint.toa import get_TOAs
+from pint.simulation import make_fake_toas_uniform
 from pint.utils import weighted_mean
 
 os.chdir(datadir)
@@ -37,7 +38,7 @@ def wideband_fake():
             """
         )
     )
-    toas = make_fake_toas(
+    toas = make_fake_toas_uniform(
         57000, 59000, 40, model=model, error=1 * u.us, dm=10 * u.pc / u.cm ** 3
     )
     toas.compute_pulse_numbers(model)
@@ -136,7 +137,7 @@ def test_residuals_scaled_uncertainties():
             """
         )
     )
-    toas = make_fake_toas(57000, 59000, 20, model=model, error=1 * u.us)
+    toas = make_fake_toas_uniform(57000, 59000, 20, model=model, error=1 * u.us)
     r = Residuals(toas, model)
     e = r.get_data_error(scaled=True)
     assert np.all(e != 0)
@@ -159,7 +160,7 @@ def test_residuals_fake_wideband():
             """
         )
     )
-    toas = make_fake_toas(
+    toas = make_fake_toas_uniform(
         57000, 59000, 20, model=model, error=1 * u.us, dm=10 * u.pc / u.cm ** 3
     )
     r = WidebandTOAResiduals(toas, model)
@@ -183,7 +184,7 @@ def test_residuals_wls_chi2():
             """
         )
     )
-    toas = make_fake_toas(57000, 59000, 20, model=model, error=1 * u.us)
+    toas = make_fake_toas_uniform(57000, 59000, 20, model=model, error=1 * u.us)
     np.random.seed(0)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
     r = Residuals(toas, model)
@@ -205,7 +206,7 @@ def test_residuals_gls_chi2():
             """
         )
     )
-    toas = make_fake_toas(57000, 59000, 20, model=model, error=1 * u.us)
+    toas = make_fake_toas_uniform(57000, 59000, 20, model=model, error=1 * u.us)
     np.random.seed(0)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
     r = Residuals(toas, model)
@@ -242,7 +243,7 @@ def test_gls_chi2_reasonable(full_cov):
             """
         )
     )
-    toas = make_fake_toas(57000, 59000, 40, model=model, error=1 * u.us)
+    toas = make_fake_toas_uniform(57000, 59000, 40, model=model, error=1 * u.us)
     np.random.seed(0)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
     f = GLSFitter(toas, model)
@@ -268,7 +269,7 @@ def test_gls_chi2_full_cov():
         )
     )
     model.free_params = ["ELAT", "ELONG"]
-    toas = make_fake_toas(57000, 59000, 100, model=model, error=1 * u.us)
+    toas = make_fake_toas_uniform(57000, 59000, 100, model=model, error=1 * u.us)
     np.random.seed(0)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
     r = Residuals(toas, model)
@@ -292,7 +293,7 @@ def test_gls_chi2_behaviour():
         )
     )
     model.free_params = ["F0", "ELAT", "ELONG"]
-    toas = make_fake_toas(57000, 59000, 40, model=model, error=1 * u.us)
+    toas = make_fake_toas_uniform(57000, 59000, 40, model=model, error=1 * u.us)
     np.random.seed(0)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
     f = GLSFitter(toas, model)

--- a/tests/test_solar_wind.py
+++ b/tests/test_solar_wind.py
@@ -13,7 +13,8 @@ import astropy.units as u
 from astropy.time import Time
 from pint.models import get_model
 from pint.fitter import WidebandTOAFitter
-from pint.toa import get_TOAs, make_fake_toas
+from pint.toa import get_TOAs
+from pint.simulation import make_fake_toas_uniform
 from pinttestdata import datadir
 
 os.chdir(datadir)
@@ -34,7 +35,7 @@ year = 365.25  # in mjd
 @pytest.mark.parametrize("frac", [0, 0.25, 0.5, 0.123])
 def test_sun_angle_ecliptic(frac):
     model = get_model(StringIO(par))
-    toas = make_fake_toas(
+    toas = make_fake_toas_uniform(
         march_equinox, march_equinox + 2 * year, 10, model=model, obs="gbt"
     )
     # Sun longitude, from Astronomical Almanac
@@ -53,5 +54,5 @@ def test_sun_angle_ecliptic(frac):
 
 def test_solar_wind_delays_positive():
     model = get_model(StringIO("\n".join([par, "NE_SW 1"])))
-    toas = make_fake_toas(54000, 54000 + year, 13, model=model, obs="gbt")
+    toas = make_fake_toas_uniform(54000, 54000 + year, 13, model=model, obs="gbt")
     assert np.all(model.components["SolarWindDispersion"].solar_wind_dm(toas) > 0)

--- a/tests/test_stigma.py
+++ b/tests/test_stigma.py
@@ -9,6 +9,7 @@ import tempfile
 
 from pint.models import get_model
 import pint.toa as toa
+import pint.simulation as simulation
 import test_derivative_utils as tdu
 from pint.residuals import Residuals
 from pinttestdata import datadir
@@ -55,9 +56,9 @@ def test_stigma_zero(tmpdir):
         get_model(parfile_name(tmpdir, stigma_template.format(0)))
     # if STIGMA is zero everything goes wrong.
     # with np.errstate(invalid="raise"):
-    #    toa.make_fake_toas(58000, 59000, 10, model=m)
+    #    simulation.make_fake_toas_uniform(58000, 59000, 10, model=m)
 
 
 def test_stigma_nonzero(tmpdir):
     m = get_model(parfile_name(tmpdir, stigma_template.format(0.5)))
-    toa.make_fake_toas(58000, 59000, 10, model=m)
+    simulation.make_fake_toas_uniform(58000, 59000, 10, model=m)

--- a/tests/test_timing_model.py
+++ b/tests/test_timing_model.py
@@ -7,7 +7,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from pinttestdata import datadir
-from pint.toa import make_fake_toas
+from pint.simulation import make_fake_toas_uniform
 from pint.toa import get_TOAs
 
 from pint.models import (
@@ -309,7 +309,7 @@ def test_free_params(lines, param, exception):
 
 def test_pepoch_late():
     model = get_model(io.StringIO(par_base))
-    make_fake_toas(56000, 57000, 10, model=model)
+    make_fake_toas_uniform(56000, 57000, 10, model=model)
 
 
 def test_t2cmethod_corrected():

--- a/tests/test_toa.py
+++ b/tests/test_toa.py
@@ -9,7 +9,8 @@ from pinttestdata import datadir
 
 from pint.models import get_model
 from pint.observatory import get_observatory
-from pint.toa import TOA, TOAs, make_fake_toas
+from pint.toa import TOA, TOAs
+from pint.simulation import make_fake_toas_uniform
 
 
 class TestTOA(unittest.TestCase):
@@ -105,7 +106,7 @@ class TestTOAs(unittest.TestCase):
 
 def test_toa_summary():
     m = get_model(os.path.join(datadir, "NGC6440E.par"))
-    toas = make_fake_toas(57000, 58000, 10, m, obs="ao", freq=2000 * u.MHz)
+    toas = make_fake_toas_uniform(57000, 58000, 10, m, obs="ao", freq=2000 * u.MHz)
     s = toas.get_summary()
 
     assert re.search(r"Number of commands: *0", s)

--- a/tests/test_toa_pickle.py
+++ b/tests/test_toa_pickle.py
@@ -14,6 +14,7 @@ from pinttestdata import datadir
 import pint.models
 import pint.toa
 from pint import toa
+from pint import simulation
 
 
 @pytest.fixture
@@ -125,7 +126,7 @@ def test_pickle_moved(temp_tim):
 def test_group_survives_pickle(tmpdir):
     p = os.path.join(tmpdir, "test.pickle.gz")
     test_model = pint.models.get_model(os.path.join(datadir, "NGC6440E.par"))
-    test_toas = pint.toa.make_fake_toas(58000, 59000, 5, model=test_model)
+    test_toas = simulation.make_fake_toas_uniform(58000, 59000, 5, model=test_model)
     test_toas.adjust_TOAs(
         astropy.time.TimeDelta((np.random.uniform(0, 1, size=(5,)) * u.d))
     )
@@ -141,7 +142,7 @@ def test_group_survives_pickle(tmpdir):
 def test_astropy_group_survives_pickle(tmpdir):
     p = os.path.join(tmpdir, "test.pickle.gz")
     test_model = pint.models.get_model(os.path.join(datadir, "NGC6440E.par"))
-    test_toas = pint.toa.make_fake_toas(58000, 59000, 5, model=test_model)
+    test_toas = simulation.make_fake_toas_uniform(58000, 59000, 5, model=test_model)
 
     with open(p, "wb") as f:
         pickle.dump(test_toas.table, f)
@@ -155,7 +156,7 @@ def test_astropy_group_survives_pickle(tmpdir):
 
 def test_group_survives_plain_pickle(tmpdir):
     test_model = pint.models.get_model(os.path.join(datadir, "NGC6440E.par"))
-    test_toas = pint.toa.make_fake_toas(58000, 59000, 5, model=test_model)
+    test_toas = simulation.make_fake_toas_uniform(58000, 59000, 5, model=test_model)
 
     new_toas = pickle.loads(pickle.dumps(test_toas))
 

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -9,7 +9,7 @@ from glob import glob
 from hypothesis import given
 from hypothesis.strategies import integers, floats, sampled_from
 from hypothesis.extra.numpy import arrays
-from pint import toa
+from pint import toa, simulation
 from pint.observatory import bipm_default
 from pint.models import get_model, get_model_and_toas
 from pinttestdata import datadir
@@ -263,9 +263,9 @@ def test_load_multiple(tmpdir):
     m = get_model(StringIO(simplepar))
 
     fakes = [
-        toa.make_fake_toas(55000, 55500, 10, model=m, obs="ao"),
-        toa.make_fake_toas(56000, 56500, 10, model=m, obs="gbt"),
-        toa.make_fake_toas(57000, 57500, 10, model=m, obs="@"),
+        simulation.make_fake_toas_uniform(55000, 55500, 10, model=m, obs="ao"),
+        simulation.make_fake_toas_uniform(56000, 56500, 10, model=m, obs="gbt"),
+        simulation.make_fake_toas_uniform(57000, 57500, 10, model=m, obs="@"),
     ]
 
     filenames = [os.path.join(tmpdir, f"t{i+1}.tim") for i in range(len(fakes))]
@@ -282,9 +282,9 @@ def test_pickle_multiple(tmpdir):
     m = get_model(StringIO(simplepar))
 
     fakes = [
-        toa.make_fake_toas(55000, 55500, 10, model=m, obs="ao"),
-        toa.make_fake_toas(56000, 56500, 10, model=m, obs="gbt"),
-        toa.make_fake_toas(57000, 57500, 10, model=m, obs="@"),
+        simulation.make_fake_toas_uniform(55000, 55500, 10, model=m, obs="ao"),
+        simulation.make_fake_toas_uniform(56000, 56500, 10, model=m, obs="gbt"),
+        simulation.make_fake_toas_uniform(57000, 57500, 10, model=m, obs="@"),
     ]
 
     filenames = [os.path.join(tmpdir, f"t{i+1}.tim") for i in range(len(fakes))]
@@ -308,9 +308,9 @@ def test_pickle_multiple(tmpdir):
 def test_merge_indices():
     m = get_model(StringIO(simplepar))
     fakes = [
-        toa.make_fake_toas(55000, 55500, 5, model=m, obs="ao"),
-        toa.make_fake_toas(56000, 56500, 10, model=m, obs="gbt"),
-        toa.make_fake_toas(57000, 57500, 15, model=m, obs="@"),
+        simulation.make_fake_toas_uniform(55000, 55500, 5, model=m, obs="ao"),
+        simulation.make_fake_toas_uniform(56000, 56500, 10, model=m, obs="gbt"),
+        simulation.make_fake_toas_uniform(57000, 57500, 15, model=m, obs="@"),
     ]
     toas = toa.merge_TOAs(fakes)
     check_indices_contiguous(toas)
@@ -319,9 +319,9 @@ def test_merge_indices():
 def test_merge_indices_excised():
     m = get_model(StringIO(simplepar))
     fakes = [
-        toa.make_fake_toas(55000, 55500, 5, model=m, obs="ao"),
-        toa.make_fake_toas(56000, 56500, 10, model=m, obs="gbt"),
-        toa.make_fake_toas(57000, 57500, 15, model=m, obs="@"),
+        simulation.make_fake_toas_uniform(55000, 55500, 5, model=m, obs="ao"),
+        simulation.make_fake_toas_uniform(56000, 56500, 10, model=m, obs="gbt"),
+        simulation.make_fake_toas_uniform(57000, 57500, 15, model=m, obs="@"),
     ]
     fakes_excised = [f[1:-1] for f in fakes]
     toas = toa.merge_TOAs(fakes)
@@ -336,7 +336,7 @@ def test_merge_indices_excised():
 
 def test_renumber_subset():
     m = get_model(StringIO(simplepar))
-    toas = toa.make_fake_toas(55000, 55500, 10, model=m, obs="ao")
+    toas = simulation.make_fake_toas_uniform(55000, 55500, 10, model=m, obs="ao")
 
     sub = toas[1:-1]
     assert 0 not in sub.table["index"]
@@ -347,7 +347,7 @@ def test_renumber_subset():
 
 def test_renumber_order():
     m = get_model(StringIO(simplepar))
-    toas = toa.make_fake_toas(55000, 55500, 10, model=m, obs="ao")
+    toas = simulation.make_fake_toas_uniform(55000, 55500, 10, model=m, obs="ao")
     rev = toas[::-1]
     assert np.all(rev.table["index"] == np.arange(len(rev))[::-1])
     rev.renumber()
@@ -363,9 +363,9 @@ def test_renumber_order():
 def test_renumber_subset_reordered():
     m = get_model(StringIO(simplepar))
     fakes = [
-        toa.make_fake_toas(55000, 55500, 5, model=m, obs="ao"),
-        toa.make_fake_toas(56000, 56500, 10, model=m, obs="gbt"),
-        toa.make_fake_toas(57000, 57500, 15, model=m, obs="@"),
+        simulation.make_fake_toas_uniform(55000, 55500, 5, model=m, obs="ao"),
+        simulation.make_fake_toas_uniform(56000, 56500, 10, model=m, obs="gbt"),
+        simulation.make_fake_toas_uniform(57000, 57500, 15, model=m, obs="@"),
     ]
     fakes_excised = [f[1:-1] for f in fakes]
     toas_excised = toa.merge_TOAs(fakes_excised)

--- a/tests/test_toa_writer.py
+++ b/tests/test_toa_writer.py
@@ -4,7 +4,7 @@ import os.path
 import pytest
 
 from pint.models import get_model
-from pint import toa
+from pint import toa, simulation
 from pinttestdata import datadir
 from astropy.time import Time
 import numpy as np
@@ -144,9 +144,9 @@ DILATEFREQ          N
 def test_tim_writing_order():
     m = get_model(StringIO(simplepar))
     fakes = [
-        toa.make_fake_toas(55000, 56000, 5, model=m, obs="ao"),
-        toa.make_fake_toas(55000, 56000, 5, model=m, obs="gbt"),
-        toa.make_fake_toas(55000, 56000, 5, model=m, obs="@"),
+        simulation.make_fake_toas_uniform(55000, 56000, 5, model=m, obs="ao"),
+        simulation.make_fake_toas_uniform(55000, 56000, 5, model=m, obs="gbt"),
+        simulation.make_fake_toas_uniform(55000, 56000, 5, model=m, obs="@"),
     ]
     toas = toa.merge_TOAs(fakes)
     toas.table["index"][np.argsort(toas.table["tdbld"])] = np.arange(len(toas))


### PR DESCRIPTION
Making sure that `zima` works correctly, using the same `make_fake_toas` functions as other parts of the code.

This led to some changes:
* Moved the functions (and `calculate_random_models`) to a new module `pint.simulation`.  The reason for this was that including them in `toa` led to circular import worries, and the same for including them in `utils`.  Those imports should really be sorted elsewhere but I didn't want to get into that.
* Added a base function `make_fake_toas` that accepts a `TOAs` object as input.  This then has specific uses:
* `make_fake_toas_uniform` (the old function - uniformly spaced)
* `make_fake_toas_fromtim` (`zima` did this too)
* added the ability to "fuzz" the uniform MJDs (replicating `zima`) 
* added the ability to actually include the error as noise on the TOAs, not just populate a column (again, `zima` did this, but it's now optional for both)
* checked that this works with `EFAC` and `EQUAD`
* added unit tests

I updated all of the existing tests and docs to reflect these changes.  

Usages:
```
toas = pint.simulation.make_fake_toas_uniform(57001, 58000, 200, model=model, error=1 * u.us,add_noise=True )
```
or
```
m, t = get_model_and_toas(
        pint.config.examplefile("B1855+09_NANOGrav_9yv1.gls.par"),
        pint.config.examplefile("B1855+09_NANOGrav_9yv1.tim"),)
# refit the data to get rid of a trend
f = GLSFitter(t, m)
f.fit_toas()
t_sim = pint.simulation.make_fake_toas(t, f.model, add_noise=True)
```