### PR TITLE
Bump required python to 3.8

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -24,31 +24,31 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.8'
+            python: '3.10'
             tox_env: 'ephemeris_connection'
           - os: ubuntu-latest
-            python: '3.8'
+            python: '3.10'
             tox_env: 'black'
           - os: ubuntu-latest
-            python: '3.8'
-            tox_env: 'py38-test-cov'
+            python: '3.10'
+            tox_env: 'py310-test-cov'
           - os: ubuntu-latest
-            python: '3.8'
+            python: '3.10'
             tox_env: 'notebooks'
 #          - os: ubuntu-latest
 #            python: '3.8'
 #            tox_env: 'docs'
-          - os: ubuntu-latest
-            python: '3.8'
-            tox_env: 'py38-test-alldeps-cov'
+#          - os: ubuntu-latest
+#            python: '3.10'
+#            tox_env: 'py310-test-alldeps-cov'
           - os: macos-latest
-            python: '3.7'
-            tox_env: 'py37-test'
+            python: '3.10'
+            tox_env: 'py310-test'
 #          - os: windows-latest
 #            python: '3.8'
 #            tox_env: 'py38-test'
           - os: ubuntu-latest
-            python: '3.7'
+            python: '3.8'
             tox_env: 'oldestdeps'
 #          - os: ubuntu-latest
 #            python: '3.8'

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: requirements_dev.txt
     - requirements: requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 ### Fixed
 - INCLUDE lines in tim files are now relative to the location of the tim file (bug #1269)
 ### Changed
+- Required version of python updated to 3.8
 
 ## [0.8.8] 2022-05-26
 ### Added

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,10 +15,9 @@ classifier =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Software Development :: Libraries :: Python Modules
 
@@ -28,6 +27,7 @@ packages = find:
 package_dir =
     = src
 include_package_data = True
+python_requires = >=3.8
 install_requires =
     astropy>=4.0,!=4.0.1,!=4.0.1.post1
     numpy>=1.17.0

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist =
     report
     codestyle
     black
-    py{37,38}-test{,-alldeps,-devdeps}{,-cov}
+    py{38,39,310}-test{,-alldeps,-devdeps}{,-cov}
 
 skip_missing_interpreters = True
 
@@ -43,8 +43,8 @@ commands =
     cov: coverage xml -o {toxinidir}/coverage.xml
 
 depends =
-    {py36,py37}: clean
-    report: py36,py37
+    {py38,py39,py310}: clean
+    report: py38,py39,py310
     docs: notebooks
 
 [testenv:ephemeris_connection]
@@ -56,6 +56,7 @@ deps =
 [testenv:oldestdeps]
 description =
     Run tests on Python 3 with minimum supported versions of astropy, numpy
+basepython = python3.8
 deps =
     numpy==1.17.*
     astropy==4.0


### PR DESCRIPTION
I'm not sure this covers everything required, but:

- Add a python version requirement to `setup.cfg` (there wasn't one)
- Change CI to not run any pre-3.8 jobs (and add a 3.10 job)
- Change tox.ini to refer only to 3.8, 3.9, and 3.10
- Switch readthedocs to use 3.8
- Changelog
- PyPI picks up version requirements from setup.cfg

Also probably required but not done yet:

- Update Conda metadata (https://github.com/conda-forge/pint-pulsar-feedstock/blob/main/recipe/meta.yaml)
- Update versions of dependencies (astropy, numpy)? 

Closes #1278