### PR TITLE
Remove requirement to keep TOAs grouped

### DIFF
--- a/src/pint/models/solar_system_shapiro.py
+++ b/src/pint/models/solar_system_shapiro.py
@@ -103,23 +103,19 @@ class SolarSystemShapiro(DelayComponent):
         # Start out with 0 delay with units of seconds
         tbl = toas.table
         delay = numpy.zeros(len(tbl))
-        # FIXME: is there any reason to use groups here? it's slow
-        for ii, key in enumerate(tbl.groups.keys):
-            if key["obs"].lower() == "barycenter":
+        for key, grp in toas.get_obs_groups():
+            if key.lower() == "barycenter":
                 log.debug("Skipping Shapiro delay for Barycentric TOAs")
                 continue
-            grp = tbl.groups[ii]
-            # obs = tbl.groups.keys[ii]["obs"]
-            loind, hiind = tbl.groups.indices[ii : ii + 2]
             psr_dir = self._parent.ssb_to_psb_xyz_ICRS(
-                epoch=grp["tdbld"].astype(numpy.float64)
+                epoch=tbl[grp]["tdbld"].astype(numpy.float64)
             )
-            delay[loind:hiind] += self.ss_obj_shapiro_delay(
-                grp["obs_sun_pos"], psr_dir, self._ss_mass_sec["sun"]
+            delay[grp] += self.ss_obj_shapiro_delay(
+                tbl[grp]["obs_sun_pos"], psr_dir, self._ss_mass_sec["sun"]
             )
             if self.PLANET_SHAPIRO.value:
                 for pl in ("jupiter", "saturn", "venus", "uranus", "neptune"):
-                    delay[loind:hiind] += self.ss_obj_shapiro_delay(
-                        grp["obs_" + pl + "_pos"], psr_dir, self._ss_mass_sec[pl]
+                    delay[grp] += self.ss_obj_shapiro_delay(
+                        tbl[grp]["obs_" + pl + "_pos"], psr_dir, self._ss_mass_sec[pl]
                     )
         return delay * u.second

--- a/src/pint/models/troposphere_delay.py
+++ b/src/pint/models/troposphere_delay.py
@@ -161,10 +161,8 @@ class TroposphereDelay(DelayComponent):
 
             # the only python for loop is to iterate through the unique observatory locations
             # all other math is computed through numpy
-            for ii, key in enumerate(tbl.groups.keys):
-                grp = tbl.groups[ii]
-                loind, hiind = tbl.groups.indices[ii : ii + 2]
-                obsobj = get_observatory(tbl.groups.keys[ii]["obs"])
+            for key, grp in toas.get_obs_groups():
+                obsobj = get_observatory(key)
 
                 # exclude non topocentric observations
                 if not isinstance(obsobj, TopoObs):
@@ -176,12 +174,12 @@ class TroposphereDelay(DelayComponent):
 
                 obs = obsobj.earth_location_itrf()
 
-                alt = self._get_target_altitude(obs, grp, radec)
+                alt = self._get_target_altitude(obs, tbl[grp], radec)
 
                 # now actually calculate the atmospheric delay based on the models
 
-                delay[loind:hiind] = self.delay_model(
-                    alt, obs.lat, obs.height, grp["tdbld"]
+                delay[grp] = self.delay_model(
+                    alt, obs.lat, obs.height, tbl[grp]["tdbld"]
                 )
         return delay * u.s
 

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -168,6 +168,7 @@ def make_fake_toas(ts, model, add_noise=False, name="fake"):
     for f in tsim.table["flags"]:
         f["name"] = name
 
+    tsim.table = tsim.table.group_by("obs")
     return tsim
 
 

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -79,6 +79,7 @@ __all__ = [
     "info_string",
     "print_color_examples",
     "colorize",
+    "group_iterator",
 ]
 
 COLOR_NAMES = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]
@@ -1588,3 +1589,20 @@ def print_color_examples():
                     end="",
                 )
             print("")
+
+
+def group_iterator(items):
+    """An iterator to step over identical items in a :class:`numpy.ndarray`
+
+    Example
+    -------
+    This will step over all of the observatories in the TOAs.
+    For each iteration it gives the observatory name and the indices that correspond to it
+
+        t = pint.toa.get_TOAs("grouptest.tim")
+        for o, i in group_iterator(t["obs"]):
+            print(f"{o} {i}")
+
+    """
+    for item in np.unique(items):
+        yield item, np.where(items == item)[0]

--- a/tests/test_toa.py
+++ b/tests/test_toa.py
@@ -87,19 +87,17 @@ class TestTOAs(unittest.TestCase):
 
         toas = TOAs(toalist=[t1, t2, t3])
 
-        # Table will be grouped by observatories, and will be sorted by the
-        # observatory so the TOA order will be different
-        assert toas.table["obs"][0] == site2.name
-        assert toas.table["mjd"][0] == t2.mjd
-        assert toas.table["obs"][1] == site3.name
-        assert toas.table["mjd"][1] == t3.mjd
-        assert toas.table["obs"][2] == site1.name
-        assert toas.table["mjd"][2] == t1.mjd
+        assert toas.table["obs"][0] == site1.name
+        assert toas.table["mjd"][0] == t1.mjd
+        assert toas.table["obs"][1] == site2.name
+        assert toas.table["mjd"][1] == t2.mjd
+        assert toas.table["obs"][2] == site3.name
+        assert toas.table["mjd"][2] == t3.mjd
 
         # obs in time object
-        assert toas.table["mjd"][0].location == site2.earth_location_itrf()
-        assert toas.table["mjd"][1].location == site3.earth_location_itrf()
-        assert toas.table["mjd"][2].location == site1.earth_location_itrf()
+        assert toas.table["mjd"][0].location == site1.earth_location_itrf()
+        assert toas.table["mjd"][1].location == site2.earth_location_itrf()
+        assert toas.table["mjd"][2].location == site3.earth_location_itrf()
 
 
 def test_toa_summary():

--- a/tests/test_toa_indexing.py
+++ b/tests/test_toa_indexing.py
@@ -74,7 +74,6 @@ def test_getitem_where(a):
     assert len(s) == len(a)
     assert set(s.get_mjds()) == set(m[a])
     if len(s) > 0:
-        assert np.all(s.table["mjd_float"] == s.table.group_by("obs")["mjd_float"])
         toas.get_summary()
 
 
@@ -85,7 +84,6 @@ def test_getitem_slice(c):
     s = toas[c]
     assert set(s.get_mjds()) == set(m[c])
     if len(s) > 0:
-        assert np.all(s.table["mjd_float"] == s.table.group_by("obs")["mjd_float"])
         toas.get_summary()
 
 


### PR DESCRIPTION
TOAs no longer need to be grouped, although they still can be.  Slight change in order of operations/interpolation in `apply_clock_correction` that results in ~3e-15s changes.

(3rd attempt at this, after messing up previous PRs)