### PR TITLE
Fix bug in d_phase_d_toa()

### DIFF
--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1391,8 +1391,9 @@ class TimingModel:
         copy_toas = copy.deepcopy(toas)
         if sample_step is None:
             pulse_period = 1.0 / (self.F0.quantity)
-            sample_step = pulse_period * 1000
-        sample_dt = [-sample_step, sample_step]
+            sample_step = pulse_period * 2
+        # Note that sample_dt is applied cumulatively, so this evaulates phase at TOA-dt and TOA+dt
+        sample_dt = [-sample_step, 2 * sample_step]
 
         sample_phase = []
         for dt in sample_dt:

--- a/tests/test_d_phase_d_toa.py
+++ b/tests/test_d_phase_d_toa.py
@@ -39,7 +39,7 @@ class TestD_phase_d_toa(unittest.TestCase):
         tempo_d_phase_d_toa = self.plc.eval_spin_freq(mjd)
         diff = pint_d_phase_d_toa.value - tempo_d_phase_d_toa
         relative_diff = diff / tempo_d_phase_d_toa
-        assert np.all(relative_diff < 1e-20), "d_phae_d_toa test filed."
+        assert np.all(np.abs(relative_diff) < 1e-7), "d_phase_d_toa test failed."
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1128

This was a bug in both the computation and the test. Both are now fixed.

The other change I made was to change the finite difference dt from being 1000*P0 to 2*P0. Since PINT can compute accurate phases from one pulse to the next, 1000*P0 seems excessive and dangerous for long period pulsars. For a 1000s pulsar, that is 10 days away!!

The (broken) test used to try to compare to TEMPO polyco computation of local freq and insisted it was good to a relative tolerance of 1E-20.  I had to relax this to 1E-7 to make this work. I'm not sure what accuracy we should insist on for the two different computations of local frequency.  Thoughts?