### PR TITLE
Fix pintk merge problem

### DIFF
--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -620,6 +620,7 @@ class Pulsar:
                 include_gps=sim_sel.clock_corr_info["include_gps"],
             )
         self.faketoas1.compute_pulse_numbers(self.postfit_model)
+        self.faketoas1.get_clusters(add_column=True)
 
         # Combine our TOAs
         toas = merge_TOAs([sim_sel, self.faketoas1])


### PR DESCRIPTION
Pintk was crashing because fake TOAs were missing a column. This adds that column.