### PR TITLE
Fix bug #1316

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project, at least loosely, adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+### Added
+### Fixed
+- Ensure Fitters work with ELL1 even on Astropy 4 (bug #1316)
+
 ## [0.9.0] 2022-06-24
 ### Changed
 - `model.phase()` now defaults to `abs_phase=True` when TZR* params are in the model

--- a/tests/test_fitter.py
+++ b/tests/test_fitter.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 import os
+from io import StringIO
 from copy import deepcopy
 
 # import matplotlib
@@ -242,3 +243,26 @@ def test_fitselector():
     assert isinstance(f, fitter.DownhillWLSFitter)
     f = fitter.Fitter.auto(t, m, downhill=False)
     assert isinstance(f, fitter.WLSFitter)
+
+
+def test_unitless_ell1h_bug_1316():
+    m = get_model(
+        StringIO(
+            """
+    PSR J1234+5678
+    ELAT 0
+    ELONG 0
+    PEPOCH 57000
+    F0 1
+    BINARY ELL1
+    PB 1 1
+    A1 4 1
+    TASC 57000 1
+    EPS1 0 1
+    EPS2 0 1
+    """
+        )
+    )
+    t = simulation.make_fake_toas_uniform(56000, 59000, 16, m)
+    f = fitter.Fitter.auto(t, m)
+    f.get_derived_params()

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,7 @@ deps =
     coverage
     hypothesis
     numdifftools
+commands = {posargs:pytest}
 
 [testenv:report]
 skip_install = true


### PR DESCRIPTION
Uses `*u.s/u.s` to fix a problem that arises with `@quantity_input` and Astropy 4.0. Also adds the ability to run custom commands with `tox -e oldestdeps`. 

Closes #1316