### PR TITLE
Add How-to questions from Wiki

### DIFF
--- a/docs/common-timing-workflow.rst
+++ b/docs/common-timing-workflow.rst
@@ -1,0 +1,44 @@
+
+How to: Common timing workflow
+==============================
+
+(This was originally written by Alex McEwen on the PINT wiki.)
+
+When I'm working on new pulsar solutions, my work flow usually follows
+something like this. This uses some of the basic tools that are included in the
+:ref:`user questions <user-questions>`. Please send
+suggestions/comments/questions to aemcewen@uwm.edu.
+
+
+1. load pulsar model/TOAs via get_TOAs() and get_model()::
+
+     model = get_model('parfile.par')
+     toas = get_TOAs('toas.tim', model=model)
+
+2. make a copy of the TOAs that I will edit (for easy resets)::
+
+     newtoas = toas
+
+3. use plot_fit(newtoas), identify bad toas/missing wraps and mask those data. in this example, i am zapping all TOAs before MJD 59000 and also on 59054.321. also, i'm adding a wrap on 59166::
+
+     newtoas = mask_toas(newtoas,before=59000,on=[59054.321])
+     newtoas.compute_pulse_numbers(model)
+     add_wraps(newtoas,59166,'-')
+     plot_fit(newtoas,model)
+
+4. once i have the TOAs i want, i fit the data, look at the residuals, and see how the model changed::
+
+     f=WLSFitter(newtoas,model,track_mode='use_pulse_numbers')
+     f.model.free_params=['F0']
+     f.fit_toas()
+     plot_fit(newtoas,f.model)
+     f.print_summary()
+     f.model.compare(model,verbosity='check')
+
+5. when the model appears to be a good fit, i update the model and add new observations::
+
+     model=f.model
+     newtoas=mask_toas(toas,before=58000,on=59054.321)
+     plot_fit(newtoas,model)
+
+6. iterate these last two steps until the fit breaks/i run out of data.

--- a/docs/examples/time_a_pulsar.py
+++ b/docs/examples/time_a_pulsar.py
@@ -28,8 +28,11 @@ from pint.residuals import Residuals
 from pint.toa import get_TOAs
 import pint.logging
 
-# setup logging
 pint.logging.setup(level="INFO")
+
+# %% [markdown]
+#
+# We want to load a parameter file and some TOAs. For the purposes of this notebook, we'll load in ones that are included with PINT; the `pint.config.examplefile()` calls return the path to where those files are in the PINT distribution. If you wanted to use your own files, you would probably know their filenames and could just set `parfile="myfile.par"` and `timfile="myfile.tim"`.
 
 # %%
 import pint.config
@@ -37,18 +40,21 @@ import pint.config
 parfile = pint.config.examplefile("NGC6440E.par")
 timfile = pint.config.examplefile("NGC6440E.tim")
 
+# %% [markdown]
+# Let's load the par and tim files. We could load them separately with the `get_model` and `get_TOAs` functions, but the parfile may contain information about how to interpret the TOAs, so it is convenient to load the two together so that the TOAs take into account details in the par file.
+
 # %%
 m, t_all = get_model_and_toas(parfile, timfile)
 m
+
+# %% [markdown]
+# There are many messages here. As a rule messages marked `INFO` can safely be ignored, they are simply informational; take a look at them if something unexpected happens. Messages marked `WARNING` or `ERROR` are more serious. (These messages are emitted by the python `logger` module and can be suppressed or written to a log file if they are annoying.)
 
 # %%
 t_all.print_summary()
 
 # %% [markdown]
