### PR TITLE
WIP: maskParameter (e.g., for jump) select by clusters

### DIFF
--- a/src/pint/models/absolute_phase.py
+++ b/src/pint/models/absolute_phase.py
@@ -2,6 +2,7 @@
 import logging
 
 import astropy.units as u
+from astropy.table import Column
 
 import pint.toa as toa
 from pint.models.parameter import MJDParameter, floatParameter, strParameter
@@ -109,6 +110,8 @@ class AbsPhase(PhaseComponent):
             ephem=toas.ephem,
             planets=toas.planets,
         )
+        if "clusters" in toas.table.colnames:
+            tz.table.add_column(Column([-1], name="clusters"))
         self.tz_cache = tz
         self.tz_hash = hash((self.TZRMJD.value, self.TZRSITE.value, self.TZRFRQ.value))
         self.tz_clkc_info = clkc_info
@@ -117,7 +120,7 @@ class AbsPhase(PhaseComponent):
         return tz
 
     def make_TZR_toa(self, toas):
-        """ Calculate the TZRMJD if one not given.
+        """Calculate the TZRMJD if one not given.
 
         TZRMJD = first toa after PEPOCH.
         """


### PR DESCRIPTION
You can define TOA clusters (using gaps etc) by:
```
clusters = t.get_clusters(add_column=True)
```
It seems that you should be able to use that column (when added) to select TOAs for jumping.  Previously this wasn't possible (I think) but this seems to work.

E.g., the old way:
```
par = parameter.maskParameter(
    "JUMP",
    key="mjd",
    value=0.0,
    key_value=[t[clusters==3].get_mjds().min().value,
               t[clusters==3].get_mjds().max().value],
    units=u.s,
    frozen=False,
    )
```

And I get the same results via:
```
par = parameter.maskParameter(
    "JUMP",
    key="cluster",
    value=0.0,
    key_value=3,
    units=u.s,
    frozen=False,
    )
```

Was I missing anything in another way to do this?

I think this works, just need to test more.