### PR TITLE
Allow PINT to write clock correction files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Added functions in pint.observatory to request the status of PINT's available clock corrections
 - Added the ability to query clock correction files or observatories for their last corrected MJD
 - Added an example showing how to check the status of your clock corrections
+- Added the ability to write clock files in TEMPO or TEMPO2 format
 ### Fixed
 - WLS fitters no longer ignore EFAC/EQUAD (bug #1226)
 ### Changed

--- a/src/pint/observatory/clock_file.py
+++ b/src/pint/observatory/clock_file.py
@@ -1,17 +1,12 @@
 """Routines for reading various formats of clock file."""
 
 import os
-import warnings
+import re
 from textwrap import dedent
 
 import astropy.units as u
 import numpy as np
 from loguru import logger as log
-
-try:
-    from erfa import ErfaWarning
-except ImportError:
-    from astropy._erfa import ErfaWarning
 
 from pint.pulsar_mjd import Time
 from pint.utils import open_or_use, lines_of
@@ -30,7 +25,7 @@ class ClockFileMeta(type):
             setattr(cls, regname, {})
         if "format" in members:
             getattr(cls, regname)[cls.format] = cls
-        super(ClockFileMeta, cls).__init__(name, bases, members)
+        super().__init__(name, bases, members)
 
 
 class ClockFile(metaclass=ClockFileMeta):
@@ -59,6 +54,12 @@ class ClockFile(metaclass=ClockFileMeta):
            2.10000000e-08   2.30000000e-08] s
 
     """
+
+    def __init__(self):
+        # FIXME: require filename?
+        self._time = None
+        self._clock = None
+        self.comments = None
 
     @classmethod
     def read(cls, filename, format="tempo", **kwargs):
@@ -133,6 +134,11 @@ class ClockFile(metaclass=ClockFileMeta):
     def merge(clocks, *, trim=True):
         """Compute clock correction information for a combination of clocks.
 
+        This combines the clock correction files to produce a single file that
+        produces clock corrections that are the *sum* of the original input files.
+        For example, one could combine `ao2gps.clk` and `gps2utc.clk` to produce
+        `ao2utc.clk`.
+
         Note that clock correction files can specify discontinuities by
         repeating MJDs. This merged object should accurately propagate these
         discontinuities.
@@ -188,15 +194,110 @@ class ClockFile(metaclass=ClockFileMeta):
         if trim:
             b = max([c._time.mjd[0] for c in clocks])
             e = min([c._time.mjd[-1] for c in clocks])
-            l = np.searchsorted(times.mjd, b)
-            r = np.searchsorted(times.mjd, e, side="right")
-            times = times[l:r]
-            corr = corr[l:r]
+            il = np.searchsorted(times.mjd, b)
+            ir = np.searchsorted(times.mjd, e, side="right")
+            times = times[il:ir]
+            corr = corr[il:ir]
         return ConstructedClockFile(
             mjd=times.mjd,
             clock=corr,
             filename=f"Merged from {[c.filename for c in clocks]}",
         )
+
+    def write_tempo_clock_file(self, filename, obscode, extra_comments=None):
+        """Write clock corrections as a TEMPO-format clock correction file.
+
+        Parameters
+        ----------
+        filename : str or pathlib.Path or file-like
+            The destination
+        obscode : str
+            The TEMPO observatory code. TEMPO effectively concatenates
+            all its clock corrections and uses this field to determine
+            which observatory the clock corrections are relevant to.
+            TEMPO observatory codes are case-insensitive one-character values agreed upon
+            by convention and occurring in tim files. PINT recognizes
+            these as aliases of observatories for which they are agreed upon,
+            and an Observatory object contains a field that can be used to
+            retrieve this.
+        comments : str
+            Additional comments to include. These will be included below the headings
+            and each line should be prefaced with `#` to avoid conflicting with the
+            clock corrections.
+        """
+        if not isinstance(obscode, str) or len(obscode) != 1:
+            raise ValueError(
+                "Invalid TEMPO obscode {obscode!r}, should be one printable character"
+            )
+        mjds = self.time.mjd
+        corr = self.clock.to_value(u.us)
+        comments = self.comments if self.comments else [""] * len(self.clock)
+        # TEMPO writes microseconds
+        with open_or_use(filename) as f:
+            f.write(tempo_standard_header)
+            if extra_comments is not None:
+                f.write(extra_comments.strip())
+                f.write("\n")
+            if self.leading_comment is not None:
+                f.write(self.leading_comment)
+                f.write("\n")
+            # Do not use EECO-REF column as TEMPO does a weird subtraction thing
+            for mjd, corr, comment in zip(mjds, corr, comments):
+                # 0:9 for MJD
+                # 9:21 for clkcorr1 (do not use)
+                # 21:33 for clkcorr2
+                # 34 for obscode
+                # Extra stuff ignored
+                # FIXME: always use C locale
+                date = Time(mjd, format="pulsar_mjd").datetime.strftime("%d-%b-%y")
+                eeco = 0.0
+                f.write(f"{mjd:9.2f}{eeco:12.3f}{corr:12.3f} {obscode}    {date}")
+                if comment:
+                    # Try to avoid trailing whitespace
+                    if comment.startswith("\n"):
+                        f.write(f"{comment}".rstrip())
+                    else:
+                        f.write(f"  {comment}".rstrip())
+                f.write("\n")
+
+    def write_tempo2_clock_file(self, filename, hdrline=None, comments=None):
+        """Write clock corrections as a TEMPO2-format clock correction file.
+
+        Parameters
+        ----------
+        filename : str or pathlib.Path or file-like
+            The destination
+        hdrline : str
+            The first line of the file. Should start with `#` and consist
+            of a pair of timescales, like `UTC(AO) UTC(GPS)` that this clock
+            file transforms between.
+        comments : str
+            Additional comments to include. Lines should probably start with `#`
+            so they will be interpreted as comments. This field frequently
+            contains details of the origin of the file, or at least the
+            commands used to convert it from its original format.
+        """
+        # Tempo2 requires headerlines to look like "# CLK1 CLK2"
+        # listing two time scales
+        # Tempo2 can't cope with lines longer than 1023 characters
+        # Initial lines starting with # are ignored (not indented)
+        # https://bitbucket.org/psrsoft/tempo2/src/master/tabulatedfunction.C
+        # Lines starting with # (not indented) are skipped
+        # `sscanf("%lf %lf")` means anything after the two values is ignored
+        # Also any line that doesn't start with two floats is ignored
+        # decreasing forbidden
+        if hdrline is None:
+            hdrline = self.header
+        if not hdrline.startswith("#"):
+            raise ValueError(f"Header line must start with #: {hdrline!r}")
+        mjds = self.time.mjd
+        corr = self.clock
+        # TEMPO2 writes seconds
+        a = np.array([mjds, corr.to_value(u.s)]).T
+        header = hdrline.strip() + "\n"
+        if comments is not None:
+            header += comments
+        np.savetxt(filename, a, header=header)
 
 
 class ConstructedClockFile(ClockFile):
