### PR TITLE
Tweak logging

### DIFF
--- a/src/pint/logging.py
+++ b/src/pint/logging.py
@@ -76,8 +76,6 @@ def warn(message, *args, **kwargs):
     Want ``loguru`` to capture warnings emitted by ``warnings.warn``.
     See https://loguru.readthedocs.io/en/stable/resources/recipes.html#capturing-standard-stdout-stderr-and-warnings
     """
-    print(f"message={message} args={args} kwargs={kwargs}")
-    print(args[0].__class__)
     # check to see if a standard warning filter has already been inserted that would catch whatever this is
     # this isn't the exact same implementation as the standard filter because we don't get all of the relevant pieces
     # but it works for ignoring

--- a/src/pint/logging.py
+++ b/src/pint/logging.py
@@ -97,18 +97,6 @@ def warn(message, *args, **kwargs):
             and action == "ignore"
         ):
             return
-        if (
-            (mod is not None)
-            and (
-                "category" in kwargs
-                and (
-                    (msg is None or msg.match(message))
-                    and mod.match(kwargs["category"])
-                )
-            )
-            and action == "ignore"
-        ):
-            return
     if len(args) > 0:
         log.warning(f"{args[0]} {message}")
     elif "category" in kwargs:

--- a/src/pint/logging.py
+++ b/src/pint/logging.py
@@ -185,7 +185,6 @@ class LogFilter:
             "DeprecationWarning",
             "ProvisionalCompleterWarning",
             "deprecated in Matplotlib",
-            'ERFA function "pmsafe" yielded \d+ of "distance overridden \(Note 6\)"',
         ]
         # add in any more defined on init
         if never is not None:

--- a/src/pint/logging.py
+++ b/src/pint/logging.py
@@ -78,7 +78,7 @@ def warn(message, *args, **kwargs):
     """
     # print(f"message={message} args={args} kwargs={kwargs}")
     # check to see if a standard warning filter has already been inserted that would catch whatever this is
-    # this isn't the exact same implementation as the standard filter
+    # this isn't the exact same implementation as the standard filter because we don't get all of the relevant pieces
     # but it works for ignoring
     for filter in warnings.filters:
         action, msg, cat, mod, ln = filter
@@ -93,6 +93,18 @@ def warn(message, *args, **kwargs):
             and (
                 len(args) > 0
                 and ((msg is None or msg.match(message)) and issubclass(args[0], cat))
+            )
+            and action == "ignore"
+        ):
+            return
+        if (
+            (mod is not None)
+            and (
+                "category" in kwargs
+                and (
+                    (msg is None or msg.match(message))
+                    and mod.match(kwargs["category"])
+                )
             )
             and action == "ignore"
         ):

--- a/src/pint/logging.py
+++ b/src/pint/logging.py
@@ -112,7 +112,7 @@ class LogFilter:
     Define some messages that are never seen (e.g., Deprecation Warnings).
     Others that will only be seen once.  Filtering of those is done on the basis of regular expressions."""
 
-    def __init__(self, onlyonce=None, never=None, onlyonce_level="WARNING"):
+    def __init__(self, onlyonce=None, never=None, onlyonce_level="INFO"):
         """
         Define regexs for messages that will only be seen once.  Use ``\S+`` for a variable that might change.
         If a message comes through with a new value for that variable, it will be seen.
@@ -159,6 +159,7 @@ class LogFilter:
             "Column \S+ already exists. Removing...": False,
             "Skipping Shapiro delay for Barycentric TOAs": False,
             "Special observatory location. No clock corrections applied.": False,
+            "DDK model uses KIN as inclination angle. SINI will not be used. This happens every time a DDK model is constructed.": False,
         }
         # add in any more defined on init
         if onlyonce is not None:

