### PR TITLE
Eliminate spurious "Data points out of range in clock file" warnings

### DIFF
--- a/src/pint/observatory/clock_file.py
+++ b/src/pint/observatory/clock_file.py
@@ -194,7 +194,9 @@ class TempoClockFile(ClockFile):
             # Parse MJD
             try:
                 mjd = float(l[0:9])
-                if mjd < 0 or mjd > 100000:
+                # allow mjd=0 to pass, since that is often used
+                # for effectively null clock files
+                if (mjd < 39000 and mjd != 0) or mjd > 100000:
                     mjd = None
             except (ValueError, IndexError):
                 mjd = None

--- a/src/pint/observatory/clock_file.py
+++ b/src/pint/observatory/clock_file.py
@@ -194,7 +194,7 @@ class TempoClockFile(ClockFile):
             # Parse MJD
             try:
                 mjd = float(l[0:9])
-                if mjd < 39000 or mjd > 100000:
+                if mjd < 0 or mjd > 100000:
                     mjd = None
             except (ValueError, IndexError):
                 mjd = None


### PR DESCRIPTION
Addressed #1146.  Warnings were coming because MJDs for barycenter and CHIME included 0,99999, meant to span everything.  But in `clock_file.py` it rejected MJDs less than 39000.  Since this also needs to work for `tempo` and `tempo2` clock files, I changed the lower MJD limit to 0.

A very minor change, meant to eliminate spurious warnings.