### PR TITLE
WIP: T_t2 friendly

### DIFF
--- a/src/pint/io/parfile_format.py
+++ b/src/pint/io/parfile_format.py
@@ -2,7 +2,7 @@
 way is to move this to the parameter class.
 """
 import yaml
-
+import numpy as np
 
 class ParfileFormat:
     """Class for different parfile format.
@@ -18,8 +18,10 @@ class ParfileFormat:
     format: str
         The name of the request format.
     """
+    _operations = ('to_name', 'to_value', 'to_type', 'to_unit')
+
     def __init__(self, format_config, format):
-        with open(config_file, "r") as cf:
+        with open(format_config, "r") as cf:
             config = yaml.safe_load(cf)
         try:
             self.entry = config[format]
@@ -28,5 +30,39 @@ class ParfileFormat:
                 "not have format {format}")
         self.format_name = format
 
-    def translate_format(self, pint_par):
-        param_entry = self.entry.get(pint_par, None)
+    def to_format(self, pint_par):
+        """Translate the PINT parameter to .parfile formate that accepted by other package.
+
+        Parameter
+        ---------
+        pint_par: `pint.models.parameter.Parameter` object
+            The parameter object that needs to be translated.
+        """
+        param_entry = self.entry.get(pint_par.name, None)
+        # Make a new pint parameter and apply the translations on the new object
+        translated_par = copy.deepcopy(pint_par)
+        if param_entry:
+            for op in self._operations:
+                func = getattr(self, op)
+                translated_par = func(translated_par, param_entry)
+        return translated_par
+
+    def to_name(self, pint_par, translate_entry):
+        """Replace the parameter name"""
+        pint_par.name = translate_entry['to_name']
+        return pint_par
+
+    def to_value(self, pint_par, translate_entry):
+        """Hard Replace the parameter value"""
+        pint_par.value = translate_entry['to_value']
+        return pint_par
+
+    def to_unit(self, pint_par, translate_entry):
+        """Change the parameter quantity's unit"""
+        pint_par.units = u.Unit(translate_entry['to_unit'])
+        return pint_par
+
+    def to_type(self, pint_par, translate_entry):
+        """Change the parameter quantity to a new type"""
+        pint_par.quantity = pint_par.quantity.astype(translate_entry['to_type'])
+        return pint_par

--- a/src/pint/io/parfile_format.py
+++ b/src/pint/io/parfile_format.py
@@ -28,5 +28,5 @@ class ParfileFormat:
                 "not have format {format}")
         self.format_name = format
 
-    def translate_name(self, pint_par):
-        return self.entry.get(pint_par, None)
+    def translate_format(self, pint_par):
+        param_entry = self.entry.get(pint_par, None)

--- a/src/pint/io/parfile_format.py
+++ b/src/pint/io/parfile_format.py
@@ -3,32 +3,64 @@ way is to move this to the parameter class.
 """
 import yaml
 import numpy as np
+import copy
 
-class ParfileFormat:
-    """Class for different parfile format.
+import astropy.units as u
+
+class ParfileTranslator:
+    """Class for translating PINT-style parfile to other formats.
 
     Parameters
     ----------
-    format_config: str
-        Configuration file for the parfile format. It is a yaml file with format
-        name as the top level keys and the value is a dictionary map from PINT
-        parameter name to other format name. If the format has a head, one can
-        add a head entry, where 'head' is the key and the head string is the
-        value.
+    format_config: str, dict
+        Configuration file for the parfile format. It is a yaml file or a
+        dictionary with format name as the top level keys and the value is a
+        dictionary map from PINT parameter name to other format name. If the
+        format has a head, one can add a head entry, where 'head' is the key
+        and the head string is the value.
     format: str
         The name of the request format.
     """
     _operations = ('to_name', 'to_value', 'to_type', 'to_unit')
 
     def __init__(self, format_config, format):
