### PR TITLE
Color TOAs by jump in pintk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project, at least loosely, adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Color-by-jump mode for pintk
+### Fixed
+### Changed
+
 ## [0.8.8] 2022-05-26
 ### Added
 - Warning when A1DOT parameter used with DDK model

--- a/src/pint/pintk/colormodes.py
+++ b/src/pint/pintk/colormodes.py
@@ -362,6 +362,7 @@ class JumpMode(ColorMode):
         return model.get_jump_param_objects()
 
     jump_colors = named_colors
+    selected_color = "orange"
 
     def displayInfo(self):
         outstr = '"Jump" mode selected\n'
@@ -375,7 +376,7 @@ class JumpMode(ColorMode):
             if jump.key_value is not None:
                 outstr += " " + " ".join(jump.key_value)
             outstr += f" = {color_name}\n"
-        outstr += "  selected = orange\n"
+        outstr += f"  selected = {selected_color}\n"
         print(outstr)
 
     def plotColorMode(self):
@@ -404,7 +405,9 @@ class JumpMode(ColorMode):
                 self.application.xvals[self.application.selected],
                 self.application.yvals[self.application.selected],
                 marker=".",
-                color="orange",
+                color=selected_color,
             )
         else:
-            self.application.plotErrorbar(self.application.selected, color="orange")
+            self.application.plotErrorbar(
+                self.application.selected, color=selected_color
+            )

--- a/src/pint/pintk/colormodes.py
+++ b/src/pint/pintk/colormodes.py
@@ -320,3 +320,85 @@ class ObsMode(ColorMode):
             )
         else:
             self.application.plotErrorbar(self.application.selected, color="orange")
+
+
+class JumpMode(ColorMode):
+    """
+    A class to manage the Jump color mode, where TOAs are colored
+    according to their jump.
+    """
+
+    def __init__(self, application):
+        super(JumpMode, self).__init__(application)
+        self.mode_name = "jump"
+
+    def get_jumps(self):
+        if self.application.psr.fitted:
+            model = self.application.psr.postfit_model
+        else:
+            model = self.application.psr.prefit_model
+        return model.get_jump_param_objects()
+
+    jump_colors = [
+        ["red", "red"],
+        ["green", "green"],  # this is any green bank obs
+        ["cyan", "cyan"],
+        ["blue", "blue"],
+        ["burnt orange", "#CC6600"],  # burnt orange
+        ["brown", "#362511"],  # brown
+        ["indigo", "#4B0082"],  # indigo
+        ["purple", "#7C11AD"],  # purple
+        ["dark blue", "#00006B"],  # dark blue
+        ["light green", "#52E222"],  # light green
+        ["dark green", "#006D35"],  # dark green
+        ["light blue", "#0091AE"],  # light blue
+        ["dark red", "#8C0000"],  # dark red
+        ["magenta", "#E4008D"],  # magenta
+        ["black", "black"],
+        ["grey", "#7E7E7E"],  # grey
+        ["light grey", "#E2E2E1"],  # light grey
+        ["yellow-ish", "#FFF133"],  # yellow-ish
+    ]
+
+    def displayInfo(self):
+        outstr = '"Jump" mode selected\n'
+        for jumpnum, jump in enumerate(self.get_jumps()):
+            color_number = jumpnum % len(self.jump_colors)
+            outstr += f"{jump.name}"
+            if jump.key is not None:
+                outstr += f" {jump.key}"
+            if jump.key_value is not None:
+                outstr += " " + " ".join(jump.key_value)
+            outstr += f" = {self.jump_colors[color_number][0]}\n"
+        outstr += "  selected = orange\n"
+        print(outstr)
+
+    def plotColorMode(self):
+        """
+        Plots application's residuals in proper color scheme.
+        """
+        alltoas = self.application.psr.all_toas
+        for jumpnum, jump in enumerate(self.get_jumps()):
+            color_number = jumpnum % len(self.jump_colors)
+            # group toa indices by observatory
+            toas = jump.select_toa_mask(alltoas)
+            color = self.jump_colors[color_number][1]
+            if self.application.yerrs is None:
+                self.application.plkAxes.scatter(
+                    self.application.xvals[toas],
+                    self.application.yvals[toas],
+                    marker=".",
+                    color=color,
+                )
+            else:
+                self.application.plotErrorbar(toas, color=color)
+        # Now handle the selected TOAs
+        if self.application.yerrs is None:
+            self.application.plkAxes.scatter(
+                self.application.xvals[self.application.selected],
+                self.application.yvals[self.application.selected],
+                marker=".",
+                color="orange",
+            )
+        else:
+            self.application.plotErrorbar(self.application.selected, color="orange")

