### PR TITLE
WIP: keep Kopeikin corrections in ECL coordinates

### DIFF
--- a/src/pint/models/binary_ddk.py
+++ b/src/pint/models/binary_ddk.py
@@ -73,29 +73,29 @@ class BinaryDDK(BinaryDD):
             )
         )
         self.remove_param("SINI")
-        self.internal_params += ["PMRA_DDK", "PMDEC_DDK"]
+        #self.internal_params += ["PMRA_DDK", "PMDEC_DDK"]
 
-    @property
-    def PMRA_DDK(self):
-        params = self._parent.get_params_as_ICRS()
-        par_obj = floatParameter(
-            name="PMRA",
-            units="mas/year",
-            value=params["PMRA"],
-            description="Proper motion in RA",
-        )
-        return par_obj
+    # @property
+    # def PMRA_DDK(self):
+    #     params = self._parent.get_params_as_ICRS()
+    #     par_obj = floatParameter(
+    #         name="PMRA",
+    #         units="mas/year",
+    #         value=params["PMRA"],
+    #         description="Proper motion in RA",
+    #     )
+    #     return par_obj
 
-    @property
-    def PMDEC_DDK(self):
-        params = self._parent.get_params_as_ICRS()
-        par_obj = floatParameter(
-            name="PMDEC",
-            units="mas/year",
-            value=params["PMDEC"],
-            description="Proper motion in DEC",
-        )
-        return par_obj
+    # @property
+    # def PMDEC_DDK(self):
+    #     params = self._parent.get_params_as_ICRS()
+    #     par_obj = floatParameter(
+    #         name="PMDEC",
+    #         units="mas/year",
+    #         value=params["PMDEC"],
+    #         description="Proper motion in DEC",
+    #     )
+    #     return par_obj
 
     def validate(self):
         """Validate parameters."""

--- a/src/pint/models/pulsar_binary.py
+++ b/src/pint/models/pulsar_binary.py
@@ -294,7 +294,10 @@ class PulsarBinary(DelayComponent):
                 self.barycentric_time = tbl["tdbld"] * u.day - acc_delay
             updates["barycentric_toa"] = self.barycentric_time
             updates["obs_pos"] = tbl["ssb_obs_pos"].quantity
-            updates["psr_pos"] = self._parent.ssb_to_psb_xyz_ICRS(
+            #updates["psr_pos"] = self._parent.ssb_to_psb_xyz_ICRS(
+            #    epoch=tbl["tdbld"].astype(np.float64)
+            #)
+            updates["psr_pos"] = self._parent.ssb_to_psb_xyz_ECL(
                 epoch=tbl["tdbld"].astype(np.float64)
             )
         for par in self.binary_instance.binary_params:


### PR DESCRIPTION
Note that it is not smart enough to keep in ICRS if the model is ICRS (yet) but that is the eventual goal

So far I didn't recheck all of the equations but just did `alpha` -> `ELONG` and `delta` -> `ELAT`