@@ -204,22 +305,75 @@ class ConstructedClockFile(ClockFile):
     # No format set because these can't be read
 
     def __init__(self, mjd, clock, filename=None, **kwargs):
+        super().__init__()
         if len(mjd) != len(clock):
             raise ValueError(f"MJDs have {len(mjd)} entries but clock has {len(clock)}")
         self._time = Time(mjd, format="pulsar_mjd", scale="utc")
         self._clock = clock.to(u.us)
         self.filename = "Constructed" if filename is None else filename
+        self.comments = None
+        self.leading_comment = None
 
 
 class Tempo2ClockFile(ClockFile):
 
     format = "tempo2"
 
+    hdrline_re = re.compile(r"#\s*(\S+)\s+(\S+)\s+(\d+)?(.*)")
+    # This horror is based on https://docs.python.org/3/library/re.html#simulating-scanf
+    clkcorr_re = re.compile(
+        r"\s*([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eEdD][-+]?\d+)?)"
+        r"\s+([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eEdD][-+]?\d+)?)"
+        r"(.*)"
+    )
+
     def __init__(self, filename, bogus_last_correction=False, **kwargs):
+        super().__init__()
         self.filename = filename
         log.debug(f"Loading {self.format} observatory clock correction file {filename}")
         try:
-            mjd, clk, self.header = self.load_tempo2_clock_file(filename)
+            mjd = []
+            clk = []
+            self.leading_comment = ""
+            self.comments = []
+            with open_or_use(filename) as f:
+                hdrline = f.readline()
+                m = self.hdrline_re.match(hdrline)
+                if not m:
+                    raise ValueError(
+                        f"Header line must start with # and contain two time scales: {hdrline!r}"
+                    )
+                self.header = hdrline
+                self.timescale_from = m.group(1)
+                self.timescale_to = m.group(2)
+                self.badness = 1 if m.group(3) is None else int(m.group(3))
+                # Extra stuff on the hdrline <shrug />
+                self.hdrline_extra = "" if m.group(4) is None else m.group(4)
+
+                def add_comment(s):
+                    if self.comments:
+                        self.comments[-1] = "\n".join([self.comments[-1], s.strip()])
+                    else:
+                        self.leading_comment = "\n".join(
+                            [self.leading_comment, s.strip()]
+                        )
+
+                for line in f.readlines():
+                    if line.startswith("#"):
+                        add_comment(line)
+                        continue
+                    m = self.clkcorr_re.match(line)
+                    if m is None:
+                        # Anything that doesn't match is a comment, what fun!
+                        # This is what T2 does, using sscanf
+                        add_comment(line)
+                        continue
+                    mjd.append(float(m.group(1)))
+                    clk.append(float(m.group(2)))
+                    if m.group(3) is not None:
+                        # Anything else on the line is a comment too
+                        add_comment(m.group(3))
+            clk = np.array(clk)
         except (FileNotFoundError, OSError):
             log.error(f"TEMPO2-style clock correction file {filename} not found")
             mjd = np.array([], dtype=float)
@@ -235,232 +389,172 @@ class Tempo2ClockFile(ClockFile):
         self._time = Time(mjd, format="pulsar_mjd", scale="utc")
         self._clock = clk * u.s
 