-# There are many messages here. As a rule messages marked `INFO` can safely be ignored, they are simply informational; take a look at them if something unexpected happens. Messages marked `WARNING` or `ERROR` are more serious. (These messages are emitted by the python `logger` module and can be suppressed or written to a log file if they are annoying.)
-
-# %% [markdown]
-# Let's discard the data points with uncertainties $>30\,\mu\text{s}$ - uncertainty estimation is not always reliable when the signal-to-noise is low.
+# We could proceed immediately to plotting residuals or fitting the par file, but some of thode uncertainties seem a little large. Let's discard the data points with uncertainties $>30\,\mu\text{s}$ - uncertainty estimation is not always reliable when the signal-to-noise is low.
 
 # %%
 error_ok = t_all.table["error"] <= 30 * u.us
@@ -126,7 +132,3 @@ plt.show()
 # %%
 f.model.write_parfile("/tmp/output.par", "wt")
 print(f.model.as_parfile())
-
-# %%
-
-# %%

--- a/docs/examples/time_a_pulsar.py
+++ b/docs/examples/time_a_pulsar.py
@@ -49,12 +49,24 @@ m
 
 # %% [markdown]
 # There are many messages here. As a rule messages marked `INFO` can safely be ignored, they are simply informational; take a look at them if something unexpected happens. Messages marked `WARNING` or `ERROR` are more serious. (These messages are emitted by the python `logger` module and can be suppressed or written to a log file if they are annoying.)
+#
+# Let's just print out a quick summary.
 
 # %%
 t_all.print_summary()
 
+# %%
+rs = Residuals(t_all, m).phase_resids
+xt = t_all.get_mjds()
+plt.figure()
+plt.plot(xt, rs, "x")
+plt.title("%s Pre-Fit Timing Residuals" % m.PSR.value)
+plt.xlabel("MJD")
+plt.ylabel("Residual (phase)")
+plt.grid()
+
 # %% [markdown]
-# We could proceed immediately to plotting residuals or fitting the par file, but some of thode uncertainties seem a little large. Let's discard the data points with uncertainties $>30\,\mu\text{s}$ - uncertainty estimation is not always reliable when the signal-to-noise is low.
+# We could proceed immediately to fitting the par file, but some of those uncertainties seem a little large. Let's discard the data points with uncertainties $>30\,\mu\text{s}$ - uncertainty estimation is not always reliable when the signal-to-noise is low.
 
 # %%
 error_ok = t_all.table["error"] <= 30 * u.us
@@ -62,7 +74,6 @@ t = t_all[error_ok]
 t.print_summary()
 
 # %%
-# These are pre-fit residuals
 rs = Residuals(t, m).phase_resids
 xt = t.get_mjds()
 plt.figure()
@@ -71,6 +82,9 @@ plt.title("%s Pre-Fit Timing Residuals" % m.PSR.value)
 plt.xlabel("MJD")
 plt.ylabel("Residual (phase)")
 plt.grid()
+
+# %% [markdown]
+# Now let's fit the par file to the residuals.
 
 # %%
 f = pint.fitter.DownhillWLSFitter(t, m)

--- a/docs/examples/time_a_pulsar.py
+++ b/docs/examples/time_a_pulsar.py
@@ -84,10 +84,10 @@ plt.ylabel("Residual (phase)")
 plt.grid()
 
 # %% [markdown]
-# Now let's fit the par file to the residuals.
+# Now let's fit the par file to the residuals, using the `auto` function to pick the right fitter for our data.
 
 # %%
-f = pint.fitter.DownhillWLSFitter(t, m)
+f = pint.fitter.Fitter.auto(t, m)
 f.fit_toas()
 
 # %%

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -10,9 +10,11 @@ to use PINT. Please feel free to change this by writing more.
 .. toctree::
 
    installation
+   user-questions
+   common-timing-workflow
+   simple-python-pint-tools
    contributing
    development-setup
    editing-documentation
    working-with-notebooks
    controlling-logging
-   user-questions

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -15,3 +15,4 @@ to use PINT. Please feel free to change this by writing more.
    editing-documentation
    working-with-notebooks
    controlling-logging
+   user-questions

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -3,9 +3,9 @@
 How-tos
 =======
 
