### PR TITLE
Remove obsolete super() syntax

### DIFF
--- a/src/pint/mcmc_fitter.py
+++ b/src/pint/mcmc_fitter.py
@@ -139,9 +139,7 @@ class MCMCFitter(Fitter):
     """
 
     def __init__(self, toas, model, sampler, **kwargs):
-        super(MCMCFitter, self).__init__(
-            toas, model, track_mode=kwargs.get("track_mode", None)
-        )
+        super().__init__(toas, model, track_mode=kwargs.get("track_mode", None))
         self.toas = toas
         self.model_init = model
         self.use_resids = kwargs.get("resids", True)
@@ -451,7 +449,7 @@ class MCMCFitterBinnedTemplate(MCMCFitter):
     """
 
     def __init__(self, toas, model, sampler, **kwargs):
-        super(MCMCFitterBinnedTemplate, self).__init__(toas, model, sampler, **kwargs)
+        super().__init__(toas, model, sampler, **kwargs)
 
     def set_template(self, template):
         """
@@ -495,9 +493,7 @@ class MCMCFitterAnalyticTemplate(MCMCFitter):
     """
 
     def __init__(self, toas, model, sampler, template, **kwargs):
-        super(MCMCFitterAnalyticTemplate, self).__init__(
-            toas, model, sampler, template=template, **kwargs
-        )
+        super().__init__(toas, model, sampler, template=template, **kwargs)
 
     def set_template(self, template):
         """

--- a/src/pint/models/absolute_phase.py
+++ b/src/pint/models/absolute_phase.py
@@ -27,7 +27,7 @@ class AbsPhase(PhaseComponent):
     category = "absolute_phase"
 
     def __init__(self):
-        super(AbsPhase, self).__init__()
+        super().__init__()
         self.add_param(
             MJDParameter(
                 name="TZRMJD", description="Epoch of the zero phase.", time_scale="utc"
@@ -48,10 +48,10 @@ class AbsPhase(PhaseComponent):
         self.tz_cache = None
 
     def setup(self):
-        super(AbsPhase, self).setup()
+        super().setup()
 
     def validate(self):
-        super(AbsPhase, self).validate()
+        super().validate()
         # Make sure the cached TOA is cleared
         self.tz_cache = None
         # Check input Parameters

--- a/src/pint/models/binary_dd.py
+++ b/src/pint/models/binary_dd.py
@@ -29,7 +29,7 @@ class BinaryDD(PulsarBinary):
     def __init__(
         self,
     ):
-        super(BinaryDD, self).__init__()
+        super().__init__()
         self.binary_model_name = "DD"
         self.binary_model_class = DDmodel
         self.add_param(

--- a/src/pint/models/binary_ddk.py
+++ b/src/pint/models/binary_ddk.py
@@ -69,7 +69,7 @@ class BinaryDDK(BinaryDD):
     def __init__(
         self,
     ):
-        super(BinaryDDK, self).__init__()
+        super().__init__()
         self.binary_model_name = "DDK"
         self.binary_model_class = DDKmodel
 

--- a/src/pint/models/priors.py
+++ b/src/pint/models/priors.py
@@ -80,7 +80,7 @@ class RandomInclinationPrior(rv_continuous):
     def __init__(self, **kwargs):
         kwargs["a"] = 0
         kwargs["b"] = 1
-        super(RandomInclinationPrior, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def _pdf(self, v):
         return v / (1 - v**2) ** 0.5

--- a/src/pint/models/solar_system_shapiro.py
+++ b/src/pint/models/solar_system_shapiro.py
@@ -33,7 +33,7 @@ class SolarSystemShapiro(DelayComponent):
     category = "solar_system_shapiro"
 
     def __init__(self):
-        super(SolarSystemShapiro, self).__init__()
+        super().__init__()
         self.add_param(
             boolParameter(
                 name="PLANET_SHAPIRO",
@@ -42,12 +42,6 @@ class SolarSystemShapiro(DelayComponent):
             )
         )
         self.delay_funcs_component += [self.solar_system_shapiro_delay]
-
-    def setup(self):
-        super(SolarSystemShapiro, self).setup()
-
-    def validate(self):
-        super(SolarSystemShapiro, self).validate()
 
     # Put masses in a convenient dictionary
     _ss_mass_sec = {

--- a/src/pint/models/stand_alone_psr_binaries/BT_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/BT_model.py
@@ -81,7 +81,7 @@ class BTmodel(PSR_BINARY):
     """
 
     def __init__(self, t=None, input_params=None):