--- a/src/pint/pintk/colormodes.py
+++ b/src/pint/pintk/colormodes.py
@@ -5,6 +5,27 @@ import matplotlib
 import pint.logging
 from loguru import logger as log
 
+named_colors = {
+    "red": "red",
+    "green": "green",  # this is any green bank obs
+    "cyan": "cyan",
+    "blue": "blue",
+    "burnt orange": "#CC6600",  # burnt orange
+    "brown": "#362511",  # brown
+    "indigo": "#4B0082",  # indigo
+    "purple": "#7C11AD",  # purple
+    "dark blue": "#00006B",  # dark blue
+    "light green": "#52E222",  # light green
+    "dark green": "#006D35",  # dark green
+    "light blue": "#0091AE",  # light blue
+    "dark red": "#8C0000",  # dark red
+    "magenta": "#E4008D",  # magenta
+    "black": "black",
+    "grey": "#7E7E7E",  # grey
+    "light grey": "#E2E2E1",  # light grey
+    "yellow-ish": "#FFF133",  # yellow-ish
+}
+
 
 class ColorMode:
     """Base Class for color modes."""
@@ -339,37 +360,19 @@ class JumpMode(ColorMode):
             model = self.application.psr.prefit_model
         return model.get_jump_param_objects()
 
-    jump_colors = [
-        ["red", "red"],
-        ["green", "green"],  # this is any green bank obs
-        ["cyan", "cyan"],
-        ["blue", "blue"],
-        ["burnt orange", "#CC6600"],  # burnt orange
-        ["brown", "#362511"],  # brown
-        ["indigo", "#4B0082"],  # indigo
-        ["purple", "#7C11AD"],  # purple
-        ["dark blue", "#00006B"],  # dark blue
-        ["light green", "#52E222"],  # light green
-        ["dark green", "#006D35"],  # dark green
-        ["light blue", "#0091AE"],  # light blue
-        ["dark red", "#8C0000"],  # dark red
-        ["magenta", "#E4008D"],  # magenta
-        ["black", "black"],
-        ["grey", "#7E7E7E"],  # grey
-        ["light grey", "#E2E2E1"],  # light grey
-        ["yellow-ish", "#FFF133"],  # yellow-ish
-    ]
+    jump_colors = named_colors
 
     def displayInfo(self):
         outstr = '"Jump" mode selected\n'
         for jumpnum, jump in enumerate(self.get_jumps()):
             color_number = jumpnum % len(self.jump_colors)
+            color_name = list(self.jump_colors)[color_number]
             outstr += f"{jump.name}"
             if jump.key is not None:
                 outstr += f" {jump.key}"
             if jump.key_value is not None:
                 outstr += " " + " ".join(jump.key_value)
-            outstr += f" = {self.jump_colors[color_number][0]}\n"
+            outstr += f" = {color_name}\n"
         outstr += "  selected = orange\n"
         print(outstr)
 
@@ -380,9 +383,10 @@ class JumpMode(ColorMode):
         alltoas = self.application.psr.all_toas
         for jumpnum, jump in enumerate(self.get_jumps()):
             color_number = jumpnum % len(self.jump_colors)
-            # group toa indices by observatory
+            color_name = list(self.jump_colors)[color_number]
             toas = jump.select_toa_mask(alltoas)
