### PR TITLE
Convert a cluster into a flag

### DIFF
--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1658,7 +1658,7 @@ class TOAs:
         add_column : bool, optional
             Whether or not to add a ``clusters`` column to the TOA table (default: False)
         add_flag : str, optional
-            If not ``None``, will add a flag with that name to the TOA table (default: None)
+            If not ``None``, will add a flag with that name to the TOA table whose value is the cluster number (as a string, starting at 0) (default: None)
 
         Returns
         -------

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1637,7 +1637,7 @@ class TOAs:
             raise AttributeError("No DM error is provided.")
         return np.array(result)[valid] * pint.dmu
 
-    def get_clusters(self, gap_limit=2 * u.h, add_column=False, add_flag=False):
+    def get_clusters(self, gap_limit=2 * u.h, add_column=False, add_flag=None):
         """Identify toas within gap limit (default 2h = 0.0833d)
         of each other as the same cluster.
 
@@ -1646,7 +1646,7 @@ class TOAs:
         starts and continues until another such gap is found.
 
         Cluster info can be added as a ``clusters`` column to the
-        :attr:`pint.toa.TOAs.table` object if `add_column` is True.  Cluster info can also be added as a ``cluster`` flag.
+        :attr:`pint.toa.TOAs.table` object if `add_column` is True.  Cluster info can also be added as a flag with name specified.
         In those cases  ``self.table.meta['cluster_gap']``  will be set to the
         `gap_limit`.  If the desired clustering corresponds to that in
         :attr:`pint.toa.TOAs.table` then that column is returned.
@@ -1657,8 +1657,8 @@ class TOAs:
             The minimum size of gap to create a new group. Defaults to two hours.
         add_column : bool, optional
             Whether or not to add a ``clusters`` column to the TOA table (default: False)
-        add_flag : bool, optional
-            Whether or not to add a ``cluster`` flag to the TOA table (default: False)
+        add_flag : str, optional
+            If not ``None``, will add a flag with that name to the TOA table (default: None)
 
         Returns
         -------
@@ -1678,11 +1678,11 @@ class TOAs:
                 self.table.add_column(clusters, name="clusters")
                 self.table.meta["cluster_gap"] = gap_limit
                 log.debug(f"Added 'clusters' column to TOA table with gap={gap_limit}")
-            if add_flag:
+            if add_flag is not None:
                 for i in range(len(clusters)):
-                    self.table["flags"][i]["cluster"] = str(clusters[i])
+                    self.table["flags"][i][add_flag] = str(clusters[i])
                 self.table.meta["cluster_gap"] = gap_limit
-                log.debug(f"Added 'cluster' flag to TOA table with gap={gap_limit}")
+                log.debug(f"Added '{add_flag}' flag to TOA table with gap={gap_limit}")
 
             return clusters
 

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1637,7 +1637,7 @@ class TOAs:
             raise AttributeError("No DM error is provided.")
         return np.array(result)[valid] * pint.dmu
 
-    def get_clusters(self, gap_limit=2 * u.h, add_column=False):
+    def get_clusters(self, gap_limit=2 * u.h, add_column=False, add_flag=False):
         """Identify toas within gap limit (default 2h = 0.0833d)
         of each other as the same cluster.
 
@@ -1646,8 +1646,8 @@ class TOAs:
         starts and continues until another such gap is found.
 
         Cluster info can be added as a ``clusters`` column to the
-        :attr:`pint.toa.TOAs.table` object if `add_column` is True.
-        In that case  ``self.table.meta['cluster_gap']``  will be set to the
+        :attr:`pint.toa.TOAs.table` object if `add_column` is True.  Cluster info can also be added as a ``cluster`` flag.
+        In those cases  ``self.table.meta['cluster_gap']``  will be set to the
         `gap_limit`.  If the desired clustering corresponds to that in
         :attr:`pint.toa.TOAs.table` then that column is returned.
 
@@ -1657,6 +1657,8 @@ class TOAs:
             The minimum size of gap to create a new group. Defaults to two hours.
         add_column : bool, optional
             Whether or not to add a ``clusters`` column to the TOA table (default: False)
+        add_flag : bool, optional
+            Whether or not to add a ``cluster`` flag to the TOA table (default: False)
 
         Returns
         -------
@@ -1675,6 +1677,13 @@ class TOAs:
             if add_column:
                 self.table.add_column(clusters, name="clusters")
                 self.table.meta["cluster_gap"] = gap_limit