-        super(BTmodel, self).__init__()
+        super().__init__()
         self.binary_name = "BT"
         self.binary_params = list(self.param_default_value.keys())
         self.set_param_values()  # Set parameters to default values.

--- a/src/pint/models/stand_alone_psr_binaries/DDK_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/DDK_model.py
@@ -55,7 +55,7 @@ class DDKmodel(DDmodel):
     """
 
     def __init__(self, t=None, input_params=None):
-        super(DDKmodel, self).__init__()
+        super().__init__()
         self.binary_name = "DDK"
         # Add parameter that specific for DD model, with default value and units
         self.param_default_value.update(
@@ -553,7 +553,7 @@ class DDKmodel(DDmodel):
         parallax: boolean, optional, default True
             Flag for parallax correction
         """
-        a1 = super(DDKmodel, self).a1()
+        a1 = super().a1()
         corr_funs = [self.delta_a1_proper_motion, self.delta_a1_parallax]
         mask = [proper_motion, parallax]
         for ii, cf in enumerate(corr_funs):
@@ -568,7 +568,7 @@ class DDKmodel(DDmodel):
             return self.a1_k(proper_motion=False)
 
     def d_a1_k_d_par(self, par, proper_motion=True, parallax=True):
-        result = super(DDKmodel, self).d_a1_d_par(par)
+        result = super().d_a1_d_par(par)
         ko_func_name = ["d_delta_a1_proper_motion_d_", "d_delta_a1_parallax_d_"]
         for ii, flag in enumerate([proper_motion, parallax]):
             if flag:
@@ -595,7 +595,7 @@ class DDKmodel(DDmodel):
         parallax: boolean, optional, default True
             Flag for parallax correction
         """
-        omega = super(DDKmodel, self).omega()
+        omega = super().omega()
         corr_funs = [self.delta_omega_proper_motion, self.delta_omega_parallax]
         mask = [proper_motion, parallax]
         for ii, cf in enumerate(corr_funs):
@@ -610,7 +610,7 @@ class DDKmodel(DDmodel):
             return self.omega_k(proper_motion=False)
 
     def d_omega_k_d_par(self, par, proper_motion=True, parallax=True):
-        result = super(DDKmodel, self).d_omega_d_par(par)
+        result = super().d_omega_d_par(par)
         ko_func_name = ["d_delta_omega_proper_motion_d_", "d_delta_omega_parallax_d_"]
         for ii, flag in enumerate([proper_motion, parallax]):
             if flag:

--- a/src/pint/models/stand_alone_psr_binaries/DD_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/DD_model.py
@@ -33,7 +33,7 @@ class DDmodel(PSR_BINARY):
     """
 
     def __init__(self, t=None, input_params=None):