-            color = self.jump_colors[color_number][1]
+            color = self.jump_colors[color_name]
+            # group toa indices by jump
             if self.application.yerrs is None:
                 self.application.plkAxes.scatter(
                     self.application.xvals[toas],

--- a/src/pint/pintk/colormodes.py
+++ b/src/pint/pintk/colormodes.py
@@ -24,6 +24,7 @@ named_colors = {
     "grey": "#7E7E7E",  # grey
     "light grey": "#E2E2E1",  # light grey
     "yellow-ish": "#FFF133",  # yellow-ish
+    "orange": "#FFA500",
 }
 
 
@@ -118,15 +119,15 @@ class FreqMode(ColorMode):
         """
 
         colorGroups = [
-            "#8C0000",  # dark red
-            "#FF0000",  # red
-            "#FFA500",  # orange
-            "#FFF133",  # yellow-ish
-            "#008000",  # green
-            "#0000FF",  # blue
-            "#4B0082",  # indigo
-            "#000000",  # black
-            "#7E7E7E",  # grey
+            named_colors["dark red"],  # dark red
+            named_colors["red"],  # red
+            named_colors["orange"],  # orange
+            named_colors["yellow-ish"],  # yellow-ish
+            named_colors["green"],  # green
+            named_colors["blue"],  # blue
+            named_colors["indigo"],  # indigo
+            named_colors["black"],  # black
+            named_colors["grey"],  # grey
         ]
         highfreqs = [300.0, 400.0, 500.0, 700.0, 1000.0, 1800.0, 3000.0, 8000.0]
 
@@ -260,26 +261,26 @@ class ObsMode(ColorMode):
         return mapping
 
     obs_colors = {
-        "parkes": "red",
-        "gb": "green",  # this is any green bank obs
-        "jodrell": "cyan",
-        "arecibo": "blue",
-        "chime": "#CC6600",  # burnt orange
-        "gmrt": "#362511",  # brown
-        "vla": "#4B0082",  # indigo
-        "effelsberg": "#7C11AD",  # purple
-        "fast": "#00006B",  # dark blue
-        "nancay": "#52E222",  # light green
-        "srt": "#006D35",  # dark green
-        "wsrt": "#0091AE",  # light blue
-        "lofar": "#8C0000",  # dark red
-        "lwa": "#8C0000",  # dark red
-        "mwa": "#8C0000",  # dark red
-        "meerkat": "#E4008D",  # magenta
-        "barycenter": "black",
-        "geocenter": "#7E7E7E",  # grey
-        "space": "#E2E2E1",  # light grey
-        "other": "#FFF133",  # yellow-ish
+        "parkes": named_colors["red"],
+        "gb": named_colors["green"],  # this is any green bank obs
+        "jodrell": named_colors["cyan"],
+        "arecibo": named_colors["blue"],
+        "chime": named_colors["burnt orange"],
+        "gmrt": named_colors["brown"],
+        "vla": named_colors["indigo"],
+        "effelsberg": named_colors["purple"],
+        "fast": named_colors["dark blue"],
+        "nancay": named_colors["light green"],
+        "srt": named_colors["dark green"],
+        "wsrt": named_colors["light blue"],
+        "lofar": named_colors["dark red"],
+        "lwa": named_colors["dark red"],
+        "mwa": named_colors["dark red"],
+        "meerkat": named_colors["magenta"],
+        "barycenter": named_colors["black"],
+        "geocenter": named_colors["grey"],
+        "space": named_colors["light grey"],
+        "other": named_colors["yellow-ish"],
     }
 
     obs_text = {
@@ -365,7 +366,8 @@ class JumpMode(ColorMode):
     def displayInfo(self):
         outstr = '"Jump" mode selected\n'
         for jumpnum, jump in enumerate(self.get_jumps()):
-            color_number = jumpnum % len(self.jump_colors)
+            # only use the number of colors - 1 to preserve orange for selected
+            color_number = jumpnum % (len(self.jump_colors) - 1)
             color_name = list(self.jump_colors)[color_number]
             outstr += f"{jump.name}"
             if jump.key is not None:
@@ -382,7 +384,7 @@ class JumpMode(ColorMode):
         """
         alltoas = self.application.psr.all_toas
         for jumpnum, jump in enumerate(self.get_jumps()):
-            color_number = jumpnum % len(self.jump_colors)
+            color_number = jumpnum % (len(self.jump_colors) - 1)
             color_name = list(self.jump_colors)[color_number]
             toas = jump.select_toa_mask(alltoas)
             color = self.jump_colors[color_name]

--- a/src/pint/pintk/colormodes.py
+++ b/src/pint/pintk/colormodes.py
@@ -284,35 +284,28 @@ class ObsMode(ColorMode):
         "space": "xkcd:light grey",
         "other": "xkcd:yellow",
     }
