### PR TITLE
Clean-up covariance matrix pretty-printing.

### DIFF
--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -555,8 +555,6 @@ class Fitter:
         self.model.FINISH.value = self.toas.last_MJD
         self.model.NTOA.value = len(self.toas)
         self.model.EPHEM.value = self.toas.ephem
-        if chi2:
-            self.model.CHI2.value = self.resids.chi2
         self.model.DMDATA.value = hasattr(self.resids, "dm")
         if not self.toas.clock_corr_info["include_bipm"]:
             self.model.CLOCK.value = "TT(TAI)"

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -555,6 +555,8 @@ class Fitter:
         self.model.FINISH.value = self.toas.last_MJD
         self.model.NTOA.value = len(self.toas)
         self.model.EPHEM.value = self.toas.ephem
+        if chi2:
+            self.model.CHI2.value = self.resids.chi2
         self.model.DMDATA.value = hasattr(self.resids, "dm")
         if not self.toas.clock_corr_info["include_bipm"]:
             self.model.CLOCK.value = "TT(TAI)"
@@ -581,6 +583,21 @@ class Fitter:
         """Return the model's design matrix for these TOAs."""
         return self.model.designmatrix(toas=self.toas, incfrozen=False, incoffset=True)
 
+    def _get_corr_cov_matrix(
+        self, matrix_type, with_phase, pretty_print, prec, usecolor
+    ):
+        if hasattr(self, f"parameter_{matrix_type}_matrix"):
+            cm = getattr(self, f"parameter_{matrix_type}_matrix")
+            if not pretty_print:
+                return cm.prettyprint(prec=prec, offset=with_phase)
+            else:
+                print(cm.prettyprint(prec=prec, offset=with_phase, usecolor=usecolor))
+        else:
+            log.error(
+                f"You must run .fit_toas() before accessing the {matrix_type} matrix"
+            )
+            raise AttributeError
+
     def get_parameter_covariance_matrix(
         self, with_phase=False, pretty_print=False, prec=3
     ):
@@ -590,109 +607,23 @@ class Fitter:
         If pretty_print, then also pretty-print on stdout the matrix.
         prec is the precision of the floating point results.
         """
-        if hasattr(self, "parameter_covariance_matrix"):
-            if isinstance(self.parameter_covariance_matrix, np.ndarray):
-                # it's just a raw ndarray
-                fps = list(self.model.free_params)
-                cm = self.parameter_covariance_matrix
-                if with_phase:
-                    fps = ["PHASE"] + fps
-                else:
-                    cm = cm[1:, 1:]
-            elif isinstance(self.parameter_covariance_matrix, CovarianceMatrix):
-                if with_phase:
-                    return self.parameter_covariance_matrix.prettyprint(prec=prec)
-                    fps = self.parameter_covariance_matrix.get_label_names(axis=0)
-                    cm = self.parameter_covariance_matrix.matrix
-                else:
-                    # exclude that
-                    fps = [
-                        x
-                        for x in self.parameter_covariance_matrix.get_label_names(
-                            axis=0
-                        )
-                        if not x == "Offset"
-                    ]
-                    new_matrix = self.parameter_covariance_matrix.get_label_matrix(fps)
-                    print(new_matrix.prettyprint(prec=prec))
-                    return new_matrix
-            if pretty_print:
-                lens = [max(len(fp) + 2, prec + 8) for fp in fps]
-                maxlen = max(lens)
-                print("\nParameter covariance matrix:")
-                line = "{0:^{width}}".format("", width=maxlen)
-                for fp, ln in zip(fps, lens):
-                    line += "{0:^{width}}".format(fp, width=ln)
-                print(line)
-                for ii, fp1 in enumerate(fps):
-                    line = "{0:^{width}}".format(fp1, width=maxlen)
-                    for jj, (fp2, ln) in enumerate(zip(fps[: ii + 1], lens[: ii + 1])):
-                        line += "{0: {width}.{prec}e}".format(
-                            cm[ii, jj], width=ln, prec=prec
-                        )
-                    print(line)
-                print("\n")
-            return cm
-        else:
-            log.error("You must run .fit_toas() before accessing the covariance matrix")
-            raise AttributeError
+        return self._get_corr_cov_matrix(
+            "covariance", with_phase, pretty_print, prec, "False"
+        )
 
     def get_parameter_correlation_matrix(
-        self, with_phase=False, pretty_print=False, prec=3
+        self, with_phase=False, pretty_print=False, prec=3, usecolor=True
     ):
         """Show the parameter correlation matrix post-fit.
 
         If with_phase, then show and return the phase column as well.
         If pretty_print, then also pretty-print on stdout the matrix.
