### PR TITLE
Fixing fitters to work with random models

### DIFF
--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1141,6 +1141,10 @@ class DownhillFitter(Fitter):
             raise MaxiterReached(f"Convergence not detected after {maxiter} steps.")
         return self.converged
 
+    @property
+    def fac(self):
+        return self.current_state.fac
+
 
 class WLSState(ModelState):
     def __init__(self, fitter, model, threshold=None):
@@ -1329,6 +1333,7 @@ class GLSState(ModelState):
         norm[norm == 0] = 1
         M /= norm
         self.M = M
+        self.fac = norm
 
         # compute covariance matrices
         if self.full_cov:
@@ -1539,6 +1544,7 @@ class WidebandState(ModelState):
         if not self.full_cov:
             phiinv /= norm ** 2
             self.phiinv = phiinv
+        self.fac = norm
 
         return M, params, units, norm
 
@@ -2053,6 +2059,7 @@ class GLSFitter(Fitter):
                     DegeneracyWarning,
                 )
             norm[norm == 0] = 1
+            self.fac = norm
             M /= norm
 
             # compute covariance matrices
@@ -2414,6 +2421,7 @@ class WidebandTOAFitter(Fitter):  # Is GLSFitter the best here?
                 )
             norm[norm == 0] = 1
             M /= norm
+            self.fac = norm
 
             # compute covariance matrices
             if full_cov:

--- a/tests/test_random_models.py
+++ b/tests/test_random_models.py
@@ -9,20 +9,31 @@ import numpy as np
 import astropy.units as u
 
 from pint.models import get_model, get_model_and_toas
-from pint import fitter, toa, simulation
+from pint.toa import get_TOAs
+import pint.fitter
+from pint import toa, simulation
 from pinttestdata import datadir
 import pint.models.parameter as param
 from pint import ls
 from pint import utils
 
 
-def test_random_models():
+@pytest.mark.parametrize(
+    "fitter",
+    [
+        pint.fitter.GLSFitter,
+        pint.fitter.WLSFitter,
+        pint.fitter.DownhillWLSFitter,
+        pint.fitter.DownhillGLSFitter,
+    ],
+)
+def test_random_models(fitter):
     # Get model and TOAs
     m, t = get_model_and_toas(
         os.path.join(datadir, "NGC6440E.par"), os.path.join(datadir, "NGC6440E.tim")
     )
 
-    f = fitter.WLSFitter(toas=t, model=m)
+    f = fitter(toas=t, model=m)
     # Do a 4-parameter fit
     f.model.free_params = ("F0", "F1", "RAJ", "DECJ")
     f.fit_toas()
@@ -30,7 +41,7 @@ def test_random_models():
     # this contains TOAs up through 54200
     # make new ones starting there
     tnew = simulation.make_fake_toas_uniform(54200, 59000, 59000 - 54200, f.model)
-    dphase, mrand = simulation.calculate_random_models(f, tnew, Nmodels=100)
+    dphase, mrand = simulation.calculate_random_models(f, tnew, Nmodels=30)
 
     # this is a bit stochastic, but I see typically < 0.14 cycles
     # for the uncertainty at 59000
@@ -43,3 +54,28 @@ def test_random_models():
 
     # this should be less than the fully free version
     assert dphase_F.std(axis=0).max() < dphase.std(axis=0).max()
+
+
+@pytest.mark.parametrize(
+    "fitter", [pint.fitter.WidebandTOAFitter, pint.fitter.WidebandDownhillFitter],
+)
+def test_random_models_wb(fitter):
+    model = get_model(os.path.join(datadir, "J1614-2230_NANOGrav_12yv3.wb.gls.par"))
+    toas = get_TOAs(
+        os.path.join(datadir, "J1614-2230_NANOGrav_12yv3.wb.tim"),
+        ephem="DE436",
+        bipm_version="BIPM2015",
+    )
+    f = fitter(toas, model)
+    # Do a 4-parameter fit
+    f.model.free_params = ("F0", "F1", "ELONG", "ELAT")
+    f.fit_toas()
+
+    tnew = simulation.make_fake_toas_uniform(
+        54200, 59000, (59000 - 54200) // 10, f.model
+    )
+    dphase, mrand = simulation.calculate_random_models(f, tnew, Nmodels=30)
+
+    # this is a bit stochastic, but I see typically < 1e-4 cycles for this
+    # for the uncertainty at 59000
+    assert np.all(dphase.std(axis=0) < 1e-4)


### PR DESCRIPTION
Previously random models only worked with `WLSFitter`.  Now will work with `GLSFitter`, `DownhillWLSFitter`, `DownhillGLSFitter`, `WidebandTOAFitter`, `WidebandDownhillFitter.

Specifically I added `.fac` attributes to all fitters (for some it was present in the `current_state`, for others it was calculated as the matrix norm but not saved). 

Also added random model tests with other fitters