### PR TITLE
add tempo/tempo2 parfile output

### DIFF
--- a/src/pint/gridutils.py
+++ b/src/pint/gridutils.py
@@ -57,7 +57,7 @@ def doonefit(ftr, parnames, parvalues):
 
 
 def grid_chisq(
-    ftr, parnames, parvalues, executor=None, ncpu=None, chunksize=1, printprogress=True,
+    ftr, parnames, parvalues, executor=None, ncpu=None, chunksize=1, printprogress=True
 ):
     """Compute chisq over a grid of parameters
 

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -25,11 +25,7 @@ log = logging.getLogger(__name__)
 astropy_version = sys.modules["astropy"].__version__
 mas_yr = u.mas / u.yr
 
-__all__ = [
-    "AstrometryEquatorial",
-    "AstrometryEcliptic",
-    "Astrometry",
-]
+__all__ = ["AstrometryEquatorial", "AstrometryEcliptic", "Astrometry"]
 
 
 class Astrometry(DelayComponent):

--- a/src/pint/models/parfile_format.py
+++ b/src/pint/models/parfile_format.py
@@ -1,0 +1,69 @@
+"""Utility Fuctions to translate parfile format. This funciton is based on
+Nihan Pol's format translator function at
+https://gitlab.nanograv.org/nano-time/timing_analysis/-/blob/15yr/src/timing_analysis/lite_utils.py
+"""
+
+
+__all__ = ["convert_pint_to_tempo_parfile"]
+
+
+def convert_pint_to_tempo_parfile(parfile_str, format):
+    """Function to convert PINT produced parfile to tempo-compatible parfile.
+
+    Removes CHI2 and SWM from the parfile. Changes EFAC/EQUAD to T2EFAC/T2EQUAD.
+    If converting to tempo2 parfile, make sure ECL IERS2003 is set.
+
+    Parameters
+    ----------
+    parfile_str: str
+        PINT parfile string.
+    format : str
+        Output format ['tempo', 'tempo2']; if tempo2, sets ECL IERS2003.
+
+    Returns
+    -------
+    new_par : str
+        The new parfile format string.
+    """
+    par_lines = parfile_str.split('\n')
+    new_par = []
+    for ii in range(len(par_lines)):
+        entries = par_lines[ii].split(" ")
+        if ii == 0:
+            if format == 'tempo2':
+                new_par.append("MODE 1")
+        if "CHI2" in entries:
+            continue
+        elif "SWM" in entries:
+            continue
+        elif "A1DOT" in entries:
+            entries[0] = "XDOT"
+            new_entry = " ".join(entries)
+            new_par.append(new_entry)
+        elif "STIGMA" in entries:
+            entries[0] = "VARSIGMA"
+            new_entry = " ".join(entries)
+            new_par.append(new_entry)
+        elif "NHARMS" in entries:
+            entries[-1] = str(int(float(entries[-1])))
+            new_entry = " ".join(entries)
+            new_par.append(new_entry)
+        elif ("ECL" in entries) and (format == 'tempo2'):
+            entries[-1] = "IERS2003"
+            new_entry = " ".join(entries)
+            new_par.append(new_entry)
+        elif "EFAC" in entries:
+            entries[0] = "T2EFAC"
+            new_entry = " ".join(entries)
+            new_par.append(new_entry)
+        elif "EQUAD" in entries:
+            entries[0] = "T2EQUAD"
+            new_entry = " ".join(entries)
+            new_par.append(new_entry)
+        elif ("T2CMETHOD" in entries) and (format == 'tempo2'):
+            entries[0] = "#T2CMETHOD"
+            new_entry = " ".join(entries)
+            new_par.append(new_entry)
+        else:
+            new_par.append(par_lines[ii])
+    return '\n'.join(new_par)

--- a/src/pint/models/parfile_format.py
+++ b/src/pint/models/parfile_format.py
@@ -24,6 +24,32 @@ def convert_pint_to_tempo_parfile(parfile_str, format):
     -------
     new_par : str
         The new parfile format string.
+    Notes
+    -----
+    The parfile line changes from PINT to Tempo and Tempo2 format.
+    +-----------+----------------+----------------+
+    | PINT line | TEMPO line     | TEMPO2 line    |
+    +===========+================+================+
+    | Head      | Empty          | MODE 1         |
+    +-----------+----------------+----------------+
+    | CHI2      | No Change      | No Change      |
+    +-----------+----------------+----------------+
+    | SWM       | No Change      | No Change      |
+    +-----------+----------------+----------------+
+    | A1DOT     | name: XDOT     | name: XDOT     |
+    +-----------+----------------+----------------+
+    | STIGMA    | name: VARSIGMA | name: VARSIGMA |
+    +-----------+----------------+----------------+
+    | NHARMS    | type: int      | type: int      |
+    +-----------+----------------+----------------+
+    | ECL       | No Change      | value: IERS2003|
+    +-----------+----------------+----------------+
+    | EFAC      | name: T2EFAC   | name: T2EFAC   |
+    +-----------+----------------+----------------+
+    | EQUAD     | name: T2EQUAD  | name: T2EQUAD  |
+    +-----------+----------------+----------------+
+    | T2CMETHOD | No Change      | Comment out    |
+    +-----------+----------------+----------------+
     """
     par_lines = parfile_str.split("\n")
     new_par = []

