### PR TITLE
Change deprecated behavior

### DIFF
--- a/src/pint/models/binary_bt.py
+++ b/src/pint/models/binary_bt.py
@@ -63,9 +63,9 @@ class BinaryBT(PulsarBinary):
         # If any *DOT is set, we need T0
         for p in ("PBDOT", "OMDOT", "EDOT", "A1DOT"):
             if getattr(self, p).value is None:
-                getattr(self, p).set("0")
+                getattr(self, p).value = "0"
                 getattr(self, p).frozen = True
 
         if self.GAMMA.value is None:
-            self.GAMMA.set("0")
+            self.GAMMA.value = "0"
             self.GAMMA.frozen = True


### PR DESCRIPTION
In [these tests](https://github.com/StingraySoftware/HENDRICS/runs/4809551034?check_suite_focus=true) I found the following deprecation warning (turned into error for this testing suite):
```
../../.tox/py38-test-alldeps-cov/lib/python3.8/site-packages/pint/models/timing_model.py:357: in validate
    cp.validate()
../../.tox/py38-test-alldeps-cov/lib/python3.8/site-packages/pint/models/binary_bt.py:66: in validate
    getattr(self, p).set("0")
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = floatParameter( PBDOT               UNSET, value = '0'

    def set(self, value):
        """Deprecated - just assign to .value."""
>       warn(
            "The .set() function is deprecated. Set self.value directly instead.",
            category=DeprecationWarning,
        )
E       DeprecationWarning: The .set() function is deprecated. Set self.value directly instead.
```
This change should fix it, hopefully.