### PR TITLE
Added polycos argument to photonphase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Added computation of extra parameters in gridding
 - Added gridding based on tuples of parameters (not just regular mesh)
 - Added passing of extra parameters to gridding fitter
+- Added option to photonphase to compute phases using polycos
 
 ## [0.8.5] 2022-02-24
 ### Added

--- a/src/pint/scripts/photonphase.py
+++ b/src/pint/scripts/photonphase.py
@@ -15,7 +15,7 @@ from pint.fits_utils import read_fits_event_mjds
 from pint.observatory.satellite_obs import get_satellite_observatory
 from pint.plot_utils import phaseogram_binned
 from pint.pulsar_mjd import Time
-import polycos
+import pint.polycos
 
 __all__ = ["main"]
 

--- a/src/pint/scripts/photonphase.py
+++ b/src/pint/scripts/photonphase.py
@@ -231,8 +231,7 @@ def main(argv=None):
             phases[i] += 1 
         h = float(hm(phases))
         print("Htest : {0:.2f} ({1:.2f} sigma)".format(h, h2sig(h)))
-
-    if args.polycos == False:
+    else: # Normal mode, not polycos
         ts = toa.get_TOAs_list(
             tl,
             ephem=args.ephem,

--- a/src/pint/scripts/photonphase.py
+++ b/src/pint/scripts/photonphase.py
@@ -113,7 +113,7 @@ def main(argv=None):
         "--polycos",
         default=False,
         action="store_true",
-        help="Use polycos to calculate phases; use when working with very large event files"
+        help="Use polycos to calculate phases; use when working with very large event files",
     )
     args = parser.parse_args(argv)
     log.remove()
@@ -159,9 +159,11 @@ def main(argv=None):
                 "Please barycenter the event file using the official mission tools before processing with PINT"
             )
     # Read event file and return list of TOA objects, if not using polycos
-    if args.polycos==False:
+    if args.polycos == False:
         try:
-            tl = load_event_TOAs(args.eventfile, telescope, minmjd=minmjd, maxmjd=maxmjd)
+            tl = load_event_TOAs(
+                args.eventfile, telescope, minmjd=minmjd, maxmjd=maxmjd
+            )
         except KeyError:
             log.error(
                 "Observatory not recognized. This probably means you need to provide an orbit file or barycenter the event file."
@@ -202,7 +204,7 @@ def main(argv=None):
             raise ValueError("Cannot use orbphase with polycos.")
 
         # Polycos parameters
-        segLength = 120 #in minutes
+        segLength = 120  # in minutes
         ncoeff = 10
         obsfreq = 0
 
@@ -214,24 +216,26 @@ def main(argv=None):
         maxmjd = max(mjds)
 
         # Check if event file is barycentered
-        if hdulist[1].header['TIMESYS'] != 'TDB':
-            raise ValueError("The event file has not been barycentered. Polycos can only be used with barycentered data.")
+        if hdulist[1].header["TIMESYS"] != "TDB":
+            raise ValueError(
+                "The event file has not been barycentered. Polycos can only be used with barycentered data."
+            )
 
         # Create polycos table
-        telescope_n = '@'
+        telescope_n = "@"
         p = polycos.Polycos()
         ptable = p.generate_polycos(
-            modelin, minmjd, maxmjd, telescope_n,
-            segLength, ncoeff, obsfreq)
+            modelin, minmjd, maxmjd, telescope_n, segLength, ncoeff, obsfreq
+        )
 
         # Calculate phases
         phases = p.eval_phase(mjds)
         rows = np.where(phases < 0)
         for i in rows:
-            phases[i] += 1 
+            phases[i] += 1
         h = float(hm(phases))
         print("Htest : {0:.2f} ({1:.2f} sigma)".format(h, h2sig(h)))
-    else: # Normal mode, not polycos
+    else:  # Normal mode, not polycos
         ts = toa.get_TOAs_list(
             tl,
             ephem=args.ephem,
@@ -253,7 +257,7 @@ def main(argv=None):
         phases = phss.value % 1
         h = float(hm(phases))
         print("Htest : {0:.2f} ({1:.2f} sigma)".format(h, h2sig(h)))
-    
+
     if args.plot:
         phaseogram_binned(mjds, phases, bins=100, plotfile=args.plotfile)
 

--- a/src/pint/scripts/photonphase.py
+++ b/src/pint/scripts/photonphase.py
@@ -4,7 +4,6 @@ import sys
 import astropy.io.fits as pyfits
 import astropy.units as u
 import numpy as np
-from astropy import log
 
 import pint.logging
 from loguru import logger as log

--- a/tests/test_photonphase.py
+++ b/tests/test_photonphase.py
@@ -4,7 +4,7 @@ import unittest
 
 import pytest
 
-import photonphase
+import pint.scripts.photonphase as photonphase
 from pinttestdata import datadir
 from astropy.io import fits
 import numpy as np

--- a/tests/test_photonphase.py
+++ b/tests/test_photonphase.py
@@ -4,7 +4,7 @@ import unittest
 
 import pytest
 
-import pint.scripts.photonphase as photonphase
+import photonphase
 from pinttestdata import datadir
 from astropy.io import fits
 import numpy as np
@@ -42,7 +42,7 @@ eventfile_nicer = os.path.join(datadir, "ngc300nicer_bary.evt")
 )
 def test_nicer_result_bary(capsys):
     "Check that barycentered NICER data is processed correctly."
-    cmd = "{0} {1}".format(eventfile_nicer, parfile_nicer)
+    cmd = " {0} {1}".format(eventfile_nicer, parfile_nicer)
     photonphase.main(cmd.split())
     out, err = capsys.readouterr()
     v = 0.0
@@ -127,6 +127,20 @@ def test_OrbPhase_column():
     hdul.close()
     os.remove(outfile)
 
+@pytest.mark.skipif(
+    "DISPLAY" not in os.environ, reason="Needs an X server, xvfb counts"
+)
+def test_nicer_result_bary_polyco(capsys):
+    "Check that barycentered NICER data is processed correctly with --polyco."
+    cmd = "--polycos {0} {1}".format(eventfile_nicer, parfile_nicer)
+    photonphase.main(cmd.split())
+    out, err = capsys.readouterr()
+    v = 0.0
+    for l in out.split("\n"):
+        if l.startswith("Htest"):
+            v = float(l.split()[2])
+    # Check that H-test is 216.67
+    assert abs(v - 216.67) < 1
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_photonphase.py
+++ b/tests/test_photonphase.py
@@ -127,6 +127,7 @@ def test_OrbPhase_column():
     hdul.close()
     os.remove(outfile)
 
+
 @pytest.mark.skipif(
     "DISPLAY" not in os.environ, reason="Needs an X server, xvfb counts"
 )
@@ -141,6 +142,7 @@ def test_nicer_result_bary_polyco(capsys):
             v = float(l.split()[2])
     # Check that H-test is 216.67
     assert abs(v - 216.67) < 1
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Fixed version of feature-photonphase-polycos which only includes the necessary changes.
A polycos argument has been added to photonphase.py, which uses polycos to calculate pulse phases without using the full model of the pulsar. Useful for large files, where photonphase.py previously used to crash/time out. A test of the polycos argument has also been added to test_photonphase.py.