+                log.debug(f"Added 'clusters' column to TOA table with gap={gap_limit}")
+            if add_flag:
+                for i in range(len(clusters)):
+                    self.table["flags"][i]["cluster"] = str(clusters[i])
+                self.table.meta["cluster_gap"] = gap_limit
+                log.debug(f"Added 'cluster' flag to TOA table with gap={gap_limit}")
+
             return clusters
 
         else:

--- a/tests/test_flagging_clustering.py
+++ b/tests/test_flagging_clustering.py
@@ -48,7 +48,9 @@ def test_jump_by_cluster(setup_NGC6440E):
     cp.add_param(par, setup=True)
 
     # add clusters to the TOAs
-    clusters = setup_NGC6440E.t.get_clusters(2 * u.hr, add_column=False, add_flag=True)
+    clusters = setup_NGC6440E.t.get_clusters(
+        2 * u.hr, add_column=False, add_flag="cluster"
+    )
 
     m_copy.add_component(PhaseJump(), validate=False)
     cp_copy = m_copy.components["PhaseJump"]

--- a/tests/test_flagging_clustering.py
+++ b/tests/test_flagging_clustering.py
@@ -64,5 +64,26 @@ def test_jump_by_cluster(setup_NGC6440E):
     )
 
 
+def test_jump_by_cluster_invalidflags(setup_NGC6440E):
+
+    # add clusters to the TOAs
+    t = copy.deepcopy(setup_NGC6440E.t)
+    with pytest.raises(ValueError):
+        clusters = t.get_clusters(
+            2 * u.hr,
+            add_column=False,
+            add_flag=True,
+        )
+
+    # add clusters to the TOAs
+    t = copy.deepcopy(setup_NGC6440E.t)
+    with pytest.raises(ValueError):
+        clusters = t.get_clusters(
+            2 * u.hr,
+            add_column=False,
+            add_flag=1,
+        )
+
+
 if __name__ == "__main__":
     pass

--- a/tests/test_flagging_clustering.py
+++ b/tests/test_flagging_clustering.py
@@ -48,14 +48,12 @@ def test_jump_by_cluster(setup_NGC6440E):
     cp.add_param(par, setup=True)
 
     # add clusters to the TOAs
-    clusters = setup_NGC6440E.t.get_clusters(2 * u.hr, add_column=False)
-    for i, v in zip(np.arange(len(setup_NGC6440E.t)), clusters):
-        setup_NGC6440E.t.table[i]["flags"]["toacluster"] = str(v)
+    clusters = setup_NGC6440E.t.get_clusters(2 * u.hr, add_column=False, add_flag=True)
 
     m_copy.add_component(PhaseJump(), validate=False)
     cp_copy = m_copy.components["PhaseJump"]
     par_copy = p.maskParameter(
-        name="JUMP", key="-toacluster", value=0.2, key_value=41, units=u.s
+        name="JUMP", key="-cluster", value=0.2, key_value=41, units=u.s
     )
     # this should be identical to the cluster above
     cp_copy.add_param(par_copy, setup=True)


### PR DESCRIPTION
To aid in selecting data by "clusters", convert clusters to flags that can easily be used for JUMP/EFAC/etc.

e.g., 
```
t.get_clusters(add_flag = True)
```
then the TOA table looks like:
```
t.table['flags']
                                          {'format': 'Tempo2', 'name': 'ALL.T16Fp', 'clkcorr': '2.800489029156601e-05', 'cluster': '4'}
                                          {'format': 'Tempo2', 'name': 'ALL.T16Fp', 'clkcorr': '2.800489016085896e-05', 'cluster': '4'}
                                         {'format': 'Tempo2', 'name': 'ALL.T16Fp', 'clkcorr': '2.8004890030153187e-05', 'cluster': '4'}
...
                                         {'format': 'Tempo2', 'name': 'ALL.T16Fp', 'clkcorr': '2.8004888308595357e-05', 'cluster': '4'}
                                         {'format': 'Tempo2', 'name': 'ALL.T16Fp', 'clkcorr': '2.8004888185360825e-05', 'cluster': '4'}
                           {'format': 'Tempo2', 'name': 'J0523-7125_PSMC.rf.f4t4', 'clkcorr': '2.6823950390193516e-05', 'cluster': '0'}
                                                                                                                                    ...
 {'format': 'Tempo2', 'name': 'uwl_220130_090227_2.calib.0000_0000.low.paz1.pFT8', 'clkcorr': '2.760637484357018e-05', 'cluster': '13'}
```

and then:
```
m.add_component(DelayJump(), validate=False)
par = parameter.maskParameter(
    "JUMP",
    key="-cluster",
    value=0.0,
    key_value="1",
    units=u.s,
    frozen=False,
)
m.components["DelayJump"].add_param(par, setup=True)
```