--- a/src/pint/models/parfile_format.py
+++ b/src/pint/models/parfile_format.py
@@ -25,12 +25,12 @@ def convert_pint_to_tempo_parfile(parfile_str, format):
     new_par : str
         The new parfile format string.
     """
-    par_lines = parfile_str.split('\n')
+    par_lines = parfile_str.split("\n")
     new_par = []
     for ii in range(len(par_lines)):
         entries = par_lines[ii].split(" ")
         if ii == 0:
-            if format == 'tempo2':
+            if format == "tempo2":
                 new_par.append("MODE 1")
         if "CHI2" in entries:
             continue
@@ -48,7 +48,7 @@ def convert_pint_to_tempo_parfile(parfile_str, format):
             entries[-1] = str(int(float(entries[-1])))
             new_entry = " ".join(entries)
             new_par.append(new_entry)
-        elif ("ECL" in entries) and (format == 'tempo2'):
+        elif ("ECL" in entries) and (format == "tempo2"):
             entries[-1] = "IERS2003"
             new_entry = " ".join(entries)
             new_par.append(new_entry)
@@ -60,10 +60,10 @@ def convert_pint_to_tempo_parfile(parfile_str, format):
             entries[0] = "T2EQUAD"
             new_entry = " ".join(entries)
             new_par.append(new_entry)
-        elif ("T2CMETHOD" in entries) and (format == 'tempo2'):
+        elif ("T2CMETHOD" in entries) and (format == "tempo2"):
             entries[0] = "#T2CMETHOD"
             new_entry = " ".join(entries)
             new_par.append(new_entry)
         else:
             new_par.append(par_lines[ii])
-    return '\n'.join(new_par)
+    return "\n".join(new_par)

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -2124,7 +2124,7 @@ class TimingModel:
         *,
         include_info=True,
         comment=None,
-        format='pint'
+        format="pint",
     ):
         """Represent the entire model as a parfile string.
 
@@ -2187,7 +2187,7 @@ class TimingModel:
         # TODO this convert the parfile string to the new format, maybe not the
         # best way to do it. A better way is to change the foramt directly in the
         # parameter class.
-        if format != 'pint':
+        if format != "pint":
             out_str = convert_pint_to_tempo_parfile(out_str, format)
         return out_str
 
@@ -2303,9 +2303,7 @@ class TimingModel:
         elif "AstrometryEcliptic" in self.components:
             astrometry_model_type = "AstrometryEcliptic"
         astrometry_model_component = self.components[astrometry_model_type]
-        new_astrometry_model_component = astrometry_model_component.as_ICRS(
-            epoch=epoch,
-        )
+        new_astrometry_model_component = astrometry_model_component.as_ICRS(epoch=epoch)
         new_model = copy.deepcopy(self)
         new_model.remove_component(astrometry_model_type)
         new_model.add_component(new_astrometry_model_component)

--- a/src/pint/plot_utils.py
+++ b/src/pint/plot_utils.py
@@ -180,13 +180,7 @@ def phaseogram_binned(
 
 
 def plot_priors(
-    model,
-    chains,
-    maxpost_fitvals=None,
-    fitvals=None,
-    burnin=100,
-    bins=100,
-    scale=False,
+    model, chains, maxpost_fitvals=None, fitvals=None, burnin=100, bins=100, scale=False
 ):
     """Plot of priors and the post-MCMC histogrammed samples
     

--- a/tests/test_model_manual.py
+++ b/tests/test_model_manual.py
@@ -111,7 +111,7 @@ def test_get_model_roundtrip(tmp_dir, parfile, format):
 
     fn = join(tmp_dir, "file.par")
     with open(fn, "w") as f:
-        f.write(m_old.as_parfile(format))
+        f.write(m_old.as_parfile(format=format))
     m_roundtrip = get_model(fn)
     assert set(m_roundtrip.get_params_mapping().keys()) == set(
         m_old.get_params_mapping().keys()

--- a/tests/test_model_manual.py
+++ b/tests/test_model_manual.py
@@ -100,7 +100,8 @@ bad_trouble = ["J1923+2515_NANOGrav_9yv1.gls.par", "J1744-1134.basic.ecliptic.pa
 
 # @pytest.mark.xfail(reason="inexact conversions")
 @pytest.mark.parametrize("parfile", glob(join(datadir, "*.par")))
-def test_get_model_roundtrip(tmp_dir, parfile):
+@pytest.mark.parametrize("format", ['pint', 'tempo', 'tempo2'])
+def test_get_model_roundtrip(tmp_dir, parfile, format):
     if basename(parfile) in bad_trouble:
         pytest.skip("This parfile is unclear")
     try:
@@ -110,7 +111,7 @@ def test_get_model_roundtrip(tmp_dir, parfile):
 
     fn = join(tmp_dir, "file.par")
     with open(fn, "w") as f:
-        f.write(m_old.as_parfile())
+        f.write(m_old.as_parfile(format))
     m_roundtrip = get_model(fn)
     assert set(m_roundtrip.get_params_mapping().keys()) == set(
         m_old.get_params_mapping().keys()

--- a/tests/test_model_manual.py
+++ b/tests/test_model_manual.py
@@ -100,7 +100,7 @@ bad_trouble = ["J1923+2515_NANOGrav_9yv1.gls.par", "J1744-1134.basic.ecliptic.pa
 
 # @pytest.mark.xfail(reason="inexact conversions")
 @pytest.mark.parametrize("parfile", glob(join(datadir, "*.par")))
-@pytest.mark.parametrize("format", ['pint', 'tempo', 'tempo2'])
+@pytest.mark.parametrize("format", ["pint", "tempo", "tempo2"])
 def test_get_model_roundtrip(tmp_dir, parfile, format):
     if basename(parfile) in bad_trouble:
         pytest.skip("This parfile is unclear")


### PR DESCRIPTION
This is a new pull request that is based on Nihan pol's parfile converter https://gitlab.nanograv.org/nano-time/timing_analysis/-/blob/15yr/src/timing_analysis/lite_utils.py. It converts the output parfile string to 'tempo/tempo2''s format. This is a simplified version for PR #1156 but loses the format flexibility. 