-        with open(format_config, "r") as cf:
-            config = yaml.safe_load(cf)
+        if isinstance(format_config, str):
+            self.format_config_file = format_config
+            with open(format_config, "r") as cf:
+                config = yaml.safe_load(cf)
+        elif isinstance(format_config, dict):
+            config = format_config
+            self.format_config_file = None
+        else:
+            raise ValueError(f"Unacceptable format of config: {type(format_config)}.")
+
         try:
-            self.entry = config[format]
+            self.format_entry = config[format]
         except KeyError:
             raise KeyError(f"Parfile format config file {format_config} does "
-                "not have format {format}")
+                f"not have the format {format}")
         self.format_name = format
+
+    def _get_param_entry(self, param_name):
+        """Get the parameter translation entry.
+
+        Parameter
+        ---------
+        param_name: str
+            Name of the parameter that need to be translated.
+
+        Raises
+        ------
+        KeyError
+            If the parameter name not in the .format_entry dictionary.
+        """
+        try:
+            param_entry = self.format_entry[param_name]
+        except KeyError:
+            raise KeyError(f"Parameter {param_name} is not in the"
+                f" '{self.format_name}' translator. Please check your format"
+                f" config file {self.format_config_file}.")
+        return param_entry
 
     def to_format(self, pint_par):
         """Translate the PINT parameter to .parfile formate that accepted by other package.
@@ -38,31 +70,59 @@ class ParfileFormat:
         pint_par: `pint.models.parameter.Parameter` object
             The parameter object that needs to be translated.
         """
-        param_entry = self.entry.get(pint_par.name, None)
         # Make a new pint parameter and apply the translations on the new object
         translated_par = copy.deepcopy(pint_par)
-        if param_entry:
-            for op in self._operations:
+        param_entry = self._get_param_entry(translated_par.name)
+        for op in param_entry.keys():
+            if op in self._operations:
                 func = getattr(self, op)
                 translated_par = func(translated_par, param_entry)
         return translated_par
 
-    def to_name(self, pint_par, translate_entry):
-        """Replace the parameter name"""
-        pint_par.name = translate_entry['to_name']
+    def to_name(self, pint_par, param_entry):
+        """Replace the parameter name to the format required name.
+
+        Parameters
+        ----------
+        pint_par: `pint.models.parameter.Parameter` object
+            The parameter object that needs to be translated.
+        param_entry: dict
+            The parameter translate entry that includes 'to_name'.
+        """
+        pint_par.name = param_entry['to_name']
         return pint_par
 
-    def to_value(self, pint_par, translate_entry):
-        """Hard Replace the parameter value"""
-        pint_par.value = translate_entry['to_value']
+    def to_value(self, pint_par, param_entry):
+        """Hard Replace the parameter value.
+
+        Parameters
+        ----------
+        pint_par: `pint.models.parameter.Parameter` object
+            The parameter object that needs to be translated.
+        param_entry: dict
+            The parameter translate entry that includes 'to_value'.
+        """
+        pint_par.value = param_entry['to_value']
         return pint_par
 
-    def to_unit(self, pint_par, translate_entry):
-        """Change the parameter quantity's unit"""
-        pint_par.units = u.Unit(translate_entry['to_unit'])
+    def to_unit(self, pint_par, param_entry):
+        """Change the parameter quantity's unit
+
+        pint_par: `pint.models.parameter.Parameter` object
+            The parameter object that needs to be translated.
+        param_entry: dict
+            The parameter translate entry that includes 'to_unit'.
+        """
+        pint_par.units = u.Unit(param_entry['to_unit'])
         return pint_par
 
-    def to_type(self, pint_par, translate_entry):
-        """Change the parameter quantity to a new type"""
-        pint_par.quantity = pint_par.quantity.astype(translate_entry['to_type'])
+    def to_type(self, pint_par, param_entry):
+        """Change the parameter quantity to a new type
+
+        pint_par: `pint.models.parameter.Parameter` object
+            The parameter object that needs to be translated.
+        param_entry: dict
+            The parameter translate entry that includes 'to_type'.
+        """
+        pint_par.quantity = pint_par.quantity.astype(param_entry['to_type'])
         return pint_par