-        prec is the precision of the floating point results.
+        prec is the precision of the floating point results. If
+        usecolor is True, then pretty printing will have color.
         """
-        if hasattr(self, "parameter_correlation_matrix"):
-            if isinstance(self.parameter_correlation_matrix, np.ndarray):
-                # it's just a raw ndarray
-                fps = list(self.model.free_params)
-                cm = self.parameter_correlation_matrix
-                if with_phase:
-                    fps = ["PHASE"] + fps
-                else:
-                    cm = cm[1:, 1:]
-            elif isinstance(self.parameter_correlation_matrix, CorrelationMatrix):
-                if with_phase:
-                    return self.parameter_correlation_matrix.prettyprint(prec=prec)
-                    fps = self.parameter_correlation_matrix.get_label_names(axis=0)
-                    cm = self.parameter_correlation_matrix.matrix
-                else:
-                    # exclude that
-                    fps = [
-                        x
-                        for x in self.parameter_correlation_matrix.get_label_names(
-                            axis=0
-                        )
-                        if not x == "Offset"
-                    ]
-                    new_matrix = self.parameter_correlation_matrix.get_label_matrix(fps)
-                    return new_matrix.prettyprint(prec=prec)
-            if pretty_print:
-                lens = [max(len(fp) + 2, prec + 4) for fp in fps]
-                maxlen = max(lens)
-                print("\nParameter correlation matrix:")
-                line = "{0:^{width}}".format("", width=maxlen)
-                for fp, ln in zip(fps, lens):
-                    line += "{0:^{width}}".format(fp, width=ln)
-                print(line)
-                for ii, fp1 in enumerate(fps):
-                    line = "{0:^{width}}".format(fp1, width=maxlen)
-                    for jj, (fp2, ln) in enumerate(zip(fps, lens)):
-                        line += "{0:^{width}.{prec}f}".format(
-                            cm[ii, jj], width=ln, prec=prec
-                        )
-                    print(line)
-                print("\n")
-            return cm
-        else:
-            log.error(
-                "You must run .fit_toas() before accessing the correlation matrix"
-            )
-            raise AttributeError
+        return self._get_corr_cov_matrix(
+            "correlation", with_phase, pretty_print, prec, usecolor
+        )
 
     def ftest(self, parameter, component, remove=False, full_output=False, maxiter=1):
         """Compare the significance of adding/removing parameters to a timing model.

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -1450,10 +1450,8 @@ class PlkWidget(tk.Frame):
             self.call_updates()
         elif event.key == "c":
             if self.psr.fitted:
