### PR TITLE
Updating CHIME observatory coordinates

### DIFF
--- a/src/pint/observatory/observatories.py
+++ b/src/pint/observatory/observatories.py
@@ -228,11 +228,13 @@ TopoObs(
     "chime",
     tempo_code="y",
     itoa_code="CH",
-    itrf_xyz=[-2058795.0, -3621559.0, 4814280.0],
-    origin="""The Canadian HI Mapping Experiment.
+    itrf_xyz=[-2059166.313, -3621302.972, 4814304.113],
+    origin="""The Canadian Hydrogen Intensity Mapping Experiment.
 
-    Origin of this data is unknown but as of 2021 June 8 this value agrees exactly with
-    the value used by TEMPO2 and TEMPO.
+    Origin of these coordinates are from surveyor reports of the CHIME site
+    (circa 2019 & 2020) and technical documents on the dimensions of the telescope
+    structure (circa 2015). Results were compiled in January 2021. The coordinates
+    are relative to the GRS80 ellipsoid.
     """,
 )
 TopoObs(


### PR DESCRIPTION
As of January 2021 we have a better handle on the centre position of the CHIME telescope structure. I've also provided some details about where these new numbers come from, for posterity. I _think_ this is the only change needed, but happy for the devs to point me elsewhere and I can adjust as necessary. 

(And a minor correction to the expanded name.)