--- a/src/pint/logging.py
+++ b/src/pint/logging.py
@@ -76,11 +76,11 @@ debug_color = "<fg #b790d4><bold>"
 # ErfaWarning: ERFA function "pmsafe" yielded 89 of "distance overridden (Note 6)"
 # these don't get emitted by the logger but still get through the warn() function
 # would be better to find where these are emitted
-warnings.filterwarnings(
-    "ignore",
-    message='ERFA function "pmsafe" yielded',
-    category=ErfaWarning,
-)
+# warnings.filterwarnings(
+#    "ignore",
+#    message='ERFA function "pmsafe" yielded',
+#    category=ErfaWarning,
+# )
 warn_ = warnings.warn
 
 

--- a/src/pint/logging.py
+++ b/src/pint/logging.py
@@ -76,7 +76,8 @@ def warn(message, *args, **kwargs):
     Want ``loguru`` to capture warnings emitted by ``warnings.warn``.
     See https://loguru.readthedocs.io/en/stable/resources/recipes.html#capturing-standard-stdout-stderr-and-warnings
     """
-    # print(f"message={message} args={args} kwargs={kwargs}")
+    print(f"message={message} args={args} kwargs={kwargs}")
+    print(args[0].__class__)
     # check to see if a standard warning filter has already been inserted that would catch whatever this is
     # this isn't the exact same implementation as the standard filter because we don't get all of the relevant pieces
     # but it works for ignoring
@@ -91,7 +92,7 @@ def warn(message, *args, **kwargs):
         if (
             (cat is not None)
             and (
-                len(args) > 0
+                (len(args) > 0 and isinstance(args[0], type))
                 and ((msg is None or msg.match(message)) and issubclass(args[0], cat))
             )
             and action == "ignore"

--- a/src/pint/logging.py
+++ b/src/pint/logging.py
@@ -75,6 +75,7 @@ debug_color = "<fg #b790d4><bold>"
 # filter  warnings globally like
 # ErfaWarning: ERFA function "pmsafe" yielded 89 of "distance overridden (Note 6)"
 # these don't get emitted by the logger but still get through the warn() function
+# would be better to find where these are emitted
 warnings.filterwarnings(
     "ignore",
     message='ERFA function "pmsafe" yielded',

--- a/src/pint/logging.py
+++ b/src/pint/logging.py
@@ -50,6 +50,11 @@ import sys
 import warnings
 from loguru import logger as log
 
+try:
+    from erfa import ErfaWarning
+except ImportError:
+    from astropy._erfa import ErfaWarning
+
 __all__ = [
     "LogFilter",
 ]
@@ -67,7 +72,14 @@ debug_color = "<fg #b790d4><bold>"
 # Other formatting:
 # https://loguru.readthedocs.io/en/stable/api/logger.html#color
 
-
+# filter  warnings globally like
+# ErfaWarning: ERFA function "pmsafe" yielded 89 of "distance overridden (Note 6)"
+# these don't get emitted by the logger but still get through the warn() function
+warnings.filterwarnings(
+    "ignore",
+    message='ERFA function "pmsafe" yielded',
+    category=ErfaWarning,
+)
 warn_ = warnings.warn
 
 
@@ -102,6 +114,7 @@ def warn(message, *args, **kwargs):
         log.warning(f"{kwargs['category']} {message}")
     else:
         log.warning(f"{message}")
+    warn_(message, *args, **kwargs)
 
 
 warnings.warn = warn

--- a/src/pint/models/stand_alone_psr_binaries/DDK_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/DDK_model.py
@@ -104,7 +104,7 @@ class DDKmodel(DDmodel):
 
     @SINI.setter
     def SINI(self, val):
-        log.warning(
+        log.info(
             "DDK model uses KIN as inclination angle. SINI will not be "
             "used. This happens every time a DDK model is constructed."
         )


### PR DESCRIPTION
Add more types of warnings to ignore, pay attention to the standard `warnings` filter.

Fixes some of https://github.com/nanograv/PINT/issues/1224