### PR TITLE
Fix remove fn

### DIFF
--- a/src/pint/models/binary_ell1.py
+++ b/src/pint/models/binary_ell1.py
@@ -162,14 +162,10 @@ class BinaryELL1(PulsarBinary):
             dPB = PBDOT * dt_integer_orbits
             self.PB.quantity = self.PB.quantity + dPB
         else:
-            fbterms = [
-                getattr(self, k).quantity
-                for k in self.get_prefix_mapping("FB").values()
-            ]
-            fbterms = [0.0 * u.Unit("")] + fbterms
+            fbterms = [0.0 * u.Unit("")] + self._parent.get_prefix_list("FB")
 
             for n in range(len(fbterms) - 1):
-                cur_deriv = getattr(self, "FB{}".format(n))
+                cur_deriv = getattr(self, f"FB{n}")
                 cur_deriv.value = taylor_horner_deriv(
                     dt_integer_orbits.to(u.s), fbterms, deriv_order=n + 1
                 )

--- a/src/pint/models/pulsar_binary.py
+++ b/src/pint/models/pulsar_binary.py
@@ -417,11 +417,7 @@ class PulsarBinary(DelayComponent):
             dPB = PBDOT * dt_integer_orbits
             self.PB.quantity = self.PB.quantity + dPB
         else:
-            fbterms = [
-                getattr(self, k).quantity
-                for k in self.get_prefix_mapping("FB").values()
-            ]
-            fbterms = [0.0 * u.Unit("")] + fbterms
+            fbterms = [0.0 * u.Unit("")] + self._parent.get_prefix_list("FB")
 
             for n in range(len(fbterms) - 1):
                 cur_deriv = getattr(self, "FB{}".format(n))

--- a/src/pint/models/spindown.py
+++ b/src/pint/models/spindown.py
@@ -66,8 +66,6 @@ class Spindown(PhaseComponent):
 
     def setup(self):
         super().setup()
-        self.num_spin_terms = len(self.F_terms) + 1
-        # Add derivative functions
         for fp in list(self.get_prefix_mapping_component("F").values()) + ["F0"]:
             self.register_deriv_funcs(self.d_phase_d_F, fp)
 
@@ -78,11 +76,7 @@ class Spindown(PhaseComponent):
             if getattr(self, p).value is None:
                 raise MissingParameter("Spindown", p)
         # Check continuity
-        sort_F_terms = sorted(self.F_terms)
-        F_in_order = list(range(1, max(self.F_terms) + 1))
-        if not sort_F_terms == F_in_order:
-            diff = list(set(F_in_order) - set(sort_F_terms))
-            raise MissingParameter("Spindown", "F%d" % diff[0])
+        self._parent.get_prefix_list("F", start_index=1)
         # If F1 is set, we need PEPOCH
         if self.F1.value != 0.0:
             if self.PEPOCH.value is None:
@@ -92,20 +86,19 @@ class Spindown(PhaseComponent):
 
     @property
     def F_terms(self):
-        return list(self.get_prefix_mapping_component("F").keys())
+        return "F0" + ["F{i+1}" for i in range(len(self._parent.get_prefix_list("F", 1)))]
 
     def F_description(self, n):
-        """Template function for description"""
+        """Template function for description."""
         return "Spin-frequency %d derivative" % n if n else "Spin-frequency"
 
     def F_unit(self, n):
-        """Template function for unit"""
+        """Template function for unit."""
         return "Hz/s^%d" % n if n else "Hz"
 
     def get_spin_terms(self):
