### PR TITLE
WIP: Remove requirement to keep TOAs grouped

### DIFF
--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -289,7 +289,6 @@ def get_TOAs(
     t.table = t.table.group_by("obs")
     if recalc or "tdb" not in t.table.colnames:
         t.compute_TDBs(method=tdb_method, ephem=ephem)
-        log.debug(f"TDB on reading: {t.table[0]['tdb'].tdb.mjd_long:.20f}")
     if planets is None:
         planets = t.planets
     elif planets != t.planets:
@@ -302,11 +301,7 @@ def get_TOAs(
     if usepickle and updatepickle:
         log.info("Pickling TOAs.")
         save_pickle(t, picklefilename=picklefilename)
-    log.debug(f"TDB on return: {t.table[0]['tdb'].tdb.mjd_long:.20f}")
-    print(f"{t.table[0]['tdb'].tdb.mjd_long:.20f}")
-    tdb = copy.deepcopy(t.table[0]["tdb"].tdb.mjd_long)
-    print(f"{tdb:.20f}")
-    return t, tdb
+    return t
 
 
 def load_pickle(toafilename, picklefilename=None):
@@ -2153,9 +2148,6 @@ class TOAs:
                 grpmjds = time.Time(
                     self.table[grp]["mjd"], location=self.table[grp]["mjd"][0].location
                 )
-                log.debug(
-                    f"{obs} site={site} grp={grp} grpmjds={grpmjds} locations={grpmjds.location} location={self.table[grp]['mjd'][0].location}"
-                )
             else:
                 # Grab locations for each TOA
                 # It is crazy that I have to deconstruct the locations like
@@ -2176,7 +2168,6 @@ class TOAs:
 
             grptdbs = site.get_TDBs(grpmjds, method=method, ephem=ephem)
             tdbs[grp] = np.asarray([t for t in grptdbs])
-            log.debug(f"TDBs: {grptdbs} {tdbs} {tdbs[0].tdb.mjd_long:.20f}")
         # Now add the new columns to the table
         col_tdb = table.Column(name="tdb", data=tdbs)
         col_tdbld = table.Column(name="tdbld", data=[t.tdb.mjd_long for t in tdbs])

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -2058,7 +2058,6 @@ class TOAs:
         )
         corr = np.zeros(self.ntoas) * u.s
         times = self.table["mjd"]
-        log.debug(f"times[0] = {times[0].value:.20f}")
         t0 = copy.deepcopy(times[0])
         for obs, grp in self.get_obs_groups():
             site = get_observatory(

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -2138,7 +2138,7 @@ class TOAs:
         log.debug(f"Using EPHEM = {self.ephem} for TDB calculation.")
 
         # Compute in observatory groups
-        tdbs = np.zeros_like(self.table["mjd"].data)
+        tdbs = np.zeros_like(self.table["mjd"])
         for obs, grp in self.get_obs_groups():
             site = get_observatory(obs)
             if isinstance(site, TopoObs):
@@ -2168,6 +2168,9 @@ class TOAs:
 
             grptdbs = site.get_TDBs(grpmjds, method=method, ephem=ephem)
             tdbs[grp] = np.asarray([t for t in grptdbs])
+            log.debug(
+                f"obs={obs} grpmjds={grpmjds[0].value:.15f} grptdbs={grptdbs[0].value:.20f}  tdbs={tdbs[0].value:.20f}"
+            )
         # Now add the new columns to the table
         col_tdb = table.Column(name="tdb", data=tdbs)
         col_tdbld = table.Column(name="tdbld", data=[t.tdb.mjd_long for t in tdbs])

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -79,6 +79,7 @@ __all__ = [
     "info_string",
     "print_color_examples",
     "colorize",
+    "GroupIterator",
 ]
 
 COLOR_NAMES = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]
@@ -1595,3 +1596,38 @@ def print_color_examples():
                     end="",
                 )
             print("")
+
+
+class GroupIterator:
+    """An iterator to step over identical items in a :class:`numpy.ndarray`
+
+    Example
+    -------
+    This will step over all of the observatories in the TOAs.
+    For each iteration it gives the observatory name and the indices that correspond to it
+
+        t = pint.toa.get_TOAs("grouptest.tim")
+        I = GroupIterator(t["obs"])
+        for o, i in I:
+            print(f"{o} {i}")
+
+    """
+
+    def __init__(self, items):
+        self.items = items
+        self.unique_items = np.unique(items)
+        self.indices = []
+        for item in self.unique_items:
+            self.indices.append(np.where(self.items == item)[0])
+
+    def __iter__(self):
+        self.index = 0
+        return self
+
+    def __next__(self):
+        if self.index < len(self.unique_items):
+            out = self.unique_items[self.index], self.indices[self.index]
+            self.index += 1
+            return out
+        else:
+            raise StopIteration


### PR DESCRIPTION
Previously TOAs had to be grouped by observatory.  So any resorting could mess up later access (#1252). This just uses fancy indexing to eliminate that requirement.