--- a/src/pint/io/parfile_format.py
+++ b/src/pint/io/parfile_format.py
@@ -1,0 +1,32 @@
+"""Functions for helping write .parfile out in different format. Maybe a better
+way is to move this to the parameter class.
+"""
+import yaml
+
+
+class ParfileFormat:
+    """Class for different parfile format.
+
+    Parameters
+    ----------
+    format_config: str
+        Configuration file for the parfile format. It is a yaml file with format
+        name as the top level keys and the value is a dictionary map from PINT
+        parameter name to other format name. If the format has a head, one can
+        add a head entry, where 'head' is the key and the head string is the
+        value.
+    format: str
+        The name of the request format.
+    """
+    def __init__(self, format_config, format):
+        with open(config_file, "r") as cf:
+            config = yaml.safe_load(cf)
+        try:
+            self.entry = config[format]
+        except KeyError:
+            raise KeyError(f"Parfile format config file {format_config} does "
+                "not have format {format}")
+        self.format_name = format
+
+    def translate_name(self, pint_par):
+        return self.entry.get(pint_par, None)

--- a/src/pint/io/parfile_format.yml
+++ b/src/pint/io/parfile_format.yml
@@ -1,0 +1,18 @@
+# PINT built-in parfile format
+
+tempo:
+  head: MODE 1
+
+tempo2:
+  A1DOT:
+    to_name: XDOT
+  STIGMA:
+    to_name: VARSIGMA
+  NHARMS:
+    to_value: 
+  EFAC:
+    to_name: T2EFAC
+  EQUAD:
+    to_name: T2EQUAD
+  ECL:
+    to_value: IERS2003

--- a/src/pint/io/parfile_format.yml
+++ b/src/pint/io/parfile_format.yml
@@ -8,8 +8,8 @@ tempo2:
     to_name: XDOT
   STIGMA:
     to_name: VARSIGMA
-  NHARMS:
-    to_value: 
+  NHARMS: 
+    to_type: int
   EFAC:
     to_name: T2EFAC
   EQUAD:

--- a/tests/test_parfile_format.py
+++ b/tests/test_parfile_format.py
@@ -1,0 +1,17 @@
+"""Verious of tests for the parfile format"""
+import os
+import pytest
+
+from pint.io.parfile_format import ParfileFormat
+
+@pytest.fixture
+def test_format_config():
+    file_path = os.path.dirname(os.path.abspath(__file__))
+    file_path = os.path.join(os.path.dirname(file_path), 'src/pint/io')
+    return os.path.join(file_path, 'parfile_format.yml')
+
+
+@pytest.mark.parametrize('format', ['tempo', 'tempo2'])
+def test_format_class_build(test_format_config, format):
+    par_format = ParfileFormat(test_format_config, format)
+    assert par_format.format_name == format

--- a/tests/test_parfile_format.py
+++ b/tests/test_parfile_format.py
@@ -1,8 +1,20 @@
 """Verious of tests for the parfile format"""
 import os
 import pytest
+import yaml
+import numpy as np
 
-from pint.io.parfile_format import ParfileFormat
+import astropy.units as u
+from pint import ls
+from pint.io.parfile_format import ParfileTranslator
+import pint.models.parameter as p
+
+
+def load_config(config_file):
+    with open(config_file, "r") as cf:
+        config = yaml.safe_load(cf)
+    return config
+
 
 @pytest.fixture
 def test_format_config():
@@ -10,8 +22,84 @@ def test_format_config():
     file_path = os.path.join(os.path.dirname(file_path), 'src/pint/io')
     return os.path.join(file_path, 'parfile_format.yml')
 
+@pytest.fixture
+def test_format_config_dict():
+    config = {'test':{'TESTPARAM': {'to_name': 'NEWNAME',
+                                    'to_value': 222.5,
+                                    'to_type': 'int',
+                                    'to_unit': 'km / s'},
+                      'TESTPARAM2': {'to_value': 301.3}
+                      }
+             }
+    return config
+
+@pytest.fixture
+def example_translator(test_format_config_dict):
+    return ParfileTranslator(test_format_config_dict, 'test')
+
 
 @pytest.mark.parametrize('format', ['tempo', 'tempo2'])