-    @staticmethod
-    def load_tempo2_clock_file(filename):
-        """Read a tempo2-format clock file.
 
-        Returns three values:
-        (mjd, clk, hdrline).  The first two are float arrays of MJD and
-        clock corrections (seconds).  hdrline is the first line of the file
-        that specifies the two clock scales connected by the file.
-        """
-        with open_or_use(filename, "r") as f:
-            hdrline = f.readline().rstrip()
-            try:
-                mjd, clk = np.loadtxt(f, usecols=(0, 1), unpack=True)
-            except (FileNotFoundError, ValueError):
-                log.error("Failed loading clock file {0}".format(f))
-                raise
-        return mjd, clk, hdrline
-
-
-def write_tempo2_clock_file(filename, hdrline, clock, comments=None):
-    """Write clock corrections as a TEMPO2-format clock correction file.
-
-    Parameters
-    ----------
-    filename : str or pathlib.Path or file-like
-        The destination
-    hdrline : str
-        The first line of the file. Should start with `#` and consist
-        of a pair of timescales, like `UTC(AO) UTC(GPS)` that this clock
-        file transforms between.
-    clock : ClockFile
-        ClockFile object to write out.
-    comments : str
-        Additional comments to include. Lines should probably start with `#`
-        so they will be interpreted as comments. This field frequently
-        contains details of the origin of the file, or at least the
-        commands used to convert it from its original format.
+tempo_standard_header = dedent(
+    """\
+       MJD       EECO-REF    NIST-REF NS      DATE    COMMENTS
+    =========    ========    ======== ==    ========  ========
     """
-    if not hdrline.startswith("#"):
-        raise ValueError(f"Header line must start with #: {hdrline!r}")
-    mjds = clock.time.mjd
-    corr = clock.clock
-    # TEMPO2 writes seconds
-    a = np.array([mjds, corr.to_value(u.s)]).T
-    header = hdrline.strip() + "\n"
-    if comments is not None:
-        header += comments
-    np.savetxt(filename, a, header=header)
+)
 
 
 class TempoClockFile(ClockFile):
+    """Load a TEMPO format clock file for a site
+
+    Given the specified full path to the tempo1-format clock file,
+    will return two numpy arrays containing the MJDs and the clock
+    corrections (us).  All computations here are done as in tempo, with
+    the exception of the 'F' flag (to disable interpolation), which
+    is currently not implemented.
+
+    INCLUDE statments are processed.
+
+    If the 'site' argument is set to an appropriate one-character tempo
+    site code, only values for that site will be returned. If the 'site'
+    argument is None, the file is assumed to contain only clock corrections
+    for the desired telescope, so all values found in the file will be returned
+    but INCLUDEs will *not* be processed.
+    """
 
     format = "tempo"
 
-    def __init__(self, filename, obscode=None, bogus_last_correction=False, **kwargs):
+    def __init__(
+        self,
+        filename,
+        obscode=None,
+        bogus_last_correction=False,
+        process_includes=True,
+        **kwargs,
+    ):
+        super().__init__()
         self.filename = filename
         self.obscode = obscode
+        self.leading_comment = None
         log.debug(
             f"Loading {self.format} observatory ({obscode}) clock correction file {filename}"
         )
+        mjds = []
+        clkcorrs = []
+        self.comments = []
+
+        def add_comment(s):
+            if self.comments:
+                if self.comments[-1] is None:
+                    self.comments[-1] = s.rstrip()
+                else:
+                    self.comments[-1] += "\n" + s.rstrip()
+            elif self.leading_comment is None:
+                self.leading_comment = s.rstrip()
+            else:
+                self.leading_comment += "\n" + s.rstrip()
+
         try:
-            mjd, clk = self.load_tempo1_clock_file(filename, site=obscode)
+            # TODO we might want to handle 'f' flags by inserting addtional
+            # entries so that interpolation routines will give the right result.
+            # The way TEMPO interprets 'f' flags is that an MJD with an 'f' flag
+            # gives the constant clock correction value for at most a day either side.
+            # If the sought-after clock correction is within a day of two different
+            # 'f' values, the nearest is used.
+            # https://github.com/nanograv/tempo/blob/618afb2e901d3e4b8324d4ba12777c055e128696/src/clockcor.f#L79
+            # This could be (roughly) implemented by splicing in additional clock correction points
+            # between 'f' values or +- 1 day.
+            # (The deviation would be that in gaps you get an interpolated value rather than
+            # an error message.)
+            seen_header = 0
+
+            for l in lines_of(filename):
+                # Ignore comment lines
+                if l.startswith("#"):
+                    add_comment(l)
+                    continue
+
+                if seen_header < 2:
+                    if [w.upper() for w in l.split()] != tempo_standard_header.split(
+                        "\n"
+                    )[seen_header].split():
+                        raise ValueError(
+                            "TEMPO-format clock files should start with a standard header"
+                        )
+                    else:
+                        seen_header += 1
+                        continue
+
+                # Process INCLUDE
+                # Assumes included file is in same dir as this one
+                if l.startswith("INCLUDE"):
+                    # Bleurgh. What do we do with comments?
+                    raise NotImplementedError
+                    if site is not None:
+                        clkdir = os.path.dirname(os.path.abspath(filename))
+                        filename1 = os.path.join(clkdir, l.split()[1])
+                        mjds1, clkcorrs1 = TempoClockFile.load_tempo1_clock_file(
+                            filename1, site=site
+                        )
+                        mjds.extend(mjds1)
+                        clkcorrs.extend(clkcorrs1)
+                    continue
+
+                # Parse MJD
+                try:
+                    mjd = float(l[0:9])
+                    # allow mjd=0 to pass, since that is often used
+                    # for effectively null clock files
+                    if (mjd < 39000 and mjd != 0) or mjd > 100000:
+                        mjd = None
+                except (ValueError, IndexError):
+                    mjd = None
+                # Parse two clkcorr values
+                try:
+                    clkcorr1 = float(l[9:21])
+                except (ValueError, IndexError):
+                    clkcorr1 = None
+                try:
+                    clkcorr2 = float(l[21:33])
+                except (ValueError, IndexError):
+                    clkcorr2 = None
+
+                # Site code on clock file line must match
+                try:
+                    csite = l[34].lower()
+                except IndexError:
+                    csite = None
+                if (obscode is not None) and (obscode.lower() != csite):
+                    continue
+                # FIXME: f flag(?) in l[36]?
+
+                # Need MJD and at least one of the two clkcorrs
+                if mjd is None:
+                    add_comment(l)
+                    continue
+                if (clkcorr1 is None) and (clkcorr2 is None):
+                    add_comment(l)
+                    continue
+                # If one of the clkcorrs is missing, it defaults to zero
+                if clkcorr1 is None:
+                    clkcorr1 = 0.0
+                if clkcorr2 is None:
+                    clkcorr2 = 0.0
+                # This adjustment is hard-coded in tempo:
+                if clkcorr1 > 800.0:
+                    clkcorr1 -= 818.8
+                # Add the value to the list
+                mjds.append(mjd)
+                clkcorrs.append(clkcorr2 - clkcorr1)
+                self.comments.append(None)
+                add_comment(l[50:])
         except (FileNotFoundError, OSError):
             log.error(
                 f"TEMPO-style clock correction file {filename} for site {obscode} not found"
             )
-            mjd = np.array([], dtype=float)
-            clk = np.array([], dtype=float)
-        if bogus_last_correction and len(mjd):
+        if bogus_last_correction and len(mjds):
             mjd = mjd[:-1]
-            clk = clk[:-1]
-        while len(mjd) and mjd[0] == 0:
+            clkcorrs = clkcorrs[:-1]
+            # FIXME: do something sensible with comments!
+        while len(mjds) and mjds[0] == 0:
             # Zap leading zeros
-            mjd = mjd[1:]
-            clk = clk[1:]
+            mjds = mjds[1:]
+            clkcorrs = clkcorrs[1:]
+            # FIXME: do something sensible with comments!
         # FIXME: using Time may make loading clock corrections slow
-        self._time = Time(mjd, format="pulsar_mjd", scale="utc")
-        self._clock = clk * u.us
-
-    @staticmethod
-    def load_tempo1_clock_file(filename, site=None):
-        """Load a TEMPO format clock file for a site
-
-        Given the specified full path to the tempo1-format clock file,
-        will return two numpy arrays containing the MJDs and the clock
-        corrections (us).  All computations here are done as in tempo, with
-        the exception of the 'F' flag (to disable interpolation), which
-        is currently not implemented.
-
-        INCLUDE statments are processed.
-
-        If the 'site' argument is set to an appropriate one-character tempo
-        site code, only values for that site will be returned. If the 'site'
-        argument is None, the file is assumed to contain only clock corrections
-        for the desired telescope, so all values found in the file will be returned
-        but INCLUDEs will *not* be processed.
-        """
-        # TODO we might want to handle 'f' flags by inserting addtional
-        # entries so that interpolation routines will give the right result.
-        # The way TEMPO interprets 'f' flags is that an MJD with an 'f' flag
-        # gives the constant clock correction value for at most a day either side.
-        # If the sought-after clock correction is within a day of two different
-        # 'f' values, the nearest is used.
-        # https://github.com/nanograv/tempo/blob/618afb2e901d3e4b8324d4ba12777c055e128696/src/clockcor.f#L79
-        # This could be (roughly) implemented by splicing in additional clock correction points
-        # between 'f' values or +- 1 day.
-        # (The deviation would be that in gaps you get an interpolated value rather than
-        # an error message.)
-        mjds = []
-        clkcorrs = []
-        for l in lines_of(filename):
-            # Ignore comment lines
-            if l.startswith("#"):
-                continue
-
-            # Process INCLUDE
-            # Assumes included file is in same dir as this one
-            if l.startswith("INCLUDE"):
-                if site is not None:
-                    clkdir = os.path.dirname(os.path.abspath(filename))
-                    filename1 = os.path.join(clkdir, l.split()[1])
-                    mjds1, clkcorrs1 = TempoClockFile.load_tempo1_clock_file(
-                        filename1, site=site
-                    )
-                    mjds.extend(mjds1)
-                    clkcorrs.extend(clkcorrs1)
-                continue
-
-            # Parse MJD
-            try:
-                mjd = float(l[0:9])
-                # allow mjd=0 to pass, since that is often used
-                # for effectively null clock files
-                if (mjd < 39000 and mjd != 0) or mjd > 100000:
-                    mjd = None
-            except (ValueError, IndexError):
-                mjd = None
-            # Parse two clkcorr values
-            try:
-                clkcorr1 = float(l[9:21])
-            except (ValueError, IndexError):
-                clkcorr1 = None
-            try:
-                clkcorr2 = float(l[21:33])
-            except (ValueError, IndexError):
-                clkcorr2 = None
-
-            # Site code on clock file line must match
-            try:
-                csite = l[34].lower()
-            except IndexError:
-                csite = None
-            if (site is not None) and (site.lower() != csite):
-                continue
-
-            # Need MJD and at least one of the two clkcorrs
-            if mjd is None:
-                continue
-            if (clkcorr1 is None) and (clkcorr2 is None):
-                continue
-            # If one of the clkcorrs is missing, it defaults to zero
-            if clkcorr1 is None:
-                clkcorr1 = 0.0
-            if clkcorr2 is None:
-                clkcorr2 = 0.0
-            # This adjustment is hard-coded in tempo:
-            if clkcorr1 > 800.0:
-                clkcorr1 -= 818.8
-            # Add the value to the list
-            mjds.append(mjd)
-            clkcorrs.append(clkcorr2 - clkcorr1)
-
-        return mjds, clkcorrs
-
-
-def write_tempo_clock_file(filename, obscode, clock, comments=None):
-    """Write clock corrections as a TEMPO-format clock correction file.
-
-    Parameters
-    ----------
-    filename : str or pathlib.Path or file-like
-        The destination
-    obscode : str
-        The TEMPO observatory code. TEMPO effectively concatenates
-        all its clock corrections and uses this field to determine
-        which observatory the clock corrections are relevant to.
-        TEMPO observatory codes are case-insensitive one-character values agreed upon
-        by convention and occurring in tim files. PINT recognizes
-        these as aliases of observatories for which they are agreed upon,
-        and an Observatory object contains a field that can be used to
-        retrieve this.
-    clock : ClockFile
-        ClockFile object to write out.
-    comments : str
-        Additional comments to include. These will be included below the headings
-        and each line should be prefaced with `#` to avoid conflicting with the
-        clock corrections.
-    """
-    if not isinstance(obscode, str) or len(obscode) != 1:
-        raise ValueError(
-            "Invalid TEMPO obscode {obscode!r}, should be one printable character"
-        )
-    mjds = clock.time.mjd
-    corr = clock.clock
-    # TEMPO writes microseconds
-    a = np.array([mjds, corr.to_value(u.us)]).T
-    with open_or_use(filename) as f:
-        f.write(
-            dedent(
-                """\
-               MJD       EECO-REF    NIST-REF NS      DATE    COMMENTS
-            =========    ========    ======== ==    ========  ========
-            """
-            )
-        )
-        if comments is not None:
-            f.write(comments.strip())
-            f.write("\n")
-        # Do not use EECO-REF column as TEMPO does a weird subtraction thing
-        for mjd, corr in a:
-            # 0:9 for MJD
-            # 9:21 for clkcorr1 (do not use)
-            # 21:33 for clkcorr2
-            # 34 for obscode
-            # Extra stuff ignored
-            # FIXME: always use C locale
-            date = Time(mjd, format="pulsar_mjd").datetime.strftime("%d-%b-%y")
-            eeco = 0.0
-            f.write(f"{mjd:8.2f}{eeco:12.1}{corr:12.3f} {obscode}    {date}\n")
+        self._time = Time(mjds, format="pulsar_mjd", scale="utc")
+        self._clock = clkcorrs * u.us

--- a/src/pint/observatory/clock_file.py
+++ b/src/pint/observatory/clock_file.py
@@ -204,7 +204,7 @@ class ClockFile(metaclass=ClockFileMeta):
             filename=f"Merged from {[c.filename for c in clocks]}",
         )
 
-    def write_tempo_clock_file(self, filename, obscode, extra_comments=None):
+    def write_tempo_clock_file(self, filename, obscode, extra_comment=None):
         """Write clock corrections as a TEMPO-format clock correction file.
 
         Parameters
