### PR TITLE
Allow reading of archival tim files that use 'w' for ncyobs

### DIFF
--- a/src/pint/observatory/observatories.py
+++ b/src/pint/observatory/observatories.py
@@ -127,7 +127,7 @@ TopoObs(
 )
 TopoObs(
     "ncyobs",
-    aliases=["nuppi"],
+    aliases=["nuppi", "w"],
     itrf_xyz=[4324165.81, 165927.11, 4670132.83],
     clock_fmt="tempo2",
     clock_file=["ncyobs2obspm.clk", "obspm2gps.clk"],


### PR DESCRIPTION
This PR fixes #1200.  Tempo2 recognizes 'w' as "ncyobs" and we should too, especially since that is the observatory code used in IPTA DR2.