### PR TITLE
Fix Parkes/Tempo2 parsing confusion

### DIFF
--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -446,7 +446,12 @@ def _toa_format(line, fmt="Unknown"):
         return "Command"
     elif re.match(r"^\s*$", line):  # FIXME: what about empty lines?
         return "Blank"
-    elif re.match(r"^ ", line) and len(line) > 41 and line[41] == ".":
+    elif (
+        re.match(r"^ ", line)
+        and len(line) > 41
+        and line[41] == "."
+        and not fmt == "Tempo2"
+    ):
         return "Parkes"
     elif len(line) > 80 or fmt == "Tempo2":
         return "Tempo2"


### PR DESCRIPTION
If TOA lines are supposed to be Tempo2 format but start with a space and have a "." in spot 41, then they may accidentally be parsed as Parkes format.

This tries to fix that.