### PR TITLE
Compute alternative Kopeikin solutions

### DIFF
--- a/src/pint/models/binary_ddk.py
+++ b/src/pint/models/binary_ddk.py
@@ -128,7 +128,7 @@ class BinaryDDK(BinaryDD):
 
         We first define the symmetry point where a1dot is zero:
 
-        :math:`KOM_0 = \\tan^{-1} (\mu_{\delta} / \mu_{alpha})`
+        :math:`KOM_0 = \\tan^{-1} (\mu_{\delta} / \mu_{\alpha})`
 
         The solutions are then:
         

--- a/src/pint/models/binary_ddk.py
+++ b/src/pint/models/binary_ddk.py
@@ -140,7 +140,7 @@ class BinaryDDK(BinaryDD):
 
         :math:`(180^{\circ}-KIN, 2KOM_0 - KOM)`
 
-        However, there is no guarantee that they will be between 0 and :math:`360^{\circ}`.
+        All values will be between 0 and :math:`360^{\circ}`.
 
         Returns
         -------
@@ -153,8 +153,12 @@ class BinaryDDK(BinaryDD):
         # where Eqn. 8 in Kopeikin (1996) that is equal to 0
         KOM_zero = np.arctan2(self.PMDEC_DDK.quantity, self.PMRA_DDK.quantity).to(u.deg)
         # second one in the same banana
-        solutions += [(x0, 2 * (KOM_zero) - y0 - 180 * u.deg)]
+        solutions += [(x0, (2 * (KOM_zero) - y0 - 180 * u.deg) % (360 * u.deg))]
         # and the other banana
-        solutions += [(180 * u.deg - x0, 2 * (KOM_zero) - y0)]
-        solutions += [(180 * u.deg - x0, y0 + 180 * u.deg)]
+        solutions += [
+            ((180 * u.deg - x0) % (360 * u.deg), (2 * (KOM_zero) - y0) % (360 * u.deg))
+        ]
+        solutions += [
+            ((180 * u.deg - x0) % (360 * u.deg), (y0 + 180 * u.deg) % (360 * u.deg))
+        ]
         return solutions

--- a/src/pint/models/binary_ddk.py
+++ b/src/pint/models/binary_ddk.py
@@ -1,4 +1,6 @@
 """The DDK model - Damour and Deruelle with kinematics."""
+import numpy as np
+from astropy import units as u
 from pint.models.binary_dd import BinaryDD
 from pint.models.parameter import boolParameter, floatParameter
 from pint.models.stand_alone_psr_binaries.DDK_model import DDKmodel
@@ -117,3 +119,38 @@ class BinaryDDK(BinaryDD):
             )
         # Should we warn if the model is using ecliptic coordinates?
         # Should we support KOM_PINT that works this way and KOM that works the way tempo2 does?
+
+    def alternative_solutions(self):
+        """Alternative Kopeikin solutions (potential local minima)
+
+        There are 4 potential local minima for a DDK model where a1dot is the same
+        These are given by where Eqn. 8 in Kopeikin (1996) is equal to the best-fit value.
+
+        We first define the symmetry point where a1dot is zero:
+        :math:`KOM_0 = \tan^{-1} (\mu_\delta / \mu_alpha)`
+
+        The solutions are then:
+        
+        :math:`(KIN, KOM)`
+        :math:`(KIN, 2KOM_0 - KOM - 180)`
+        :math:`(180-KIN, KOM+180)`
+        :math:`(180-KIN, 2KOM_0 - KOM)`
+
+        However, there is no guarantee that they will be between 0 and 360.
+
+        Returns
+        -------
+        tuple :
+            tuple of (KIN,KOM) pairs for the four potential solutions
+        """
+        x0 = self.KIN.quantity
+        y0 = self.KOM.quantity
+        solutions = [(x0, y0)]
+        # where Eqn. 8 in Kopeikin (1996) that is equal to 0
+        KOM_zero = np.arctan2(self.PMDEC_DDK.quantity, self.PMRA_DDK.quantity).to(u.deg)
+        # second one in the same banana
+        solutions += [(x0, 2 * (KOM_zero) - y0 - 180 * u.deg)]
+        # and the other banana
+        solutions += [(180 * u.deg - x0, 2 * (KOM_zero) - y0)]
+        solutions += [(180 * u.deg - x0, y0 + 180 * u.deg)]
+        return solutions

--- a/src/pint/models/binary_ddk.py
+++ b/src/pint/models/binary_ddk.py
@@ -127,16 +127,20 @@ class BinaryDDK(BinaryDD):
         These are given by where Eqn. 8 in Kopeikin (1996) is equal to the best-fit value.
 
         We first define the symmetry point where a1dot is zero:
-        :math:`KOM_0 = \tan^{-1} (\mu_\delta / \mu_alpha)`
+
+        :math:`KOM_0 = \\tan^{-1} (\mu_{\delta} / \mu_{alpha})`
 
         The solutions are then:
         
         :math:`(KIN, KOM)`
-        :math:`(KIN, 2KOM_0 - KOM - 180)`
-        :math:`(180-KIN, KOM+180)`
-        :math:`(180-KIN, 2KOM_0 - KOM)`
 
-        However, there is no guarantee that they will be between 0 and 360.
+        :math:`(KIN, 2KOM_0 - KOM - 180^{\ocirc})`
+
+        :math:`(180^{\ocirc}-KIN, KOM+180^{\ocirc})`
+
+        :math:`(180^{\ocirc}-KIN, 2KOM_0 - KOM)`
+
+        However, there is no guarantee that they will be between 0 and :math:`360^{\ocirc}`.
 
         Returns
         -------

--- a/src/pint/models/binary_ddk.py
+++ b/src/pint/models/binary_ddk.py
@@ -128,19 +128,19 @@ class BinaryDDK(BinaryDD):
 
         We first define the symmetry point where a1dot is zero:
 
-        :math:`KOM_0 = \\tan^{-1} (\mu_{\delta} / \mu_{\alpha})`
+        :math:`KOM_0 = \\tan^{-1} (\mu_{\delta} / \mu_{\\alpha})`
 
         The solutions are then:
         
         :math:`(KIN, KOM)`
 
-        :math:`(KIN, 2KOM_0 - KOM - 180^{\ocirc})`
+        :math:`(KIN, 2KOM_0 - KOM - 180^{\circ})`
 
-        :math:`(180^{\ocirc}-KIN, KOM+180^{\ocirc})`
+        :math:`(180^{\circ}-KIN, KOM+180^{\circ})`
 
-        :math:`(180^{\ocirc}-KIN, 2KOM_0 - KOM)`
+        :math:`(180^{\circ}-KIN, 2KOM_0 - KOM)`
 
-        However, there is no guarantee that they will be between 0 and :math:`360^{\ocirc}`.
+        However, there is no guarantee that they will be between 0 and :math:`360^{\circ}`.
 
         Returns
         -------


### PR DESCRIPTION
Add the alternative Kopeikin solutions (potential minima) like the red dots in:
![J1600_fullgrid](https://user-images.githubusercontent.com/5092062/159049709-efcfe81b-8d5f-4b71-b680-b22902b40daf.png)
works like:
```
solutions = model.alternative_solutions()
```
where `model` has converged.  `solutions` is then a list of `(KIN,KOM)` tuples.
