### PR TITLE
Fix logic in remove_DMX_range() when list/array is supplied

### DIFF
--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -431,10 +431,12 @@ class DispersionDMX(Dispersion):
             or isinstance(index, np.int64)
         ):
             indices = [index]
-        elif not isinstance(index, list) or not isinstance(index, np.ndarray):
+        elif not isinstance(index, list) and not isinstance(index, np.ndarray):
             raise TypeError(
                 f"index must be a float, int, list, or array - not {type(index)}"
             )
+        else:
+            indices = index
         for index in indices:
             index_rf = f"{int(index):04d}"
             for prefix in ["DMX_", "DMXR1_", "DMXR2_"]:

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -431,12 +431,12 @@ class DispersionDMX(Dispersion):
             or isinstance(index, np.int64)
         ):
             indices = [index]
-        elif not isinstance(index, (list, np.ndarray)):
+        elif isinstance(index, (list, np.ndarray)):
+            indices = index
+        else:
             raise TypeError(
                 f"index must be a float, int, list, or array - not {type(index)}"
             )
-        else:
-            indices = index
         for index in indices:
             index_rf = f"{int(index):04d}"
             for prefix in ["DMX_", "DMXR1_", "DMXR2_"]:

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -431,7 +431,7 @@ class DispersionDMX(Dispersion):
             or isinstance(index, np.int64)
         ):
             indices = [index]
-        elif not isinstance(index, list) and not isinstance(index, np.ndarray):
+        elif not isinstance(index, (list, np.ndarray)):
             raise TypeError(
                 f"index must be a float, int, list, or array - not {type(index)}"
             )


### PR DESCRIPTION
This applies De Morgan's Laws correctly when giving `remove_DMX_range()` a list or numpy array, and then makes sure it iterates through the indices correctly if so.