### PR TITLE
Handle no clock files better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - The default version of TT(BIPM) uses BIPM2021
 - ClockFile no longer uses metaclass magic or many subclasses, and have friendly names for use in messages
 - `model.setup()` now gets called automatically after removing a parameter as part of `remove_param`
+- Cleaned up handling of telescopes with no clock files so they don't emit ERROR messages
 ### Added
 - logging now needs to be setup explicitly
 - Color-by-jump mode for pintk

--- a/src/pint/observatory/__init__.py
+++ b/src/pint/observatory/__init__.py
@@ -643,11 +643,11 @@ def list_last_correction_mjds():
         for c in o._clock:
             try:
                 print(
-                    f"    {os.path.basename(c.filename):<20}"
+                    f"    {c.friendly_name:<20}"
                     f" {Time(c.last_correction_mjd(), format='mjd').iso}"
                 )
             except (ValueError, TypeError):
-                print(f"    {os.path.basename(c.filename):<20} MISSING")
+                print(f"    {c.friendly_name:<20} MISSING")
 
 
 def update_clock_files(bipm_versions=None):

--- a/src/pint/observatory/clock_file.py
+++ b/src/pint/observatory/clock_file.py
@@ -465,7 +465,9 @@ def read_tempo2_clock_file(filename, bogus_last_correction=False, friendly_name=
         A human-readable name for this file, for use in error reporting.
         If not provided, will default to ``filename``.
     """
-    log.debug(f"Loading TEMPO2-format observatory clock correction file {filename}")
+    log.debug(
+        f"Loading TEMPO2-format observatory clock correction file {filename} with {bogus_last_correction=}"
+    )
     try:
         mjd = []
         clk = []
@@ -603,7 +605,9 @@ def read_tempo_clock_file(
     """
 
     leading_comment = None
-    log.debug(f"Loading TEMPO observatory ({obscode}) clock correction file {filename}")
+    log.debug(
+        f"Loading TEMPO observatory ({obscode}) clock correction file {filename} with {bogus_last_correction=}"
+    )
     mjds = []
     clkcorrs = []
     comments = []
@@ -793,6 +797,7 @@ class GlobalClockFile(ClockFile):
         self.filename = filename
         self.friendly_name = filename
         self.format = format
+        log.debug(f"Global clock file {self.friendly_name} saving {kwargs=}")
         self.kwargs = kwargs
         self.url_base = url_base
         self.url_mirrors = url_mirrors

--- a/src/pint/observatory/clock_file.py
+++ b/src/pint/observatory/clock_file.py
@@ -420,6 +420,8 @@ class ClockFile:
     def export(self, filename):
         """Write this clock correction file to the specified location."""
         # FIXME: fall back to writing the clock file using .write_...?
+        if self.filename is None:
+            raise ValueError("No file backing this clock correction object")
         try:
             contents = Path(self.filename).read_text()
         except IOError:
@@ -429,6 +431,9 @@ class ClockFile:
             return
         with open_or_use(filename, "wt") as f:
             f.write(contents)
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.friendly_name=}, {len(self.time)=})"
 
 
 # TEMPO2

--- a/src/pint/observatory/observatories.py
+++ b/src/pint/observatory/observatories.py
@@ -152,6 +152,7 @@ TopoObs(
     itrf_xyz=[4324165.81, 165927.11, 4670132.83],
     clock_fmt="tempo2",
     clock_file=["ncyobs2obspm.clk", "obspm2gps.clk"],
+    bogus_last_correction=True,
     origin="""The Nançay radio telescope with the NUPPI back-end.
 
     The origin of this data is unknown but as of 2021 June 8 it agrees exactly with

--- a/src/pint/observatory/topo_obs.py
+++ b/src/pint/observatory/topo_obs.py
@@ -230,6 +230,7 @@ class TopoObs(Observatory):
             self._clock = [
                 find_clock_file(c, format=self.clock_fmt, clock_dir=self.clock_dir)
                 for c in clock_files
+                if c != ""
             ]
 
     def clock_corrections(self, t, limits="warn"):
@@ -395,6 +396,8 @@ def find_clock_file(
     -------
     ClockFile
     """
+    if name == "":
+        raise ValueError("No filename supplied to find_clock_file")
     if clock_dir is None or clock_dir.upper() == "PINT":
         # Don't try loading it from a specific path
         p = None
@@ -508,4 +511,5 @@ def export_all_clock_files(directory):
         o = get_observatory(name)
         if hasattr(o, "_clock") and o._clock is not None:
             for clock in o._clock:
-                clock.export(directory / Path(clock.filename).name)
+                if clock.filename is not None:
+                    clock.export(directory / Path(clock.filename).name)

--- a/src/pint/observatory/topo_obs.py
+++ b/src/pint/observatory/topo_obs.py
@@ -228,7 +228,12 @@ class TopoObs(Observatory):
                 self.clock_file if self._multiple_clock_files else [self.clock_file]
             )
             self._clock = [
-                find_clock_file(c, format=self.clock_fmt, clock_dir=self.clock_dir)
+                find_clock_file(
+                    c,
+                    format=self.clock_fmt,
+                    clock_dir=self.clock_dir,
+                    bogus_last_correction=self.bogus_last_correction,
+                )
                 for c in clock_files
                 if c != ""
             ]