-        super(DDmodel, self).__init__()
+        super().__init__()
         self.binary_name = "DD"
         # Add parameter that specific for DD model, with default value and units
         self.param_default_value.update(

--- a/src/pint/models/stand_alone_psr_binaries/ELL1H_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/ELL1H_model.py
@@ -25,7 +25,7 @@ class ELL1Hmodel(ELL1BaseModel):
     """
 
     def __init__(self):
-        super(ELL1Hmodel, self).__init__()
+        super().__init__()
         self.binary_name = "ELL1H"
         self.param_default_value.update(
             {

--- a/src/pint/models/stand_alone_psr_binaries/ELL1_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/ELL1_model.py
@@ -17,7 +17,7 @@ class ELL1BaseModel(PSR_BINARY):
     """
 
     def __init__(self):
-        super(ELL1BaseModel, self).__init__()
+        super().__init__()
         self.binary_name = "ELL1Base"
         self.param_default_value.update(
             {
@@ -374,7 +374,7 @@ class ELL1model(ELL1BaseModel):
     """This is a ELL1 model using M2 and SINI as the Shapiro delay parameters."""
 
     def __init__(self):
-        super(ELL1model, self).__init__()
+        super().__init__()
         self.binary_name = "ELL1"
         self.binary_delay_funcs = [self.ELL1delay]
         self.d_binarydelay_d_par_funcs = [self.d_ELL1delay_d_par]

--- a/src/pint/models/stand_alone_psr_binaries/binary_generic.py
+++ b/src/pint/models/stand_alone_psr_binaries/binary_generic.py
@@ -36,7 +36,7 @@ class PSR_BINARY:
         >>> class foo(PSR_BINARY):
                 def __init__(self):
                     # This is to initialize the mother class attributes.
-                    super(foo, self).__init__()
+                    super().__init__()
                     self.binary_name = 'foo'
                     # Add parameter that specific for my_binary, with default value and units
                     self.param_default_value.update({'A0':0*u.second,'B0':0*u.second,

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -2468,7 +2468,7 @@ class ModelMeta(abc.ABCMeta):
         super().__init__(name, bases, dct)
 
 
-class Component(object, metaclass=ModelMeta):
+class Component(metaclass=ModelMeta):
     """Timing model components.
 
     When such a class is defined, it registers itself in

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -2465,7 +2465,7 @@ class ModelMeta(abc.ABCMeta):
         if "register" in dct:
             if cls.register:
                 getattr(cls, regname)[name] = cls
-        super(ModelMeta, cls).__init__(name, bases, dct)
+        super().__init__(name, bases, dct)
 
 
 class Component(object, metaclass=ModelMeta):
@@ -2863,13 +2863,13 @@ class Component(object, metaclass=ModelMeta):
 
 class DelayComponent(Component):
     def __init__(self):
-        super(DelayComponent, self).__init__()
+        super().__init__()
         self.delay_funcs_component = []
 
 
 class PhaseComponent(Component):
     def __init__(self):
-        super(PhaseComponent, self).__init__()
+        super().__init__()
         self.phase_funcs_component = []
         self.phase_derivs_wrt_delay = []
 
@@ -3199,7 +3199,7 @@ class MissingParameter(TimingModelError):
     """
 
     def __init__(self, module, param, msg=None):
-        super(MissingParameter, self).__init__(msg)
+        super().__init__(msg)
         self.module = module
         self.param = param
         self.msg = msg

--- a/src/pint/models/wave.py
+++ b/src/pint/models/wave.py
@@ -27,7 +27,7 @@ class Wave(PhaseComponent):
     category = "wave"
 
     def __init__(self):
-        super(Wave, self).__init__()
+        super().__init__()
 
         self.add_param(
             floatParameter(
@@ -56,12 +56,12 @@ class Wave(PhaseComponent):
         self.phase_funcs_component += [self.wave_phase]
 
     def setup(self):
-        super(Wave, self).setup()
+        super().setup()
         self.wave_terms = list(self.get_prefix_mapping_component("WAVE").keys())
         self.num_wave_terms = len(self.wave_terms)
 
     def validate(self):
-        super(Wave, self).validate()
+        super().validate()
         self.setup()
         if self.WAVEEPOCH.quantity is None:
             if self.PEPOCH.quantity is None:

--- a/src/pint/phase.py
+++ b/src/pint/phase.py
@@ -68,7 +68,7 @@ class Phase(namedtuple("Phase", "int frac")):
         index = ff >= 0.5
         ff[index] -= 1.0
         ii[index] += 1
-        return super(Phase, cls).__new__(cls, ii, ff)
+        return super().__new__(cls, ii, ff)
 
     def __neg__(self):
         # TODO: add type check for __neg__ and __add__

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -343,7 +343,7 @@ class DesignMatrix(PintMatrix):
     """
 
     def __init__(self, matrix, labels):
-        super(DesignMatrix, self).__init__(matrix, labels)
+        super().__init__(matrix, labels)
 
     @property
     def param_units(self):
@@ -689,7 +689,7 @@ class CovarianceMatrix(PintMatrix):
         # Check if the labels are symmetric
         if len(labels[0]) != len(labels[1]):
             raise ValueError("The input labels are not symmetric.")
-        super(CovarianceMatrix, self).__init__(matrix, labels)
+        super().__init__(matrix, labels)
 
     def _colorize_from_value(self, x, base):
         """Return color setting/un-setting codes

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -106,7 +106,7 @@ class State:
     pass
 
 
-class CreateToolTip(object):
+class CreateToolTip:
     """
     create a tooltip for a given widget
 

--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -62,7 +62,7 @@ class Pulsar:
     """
 
     def __init__(self, parfile=None, timfile=None, ephem=None, fitter="GLSFitter"):
-        super(Pulsar, self).__init__()
+        super().__init__()
 
         log.info(f"Loading pulsar parfile: {str(parfile)}")
 

--- a/src/pint/pulsar_ecliptic.py
+++ b/src/pint/pulsar_ecliptic.py
@@ -77,7 +77,7 @@ class PulsarEcliptic(coord.BaseCoordinateFrame):
                 )
             del kwargs["ecl"]
 
-        super(PulsarEcliptic, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 def _ecliptic_rotation_matrix_pulsar(obl):

--- a/src/pint/sampler.py
+++ b/src/pint/sampler.py
@@ -67,7 +67,7 @@ class EmceeSampler(MCMCSampler):
     """
 
     def __init__(self, nwalkers):
-        super(EmceeSampler, self).__init__()
+        super().__init__()
         self.method = "Emcee"
         self.nwalkers = nwalkers
         self.sampler = None

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -44,7 +44,7 @@ class custom_timing(
     pint.models.spindown.Spindown, pint.models.astrometry.AstrometryEcliptic
 ):
     def __init__(self, parfile):
-        super(custom_timing, self).__init__()
+        super().__init__()
         self.read_parfile(parfile)
 
 
@@ -259,7 +259,7 @@ class emcee_fitter(Fitter):
     def __init__(
         self, toas=None, model=None, template=None, weights=None, phs=0.5, phserr=0.03
     ):
-        # super(emcee_fitter, self).__init__(model=model, toas=toas)
+        # super().__init__(model=model, toas=toas)
         self.toas = toas
         self.model = model
         self.template = template

--- a/src/pint/templates/lctemplate.py
+++ b/src/pint/templates/lctemplate.py
@@ -776,7 +776,7 @@ class LCBridgeTemplate(LCTemplate):
         """
         if norms is None:
             norms = np.ones(len(primitives) + 1) / (len(primitives + 1))
-        super(LCBridgeTemplate, self).__init__(primitives, norms)
+        super().__init__(primitives, norms)
         self.p1 = self.primitives[-2]
         self.p2 = self.primitives[-1]
 
@@ -835,7 +835,7 @@ class LCBridgeTemplate(LCTemplate):
         raise NotImplementedError()
 
     def __str__(self):
-        s = super(LCBridgeTemplate, self).__str__()
+        s = super().__str__()
         return "TODO: Add pedestal stuff! \n\n" + s
         # prims = self.primitives
         # s0 = str(self.norms)


### PR DESCRIPTION
The presence of `super(ClassName, self)` is a holdover from Python 2. Its presence in our code misleads new people into thinking that's how you do it. This PR removes all of those. 