### PR TITLE
Change update frequency for index.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project, at least loosely, adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- index.txt is only checked at most once a day
+### Added
+### Fixed
+
 ## [0.9.0] 2022-06-24
 ### Changed
 - `model.phase()` now defaults to `abs_phase=True` when TZR* params are in the model

--- a/src/pint/observatory/global_clock_corrections.py
+++ b/src/pint/observatory/global_clock_corrections.py
@@ -31,8 +31,9 @@ global_clock_correction_url_base = (
 # checked.
 global_clock_correction_url_mirrors = [global_clock_correction_url_base]
 
+# PINT will check the index if it is more than this old
 index_name = "index.txt"
-index_update_interval_days = 0.01
+index_update_interval_days = 1
 
 
 def get_file(


### PR DESCRIPTION
`index.txt` must be checked to see what global clock corrections are available, whether old versions have been flagged as invalid, and how often other files should be checked for updates. That happens only if it is older than a certain amount. This amount was set to just a couple of minutes in the early stages of testing, but this PR sets it to 1 day. Longer would probably be fine.

`index.txt` is a small file but if one has a flaky net connection getting it can be slow and annoying. 