### PR TITLE
fix minor picking bug

### DIFF
--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -223,14 +223,15 @@ def get_TOAs(
     if usepickle:
         try:
             t = load_pickle(timfile, picklefilename=picklefilename)
+            log.info(f"Reading TOAs from the picklefile for `{timfile}`")
         except IOError:
             # Pickle either did not exist or is out of date
             updatepickle = True
         else:
             if hasattr(t, "hashes"):
-                if not t.check_hashes(timfile):
+                if not t.check_hashes():
                     updatepickle = True
-                    log.info("Pickle based on files that have changed")
+                    log.warning("Pickle file is based on files that have changed")
             else:
                 # Only pre-v0.8 pickles lack hashes.
                 updatepickle = True

--- a/tests/test_toa_pickle.py
+++ b/tests/test_toa_pickle.py
@@ -112,15 +112,20 @@ def test_pickle_invalidated_time(temp_tim):
     assert not toa.get_TOAs(tt, usepickle=True).was_pickled
 
 
+# SMR changed the behavior of this so that if the .filename
+# in the picklefile does not exist, then the pickle is
+# invalidated.  The reason is that the previous behavior
+# caused pickling to always fail to be valid for .tim files
+# that had INCLUDE statements to load other .tim files.
 def test_pickle_moved(temp_tim):
     tt, tp = temp_tim
-    tt2 = tt + ".also.tim"
-    shutil.copy(tt, tt2)
+    # The following creates "test.tim.pickle.gz" from "test.tim"
     toa.get_TOAs(tt, usepickle=True, picklefilename=tp)
-    assert toa.get_TOAs(tt2, usepickle=True, picklefilename=tp).was_pickled
-    with open(tt2, "at") as f:
-        f.write("\n")
-    assert not toa.get_TOAs(tt2, usepickle=True, picklefilename=tp).was_pickled
+    # now remove "test.tim"
+    os.remove(tt)
+    # Should fail since the original file is gone
+    with pytest.raises(FileNotFoundError):
+        toa.get_TOAs(tt, usepickle=True, picklefilename=tp)
 
 
 def test_group_survives_pickle(tmpdir):


### PR DESCRIPTION
Fixed a bug with pickling that would never validate pickle files if the original .tim file used INCLUDE commands.  This was found when testing `pintk` with archival data.