-This section is to provide detailed solutions to particular problems. In these
-early days, I'm afraid more are about how to contribute to PINT than about how
-to use PINT. Please feel free to change this by writing more.
+This section is to provide detailed solutions to particular problems.
+Some of these are based on user questions, others are more about how to develop PINT.
+Please feel free to change this by writing more; there are also some entries on the `PINT wiki <https://github.com/nanograv/PINT/wiki/How-To>`_ which you can contribute to more directly.
 
 .. toctree::
 

--- a/docs/simple-python-pint-tools.rst
+++ b/docs/simple-python-pint-tools.rst
@@ -1,0 +1,202 @@
+
+How to: Simple python PINT tools
+================================
+
+(This was originally posted by Alex McEwen to the PINT wiki.)
+
+Below are several tools I use for new pulsar timing, including cleaning TOAs, adding wraps, and fitting parameters. Please send suggestions/comments/questions to aemcewen@uwm.edu.
+
+Load various packages as well as some little convenience functions::
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+    import pint.residuals as res
+    import copy
+    from pint.models import BinaryELL1, BinaryDD, PhaseJump, parameter, get_model
+    from pint.simulation import make_fake_toas_uniform as mft
+    from astropy import units as u, constants as c
+    def dot(l1,l2):
+        return np.array([v1 and v2 for v1,v2 in zip(l1,l2)])
+    def inv(l):
+        return np.array([not i for i in l])
+
+Zapping TOAs on given MJDs, before/after some MJD, or within a window of days::
+
+    def mask_toas(toas,before=None,after=None,on=None,window=None):
+        cnd=np.array([True for t in toas.get_mjds()])
+        if before is not None:
+            cnd = dot(cnd,toas.get_mjds().value > before)
+        if after is not None:
+            cnd = dot(cnd,toas.get_mjds().value < after)
+        if on is not None:
+            on=np.array(on)
+            for i,m in enumerate(on):
+                m=m*u.day
+                if type(m) is int:
+                    cnd = dot(cnd,inv(np.abs(toas.get_mjds()-m).astype(int) == np.abs((toas.get_mjds()-m)).min().astype(int)))
+                else:
+                    cnd = dot(cnd,inv(np.abs(toas.get_mjds()-m) == np.abs((toas.get_mjds()-m)).min()))
+        if window is not None:
+            if len(window)!=2:
+                raise ValueError("window must be a 2 element list/array")
+            window = window*u.day
+            lower = window[0]
+            upper = window[1]
+            cnd = dot(cnd,toas.get_mjds() < lower)+dot(cnd,toas.get_mjds() > upper)
+        print(f'{sum(cnd)}/{len(cnd)} TOAs selected')
+        return toas[cnd]
+
+Add in integer phase wraps on a given MJD::
+
+    def add_wraps(toas,mjd,sign,nwrap=1):
+        cnd = toas.table['mjd'] > Time(mjd,scale='utc',format='mjd')
+        if sign == '-':
+            toas.table['pulse_number'][cnd] -= nwrap
+        elif sign == '+':
+            toas.table['pulse_number'][cnd] += nwrap
+        else:
+            raise TypeError('sign must be "+" or "-"')
+
+Plot residuals in phase::
+
+    def plot_fit(toas,model,track_mode="use_pulse_numbers",title=None,xlim=None,ylim=None):
+        rs=res.Residuals(toas,model,track_mode=track_mode)
+        fig, ax = plt.subplots(figsize=(12,10))
+        if xlim is not None:
+            ax.set_xlim(xlim)
+        if ylim is not None:
+            ax.set_ylim(ylim)
+        ax.errorbar(rs.toas.get_mjds().value,rs.calc_phase_resids(), \
+                     yerr=(rs.toas.get_errors()*model.F0.quantity).decompose().value,fmt='x')
+        ax.tick_params(labelsize=15)
+
+        if title is None:
+            ax.set_title('%s Residuals, %s toas' %(model.PSR.value,len(toas.get_mjds())),fontsize=18)
+        else:
+            ax.set_title(title,fontsize=18)
+        ax.set_xlabel('MJD',fontsize=15)
+        ax.set_ylabel(f'Residuals [phase, P0 = {((1/model.F0.quantity).to(u.ms)).value:2.0f} ms]',fontsize=15)
+        ax.grid()
+        return fig, ax
+
+Model phase uncertainty over a range of MJDs::
+
+    def calculate_phase_uncertainties(model, MJDmin, MJDmax, Nmodels=100, params = 'all', error=1*u.us):
+        mjds = np.arange(MJDmin,MJDmax)
+        Nmjd = len(mjds)
+        phases_i = np.zeros((Nmodels,Nmjd))
+        phases_f = np.zeros((Nmodels, Nmjd))
+        tnew = mft(MJDmin,MJDmax,Nmjd,model=model, error=error)
+        pnew = {}
+        if params == 'all':
+            params = model.free_params
+        for p in params:
+            pnew[p] = getattr(model,p).quantity + np.random.normal(size=Nmodels) * getattr(model,p).uncertainty
+        for imodel in range(Nmodels):
+            m2 = copy.deepcopy(model)
+            for p in params:
+                getattr(m2,p).quantity=pnew[p][imodel]
+            phase = m2.phase(tnew, abs_phase=True)
+            phases_i[imodel] = phase.int
+            phases_f[imodel] = phase.frac
+        phases = phases_i+ phases_f
+        phases0 = model.phase(tnew, abs_phase = True)
+        dphase = phases - (phases0.int + phases0.frac)
+        return tnew, dphase
+
+Plot the phase uncertainty from calculate_phase_uncertainties()::
+
+    def plot_phase_unc(model,start,end,params='all'):
+        if params == 'all':
+            print("calculating phase uncertainty due to all parameters")
+            plab = 'All params'
+            t, dp = calculate_phase_uncertainties(model, start, end)
+        else:
+            if type(params) is list:
+                print("calculating phase uncertainty due to params "+str(params))
+                plab = str(params)
+                t, dp = calculate_phase_uncertainties(model, start, end, params = params)
+            else:
+                raise TypeError('"params" should be either list or "all"')
+
+        plt.gcf().set_size_inches(12,10)
+        plt.plot(t.get_mjds(),dp.std(axis=0),'.',label=plab)
+        dt = t.get_mjds() - model.PEPOCH.value*u.d
+        plt.plot(t.get_mjds(), np.sqrt((model.F0.uncertainty * dt)**2 + (0.5*model.F1.uncertainty*dt**2)**2).decompose(),label='Analytic')
+        plt.xlabel('MJD')
+        plt.ylabel('Phase Uncertainty (cycles)')
+        plt.legend()
+
+Less common tools
+-----------------
+
+Plot frequency against residuals::
+
+    rs=res.Residuals(newtoas,f.model)
+    fig,ax = plt.subplots(figsize=(12,10))
+    ax.tick_params(labelsize=15)
+    ax.set_ylabel('Frequency [MHz]',fontsize=18)
+    ax.set_xlabel('Phase residuals',fontsize=18)
+
+    y = newtoas.get_freqs().to('MHz').value
+    x = rs.calc_phase_resids()
+
+    ax.errorbar(x,y,xerr=newtoas.get_errors().to('s').value*f.model.F0.value,elinewidth=2,lw=0,marker='+')
+
+Plot residuals in orbital phase::
+
+    x = f.model.orbital_phase(newtoas.get_mjds()).value
+    rs=res.Residuals(newtoas,f.model)
+    y = rs.calc_phase_resids()
+
+    fig, ax = plt.subplots(figsize=(12,10))
+    ax.tick_params(labelsize=15)
+    ax.set_xlabel('Orbital Phase',fontsize=18)
+    ax.set_ylabel('Phase Residuals',fontsize=18)
+    ax.grid()
+    for mjd in np.unique(newtoas.get_mjds().astype(int)):
+        cnd = dot(newtoas.get_mjds().astype(int) == mjd,newtoas.get_errors().astype(int) <= 125*u.us)
+        ax.errorbar(x[cnd],y[cnd],yerr=(newtoas.get_errors().to('s')*f.model.F0.quantity).value[cnd],elinewidth=2,lw=0,marker='+',label=mjd.value)
+
+
+    ax.legend(fontsize=15)
+
+Removing/adding binary components::
+
+    if 'BinaryELL1' in model.components:
+        model.remove_component('BinaryELL1')
+
+    cmp = BinaryELL1()
+    cmp.PB.value = 10
+    cmp.EPS1.value = 1e-5
+    cmp.EPS2.value = 1e-5
+    cmp.TASC.value = 59200
+    cmp.A1.value = 10
+
+    model.add_component(cmp,setup=True)
+
+
+    cmp = BinaryDD()
+    cmp.PB.value = 10
+    cmp.ECC.value = 0.8
+    cmp.T0.value = 59251.
+    cmp.OM.value = 269.
+    cmp.A1.value = 136.9
+
+    model.add_component(cmp,setup=True)
+
+Add spin-down component of a given order::
+
+    n = 2
+    model.components['Spindown'].add_param(
+        parameter.prefixParameter(
+            name='F'+str(n),
+            value=0.0,
+            units=u.Hz/u.s**n,
+            frozen=False,
+            parameter_type="float",
+            longdouble=True
+        ),
+        setup=True
+    )
+    model.components['Spindown'].validate()