-                print(
-                    self.psr.fitter.get_parameter_correlation_matrix(
-                        pretty_print=True, prec=2
-                    )
+                self.psr.fitter.get_parameter_correlation_matrix(
+                    pretty_print=True, prec=3, usecolor=True
                 )
         elif event.key == "i":
             print("\n" + "-" * 40)

--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -468,6 +468,7 @@ class Pulsar:
 
         # Do the actual fit and mark things as being fit
         self.fitter.fit_toas(maxiter=iters)
+        self.fitter.update_model()
         self.postfit_model = self.fitter.model
         self.fitted = True
         # Zero out all of the "delta_pulse_numbers" if they are set

--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -481,6 +481,8 @@ class Pulsar:
         self.selected_toas.compute_pulse_numbers(self.postfit_model)
         # Now compute the residuals using correct pulse numbers
         self.postfit_resids = Residuals(self.all_toas, self.postfit_model)
+        # Need this since it isn't updated using self.fitter.update_model()
+        self.fitter.model.CHI2.value = self.postfit_resids.chi2
         # And print the summary
         self.write_fit_summary()
 

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -66,7 +66,6 @@ __all__ = [
     "open_or_use",
     "lines_of",
     "interesting_lines",
-    "show_param_cov_matrix",
     "pmtot",
     "dmxparse",
     "dmxstats",
@@ -78,8 +77,21 @@ __all__ = [
     "add_dummy_distance",
     "remove_dummy_distance",
     "info_string",
+    "print_color_examples",
+    "colorize",
 ]
 
+COLOR_NAMES = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]
+TEXT_ATTRIBUTES = [
+    "normal",
+    "bold",
+    "subdued",
+    "italic",
+    "underscore",
+    "blink",
+    "reverse",
+    "concealed",
+]
 
 # Actual exported tools
 
@@ -450,77 +462,6 @@ def interesting_lines(lines, comments=None):
         if ln.startswith(cc):
             continue
         yield ln
-
-
-def show_param_cov_matrix(matrix, params, name="Covariance Matrix", switchRD=False):
-    """function to print covariance matrices in a clean and easily readable way
-
-    :param matrix: matrix to be printed, should be square, list of lists
-    :param params: name of the parameters in the matrix, list
-    :param name: title to be printed above, default Covariance Matrix
-    :param switchRD: if True, switch the positions of RA and DEC to match setup of TEMPO cov. matrices
-
-    :return: string to be printed
-
-    Warning
-    -------
-    **DEPRECATED**.  Use :meth:`pint.pint_matrix.CovarianceMatrix.prettyprint` instead of :func:`show_param_cov_matrix`
-    """
-
-    warn(
-        "This method is deprecated. Use `parameter_covariance_matrix.prettyprint()` instead of `show_param_cov_matrix()`",
-        category=DeprecationWarning,
-    )
-
-    output = StringIO()
-    matrix = deepcopy(matrix)
-    try:
-        RAi = params.index("RAJ")
-    except:
-        RAi = None
-        switchRD = False
-    params1 = []
-    for param in params:
-        if len(param) < 3:
-            while len(param) != 3:
-                param = " " + param
-            params1.append(param)
-        elif len(param) > 3:
-            while len(param) != 3:
-                param = param[:-1]
-            params1.append(param)
-        else:
-            params1.append(param)
-    if switchRD:
-        # switch RA and DEC so cov matrix matches TEMPO
-        params1[RAi : RAi + 2] = [params1[RAi + 1], params1[RAi]]
-        i = 0
-        while i < 2:
-            RA = deepcopy(matrix[RAi])
-            matrix[RAi] = matrix[RAi + 1]
-            matrix[RAi + 1] = RA
-            matrix = matrix.T
-            i += 1
-    output.write(name + " switch RD = " + str(switchRD) + "\n")
-    output.write(" ")
-    for param in params1:
-        output.write("         " + param)
-    i = j = 0
-    while i < len(matrix):
-        output.write("\n" + params1[i] + " :: ")
-        while j <= i:
-            num = matrix[i][j]
-            if num < 0.001 and num > -0.001:
-                output.write("{0: 1.2e}".format(num) + "   : ")
-            else:
-                output.write("  " + "{0: 1.2f}".format(num) + "   : ")
-            j += 1
-        i += 1
-        j = 0
-    output.write("\b:\n")
-    contents = output.getvalue()
-    output.close()
-    return contents
 
 
 def pmtot(model):
@@ -1606,3 +1547,50 @@ def list_parameters(class_=None):
                         )
                     results[n]["classes"].append(class_)
         return sorted(results.values(), key=lambda d: d["name"])