@@ -233,13 +233,20 @@ class ClockFile(metaclass=ClockFileMeta):
         corr = self.clock.to_value(u.us)
         comments = self.comments if self.comments else [""] * len(self.clock)
         # TEMPO writes microseconds
+        if extra_comment is not None:
+            if self.leading_comment is not None:
+                leading_comment = extra_comment.rstrip() + "\n" + self.leading_comment
+            else:
+                leading_comment = extra_comment.rstrip()
+        else:
+            leading_comment = self.leading_comment
         with open_or_use(filename, "wt") as f:
             f.write(tempo_standard_header)
             if extra_comments is not None:
                 f.write(extra_comments.strip())
                 f.write("\n")
-            if self.leading_comment is not None:
-                f.write(self.leading_comment)
+            if leading_comment is not None:
+                f.write(leading_comment)
                 f.write("\n")
             # Do not use EECO-REF column as TEMPO does a weird subtraction thing
             for mjd, corr, comment in zip(mjds, corr, comments):
@@ -260,7 +267,7 @@ class ClockFile(metaclass=ClockFileMeta):
                         f.write(f"  {comment}".rstrip())
                 f.write("\n")
 
-    def write_tempo2_clock_file(self, filename, hdrline=None, comments=None):
+    def write_tempo2_clock_file(self, filename, hdrline=None, extra_comment=None):
         """Write clock corrections as a TEMPO2-format clock correction file.
 
         Parameters
@@ -291,11 +298,18 @@ class ClockFile(metaclass=ClockFileMeta):
             hdrline = self.header
         if not hdrline.startswith("#"):
             raise ValueError(f"Header line must start with #: {hdrline!r}")
+        if extra_comment is not None:
+            if self.leading_comment is not None:
+                leading_comment = extra_comment.rstrip() + "\n" + self.leading_comment
+            else:
+                leading_comment = extra_comment.rstrip()
+        else:
+            leading_comment = self.leading_comment
         with open_or_use(filename, "wt") as f:
             f.write(hdrline.rstrip())
             f.write("\n")
-            if self.leading_comment is not None:
-                f.write(self.leading_comment.rstrip())
+            if leading_comment is not None:
+                f.write(leading_comment.rstrip())
                 f.write("\n")
             comments = self.comments if self.comments else [""] * len(self.time)
 

--- a/src/pint/observatory/clock_file.py
+++ b/src/pint/observatory/clock_file.py
@@ -242,11 +242,8 @@ class ClockFile(metaclass=ClockFileMeta):
             leading_comment = self.leading_comment
         with open_or_use(filename, "wt") as f:
             f.write(tempo_standard_header)
-            if extra_comments is not None:
-                f.write(extra_comments.strip())
-                f.write("\n")
             if leading_comment is not None:
-                f.write(leading_comment)
+                f.write(leading_comment.strip())
                 f.write("\n")
             # Do not use EECO-REF column as TEMPO does a weird subtraction thing
             for mjd, corr, comment in zip(mjds, corr, comments):

--- a/src/pint/observatory/clock_file.py
+++ b/src/pint/observatory/clock_file.py
@@ -410,6 +410,12 @@ tempo_standard_header = dedent(
     =========    ========    ======== ==    ========  ========
     """
 )
