### PR TITLE
Report the observatory when TEMPO/TEMPO2 needed.

### DIFF
--- a/src/pint/observatory/topo_obs.py
+++ b/src/pint/observatory/topo_obs.py
@@ -152,12 +152,16 @@ class TopoObs(Observatory):
             # location from CLKDIR line...
             TEMPO_dir = os.getenv("TEMPO")
             if TEMPO_dir is None:
-                raise RuntimeError(f"Cannot find TEMPO path from the enviroment, needed for {self.name} clock corrections.")
+                raise RuntimeError(
+                    f"Cannot find TEMPO path from the enviroment, needed for {self.name} clock corrections."
+                )
             dir = os.path.join(TEMPO_dir, "clock")
         elif self.clock_dir == "TEMPO2":
             TEMPO2_dir = os.getenv("TEMPO2")
             if TEMPO2_dir is None:
-                raise RuntimeError(f"Cannot find TEMPO2 path from the enviroment, needed for {self.name} clock corrections.")
+                raise RuntimeError(
+                    f"Cannot find TEMPO2 path from the enviroment, needed for {self.name} clock corrections."
+                )
             dir = os.path.join(TEMPO2_dir, "clock")
         else:
             dir = self.clock_dir

--- a/src/pint/observatory/topo_obs.py
+++ b/src/pint/observatory/topo_obs.py
@@ -152,12 +152,12 @@ class TopoObs(Observatory):
             # location from CLKDIR line...
             TEMPO_dir = os.getenv("TEMPO")
             if TEMPO_dir is None:
-                raise RuntimeError("Cannot find TEMPO path from the" " enviroment.")
+                raise RuntimeError(f"Cannot find TEMPO path from the enviroment, needed for {self.name} clock corrections.")
             dir = os.path.join(TEMPO_dir, "clock")
         elif self.clock_dir == "TEMPO2":
             TEMPO2_dir = os.getenv("TEMPO2")
             if TEMPO2_dir is None:
-                raise RuntimeError("Cannot find TEMPO2 path from the" " enviroment.")
+                raise RuntimeError(f"Cannot find TEMPO2 path from the enviroment, needed for {self.name} clock corrections.")
             dir = os.path.join(TEMPO2_dir, "clock")
         else:
             dir = self.clock_dir


### PR DESCRIPTION
Currently if you try to load TOAs from an observatory PINT knows but that needs the TEMPO or TEMPO2 runtime files, and the corresponding environment variable is not set, you get an error message that just tells you the environment variable is missing. This code reports the name of the observatory that is calling for TEMPO/TEMPO2 runtime files.