+
+
+def colorize(text, fg_color, bg_color=None, attribute=None):
+    """Colorizes a string for printing on the terminal
+
+    Parameters
+    ----------
+    text : string
+        the text to colorize
+    fg_color : _type_
+        foreground color name
+    bg_color : _type_, optional
+        background color name, by default None
+    attribute : _type_, optional
+        text attribute, by default None
+
+    Returns
+    -------
+    string
+        the colorized string using the defined text attribute
+
+    The color names (fg or bg) are one of:
+        'black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'
+    The text attributes are one of:
+        'normal', 'bold', 'subdued', 'italic', 'underscore', 'blink', 'reverse', 'concealed'
+    """
+    COLOR_FORMAT = "\033[%dm\033[%d;%dm%s\033[0m"
+    FOREGROUND = dict(zip(COLOR_NAMES, list(range(30, 38))))
+    BACKGROUND = dict(zip(COLOR_NAMES, list(range(40, 48))))
+    ATTRIBUTE = dict(zip(TEXT_ATTRIBUTES, [0, 1, 2, 3, 4, 5, 7, 8]))
+    fg = FOREGROUND.get(fg_color, 39)
+    bg = BACKGROUND.get(bg_color, 49)
+    att = ATTRIBUTE.get(attribute, 0)
+    return COLOR_FORMAT % (att, bg, fg, text)
+
+
+def print_color_examples():
+    """This prints example terminal colors and attributes for the `colorize()` function
+    """
+    for att in TEXT_ATTRIBUTES:
+        for fg in COLOR_NAMES:
+            for bg in COLOR_NAMES:
+                print(
+                    colorize(f"{fg:>8} {att:<11}", fg, bg_color=bg, attribute=att),
+                    end="",
+                )
+            print("")

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1550,28 +1550,30 @@ def list_parameters(class_=None):
 
 
 def colorize(text, fg_color, bg_color=None, attribute=None):
-    """Colorizes a string for printing on the terminal
+    """Colorizes a string (including unicode strings) for printing on the terminal
+
+    For an example of usage, as well as a demonstration as to what the
+    attributes and colors look like, check out :func:`~pint.utils.print_color_examples`
 
     Parameters
     ----------
     text : string
-        the text to colorize
+        The text to colorize. Can include unicode.
     fg_color : _type_
-        foreground color name
+        Foreground color name. The color names (fg or bg) are one of:
+        'black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan',
+        or 'white'.
     bg_color : _type_, optional
-        background color name, by default None
+        Background color name, by default None. Same choices as for `fg_color`.
     attribute : _type_, optional
-        text attribute, by default None
+        Text attribute, by default None. The text attributes are one of:
+        'normal', 'bold', 'subdued', 'italic', 'underscore', 'blink',
+        'reverse', or 'concealed'.
 
     Returns
     -------
     string
-        the colorized string using the defined text attribute
-
-    The color names (fg or bg) are one of:
-        'black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'
-    The text attributes are one of:
-        'normal', 'bold', 'subdued', 'italic', 'underscore', 'blink', 'reverse', 'concealed'
+        The colorized string using the defined text attribute.
     """
     COLOR_FORMAT = "\033[%dm\033[%d;%dm%s\033[0m"
     FOREGROUND = dict(zip(COLOR_NAMES, list(range(30, 38))))
@@ -1584,7 +1586,7 @@ def colorize(text, fg_color, bg_color=None, attribute=None):
 
 
 def print_color_examples():
-    """This prints example terminal colors and attributes for the `colorize()` function
+    """Print example terminal colors and attributes for/using :func:`~pint.utils.colorize`
     """
     for att in TEXT_ATTRIBUTES:
         for fg in COLOR_NAMES:


### PR DESCRIPTION
Removed multiply-reproduced code. 
Add color option for correlation matrix (use it in pintk).
Minor pintk improvements (updating fit info in output parfiles).

An example of the colorized correlation matrix is below.  (There is one more level, for |val| > 0.999, which is red background with white text).

![image](https://user-images.githubusercontent.com/132898/164605172-d8e87c0b-27eb-4339-bb9e-ffd481eae7fe.png)
