### PR TITLE
Fix handling of flags

### DIFF
--- a/src/pint/observatory/satellite_obs.py
+++ b/src/pint/observatory/satellite_obs.py
@@ -392,7 +392,7 @@ class SatelliteObs(SpecialLocation):
             np.array([self.X(t.tt.mjd), self.Y(t.tt.mjd), self.Z(t.tt.mjd)])
             * self.FT2["X"].unit
         )
-        log.debug("[{0}] sat_pos_geo {1}".format(self.name, sat_pos_geo[:, 0]))
+        # log.debug("[{0}] sat_pos_geo {1}".format(self.name, sat_pos_geo[:, 0]))
         sat_vel_geo = (
             np.array([self.Vx(t.tt.mjd), self.Vy(t.tt.mjd), self.Vz(t.tt.mjd)])
             * self.FT2["Vx"].unit

--- a/src/pint/observatory/special_locations.py
+++ b/src/pint/observatory/special_locations.py
@@ -224,9 +224,9 @@ class T2SpacecraftObs(SpecialLocation):
             raise ValueError("TOA group table needed for SpacecraftObs get_gcrs")
 
         try:
-            x = np.array([flags["telx"] for flags in group["flags"]])
-            y = np.array([flags["tely"] for flags in group["flags"]])
-            z = np.array([flags["telz"] for flags in group["flags"]])
+            x = np.array([float(flags["telx"]) for flags in group["flags"]])
+            y = np.array([float(flags["tely"]) for flags in group["flags"]])
+            z = np.array([float(flags["telz"]) for flags in group["flags"]])
         except:
             log.error(
                 "Missing flag. TOA line should have telx,tely,telz flags for GCRS position in km."
@@ -254,9 +254,9 @@ class T2SpacecraftObs(SpecialLocation):
             raise ValueError("TOA group table needed for SpacecraftObs posvel_gcrs")
 
         try:
-            vx = np.array([flags["vx"] for flags in group["flags"]])
-            vy = np.array([flags["vy"] for flags in group["flags"]])
-            vz = np.array([flags["vz"] for flags in group["flags"]])
+            vx = np.array([float(flags["vx"]) for flags in group["flags"]])
+            vy = np.array([float(flags["vy"]) for flags in group["flags"]])
+            vz = np.array([float(flags["vz"]) for flags in group["flags"]])
         except:
             log.error(
                 "Missing flag. TOA line should have vx,vy,vz flags for GCRS velocity in km/s."


### PR DESCRIPTION
This code got broken because all flags are returned as strings. I had to add the `float()` conversions to get back the old behavior.