### PR TITLE
MeerKAT can use the observatory clock file

### DIFF
--- a/src/pint/observatory/observatories.py
+++ b/src/pint/observatory/observatories.py
@@ -80,7 +80,7 @@ TopoObs(
     tempo_code="m",
     itoa_code="MK",
     clock_fmt="tempo2",
-    clock_file="mk2utc.clk",
+    clock_file="mk2utc_observatory.clk",
     itrf_xyz=[5109360.133, 2006852.586, -3238948.127],
     origin="""MEERKAT, used in timing mode.
 


### PR DESCRIPTION
The global repository now has an auto-updated clock file for MeerKAT but it's not quite suitable for TEMPO2, so it has a different name. This PR makes PINT use it.