### PR TITLE
Small error check in model comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Now ensures T2CMETHOD is IAU2000B if it is set at all; likewise DILATEFREQ and TIMEEPH (PR #970)
 - Merging TOAs objects now ensures that their index columns don't overlap (PR #1029)
 - change_dmepoch now works even if DMEPOCH is not set (PR #1025)
+- Fixed factor of 2 error in d_phase_d_toa() (PR #1129)
+- Fixed change_binary_epoch (PR #1120)
 ### Added
 - DownhillWLSFitter, DownhillGLSFitter, WidebandDownhillFitter are new Fitters that are more careful about convergence than the existing ones (PR #975)
 - Fitters have a .is_wideband boolean attribute (PR #975)
@@ -18,10 +20,14 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - New function utils.info_string() to return information about the PINT run (user, version, OS, optional comments).  This is run during TOA output to tim file or model output to par file by default, but can be suppressed by setting include_info=False (PR #1069)
 - New functions for calculations of post-Keplerian parameters (PR #1088)
 - New tutorial for simulating data and making a mass-mass plot (PR #1096)
+- Added better axis scaling to pintk (PR #1116)
 ### Changed
 - get_groups() is renamed to get_clusters() and is no longer automatically called during TOA creation.  Can still be run manually, with the gap specified.  Addition of a clusters column to the TOA.table object is optional (PR #1070)
 - Some functions from utils.py are now in derived_quantities.py (PR #1102)
 - Data for tutorials etc. and clock files are now installed properly, with locations retrievable at runtime (PR #1103)
+- Changed from using astropy logging to python logging (PR #1093)
+- Code coverage reports are now informational and don't cause CI to fail (PRs #1085, #1087)
+- API for TOA flags significantly changes, now only hold strings and allow fancy indexing (PR #1074)
 
 ## [0.8.2] - 2021-01-27
 ### Fixed

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1833,18 +1833,13 @@ class TimingModel:
                     newstr += "{:14s} {:>28s}".format(pn, str(par.quantity))
                     if otherpar is not None and otherpar.quantity is not None:
                         newstr += " {:>28s}\n".format(str(otherpar.quantity))
-                    else:
-                        newstr += " {:>28s}\n".format("Missing")
-                    try:
                         if otherpar.quantity != par.quantity:
                             log.info(
                                 "Parameter %s not fit, but has changed between these models"
                                 % par.name
                             )
-                    except AttributeError:
-                        log.warning(
-                            "Comparison par file is missing parameter {}".format(pn)
-                        )
+                    else:
+                        newstr += " {:>28s}\n".format("Missing")
                 else:
                     # If fitted, print both values with uncertainties
                     if par.units == u.hourangle:

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1835,10 +1835,15 @@ class TimingModel:
                         newstr += " {:>28s}\n".format(str(otherpar.quantity))
                     else:
                         newstr += " {:>28s}\n".format("Missing")
-                    if otherpar.quantity != par.quantity:
-                        log.info(
-                            "Parameter %s not fit, but has changed between these models"
-                            % par.name
+                    try:
+                        if otherpar.quantity != par.quantity:
+                            log.info(
+                                "Parameter %s not fit, but has changed between these models"
+                                % par.name
+                            )
+                    except AttributeError:
+                        log.warning(
+                            "Comparison par file is missing parameter {}".format(pn)
                         )
                 else:
                     # If fitted, print both values with uncertainties

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1391,8 +1391,9 @@ class TimingModel:
         copy_toas = copy.deepcopy(toas)
         if sample_step is None:
             pulse_period = 1.0 / (self.F0.quantity)
-            sample_step = pulse_period * 1000
-        sample_dt = [-sample_step, sample_step]
+            sample_step = pulse_period * 2
+        # Note that sample_dt is applied cumulatively, so this evaulates phase at TOA-dt and TOA+dt
+        sample_dt = [-sample_step, 2 * sample_step]
 
         sample_phase = []
         for dt in sample_dt:

--- a/tests/test_d_phase_d_toa.py
+++ b/tests/test_d_phase_d_toa.py
@@ -39,7 +39,7 @@ class TestD_phase_d_toa(unittest.TestCase):
         tempo_d_phase_d_toa = self.plc.eval_spin_freq(mjd)
         diff = pint_d_phase_d_toa.value - tempo_d_phase_d_toa
         relative_diff = diff / tempo_d_phase_d_toa
-        assert np.all(relative_diff < 1e-20), "d_phae_d_toa test filed."
+        assert np.all(np.abs(relative_diff) < 1e-7), "d_phase_d_toa test failed."
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes an exception when doing `m1.compare(m2)` in the case that `m1` has equatorial coords and `m2` has ecliptic.

Also adds some CHANGELOG entries