### PR TITLE
Fix jump_flags_to_params and jump_params_to_flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - The `temp_cache` fixture that runs tests with an empty, scratch Astropy cache
 ### Fixed
 - INCLUDE lines in tim files are now relative to the location of the tim file (bug #1269)
+- jump_flags_to_params now works if some JUMPs are present, never modifies the TOAs, and is idempotent
+- jump_params_to_flags is now idempotent and unconditionally sets the -jump flag to a correct state
 ### Changed
 - Required version of python updated to 3.8
 

--- a/src/pint/models/jump.py
+++ b/src/pint/models/jump.py
@@ -155,15 +155,21 @@ class PhaseJump(PhaseComponent):
     def jump_params_to_flags(self, toas):
         """Take jumps created from .par file and add appropriate flags to toa table.
 
-        This function was made specifically with pintk in mind for a way to properly
-        load jump flags at the same time a .par file with jumps is loaded (like how
-        jump_flags_to_params loads jumps from .tim files).
+        This function was made specifically with pintk in mind so as to maintain
+        a ``-jump`` flag on each TOA that is affected by any JUMP in the model,
+        listing the numbers of all JUMPs affecting that TOA.
+
+        This function wipes all ``-jump`` flags and reinitializes them to reflect
+        the actual situation.
 
         Parameters
         ----------
         toas: TOAs object
             The TOAs which contain the TOA table to be modified
         """
+        log.info(f"Initial TOAs {toas['jump']=}")
+        toas["jump"] = ""
+        log.info(f"Wiped TOAs {toas['jump']=}")
         # for every jump, set appropriate flag for TOAs it jumps
         for jump_par in self.get_jump_param_objects():
             # find TOAs jump applies to
@@ -172,12 +178,12 @@ class PhaseJump(PhaseComponent):
             for d in toas.table["flags"][mask]:
                 if "jump" in d:
                     index_list = d["jump"].split(",")
-                    if str(jump_par.index) in index_list:
-                        continue
                     index_list.append(str(jump_par.index))
                     d["jump"] = ",".join(index_list)
                 else:
                     d["jump"] = str(jump_par.index)
+                log.info(f"Set up on {jump_par=} {d=}")
+            log.info(f"TOAs {toas['jump']=}")
 
     def add_jump_and_flags(self, toa_table):
         """Add jump object to PhaseJump and appropriate flags to TOA tables.

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1381,68 +1381,89 @@ class TimingModel:
         return result
 
     def jump_flags_to_params(self, toas):
-        """Convert jump flags in toas.table["flags"] (loaded in .tim file) to jump parameters in the model.
+        """Add JUMP parameters corresponding to tim_jump flags.
 
-        The flag processed is ``jump``.
+        When a ``.tim`` file contains pairs of JUMP lines, the user's expectation
+        is that the TOAs between each pair of flags will be affected by a JUMP, even
+        if that JUMP does not appear in the ``.par`` file. (This is how TEMPO works.)
+        In PINT, those TOAs have a flag attached, `-tim_jump N`, where N is a
+        number that is different for each JUMPed set of TOAs. The goal of this function
+        is to add JUMP parameters to the model corresponding to these.
 
-        Note:  this method should be called *before* the PhaseJump mathod jump_params_to_flags()
+        Some complexities arise: TOAs may also have `-tim_jump` flags associated
+        with them, just as flags, for example if such a ``.tim`` file were exported
+        in PINT-native format and then reloaded. And models may already have JUMPs
+        associated with some or all ``tim_jump`` values.
+
+        This function looks at all the ``tim_jump`` values and adds JUMP parameters
+        for any that do not have any. It does not change the TOAs object it is passed.
         """
         from . import jump
 
         tjvals, idxs = toas.get_flag_value("tim_jump")
-        Ntimjumps = len({int(n) for n in tjvals if n is not None})
-        if not Ntimjumps:
+        tim_jump_values = set(tjvals)
+        tim_jump_values.remove(None)
+        if not tim_jump_values:
             log.info("No jump flags to process from .tim file")
             return None
-        log.info(f"There are {Ntimjumps} JUMPs from the timfile.")
-        # The number of parfile-based JUMPs we have
-        Nparjumps = (
-            self.components["PhaseJump"].get_number_of_jumps()
-            if "PhaseJump" in self.components
-            else 0
-        )
-        log.info(f"There are {Nparjumps} JUMPs from the model.")
-        if Nparjumps:
-            # Check to see if there are already tim-file jumps defined.
-            # If so, we will change their numbers so that the parfile ones
-            # are first in numerical order
-            log.debug(f"Increasing the timfile JUMP numbers by {Nparjumps}")
-            for idx in idxs:
-                snum = str(int(tjvals[idx]) + Nparjumps)
-                toas.table[idx]["flags"]["jump"] = snum
-                toas.table[idx]["flags"]["tim_jump"] = snum
-        # Because JUMPS are handled serially, we need to do everything
-        # via index order and *not* by group_by("obs")
-        ix_tab = toas.table[np.argsort(toas.table["index"])]
-        jumped = ["jump" in fd for fd in ix_tab["flags"]]
-        for flag_dict in ix_tab["flags"][jumped]:
-            # add PhaseJump object if model does not have one already
-            if "PhaseJump" not in self.components:
-                log.info("PhaseJump component added")
-                a = jump.PhaseJump()
-                a.setup()
-                self.add_component(a)
-                self.remove_param("JUMP1")
-            # take jumps in TOA table and add them as parameters to the model
-            num = flag_dict["jump"]
-            if f"JUMP{str(num)}" not in self.params:
-                param = maskParameter(
-                    name="JUMP",
-                    index=num,
-                    key="-tim_jump",
-                    key_value=num,
-                    value=0.0,
-                    units="second",
-                    uncertainty=0.0,
-                )
-                self.add_param_from_top(param, "PhaseJump")
-                getattr(self, param.name).frozen = False
-            flag_dict["tim_jump"] = str(num)  # this is the value select_toa_mask uses
+        log.info(f"There are {len(tim_jump_values)} JUMPs from the timfile.")
+
+        if "PhaseJump" not in self.components:
+            log.info("PhaseJump component added")
+            a = jump.PhaseJump()
+            a.setup()
+            self.add_component(a)
+            self.remove_param("JUMP1")
+            a.setup()
+
+        used_indices = set()
+        for p in self.get_jump_param_objects():
+            if p.key == "-tim_jump":
+                used_indices.add(p.index)
+                (tjv,) = p.key_value
+                if tjv in tim_jump_values:
+                    log.info(f"JUMP -tim_jump {tjv} already exists")
+                    tim_jump_values.remove(tjv)
+        if used_indices:
+            num = max(used_indices) + 1
+        else:
+            num = 1
+
+        if not tim_jump_values:
+            log.info(f"All tim_jump values have corresponding JUMPs")
+            return
+
+        # FIXME: arrange for these to be in a sensible order (might not be integers
+        # but if they are then lexicographical order is not wanted)
+        t_j_v = set()
+        for v in tim_jump_values:
+            try:
+                vi = int(v)
+            except ValueError:
+                vi = v
+            t_j_v.add(vi)
+        for v in sorted(t_j_v):
+            # Now we need to add a JUMP for each of these
+            log.info(f"Adding JUMP -tim_jump {v}")
+            param = maskParameter(
+                name="JUMP",
+                index=num,
+                key="-tim_jump",
+                key_value=v,
+                value=0.0,
+                units="second",
+                uncertainty=0.0,
+            )
+            self.add_param_from_top(param, "PhaseJump")
+            getattr(self, param.name).frozen = False
+            num += 1
+
         self.components["PhaseJump"].setup()
 
     def delete_jump_and_flags(self, toa_table, jump_num):
-        """Delete jump object from PhaseJump and remove its flags from TOA table
-        (helper function for pintk).
+        """Delete jump object from PhaseJump and remove its flags from TOA table.
+
+        This is a helper function for pintk.
 
         Parameters
         ----------

--- a/tests/test_find_clock_file.py
+++ b/tests/test_find_clock_file.py
@@ -68,7 +68,7 @@ def test_can_find_in_repo(sandbox, temp_cache):
 
 
 def test_pint_env_overrides(sandbox, temp_cache):
-    os.environ["PINT_CLOCK_OVERRIDE"] = sandbox.override_dir
+    os.environ["PINT_CLOCK_OVERRIDE"] = str(sandbox.override_dir)
     c = find_clock_file(sandbox.name, format="tempo2", url_base=sandbox.repo_uri)
     assert c.time.mjd[0] == sandbox.override_clock.time.mjd[0]
     # FIXME: how to test that a warning is emitted?

--- a/tests/test_timing_model.py
+++ b/tests/test_timing_model.py
@@ -329,9 +329,8 @@ def test_t2cmethod_corrected():
     assert model.T2CMETHOD.value == "IAU2000B"
 
 
-def test_jump_flags_to_params(timfile_jumps, timfile_nojumps, model_0437):
+def test_jump_flags_to_params_harmless(timfile_nojumps, model_0437):
     # TOAs 9, 10, 11, and 12 have jump flags (JUMP2 on 9, JUMP1 on rest)
-    t = timfile_jumps
     m = model_0437  # model with no jumps
     t_nojump = timfile_nojumps
     # sanity check
@@ -339,7 +338,26 @@ def test_jump_flags_to_params(timfile_jumps, timfile_nojumps, model_0437):
     # check nothing changed when .tim file has no jumps
     m.jump_flags_to_params(t_nojump)
     assert "PhaseJump" not in m.components
-    # add jump parameters to model based off flags in TOA table
+
+
+def test_jump_flags_to_params_adds_params(timfile_jumps, model_0437):
+    # TOAs 9, 10, 11, and 12 have jump flags (JUMP2 on 9, JUMP1 on rest)
+    t = timfile_jumps
+    m = model_0437  # model with no jumps
+
+    m.jump_flags_to_params(t)
+    assert "PhaseJump" in m.components
+    assert len(m.components["PhaseJump"].jumps) == 2
+    assert "JUMP1" in m.components["PhaseJump"].jumps
+    assert "JUMP2" in m.components["PhaseJump"].jumps
+
+
+def test_jump_flags_to_params_idempotent(timfile_jumps, model_0437):
+    # TOAs 9, 10, 11, and 12 have jump flags (JUMP2 on 9, JUMP1 on rest)
+    t = timfile_jumps
+    m = model_0437  # model with no jumps
+
+    m.jump_flags_to_params(t)
     m.jump_flags_to_params(t)
     assert "PhaseJump" in m.components
     assert len(m.components["PhaseJump"].jumps) == 2
@@ -378,16 +396,18 @@ def test_parfile_and_timfile_jumps(timfile_jumps):
     t = timfile_jumps
     # this test assumes things have been grouped by observatory to associate the jumps with specific TOA indices
     t.table = t.table.group_by("obs")
+    fs_orig, idxs_orig = t.get_flag_value("tim_jump")
     m = get_model(io.StringIO(par_base + "JUMP MJD 55729 55730 0.0 1\n"))
     # turns pre-existing jump flags in t.table['flags'] into parameters in parfile
     m.jump_flags_to_params(t)
+
     assert "PhaseJump" in m.components
+    fs, idxs = t.get_flag_value("tim_jump")
+    assert fs == fs_orig
+    assert idxs == idxs_orig
+
     # adds jump flags to t.table['flags'] for jump parameters already in parfile
     m.jump_params_to_flags(t)
-    fs, idxs = t.get_flag_value("tim_jump")
-    assert len(idxs) == 4
-    assert fs[5] == "3"  # These were both boosted because of the parfile JUMP
-    assert fs[6] == "2"
     fs, idxs = t.get_flag_value("jump")
     assert len(idxs) == 5
     assert fs[5] in ["3,1", "1,3"]


### PR DESCRIPTION
These two functions are used to relate JUMP parameters and TOA flags, and both had serious problems. This makes them do well-defined, documented things.

Closes #1294 