-        """Return a list of the spin term values in the model: [F0, F1, ..., FN]
-        """
-        return [getattr(self, "F%d" % ii).quantity for ii in range(self.num_spin_terms)]
+        """Return a list of the spin term values in the model: [F0, F1, ..., FN]."""
+        return [self.F0.quantity] + self._parent.get_prefix_list("F", start_index=1)
 
     def get_dt(self, toas, delay):
         """Return dt, the time from the phase 0 epoch to each TOA.  The
@@ -182,15 +175,11 @@ class Spindown(PhaseComponent):
 
     def print_par(self):
         result = ""
-        f_terms = ["F%d" % ii for ii in range(self.num_spin_terms)]
+        f_terms = self.F_terms
         for ft in f_terms:
             par = getattr(self, ft)
             result += par.as_parfile_line()
-        if hasattr(self, "components"):
-            p_default = self.components["Spindown"].params
-        else:
-            p_default = self.params
-        for param in p_default:
+        for param in self.params:
             if param not in f_terms:
                 result += getattr(self, param).as_parfile_line()
         return result

--- a/src/pint/models/spindown.py
+++ b/src/pint/models/spindown.py
@@ -86,7 +86,7 @@ class Spindown(PhaseComponent):
 
     @property
     def F_terms(self):
-        return [f"F{i}" for i in range(1+len(self._parent.get_prefix_list("F", 1)))]
+        return [f"F{i}" for i in range(1 + len(self._parent.get_prefix_list("F", 1)))]
 
     def F_description(self, n):
         """Template function for description."""

--- a/src/pint/models/spindown.py
+++ b/src/pint/models/spindown.py
@@ -86,7 +86,7 @@ class Spindown(PhaseComponent):
 
     @property
     def F_terms(self):
-        return "F0" + ["F{i+1}" for i in range(len(self._parent.get_prefix_list("F", 1)))]
+        return [f"F{i}" for i in range(1+len(self._parent.get_prefix_list("F", 1)))]
 
     def F_description(self, n):
         """Template function for description."""

--- a/src/pint/models/spindown.py
+++ b/src/pint/models/spindown.py
@@ -78,7 +78,7 @@ class Spindown(PhaseComponent):
         # Check continuity
         self._parent.get_prefix_list("F", start_index=1)
         # If F1 is set, we need PEPOCH
-        if self.F1.value != 0.0:
+        if hasattr(self, "F1") and self.F1.value != 0.0:
             if self.PEPOCH.value is None:
                 raise MissingParameter(
                     "Spindown", "PEPOCH", "PEPOCH is required if F1 or higher are set"

--- a/tests/test_spindown.py
+++ b/tests/test_spindown.py
@@ -23,6 +23,13 @@ def test_missing_f1():
     m = get_model(StringIO("\n".join([par_base, "F2 0"])))
     assert m.F1.value == 0
 
+def test_removed_f1():
+    m = get_model(StringIO(par_base))
+    assert m.F1.value == 0
+    m.remove_param("F1")
+    m.validate()
+    make_fake_toas_uniform(57000, 58000, 2, m)
+
 def test_missing_f2():
     with pytest.raises(ValueError):
         get_model(StringIO("\n".join([par_base, "F3 0"])))

--- a/tests/test_spindown.py
+++ b/tests/test_spindown.py
@@ -1,16 +1,29 @@
+import pytest
 from io import StringIO
 from pint.models import get_model
 from pint.simulation import make_fake_toas_uniform
 
+par_base = """
+    PSR J1235+5678
+    F0 1
+    ELAT 0
+    ELONG 0
+    PEPOCH 57000
+"""
+
 def test_fn_removal():
-    m = get_model(StringIO("""
-        PSR J1235+5678
-        F0 1
-        F1 0
-        F2 1e-30
-        ELAT 0
-        ELONG 0
-        PEPOCH 57000
-        """))
+    m = get_model(StringIO("\n".join([par_base, "F1 0", "F2 0"])))
     m.remove_param("F2")
     make_fake_toas_uniform(57000, 58000, 2, m)
+
+def test_no_f1():
+    get_model(StringIO(par_base))
+
+def test_missing_f1():
+    m = get_model(StringIO("\n".join([par_base, "F2 0"])))
+    assert m.F1.value == 0
+
+def test_missing_f2():
+    with pytest.raises(ValueError):
+        get_model(StringIO("\n".join([par_base, "F3 0"])))
+

--- a/tests/test_spindown.py
+++ b/tests/test_spindown.py
@@ -1,5 +1,7 @@
-import pytest
 from io import StringIO
+
+import pytest
+
 from pint.models import get_model
 from pint.simulation import make_fake_toas_uniform
 
@@ -11,17 +13,21 @@ par_base = """
     PEPOCH 57000
 """
 
+
 def test_fn_removal():
     m = get_model(StringIO("\n".join([par_base, "F1 0", "F2 0"])))
     m.remove_param("F2")
     make_fake_toas_uniform(57000, 58000, 2, m)
 
+
 def test_no_f1():
     get_model(StringIO(par_base))
+
 
 def test_missing_f1():
     m = get_model(StringIO("\n".join([par_base, "F2 0"])))
     assert m.F1.value == 0
+
 
 def test_removed_f1():
     m = get_model(StringIO(par_base))
@@ -30,7 +36,7 @@ def test_removed_f1():
     m.validate()
     make_fake_toas_uniform(57000, 58000, 2, m)
 
+
 def test_missing_f2():
     with pytest.raises(ValueError):
         get_model(StringIO("\n".join([par_base, "F3 0"])))
-

--- a/tests/test_spindown.py
+++ b/tests/test_spindown.py
@@ -1,0 +1,16 @@
+from io import StringIO
+from pint.models import get_model
+from pint.simulation import make_fake_toas_uniform
+
+def test_fn_removal():
+    m = get_model(StringIO("""
+        PSR J1235+5678
+        F0 1
+        F1 0
+        F2 1e-30
+        ELAT 0
+        ELONG 0
+        PEPOCH 57000
+        """))
+    m.remove_param("F2")
+    make_fake_toas_uniform(57000, 58000, 2, m)


### PR DESCRIPTION
Incorrect caching made Spindown break when parameters were removed. This fixes that, and tests that it is fixed.

Closes #1132 