--- a/docs/user-questions.rst
+++ b/docs/user-questions.rst
@@ -206,11 +206,9 @@ See :class:`pint.models.parameter.maskParameter` documentation on the ways to se
 Choose a fitter
 ---------------
 
-See :mod:`pint.fitter` documentation, but to summarize:
+Use :func:`pint.fitter.Fitter.auto`::
 
-- If you have wideband data, :class:`pint.fitter.WidebandDownhillFitter`
-- If you have narrowband data with red noise or ECORRs, :class:`pint.fitter.DownhillGLSFitter`
-- If you have narrowband data with neither red noise nor ECORRs, :class:`pint.fitter.DownhillWLSFitter`
+    f = pint.fitter.Fitter.auto(toas, model)
 
 Include logging in a script
 ---------------------------

--- a/docs/user-questions.rst
+++ b/docs/user-questions.rst
@@ -1,0 +1,247 @@
+.. highlight:: shell
+.. _user-questions:
+
+How to do a number of things users have asked about
+===================================================
+
+Quick solutions to common tasks (taken from #pint and elsewhere)
+
+How to upgrade PINT
+-------------------
+
+With ``pip``::
+
+    pip install -U pint-pulsar
+
+With ``conda``::
+
+    conda update pint-pulsar
+
+
+How to go to a specific version of PINT
+---------------------------------------
+
+With ``pip``::
+
+    pip install -U pint-pulsar==0.8.4
+
+or similar.
+
+With ``conda``::
+
+    conda install pint-pulsar=0.8.4
+
+or similar.
+
+Find data files for testing/tutorials
+-------------------------------------
+
+.. highlight:: python
+
+The data files (par and tim) associated with the tutorials and other examples
+can be located via :func:`pint.config.examplefile` (available via the
+:mod:`pint.config` module)::
+
+    import pint.config
+    fullfilename = pint.config.examplefile(filename)
+
+For example, the file ``NGC6440E.par`` from the `Time a Pulsar <https://nanograv-pint.readthedocs.io/en/latest/examples/time_a_pulsar.html>`_ notebook can be found via::
+
+    import pint
+    fullfilename = pint.config.examplefile("NGC6440E.par")
+
+
+Load a par file
+---------------
+
+To load a par file::
+
+    from pint.models import get_model
+    m = get_model(parfile)
+
+
+Load a tim file
+---------------
+
+To load a tim file::
+
+    from pint.toa import get_TOAs
+    t = get_TOAs(timfile)
+
+Note that a par file may contain information, like which solar system ephemeris to use, that affects how a tim file should be loaded::
+
+    t = get_TOAs(timfile, model=model)
+
+Load a tim and par file together
+--------------------------------
+
+To load both::
+
+    from pint.models import get_model_and_toas
+    m, t = get_model_and_toas(parfile, timfile)
+
+
+Get the red noise basis functions and the corresponding coefficients out of a PINT fitter object
+------------------------------------------------------------------------------------------------
+
+...?
+
+Select TOAs
+-----------
+
+You can index by column name into the TOAs object, so you can do ``toas["observatory"]`` or whatever the column is called; and that's an array, so you can do ``toas["observatory"]=="arecibo"`` to get a Boolean array; and you can index with boolean arrays, so you can do ``toas[toas["observatory"]=="arecibo"]`` to get a new TOAs object referencing a subset.
+
+Modify TOAs
+-----------
+
+The TOAs have a table with ``mjd``, ``mjd_float``, ``tdb``, and ``tdbld`` columns.  To modify them all safely and consistently the best way is to use::
+
+    t.adjust_TOAs(dt)
+
+where ``dt`` is an :class:`astropy.time.TimeDelta` object.  This function does not
+change the pulse numbers column, if present, but does recompute ``mjd_float``,
+the TDB times, and the observatory positions and velocities.
+
+
+Avoid "KeyError: 'obs_jupiter_pos' error when trying to grab residuals?"
+------------------------------------------------------------------------
+
+You need to have the TOAs object compute the positions of the planets and add them to the table::
+
+    ts.compute_posvels(ephem,planets=True)
+
+This should be done automatically if you load your TOAs with the
+:func:`pint.toa.get_TOAs`  or
+:func:`pint.models.model_builder.get_model_and_toas`
+
+Convert from ELAT/ELONG <-> RA/DEC if I have a timing model
+-----------------------------------------------------------
+
+If ``model`` is in ecliptic coordinates::
+
+    model.as_ICRS(epoch=epoch)
+
+which will give it to you as a model with
+:class:`pint.models.astrometry.AstrometryEquatorial` components at the
+requested epoch. Similarly::
+
+    model.as_ECL(epoch=epoch)
+
+does the same for :class:`pint.models.astrometry.AstrometryEcliptic` (with an
+optional specification of the obliquity).
+
+
+Add a jump programmatically
+---------------------------
+
+``PINT`` can handle jumps in the model outside a ``par`` file.  An example is::
+
+    import numpy as np
+    from astropy import units as u, constants as c
+    from pint.models import get_model, get_model_and_toas, parameter
+    from pint import fitter
+    from pint.models import PhaseJump
+    import pint.config
+
+    m, t = get_model_and_toas(pint.config.examplefile("NGC6440E.par"),
+                              pint.config.examplefile("NGC6440E.tim"))
+
+    # fit the nominal model
+    f = fitter.WLSFitter(toas=t, model=m)
+    f.fit_toas()
+
+    # group TOAs: find clusters with gaps of <2h
+    clusters = t.get_clusters(add_column=True)
+
+    # put in the pulse numbers based on the previous fit
+    t.compute_pulse_numbers(f.model)
+    # just for a test, add an offset to a set of TOAs
+    t['delta_pulse_number'][clusters==3]+=3
+
+    # now fit without a jump
+    fnojump = fitter.WLSFitter(toas=t, model=m, track_mode="use_pulse_numbers")
+    fnojump.fit_toas()
+
+
+    # add the Jump Component to the model
+    m.add_component(PhaseJump(), validate=False)
+
+    # now add the actual jump
+    # it can be keyed on any parameter that maskParameter will accept
+    # here we will use a range of MJDs
+    par = parameter.maskParameter(
+        "JUMP",
+        key="mjd",
+        value=0.0,
+        key_value=[t[clusters==3].get_mjds().min().value,
+                   t[clusters==3].get_mjds().max().value],
+        units=u.s,
+        frozen=False,
+        )
+    m.components['PhaseJump'].add_param(par, setup=True)
+
+    # you can also do it indirectly through the flags as:
+    # m.components["PhaseJump"].add_jump_and_flags(t.table["flags"][clusters == 3])
+
+    # and fit with a jump
+    fjump = fitter.WLSFitter(toas=t, model=m, track_mode="use_pulse_numbers")
+    fjump.fit_toas()
+
+    print(f"Original chi^2 = {f.resids.calc_chi2():.2f} for {f.resids.dof} DOF")
+    print(f"After adding 3 rotations to some TOAs, chi^2 = {fnojump.resids.calc_chi2():.2f} for {fnojump.resids.dof} DOF")
+    print(f"Then after adding a jump to those TOAs, chi^2 = {fjump.resids.calc_chi2():.2f} for {fjump.resids.dof} DOF")
+    print(f"Best-fit value of the jump is {fjump.model.JUMP1.quantity} +/- {fjump.model.JUMP1.uncertainty} ({(fjump.model.JUMP1.quantity*fjump.model.F0.quantity).decompose():.3f} +/- {(fjump.model.JUMP1.uncertainty*fjump.model.F0.quantity).decompose():.3f} rotations)")
+
+which returns::
+
+    Original chi^2 = 59.57 for 56 DOF
+    After adding 3 rotations to some TOAs, chi^2 = 19136746.30 for 56 DOF
+    Then after adding a jump to those TOAs, chi^2 = 56.60 for 55 DOF
+    Best-fit value of the jump is -0.048772786677935796 s +/- 1.114921182802775e-05 s (-2.999 +/- 0.001 rotations)
+
+showing that the offset we applied has been absorbed by the jump (plus a little extra, so chi^2 has actually improved).
+
+See :class:`pint.models.parameter.maskParameter` documentation on the ways to select the TOAs.
+
+Choose a fitter
+---------------
+
+See :mod:`pint.fitter` documentation, but to summarize:
+
+- If you have wideband data, :class:`pint.fitter.WidebandDownhillFitter`
+- If you have narrowband data with red noise or ECORRs, :class:`pint.fitter.DownhillGLSFitter`
+- If you have narrowband data with neither red noise nor ECORRs, :class:`pint.fitter.DownhillWLSFitter`
+
+Include logging in a script
+---------------------------
+
+PINT now uses `loguru <https://github.com/Delgan/loguru>`_ for its logging.  To get this working within a script, try::
+
+    import pint.logging
+    from loguru import logger as log
+
+    pint.logging.setup(sink=sys.stderr, level="WARNING", usecolors=True)
+
+That sets up the logging and ensures it will play nicely with the rest of PINT.
+You can customize the level, the destination (e.g., file, ``stderr``, ...) and
+format.  The :class:`pint.logging.LogFilter`
+suppresses some INFO/DEBUG messages that can clog up your screen: you can make
+a custom filter as well to add/remove messages.
+
+If you want to include a standard way to control the level using command line arguments, you can do::
+
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        choices=("TRACE", "DEBUG", "INFO", "WARNING", "ERROR"),
+        default=pint.logging.script_level,
+        help="Logging level",
+        dest="loglevel",
+    )
+    ...
+    pint.logging.setup(level=args.loglevel, ...)
+
+assuming you are using ``argparse``.  Note that ``loguru`` doesn't let you
+change existing loggers: you should just remove and add (which the
+:func:`pint.logging.setup` function does).
+


### PR DESCRIPTION
This adds a Howto page to our docs to cover what's currently on https://github.com/nanograv/PINT/wiki/How-To . Additional content from the wiki might should be migrated into the docs. 

The doc page added by the PR is here: https://nanograv-pint--1311.org.readthedocs.build/en/1311/user-questions.html