+    selected_color = "orange"
 
-    obs_text = {
-        "parkes": "  Parkes = red",
-        "gb": "  Green Bank = green",
-        "jodrell": "  Jodrell = cyan",
-        "arecibo": "  Arecibo = blue",
-        "chime": "  CHIME = burnt orange",
-        "gmrt": "  GMRT = brown",
-        "vla": "  VLA = indigo",
-        "effelsberg": "  Effelsberg = purple",
-        "fast": "  FAST = dark blue",
-        "nancay": "  Nancay = light green",
-        "srt": "  SRT = dark green",
-        "wsrt": "  WSRT = light blue",
-        "lofar": "  LOFAR = dark red",
-        "lwa": "  LWA = dark red",
-        "mwa": "  MWA = dark red",
-        "meerkat": "  MeerKAT = magenta",
-        "barycenter": "  barycenter = black",
-        "geocenter": "  geocenter = grey",
-        "space": "  satellite = light grey",
-        "other": "  other = yellow",
-    }
+    obs_text = {}
+    for obs in obs_colors:
+        # try to get all of the capitalization special cases right
+        if obs in ["parkes", "jodrell", "arecibo", "nancay", "effelsberg"]:
+            obs_name = obs.capitalize()
+        elif obs in ["barycenter", "geocenter", "space", "other"]:
+            obs_name = obs
+        elif obs in ["gb"]:
+            obs_name = "Green Bank"
+        elif obs in ["meerkat"]:
+            obs_name = "MeerKAT"
+        else:
+            obs_name = obs.upper()
+        obs_text[obs] = f"  {obs_name} = {obs_colors[obs].replace('xkcd:','')}"
 
     def displayInfo(self):
         outstr = '"Observatory" mode selected\n'
         for obs in self.get_obs_mapping().values():
             outstr += self.obs_text[obs].replace("xkcd", "") + "\n"
-        outstr += "  selected = orange\n"
+        outstr += f"  selected = {self.selected_color}\n"
         print(outstr)
 
     def plotColorMode(self):
@@ -340,10 +333,12 @@ class ObsMode(ColorMode):
                 self.application.xvals[self.application.selected],
                 self.application.yvals[self.application.selected],
                 marker=".",
-                color="orange",
+                color=self.selected_color,
             )
         else:
-            self.application.plotErrorbar(self.application.selected, color="orange")
+            self.application.plotErrorbar(
+                self.application.selected, color=self.selected_color
+            )
 
 
 class JumpMode(ColorMode):

--- a/src/pint/pintk/colormodes.py
+++ b/src/pint/pintk/colormodes.py
@@ -50,7 +50,7 @@ class DefaultMode(ColorMode):
     """
 
     def __init__(self, application):
-        super(DefaultMode, self).__init__(application)
+        super().__init__(application)
         self.mode_name = "default"
 
     def displayInfo(self):
@@ -97,7 +97,7 @@ class FreqMode(ColorMode):
     """
 
     def __init__(self, application):
-        super(FreqMode, self).__init__(application)
+        super().__init__(application)
         self.mode_name = "freq"
 
     def displayInfo(self):
@@ -182,7 +182,7 @@ class NameMode(ColorMode):
     """
 
     def __init__(self, application):
-        super(NameMode, self).__init__(application)
+        super().__init__(application)
         self.mode_name = "name"
 
     def displayInfo(self):
@@ -242,7 +242,7 @@ class ObsMode(ColorMode):
     """
 
     def __init__(self, application):
-        super(ObsMode, self).__init__(application)
+        super().__init__(application)
         self.mode_name = "obs"
 
     def get_obs_mapping(self):
@@ -345,14 +345,23 @@ class JumpMode(ColorMode):
     """Mode to color points according to jump"""
 
     def __init__(self, application):
-        super(JumpMode, self).__init__(application)
+        super().__init__(application)
         self.mode_name = "jump"
 
     def get_jumps(self):
+        """Return the jump objects for the `psr` model or an empty list
+
+        Returns
+        -------
+        list :
+            List of jump objects
+        """
         if self.application.psr.fitted:
             model = self.application.psr.postfit_model
         else:
             model = self.application.psr.prefit_model