@@ -473,7 +478,7 @@ def find_clock_file(
             log.info(f"Using clock file from {env_clock.filename}")
         return env_clock
     elif global_clock is not None:
-        log.info(f"Using global clock file for {name}")
+        log.info(f"Using global clock file for {name} with {bogus_last_correction=}")
         return global_clock
     elif local_clock is not None:
         log.info(f"Using local clock file for {name}")

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -8,7 +8,7 @@ from pint.pulsar_mjd import Time
 
 import pint.observatory
 import pint.observatory.observatories
-from pint.observatory import get_observatory, Observatory
+from pint.observatory import get_observatory, Observatory, NoClockCorrections
 from pint.observatory.topo_obs import TopoObs
 from pinttestdata import datadir
 
@@ -94,11 +94,8 @@ class TestObservatory(unittest.TestCase):
             site = get_observatory(
                 "Fake1", include_gps=True, include_bipm=True, bipm_version="BIPM2015"
             )
-            try:
+            with pytest.raises(NoClockCorrections):
                 site.clock_corrections(self.test_time)
-            except (OSError, IOError) as e:
-                assert e.errno == 2
-                assert os.path.basename(e.filename) == "fake2gps.clk"
         finally:
             Observatory._registry = r
 

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -8,7 +8,7 @@ from pint.pulsar_mjd import Time
 
 import pint.observatory
 import pint.observatory.observatories
-from pint.observatory import get_observatory
+from pint.observatory import get_observatory, Observatory
 from pint.observatory.topo_obs import TopoObs
 from pinttestdata import datadir
 
@@ -78,67 +78,71 @@ class TestObservatory(unittest.TestCase):
             get_observatory("Wrong_name")
 
     def test_clock_correction_file_not_available(self):
-        if os.getenv("TEMPO2") is None:
-            pytest.skip("TEMPO2 environment variable is not set, can't run this test")
-        # observatory clock correction path expections.
-        fake_obs = TopoObs(
-            "Fake1",
-            tempo_code="?",
-            itoa_code="FK",
-            clock_fmt="tempo2",
-            clock_file="fake2gps.clk",
-            clock_dir="TEMPO2",
-            itrf_xyz=[0.00, 0.0, 0.0],
-            overwrite=True,
-        )
-        site = get_observatory(
-            "Fake1", include_gps=True, include_bipm=True, bipm_version="BIPM2015"
-        )
+        r = Observatory._registry.copy()
         try:
-            site.clock_corrections(self.test_time)
-        except (OSError, IOError) as e:
-            assert e.errno == 2
-            assert os.path.basename(e.filename) == "fake2gps.clk"
+            # observatory clock correction path expections.
+            TopoObs(
+                "Fake1",
+                tempo_code="?",
+                itoa_code="FK",
+                clock_fmt="tempo2",
+                clock_file="fake2gps.clk",
+                clock_dir="TEMPO2",
+                itrf_xyz=[0.00, 0.0, 0.0],
+                overwrite=True,
+            )
+            site = get_observatory(
+                "Fake1", include_gps=True, include_bipm=True, bipm_version="BIPM2015"
+            )
+            try:
+                site.clock_corrections(self.test_time)
+            except (OSError, IOError) as e:
+                assert e.errno == 2
+                assert os.path.basename(e.filename) == "fake2gps.clk"
+        finally:
+            Observatory._registry = r
 
     def test_no_tempo2_but_tempo2_clock_requested(self):
-        if os.getenv("TEMPO2") is not None:
-            pytest.skip("TEMPO2 environment variable is set, can't run this test")
-        # observatory clock correction path expections.
-        fake_obs = TopoObs(
-            "Fake1",
-            tempo_code="?",
-            itoa_code="FK",
-            clock_fmt="tempo2",
-            clock_file="fake2gps.clk",
-            clock_dir="TEMPO2",
-            itrf_xyz=[0.00, 0.0, 0.0],
-            overwrite=True,
-        )
-        site = get_observatory(
-            "Fake1", include_gps=True, include_bipm=True, bipm_version="BIPM2015"
-        )
-        with pytest.raises(RuntimeError):
-            site.clock_corrections(self.test_time, limits="error")
+        r = Observatory._registry.copy()
+        try:
+            fake_obs = TopoObs(
+                "Fake1",
+                tempo_code="?",
+                itoa_code="FK",
+                clock_fmt="tempo2",
+                clock_file="fake2gps.clk",
+                clock_dir="TEMPO2",
+                itrf_xyz=[0.00, 0.0, 0.0],
+                overwrite=True,
+            )
+            site = get_observatory(
+                "Fake1", include_gps=True, include_bipm=True, bipm_version="BIPM2015"
+            )
+            with pytest.raises(RuntimeError):
+                site.clock_corrections(self.test_time, limits="error")
+        finally:
+            Observatory._registry = r
 
     def test_no_tempo_but_tempo_clock_requested(self):
-        if os.getenv("TEMPO") is not None:
-            pytest.skip("TEMPO environment variable is set, can't run this test")
-        # observatory clock correction path expections.
-        fake_obs = TopoObs(
-            "Fake1",
-            tempo_code="?",
-            itoa_code="FK",
-            clock_fmt="tempo",
-            clock_file="fake2gps.clk",
-            clock_dir="TEMPO",
-            itrf_xyz=[0.00, 0.0, 0.0],
-            overwrite=True,
-        )
-        site = get_observatory(
-            "Fake1", include_gps=True, include_bipm=True, bipm_version="BIPM2015"
-        )
-        with pytest.raises(RuntimeError):
-            site.clock_corrections(self.test_time, limits="error")
+        r = Observatory._registry.copy()
+        try:
+            fake_obs = TopoObs(
+                "Fake1",
+                tempo_code="?",
+                itoa_code="FK",
+                clock_fmt="tempo",
+                clock_file="fake2gps.clk",
+                clock_dir="TEMPO",
+                itrf_xyz=[0.00, 0.0, 0.0],
+                overwrite=True,
+            )
+            site = get_observatory(
+                "Fake1", include_gps=True, include_bipm=True, bipm_version="BIPM2015"
+            )
+            with pytest.raises(RuntimeError):
+                site.clock_corrections(self.test_time, limits="error")
+        finally:
+            Observatory._registry = r
 
     def test_wrong_TDB_method(self):
         site = get_observatory(
@@ -178,37 +182,32 @@ def test_last_mjd(observatory):
 
 
 def test_missing_clock_gives_exception_nonexistent():
-    o = TopoObs(
-        "arecibo_bogus",
-        clock_file="nonexistent.dat",
-        itoa_code="W",
-        itrf_xyz=[2390487.080, -5564731.357, 1994720.633],
-        overwrite=True,
-    )
+    r = Observatory._registry.copy()
+    try:
+        o = TopoObs(
+            "arecibo_bogus",
+            clock_file="nonexistent.dat",
+            itoa_code="W",
+            itrf_xyz=[2390487.080, -5564731.357, 1994720.633],
+            overwrite=True,
+        )
 
-    with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError):
+            o.clock_corrections(Time(57600, format="mjd"), limits="error")
+    finally:
+        Observatory._registry = r
+
+
+def test_no_clock_means_no_corrections():
+    r = Observatory._registry.copy()
+    try:
+        o = TopoObs(
+            "arecibo_bogus",
+            itrf_xyz=[2390487.080, -5564731.357, 1994720.633],
+        )
         o.clock_corrections(Time(57600, format="mjd"), limits="error")
-
-
-def test_missing_clock_gives_exception_no_data():
-    o = TopoObs(
-        "arecibo_bogus",
-        itrf_xyz=[2390487.080, -5564731.357, 1994720.633],
-        overwrite=True,
-    )
-
-    with pytest.raises(RuntimeError):
-        o.clock_corrections(Time(57600, format="mjd"), limits="error")
-
-
-def test_missing_clock_runs():
-    o = TopoObs(
-        "arecibo_bogus",
-        clock_file="nonexistent.dat",
-        itrf_xyz=[2390487.080, -5564731.357, 1994720.633],
-        overwrite=True,
-    )
-    o.clock_corrections(Time(57600, format="mjd"))
+    finally:
+        Observatory._registry = r
 
 
 def test_observatories_registered():
@@ -217,3 +216,7 @@ def test_observatories_registered():
 
 def test_gbt_registered():
     get_observatory("gbt")
+
+
+def test_list_last_correction_mjds_runs():
+    pint.observatory.list_last_correction_mjds()


### PR DESCRIPTION
Current master emits loud and unhelpful error messages when working with telescopes for which no clock file is needed. This PR fixes that and checks that these telescopes behave better.