-def test_format_class_build(test_format_config, format):
-    par_format = ParfileFormat(test_format_config, format)
-    assert par_format.format_name == format
+def test_translate_class_build_from_file(test_format_config, format):
+    par_trans = ParfileTranslator(test_format_config, format)
+    assert par_trans.format_name == format
+
+
+def test_unkown_config_type():
+    with pytest.raises(ValueError, match='Unacceptable'):
+        par_trans = ParfileTranslator(['test'], 'test')
+
+
+def test_unknow_format(test_format_config_dict):
+    with pytest.raises(KeyError, match=r"does not have the format"):
+        par_trans = ParfileTranslator(test_format_config_dict, 'test2')
+
+
+def test_get_param_entry_raises(test_format_config):
+    par_trans = ParfileTranslator(test_format_config, 'tempo2')
+    with pytest.raises(KeyError, match=r"Parameter .* is not in the .* translator"):
+        par_trans._get_param_entry("WRONGNAME")
+
+
+def test_name_change(test_format_config):
+    par_trans = ParfileTranslator(test_format_config, 'tempo2')
+    pint_name = 'A1DOT'
+    pint_param = p.floatParameter(name=pint_name, value=0.1, units=ls / u.s)
+    p_entry = par_trans._get_param_entry(pint_name)
+    new_par = par_trans.to_name(pint_param, p_entry)
+    raw_config = load_config(test_format_config)
+    assert new_par.name == raw_config['tempo2'][pint_name]['to_name']
+
+
+def test_value_change(example_translator, test_format_config_dict):
+    pint_name = 'TESTPARAM'
+    pint_param = p.floatParameter(name=pint_name, value=233.45, units=ls / u.s)
+    p_entry = example_translator._get_param_entry(pint_name)
+    new_param = example_translator.to_value(pint_param, p_entry)
+    assert new_param.value == test_format_config_dict['test'][pint_name]['to_value']
+
+
+def test_unit_change(example_translator, test_format_config_dict):
+    pint_name = 'TESTPARAM'
+    pint_param = p.floatParameter(name=pint_name, value=233.45, units=ls / u.s)
+    p_entry = example_translator._get_param_entry(pint_name)
+    new_param = example_translator.to_unit(pint_param, p_entry)
+    assert new_param.quantity.unit == u.Unit(test_format_config_dict['test'][pint_name]['to_unit'])
+
+
+def test_type_change(example_translator, test_format_config_dict):
+    pint_name = 'TESTPARAM'
+    pint_param = p.floatParameter(name=pint_name, value=233.45, units=ls / u.s)
+    p_entry = example_translator._get_param_entry(pint_name)
+    new_param = example_translator.to_type(pint_param, p_entry)
+    assert new_param.quantity.dtype == test_format_config_dict['test'][pint_name]['to_type']
+    assert np.modf(new_param.value)[0] == 0
+
+
+def test_all_change(example_translator, test_format_config_dict):
+    pint_name = 'TESTPARAM'
+    pint_param = p.floatParameter(name=pint_name, value=233.45, units=ls / u.s)
+    new_param = example_translator.to_format(pint_param)
+    assert new_param.value == test_format_config_dict['test'][pint_name]['to_value']
+    assert new_param.quantity.unit == u.Unit(test_format_config_dict['test'][pint_name]['to_unit'])
+    assert new_param.quantity.dtype == test_format_config_dict['test'][pint_name]['to_type']
+    assert new_param.name == test_format_config_dict['test'][pint_name]['to_name']


### PR DESCRIPTION
A pull request for making the T_T2 friendly parfile. The template for parfile translation is defined in the parfile_format.yml, the parfile translator translates the parameter from PINT defined parameter style to other defined formats. 

*  Added pint.io module
*  Added the parfile_format.py and parfile_format.yml
*  Add ParfileTranslator class to translate the PINT parameters. 