+        if not "PhaseJump" in model.components:
+            return []
         return model.get_jump_param_objects()
 
     jump_colors = named_colors

--- a/src/pint/pintk/colormodes.py
+++ b/src/pint/pintk/colormodes.py
@@ -299,13 +299,15 @@ class ObsMode(ColorMode):
             obs_name = "MeerKAT"
         else:
             obs_name = obs.upper()
-        obs_text[obs] = f"  {obs_name} = {obs_colors[obs].replace('xkcd:','')}"
+        obs_text[
+            obs
+        ] = f"  {obs_colors[obs].replace('xkcd:','').capitalize()} = {obs_name}"
 
     def displayInfo(self):
         outstr = '"Observatory" mode selected\n'
         for obs in self.get_obs_mapping().values():
             outstr += self.obs_text[obs].replace("xkcd", "") + "\n"
-        outstr += f"  selected = {self.selected_color}\n"
+        outstr += f"  {self.selected_color.capitalize()} = selected\n"
         print(outstr)
 
     def plotColorMode(self):
@@ -373,13 +375,16 @@ class JumpMode(ColorMode):
             # only use the number of colors - 1 to preserve orange for selected
             color_number = jumpnum % (len(self.jump_colors) - 1)
             color_name = self.jump_colors[color_number]
+            outstr += f"  {color_name.replace('xkcd:','').capitalize()} = "
             outstr += f"{jump.name}"
             if jump.key is not None:
                 outstr += f" {jump.key}"
             if jump.key_value is not None:
                 outstr += " " + " ".join(jump.key_value)
-            outstr += f" = {color_name.replace('xkcd:','')}\n"
-        outstr += f"  selected = {self.selected_color}\n"
+            outstr += "\n"
+        outstr += (
+            f"  {self.selected_color.replace('xkcd:','').capitalize()} = selected\n"
+        )
         print(outstr)
 
     def plotColorMode(self):

--- a/src/pint/pintk/colormodes.py
+++ b/src/pint/pintk/colormodes.py
@@ -1,31 +1,33 @@
 """ Color modes for graphed pintk TOAs. """
 import numpy as np
 import matplotlib
+import matplotlib.colors
 
 import pint.logging
 from loguru import logger as log
 
-named_colors = {
-    "red": "red",
-    "green": "green",  # this is any green bank obs
-    "cyan": "cyan",
-    "blue": "blue",
-    "burnt orange": "#CC6600",  # burnt orange
-    "brown": "#362511",  # brown
-    "indigo": "#4B0082",  # indigo
-    "purple": "#7C11AD",  # purple
-    "dark blue": "#00006B",  # dark blue
-    "light green": "#52E222",  # light green
-    "dark green": "#006D35",  # dark green
-    "light blue": "#0091AE",  # light blue
-    "dark red": "#8C0000",  # dark red
-    "magenta": "#E4008D",  # magenta
-    "black": "black",
-    "grey": "#7E7E7E",  # grey
-    "light grey": "#E2E2E1",  # light grey
-    "yellow-ish": "#FFF133",  # yellow-ish
-    "orange": "#FFA500",
-}
+# subset of other colors to allow users to distinguish between them
+named_colors = [
+    "xkcd:red",
+    "xkcd:green",
+    "xkcd:cyan",
+    "xkcd:blue",
+    "xkcd:burnt orange",
+    "xkcd:brown",
+    "xkcd:indigo",
+    "xkcd:purple",
+    "xkcd:dark blue",
+    "xkcd:light green",
+    "xkcd:dark green",
+    "lxkcd:ight blue",
+    "xkcd:dark red",
+    "xkcd:magenta",
+    "xkcd:black",
+    "xkcd:grey",
+    "xkcd:light grey",
+    "xkcd:yellow",
+    "xkcd:orange",
+]
 
 
 class ColorMode:
@@ -119,15 +121,15 @@ class FreqMode(ColorMode):
         """
 
         colorGroups = [
-            named_colors["dark red"],  # dark red
-            named_colors["red"],  # red
-            named_colors["orange"],  # orange
-            named_colors["yellow-ish"],  # yellow-ish
-            named_colors["green"],  # green
-            named_colors["blue"],  # blue
-            named_colors["indigo"],  # indigo
-            named_colors["black"],  # black
-            named_colors["grey"],  # grey
+            "xkcd:dark red",  # dark red
+            "xkcd:red",  # red
+            "xkcd:orange",  # orange
+            "xkcd:yellow",  # yellow
+            "xkcd:green",  # green
+            "xkcd:blue",  # blue
+            "xkcd:indigo",  # indigo
+            "xkcd:black",  # black
+            "xkcd:grey",  # grey
         ]
         highfreqs = [300.0, 400.0, 500.0, 700.0, 1000.0, 1800.0, 3000.0, 8000.0]
 
@@ -261,26 +263,26 @@ class ObsMode(ColorMode):
         return mapping
 
     obs_colors = {
-        "parkes": named_colors["red"],
-        "gb": named_colors["green"],  # this is any green bank obs
-        "jodrell": named_colors["cyan"],
-        "arecibo": named_colors["blue"],
-        "chime": named_colors["burnt orange"],
-        "gmrt": named_colors["brown"],
-        "vla": named_colors["indigo"],
-        "effelsberg": named_colors["purple"],
-        "fast": named_colors["dark blue"],
-        "nancay": named_colors["light green"],
-        "srt": named_colors["dark green"],
-        "wsrt": named_colors["light blue"],
-        "lofar": named_colors["dark red"],
-        "lwa": named_colors["dark red"],
-        "mwa": named_colors["dark red"],
-        "meerkat": named_colors["magenta"],
-        "barycenter": named_colors["black"],
-        "geocenter": named_colors["grey"],
-        "space": named_colors["light grey"],
-        "other": named_colors["yellow-ish"],
+        "parkes": "xkcd:red",
+        "gb": "xkcd:green",  # this is any green bank obs
+        "jodrell": "xkcd:cyan",
+        "arecibo": "xkcd:blue",
+        "chime": "xkcd:burnt orange",
+        "gmrt": "xkcd:brown",
+        "vla": "xkcd:indigo",
+        "effelsberg": "xkcd:purple",
+        "fast": "xkcd:dark blue",
+        "nancay": "xkcd:light green",
+        "srt": "xkcd:dark green",
+        "wsrt": "xkcd:light blue",
+        "lofar": "xkcd:dark red",
+        "lwa": "xkcd:dark red",
+        "mwa": "xkcd:dark red",
+        "meerkat": "xkcd:magenta",
+        "barycenter": "xkcd:black",
+        "geocenter": "xkcd:grey",
+        "space": "xkcd:light grey",
+        "other": "xkcd:yellow",
     }
 
     obs_text = {
@@ -303,13 +305,13 @@ class ObsMode(ColorMode):
         "barycenter": "  barycenter = black",
         "geocenter": "  geocenter = grey",
         "space": "  satellite = light grey",
-        "other": "  other = yellow-ish",
+        "other": "  other = yellow",
     }
 
     def displayInfo(self):
         outstr = '"Observatory" mode selected\n'
         for obs in self.get_obs_mapping().values():
-            outstr += self.obs_text[obs] + "\n"
+            outstr += self.obs_text[obs].replace("xkcd", "") + "\n"
         outstr += "  selected = orange\n"
         print(outstr)
 
@@ -359,20 +361,20 @@ class JumpMode(ColorMode):
         return model.get_jump_param_objects()
 
     jump_colors = named_colors
-    selected_color = "orange"
+    selected_color = "xkcd:orange"
 
     def displayInfo(self):
         outstr = '"Jump" mode selected\n'
         for jumpnum, jump in enumerate(self.get_jumps()):
             # only use the number of colors - 1 to preserve orange for selected
             color_number = jumpnum % (len(self.jump_colors) - 1)
-            color_name = list(self.jump_colors)[color_number]
+            color_name = self.jump_colors[color_number]
             outstr += f"{jump.name}"
             if jump.key is not None:
                 outstr += f" {jump.key}"
             if jump.key_value is not None:
                 outstr += " " + " ".join(jump.key_value)
-            outstr += f" = {color_name}\n"
+            outstr += f" = {color_name.replace('xkcd:','')}\n"
         outstr += f"  selected = {self.selected_color}\n"
         print(outstr)
 
@@ -381,19 +383,18 @@ class JumpMode(ColorMode):
         alltoas = self.application.psr.all_toas
         for jumpnum, jump in enumerate(self.get_jumps()):
             color_number = jumpnum % (len(self.jump_colors) - 1)
-            color_name = list(self.jump_colors)[color_number]
+            color_name = self.jump_colors[color_number]
             toas = jump.select_toa_mask(alltoas)
-            color = self.jump_colors[color_name]
             # group toa indices by jump
             if self.application.yerrs is None:
                 self.application.plkAxes.scatter(
                     self.application.xvals[toas],
                     self.application.yvals[toas],
                     marker=".",
-                    color=color,
+                    color=color_name,
                 )
             else:
-                self.application.plotErrorbar(toas, color=color)
+                self.application.plotErrorbar(toas, color=color_name)
         # Now handle the selected TOAs
         if self.application.yerrs is None:
             self.application.plkAxes.scatter(

--- a/src/pint/pintk/colormodes.py
+++ b/src/pint/pintk/colormodes.py
@@ -345,10 +345,7 @@ class ObsMode(ColorMode):
 
 
 class JumpMode(ColorMode):
-    """
-    A class to manage the Jump color mode, where TOAs are colored
-    according to their jump.
-    """
+    """Mode to color points according to jump"""
 
     def __init__(self, application):
         super(JumpMode, self).__init__(application)
@@ -376,13 +373,11 @@ class JumpMode(ColorMode):
             if jump.key_value is not None:
                 outstr += " " + " ".join(jump.key_value)
             outstr += f" = {color_name}\n"
-        outstr += f"  selected = {selected_color}\n"
+        outstr += f"  selected = {self.selected_color}\n"
         print(outstr)
 
     def plotColorMode(self):
-        """
-        Plots application's residuals in proper color scheme.
-        """
+        """Plot the points with the desired coloring"""
         alltoas = self.application.psr.all_toas
         for jumpnum, jump in enumerate(self.get_jumps()):
             color_number = jumpnum % (len(self.jump_colors) - 1)

--- a/src/pint/pintk/colormodes.py
+++ b/src/pint/pintk/colormodes.py
@@ -400,9 +400,9 @@ class JumpMode(ColorMode):
                 self.application.xvals[self.application.selected],
                 self.application.yvals[self.application.selected],
                 marker=".",
-                color=selected_color,
+                color=self.selected_color,
             )
         else:
             self.application.plotErrorbar(
-                self.application.selected, color=selected_color
+                self.application.selected, color=self.selected_color
             )

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -675,6 +675,7 @@ class PlkWidget(tk.Frame):
             cm.FreqMode(self),
             cm.ObsMode(self),
             cm.NameMode(self),
+            cm.JumpMode(self),
         ]
         self.current_mode = "default"
 

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -432,6 +432,14 @@ class PlkColorModeBoxes(tk.Frame):
                 # default mode should be selected at start-up
                 self.checkboxes[index].select()
 
+            if mode.mode_name == "jump":
+                if self.master.psr.fitted:
+                    model = self.master.psr.postfit_model
+                else:
+                    model = self.master.psr.prefit_model
+                if not "PhaseJump" in model.components:
+                    self.checkboxes[index].configure(state="disabled")
+
         self.updateLayout()
 
     def setCallbacks(self, boxChecked):


### PR DESCRIPTION
<img width="655" alt="Screen Shot 2022-05-31 at 2 22 19 PM" src="https://user-images.githubusercontent.com/5092062/171281493-1b4b1ce0-c756-4377-af40-be487a0bc543.png">
along with:

```
"Jump" mode selected
JUMP1 -state Coherence = red
JUMP2 -state Intensity = green
JUMP3 -gui_jump 3 = cyan
JUMP4 -gui_jump 4 = blue
JUMP5 -gui_jump 5 = burnt orange
JUMP6 -gui_jump 6 = brown
JUMP7 -gui_jump 7 = indigo
JUMP8 -gui_jump 8 = purple
  selected = orange
```
it doesn't really have a way to handle overlapping jumps, though.  