### PR TITLE
Use EQUADs and EFACs in WLS fitters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 ### Added
 - Warning when A1DOT parameter used with DDK model
 ### Fixed
+- WLS fitters no longer ignore EFAC/EQUAD (bug #1226)
 ### Changed
 
 ## [0.8.6 == 0.8.7] 2022-05-10

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1709,7 +1709,8 @@ class WidebandState(ModelState):
 
         # normalize the design matrix
         norm = np.sqrt(np.sum(M**2, axis=0))
-        ntmpar = len(self.model.free_params)
+        # The fixed offset is an unlisted parameter
+        ntmpar = len(self.model.free_params)+1
         if M.shape[1] > ntmpar:
             norm[ntmpar:] = 1
         for c in np.where(norm == 0)[0]:
@@ -1752,6 +1753,8 @@ class WidebandState(ModelState):
 
         # compute covariance matrices
         if self.full_cov:
+            # FIXME: does this handle EFAC? needs scaled_toa_uncertainty
+            # rather than get_errors
             cov = combine_covariance_matrix(
                 [
                     CovarianceMatrixMaker("toa", u.s)(self.fitter.toas, self.model),
@@ -1771,14 +1774,10 @@ class WidebandState(ModelState):
                     [
                         self.model.scaled_toa_uncertainty(self.fitter.toas).to_value(
                             u.s
-                        )
-                        if hasattr(self.model, "scaled_toa_uncertainty")
-                        else self.resids.toa.get_errors().to_value(u.s),
+                        ),
                         self.model.scaled_dm_uncertainty(self.fitter.toas).to_value(
                             u.pc / u.cm**3
                         )
-                        if hasattr(self.model, "scaled_dm_uncertainty")
-                        else self.resids.dm.get_dm_errors().to_value(u.pc / u.cm**3),
                     ]
                 )
                 ** 2

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1710,7 +1710,7 @@ class WidebandState(ModelState):
         # normalize the design matrix
         norm = np.sqrt(np.sum(M**2, axis=0))
         # The fixed offset is an unlisted parameter
-        ntmpar = len(self.model.free_params)+1
+        ntmpar = len(self.model.free_params) + 1
         if M.shape[1] > ntmpar:
             norm[ntmpar:] = 1
         for c in np.where(norm == 0)[0]:
@@ -1753,8 +1753,6 @@ class WidebandState(ModelState):
 
         # compute covariance matrices
         if self.full_cov:
-            # FIXME: does this handle EFAC? needs scaled_toa_uncertainty
-            # rather than get_errors
             cov = combine_covariance_matrix(
                 [
                     CovarianceMatrixMaker("toa", u.s)(self.fitter.toas, self.model),
@@ -1777,7 +1775,7 @@ class WidebandState(ModelState):
                         ),
                         self.model.scaled_dm_uncertainty(self.fitter.toas).to_value(
                             u.pc / u.cm**3
-                        )
+                        ),
                     ]
                 )
                 ** 2

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1336,9 +1336,7 @@ class WLSState(ModelState):
             toas=self.fitter.toas, incfrozen=False, incoffset=True
         )
         # Get residuals and TOA uncertainties in seconds
-        Nvec = (
-            self.model.scaled_toa_uncertainty(self.fitter.toas).to(u.s).value
-        )
+        Nvec = self.model.scaled_toa_uncertainty(self.fitter.toas).to(u.s).value
         scaled_resids = self.resids.time_resids.to(u.s).value / Nvec
 
         # "Whiten" design matrix and residuals by dividing by uncertainties
@@ -2049,9 +2047,7 @@ class WLSFitter(Fitter):
             # Get residuals and TOA uncertainties in seconds
             self.update_resids()
             residuals = self.resids.time_resids.to(u.s).value
-            Nvec = (
-                self.model.scaled_toa_uncertainty(self.toas).to(u.s).value
-            )
+            Nvec = self.model.scaled_toa_uncertainty(self.toas).to(u.s).value
 
             # "Whiten" design matrix and residuals by dividing by uncertainties
             M = M / Nvec.reshape((-1, 1))

--- a/tests/test_fitter_compare.py
+++ b/tests/test_fitter_compare.py
@@ -146,6 +146,34 @@ def test_step_different_with_efacs(fitter, m_t):
 
 
 @pytest.mark.parametrize(
+    "fitter",
+    [
+        GLSFitter,
+        DownhillGLSFitter,
+        WidebandTOAFitter,
+        WidebandDownhillFitter,
+    ],
+)
+def test_step_different_with_efacs_full_cov(fitter, m_t):
+    m, t = m_t
+    f = fitter(t, m)
+    try:
+        f.fit_toas(maxiter=1, full_cov=True)
+    except MaxiterReached:
+        pass
+    m2 = copy.deepcopy(m)
+    m2.EFAC1.value = 1
+    m2.EFAC2.value = 1
+    f2 = fitter(t, m2)
+    try:
+        f2.fit_toas(maxiter=1, full_cov=True)
+    except MaxiterReached:
+        pass
+    for p in m.free_params:
+        assert getattr(f.model, p).value != getattr(f2.model, p).value
+
+
+@pytest.mark.parametrize(
     "fitter1, fitter2",
     [
         (WLSFitter, DownhillWLSFitter),


### PR DESCRIPTION
Ensure fitters correctly take into account model-based adjustments to TOA uncertainties.

Minor change, strict bug fix, resolves frustrating misbehaviour, has tests.

~~Still needs tests.~~ ~~Code currently depends on #1239 as my test case needed telescopes I don't have timing data for.~~

Closes #1226 #1245 