### PR TITLE
Fixing the notebook build

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,7 @@ attrs>=19.2
 pip>=9.0.1
 setuptools>=41.0
 coverage>=4.3.4
-traitlets<5.0
+traitlets
 Sphinx>=2.2
 astropy>=4.0,!=4.0.1,!=4.0.1.post1
 #astropy-helpers>=1.3

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ commands =
 description = update the notebooks
 basepython = python3.8
 deps =
-    traitlets<5.0
+    traitlets
     sphinx >= 2.2
     nbsphinx
     sphinx_rtd_theme
@@ -102,7 +102,7 @@ changedir = {toxinidir}/docs
 description = invoke sphinx-build to build the HTML docs
 basepython = python3.8
 deps =
-    traitlets<5.0
+    traitlets
     sphinx >= 2.2
     nbsphinx
     sphinx_rtd_theme


### PR DESCRIPTION
removed traitlets<5 requirement from `tox.ini` and `requirements-dev.txt`.  With that the notebooks seems to build OK.  No obvious other errors.