+tempo_standard_header_res = [
+    re.compile(
+        r"\s*MJD\s+EECO-REF\s+NIST-REF\s+NS\s+DATE\s+COMMENTS\s*", flags=re.IGNORECASE
+    ),
+    re.compile(r"\s*=+\s+=+\s+=+\s+=+\s+=+\s+=+\s*"),
+]
 
 
 class TempoClockFile(ClockFile):
@@ -482,12 +488,10 @@ class TempoClockFile(ClockFile):
                     add_comment(l)
                     continue
 
-                if seen_header < 2:
-                    if [w.upper() for w in l.split()] != tempo_standard_header.split(
-                        "\n"
-                    )[seen_header].split():
+                if seen_header < len(tempo_standard_header_res):
+                    if not tempo_standard_header_res[seen_header].match(l):
                         raise ValueError(
-                            "TEMPO-format clock files should start with a standard header"
+                            f"TEMPO-format clock files should start with a standard header, unable to recognize line {l!r}"
                         )
                     else:
                         seen_header += 1
@@ -561,7 +565,7 @@ class TempoClockFile(ClockFile):
                 f"TEMPO-style clock correction file {filename} for site {obscode} not found"
             )
         if bogus_last_correction and len(mjds):
-            mjd = mjd[:-1]
+            mjds = mjds[:-1]
             clkcorrs = clkcorrs[:-1]
             # FIXME: do something sensible with comments!
         while len(mjds) and mjds[0] == 0:

--- a/tests/test_clock_file.py
+++ b/tests/test_clock_file.py
@@ -273,6 +273,7 @@ def test_leading_comment_tempo2():
     )
     assert c.leading_comment == "# Initial comments from c"
 
+
 def test_leading_comment_tempo():
     c = ClockFile.read(
         StringIO(

--- a/tests/test_clock_file.py
+++ b/tests/test_clock_file.py
@@ -1,0 +1,59 @@
+from io import StringIO
+
+import astropy.units as u
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from pint.observatory.clock_file import (
+    ClockFile,
+    ConstructedClockFile,
+    merged_mjds,
+    write_tempo2_clock_file,
+)
+
+
+@pytest.fixture
+def basic_clock():
+    return ConstructedClockFile(
+        mjd=np.array([50000, 55000, 60000]), clock=np.array([1.0, 2.0, -1.0]) * u.us
+    )
+
+
+def test_merge_mjds_removes_overlap():
+    a = np.array([50000, 60000])
+    b = np.array([50000, 55000, 60000])
+
+    ca = ConstructedClockFile(mjd=a, clock=np.zeros_like(a) * u.s)
+    cb = ConstructedClockFile(mjd=b, clock=np.zeros_like(b) * u.s)
+    assert_array_equal(merged_mjds([ca, cb]), b)
+
+
+def test_merge_mjds_trims_range():
+    a = np.array([50000, 60000])
+    b = np.array([40000, 55000, 61000])
+
+    ca = ConstructedClockFile(mjd=a, clock=np.zeros_like(a) * u.s)
+    cb = ConstructedClockFile(mjd=b, clock=np.zeros_like(b) * u.s)
+    assert_array_equal(merged_mjds([ca, cb]), np.array([50000, 55000, 60000]))
+
+
+def test_merge_mjds_trims_range_mixed():
+    a = np.array([50000, 61000])
+    b = np.array([40000, 55000, 60000])
+
+    ca = ConstructedClockFile(mjd=a, clock=np.zeros_like(a) * u.s)
+    cb = ConstructedClockFile(mjd=b, clock=np.zeros_like(b) * u.s)
+    assert_array_equal(merged_mjds([ca, cb]), np.array([50000, 55000, 60000]))
+
+
+def test_tempo2_round_trip(basic_clock):
+    hdrline = "# fake conversion test"
+    f = StringIO()
+    write_tempo2_clock_file(f, hdrline=hdrline, clocks=basic_clock)
+    read_clock = ClockFile.read(StringIO(f.getvalue()), format="tempo2")
+
+    assert_array_equal(read_clock.time.mjd, basic_clock.time.mjd)
+    assert_array_equal(
+        read_clock.clock.to_value(u.us), basic_clock.clock.to_value(u.us)
+    )

--- a/tests/test_clock_file.py
+++ b/tests/test_clock_file.py
@@ -147,6 +147,26 @@ def test_tempo2_round_trip(basic_clock):
     assert_allclose(read_clock.clock.to_value(u.us), basic_clock.clock.to_value(u.us))
 
 
+def test_tempo2_round_trip_file(basic_clock, tmp_path):
+    f = tmp_path / "fake.clk"
+    hdrline = "# FAKE1 FAKE2"
+    basic_clock.write_tempo2_clock_file(str(f), hdrline=hdrline)
+    read_clock = ClockFile.read(str(f), format="tempo2")
+
+    assert_allclose(read_clock.time.mjd, basic_clock.time.mjd)
+    assert_allclose(read_clock.clock.to_value(u.us), basic_clock.clock.to_value(u.us))
+
+
+def test_tempo_round_trip_file(basic_clock, tmp_path):
+    f = tmp_path / "fake.clk"
+    obscode = "{"
+    basic_clock.write_tempo_clock_file(str(f), obscode=obscode)
+    read_clock = ClockFile.read(str(f), format="tempo")
+
+    assert_allclose(read_clock.time.mjd, basic_clock.time.mjd)
+    assert_allclose(read_clock.clock.to_value(u.us), basic_clock.clock.to_value(u.us))
+
+
 loadable_observatories = ["gbt", "arecibo", "fast", "gb140", "gb853", "jb", "wsrt"]
 
 

--- a/tests/test_clock_file.py
+++ b/tests/test_clock_file.py
@@ -143,10 +143,8 @@ def test_tempo2_round_trip(basic_clock):
     basic_clock.write_tempo2_clock_file(f, hdrline=hdrline)
     read_clock = ClockFile.read(StringIO(f.getvalue()), format="tempo2")
 
-    assert_array_equal(read_clock.time.mjd, basic_clock.time.mjd)
-    assert_array_equal(
-        read_clock.clock.to_value(u.us), basic_clock.clock.to_value(u.us)
-    )
+    assert_allclose(read_clock.time.mjd, basic_clock.time.mjd)
+    assert_allclose(read_clock.clock.to_value(u.us), basic_clock.clock.to_value(u.us))
 
 
 loadable_observatories = ["gbt", "arecibo", "fast", "gb140", "gb853", "jb", "wsrt"]
@@ -206,10 +204,10 @@ def test_tempo2_round_trip_comments():
         # FAKE1 FAKE2 3 header comments
         # Initial comments
         # covering several lines
-        50000 0.000001 And some text
-        50001 0.000001
+        50000.00000 0.000001000000 And some text
+        50001.00000 0.000002000000
         # A commenty line
-        50001 0.000001 same-line text
+        50002.00000 0.000003000000 same-line text
         # and a commenty line
         """
     )

--- a/tests/test_clock_file.py
+++ b/tests/test_clock_file.py
@@ -3,16 +3,20 @@ from io import StringIO
 import astropy.units as u
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal, assert_allclose
+from astropy.time import Time
+from numpy.testing import assert_allclose, assert_array_equal
 
 from pint.observatory import get_observatory
 from pint.observatory.clock_file import (
     ClockFile,
     ConstructedClockFile,
-    merged_mjds,
     write_tempo2_clock_file,
     write_tempo_clock_file,
 )
+
+
+def t(mjd):
+    return Time(mjd, format="pulsar_mjd", scale="utc")
 
 
 @pytest.fixture
@@ -22,13 +26,73 @@ def basic_clock():
     )
 
 
-def test_merge_mjds_removes_overlap():
+def test_merge_clocks_values():
     a = np.array([50000, 60000])
+    av = np.array([0, 2]) * u.us
     b = np.array([50000, 55000, 60000])
+    bv = np.array([0, 0, 1]) * u.us
 
-    ca = ConstructedClockFile(mjd=a, clock=np.zeros_like(a) * u.s)
-    cb = ConstructedClockFile(mjd=b, clock=np.zeros_like(b) * u.s)
-    assert_array_equal(merged_mjds([ca, cb]), b)
+    ca = ConstructedClockFile(mjd=a, clock=av)
+    cb = ConstructedClockFile(mjd=b, clock=bv)
+
+    m = ClockFile.merge([ca, cb])
+
+    ts = t(np.linspace(50000, 60000, 10))
+    assert_allclose(
+        m.evaluate(ts).to_value(u.us),
+        ca.evaluate(ts).to_value(u.us) + cb.evaluate(ts).to_value(u.us),
+    )
+
+
+def test_merge_clocks_values_repeat():
+    a = np.array([50000, 60000])
+    av = np.array([0, 2]) * u.us
+    b = np.array([50000, 55000, 55000, 60000])
+    bv = np.array([0, 0, 1, 1]) * u.us
+
+    ca = ConstructedClockFile(mjd=a, clock=av)
+    cb = ConstructedClockFile(mjd=b, clock=bv)
+
+    m = ClockFile.merge([ca, cb])
+
+    ts = t(np.linspace(50000, 60000, 10))
+    assert_allclose(
+        m.evaluate(ts).to_value(u.us),
+        ca.evaluate(ts).to_value(u.us) + cb.evaluate(ts).to_value(u.us),
+    )
+
+
+def test_merge_clocks_values_repeat_more():
+    a = np.array([50000, 60000])
+    av = np.array([0, 2]) * u.us
+    b = np.array([50000, 55000, 55000, 55000, 55000, 60000])
+    bv = np.array([0, 0, 7, 8, 1, 1]) * u.us
+
+    ca = ConstructedClockFile(mjd=a, clock=av)
+    cb = ConstructedClockFile(mjd=b, clock=bv)
+
+    m = ClockFile.merge([ca, cb])
+
+    ts = t(np.linspace(50000, 60000, 10))
+    assert_allclose(
+        m.evaluate(ts).to_value(u.us),
+        ca.evaluate(ts).to_value(u.us) + cb.evaluate(ts).to_value(u.us),
+    )
+
+
+def test_merge_clocks_preserves_discontinuities():
+    a = np.array([50000, 60000])
+    av = np.array([2, 2]) * u.us
+    b = np.array([50000, 55000, 55000, 60000])
+    bv = np.array([0, 0, 1, 1]) * u.us
+
+    ca = ConstructedClockFile(mjd=a, clock=av)
+    cb = ConstructedClockFile(mjd=b, clock=bv)
+
+    m = ClockFile.merge([ca, cb])
+
+    assert m.evaluate(t(54999)) == m.evaluate(t(50000))
+    assert m.evaluate(t(55001)) == m.evaluate(t(60000))
 
 
 def test_merge_mjds_trims_range():
@@ -37,7 +101,31 @@ def test_merge_mjds_trims_range():
 
     ca = ConstructedClockFile(mjd=a, clock=np.zeros_like(a) * u.s)
     cb = ConstructedClockFile(mjd=b, clock=np.zeros_like(b) * u.s)
-    assert_array_equal(merged_mjds([ca, cb]), np.array([50000, 55000, 60000]))
+
+    m = ClockFile.merge([ca, cb])
+    assert_array_equal(m.time.mjd, np.array([50000, 55000, 60000]))
+
+
+def test_merge_mjds_trims_range_repeat_beginning():
+    a = np.array([50000, 50000, 60000])
+    b = np.array([40000, 55000, 61000])
+
+    ca = ConstructedClockFile(mjd=a, clock=np.zeros_like(a) * u.s)
+    cb = ConstructedClockFile(mjd=b, clock=np.zeros_like(b) * u.s)
+
+    m = ClockFile.merge([ca, cb])
+    assert_array_equal(m.time.mjd, np.array([50000, 50000, 55000, 60000]))
+
+
+def test_merge_mjds_trims_range_repeat_end():
+    a = np.array([50000, 60000, 60000])
+    b = np.array([40000, 55000, 61000])
+
+    ca = ConstructedClockFile(mjd=a, clock=np.zeros_like(a) * u.s)
+    cb = ConstructedClockFile(mjd=b, clock=np.zeros_like(b) * u.s)
+
+    m = ClockFile.merge([ca, cb])
+    assert_array_equal(m.time.mjd, np.array([50000, 55000, 60000, 60000]))
 
 
 def test_merge_mjds_trims_range_mixed():
@@ -46,13 +134,14 @@ def test_merge_mjds_trims_range_mixed():
 
     ca = ConstructedClockFile(mjd=a, clock=np.zeros_like(a) * u.s)
     cb = ConstructedClockFile(mjd=b, clock=np.zeros_like(b) * u.s)
-    assert_array_equal(merged_mjds([ca, cb]), np.array([50000, 55000, 60000]))
+    m = ClockFile.merge([ca, cb])
+    assert_array_equal(m.time.mjd, np.array([50000, 55000, 60000]))
 
 
 def test_tempo2_round_trip(basic_clock):
     hdrline = "# fake conversion test"
     f = StringIO()
-    write_tempo2_clock_file(f, hdrline=hdrline, clocks=basic_clock)
+    write_tempo2_clock_file(f, hdrline=hdrline, clock=basic_clock)
     read_clock = ClockFile.read(StringIO(f.getvalue()), format="tempo2")
 
     assert_array_equal(read_clock.time.mjd, basic_clock.time.mjd)
@@ -69,7 +158,7 @@ def test_tempo2_round_trip_arecibo():
     hdrline = "# fake conversion test"
 
     f = StringIO()
-    write_tempo2_clock_file(f, hdrline=hdrline, clocks=clock)
+    write_tempo2_clock_file(f, hdrline=hdrline, clock=clock)
     read_clock = ClockFile.read(StringIO(f.getvalue()), format="tempo2")
 
     assert_allclose(read_clock.time.mjd, clock.time.mjd)
@@ -79,7 +168,7 @@ def test_tempo2_round_trip_arecibo():
 def test_tempo_round_trip(basic_clock):
     obscode = "["
     f = StringIO()
-    write_tempo_clock_file(f, obscode=obscode, clocks=basic_clock)
+    write_tempo_clock_file(f, obscode=obscode, clock=basic_clock)
     read_clock = ClockFile.read(StringIO(f.getvalue()), format="tempo")
 
     assert_array_equal(read_clock.time.mjd, basic_clock.time.mjd)
@@ -96,7 +185,7 @@ def test_tempo_round_trip_arecibo():
     obscode = "1"
 
     f = StringIO()
-    write_tempo_clock_file(f, obscode=obscode, clocks=clock)
+    write_tempo_clock_file(f, obscode=obscode, clock=clock)
     read_clock = ClockFile.read(StringIO(f.getvalue()), format="tempo")
 
     assert_allclose(read_clock.time.mjd, clock.time.mjd)

--- a/tests/test_clock_file.py
+++ b/tests/test_clock_file.py
@@ -273,6 +273,23 @@ def test_leading_comment_tempo2():
     )
     assert c.leading_comment == "# Initial comments from c"
 
+def test_leading_comment_tempo():
+    c = ClockFile.read(
+        StringIO(
+            dedent(
+                """\
+           MJD       EECO-REF    NIST-REF NS      DATE    COMMENTS
+        =========    ========    ======== ==    ========  ========
+        # Initial comments
+         50000.00       0.000       1.000 1    10-Oct-95  And some text
+         50001.00       0.000       1.000 1    11-Oct-95
+        """
+            )
+        ),
+        format="tempo",
+    )
+    assert c.leading_comment == "# Initial comments"
+
 
 def test_merge_comments():
     c1 = ClockFile.read(


### PR DESCRIPTION
PINT is already able to read in clock correction files in either TEMPO or TEMPO2 format. This PR allows PINT to write out clock correction files in either format, optionally combining multiple clock correction files (for example ao2gps + gps2utc). This enables conversion of clock files between formats as well as conversion of other suitable information into clock files.

As it currently stands, the "merging" of clock files means combining them by adding the corrections from the included clock correction files. This is distinct from splicing together clock correction files that cover different intervals; that's a different problem.

When reading, writing, and merging clock correction files, comments are preserved. This allows comments at the beginning of the file, comments on clock correction lines, and comments following a clock correction. (Comments on their own line are associated with the previous clock correction.)

This allows more or less lossless conversion between TEMPO and TEMPO2 clock correction file formats, and is used by the global clock corrections [repository](https://nanograv.github.io/pulsar-clock-corrections/status.html) for this purpose.