### PR TITLE
Remove ERFA "pmsafe" warnings

### DIFF
--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -358,9 +358,12 @@ class AstrometryEquatorial(Astrometry):
             position_now = add_dummy_distance(self.get_psr_coords())
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", ErfaWarning)
-                position_then = remove_dummy_distance(
-                    position_now.apply_space_motion(new_obstime=newepoch)
-                )
+                # for the most part the dummy distance should remove any potential erfa warnings
+                # but for some very large proper motions that does not quite work
+                # so we catch the warnings
+                position_then = position_now.apply_space_motion(new_obstime=newepoch)
+                position_then = remove_dummy_distance(position_then)
+
             return position_then
 
     def coords_as_ICRS(self, epoch=None):

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -1,6 +1,7 @@
 """Astrometric models for describing pulsar sky positions."""
 import copy
 import sys
+import warnings
 
 import astropy.constants as const
 import astropy.coordinates as coords
@@ -9,6 +10,11 @@ import numpy as np
 from astropy.time import Time
 
 from loguru import logger as log
+
+try:
+    from erfa import ErfaWarning
+except ImportError:
+    from astropy._erfa import ErfaWarning
 
 from pint import ls
 from pint.models.parameter import (
@@ -350,9 +356,11 @@ class AstrometryEquatorial(Astrometry):
             else:
                 newepoch = Time(epoch, scale="tdb", format="mjd")
             position_now = add_dummy_distance(self.get_psr_coords())
-            position_then = remove_dummy_distance(
-                position_now.apply_space_motion(new_obstime=newepoch)
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", ErfaWarning)
+                position_then = remove_dummy_distance(
+                    position_now.apply_space_motion(new_obstime=newepoch)
+                )
             return position_then
 
     def coords_as_ICRS(self, epoch=None):

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1201,9 +1201,9 @@ def add_dummy_distance(c, distance=1 * u.kpc):
             "No proper motions available for %r: returning coordinates unchanged" % c
         )
         return c
-    if c.obstime is None:
-        log.warning("No obstime available for %r: returning coordinates unchanged" % c)
-        return c
+    # if c.obstime is None:
+    #    log.warning("No obstime available for %r: returning coordinates unchanged" % c)
+    #    return c
 
     if isinstance(c.frame, coords.builtin_frames.icrs.ICRS):
         if hasattr(c, "pm_ra_cosdec"):
@@ -1280,10 +1280,6 @@ def remove_dummy_distance(c):
             "No proper motions available for %r: returning coordinates unchanged" % c
         )
         return c
-    if c.obstime is None:
-        log.warning("No obstime available for %r: returning coordinates unchanged" % c)
-        return c
-
     if isinstance(c.frame, coords.builtin_frames.icrs.ICRS):
         if hasattr(c, "pm_ra_cosdec"):
 

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1201,9 +1201,6 @@ def add_dummy_distance(c, distance=1 * u.kpc):
             "No proper motions available for %r: returning coordinates unchanged" % c
         )
         return c
-    # if c.obstime is None:
-    #    log.warning("No obstime available for %r: returning coordinates unchanged" % c)
-    #    return c
 
     if isinstance(c.frame, coords.builtin_frames.icrs.ICRS):
         if hasattr(c, "pm_ra_cosdec"):


### PR DESCRIPTION
When you run for some pulsars you might get one (or many) warnings like:
```
WARNING  (pint.logging                  ): <class 'erfa.core.ErfaWarning'> ERFA function "pmsafe" yielded 1 of "distance overridden (Note 6)"
/Users/kaplan/pythonpackages/PINT_dlakaplan/src/pint/logging.py:118: ErfaWarning: ERFA function "pmsafe" yielded 1 of "distance overridden (Note 6)"
  warn_(message, *args, **kwargs)
```
These should not be happening: we add a dummy distance in before applying proper motions.  But it seems that if the proper motion is large enough that still fails somehow on the `astropy` side.  For example

```
import astropy.coordinates as coords
from astropy import units as u
import numpy as np

from astropy.time import Time
from pint.utils import add_dummy_distance, remove_dummy_distance

# normally using the dummy distances should lead to no ERFA pmsafe warning
sc = coords.SkyCoord(
    ra=180 * u.deg,
    dec=20 * u.deg,
    pm_ra_cosdec=100 * (u.mas / u.yr),
    pm_dec=100 * (u.mas / u.yr),
    obstime=Time(50000, format="pulsar_mjd", scale="tdb"),
)

sc2 = add_dummy_distance(sc)
# this should not lead to a warning
sc2.apply_space_motion(new_obstime=sc.obstime)

# but with very big proper motions, even if applied over 0 time
# we get the warning
sc = coords.SkyCoord(
    ra=180 * u.deg,
    dec=20 * u.deg,
    pm_ra_cosdec=1000 * (u.mas / u.yr),
    pm_dec=1000 * (u.mas / u.yr),
    obstime=Time(50000, format="pulsar_mjd", scale="tdb"),
)
sc2 = add_dummy_distance(sc)
# this shoudn't lead to a warning but it does
sc2.apply_space_motion(new_obstime=sc.obstime)
```
the second attempt emits a warning, and the only difference is that the proper motion is larger.

So we explicitly catch Erfa warnings in the `astrometry` module to suppress those.  Warnings issued elsewhere will still come through.