### PR TITLE
Split Jodrell observatory based on backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 ### Changed
 - index.txt is only checked at most once a day
 - Moved observatories to JSON file.  Changed way observatories are loaded/overloaded
+- Split Jodrell Bank observatory based on backend to get correct clock files
 ### Added
 ### Fixed
 

--- a/src/pint/data/runtime/observatories.json
+++ b/src/pint/data/runtime/observatories.json
@@ -92,12 +92,21 @@
         "itoa_code": "JB",
         "clock_file": "jb2gps.clk",
         "clock_fmt": "tempo2",
+        "bogus_last_correction": true,
+        "itrf_xyz": [
+            3822625.769,
+            -154105.255,
+            5086486.256
+        ],
+        "origin": "The Lovell telescope at Jodrell Bank.\nThese are the coordinates used for VLBI as of March 2020 (MJD 58919). They are based on\na fiducial position at MJD 50449 plus a (continental) drift velocity of\n[-0.0117, 0.0170, 0.0093] m/yr. This data was obtained from Ben Perera in September 2021.\nNote that any actual instrument - DFB, Roach, AFB - requires a different observatory code to obtain the correct clock files."
+    },
+    "jbroach": {
+        "clock_file": [
+            "jbroach2jb.clk",
+            "jb2gps.clk"
+        ],
+        "clock_fmt": "tempo2",
         "aliases": [
-            "jbdfb",
-            "jbroach",
-            "jbafb",
-            "jbodfb",
-            "jboafb",
             "jboroach"
         ],
         "bogus_last_correction": true,
@@ -106,7 +115,56 @@
             -154105.255,
             5086486.256
         ],
-        "origin": "The Lovell telescope at Jodrell Bank.\nThese are the coordinates used for VLBI as of March 2020 (MJD 58919). They are based on\na fiducial position at MJD 50449 plus a (continental) drift velocity of\n[-0.0117, 0.0170, 0.0093] m/yr. This data was obtained from Ben Perera in September 2021.\n"
+        "origin": [
+            "The Lovell telescope at Jodrell Bank.",
+            "These are the coordinates used for VLBI as of March 2020 (MJD 58919). They are based on",
+            "a fiducial position at MJD 50449 plus a (continental) drift velocity of",
+            "[-0.0117, 0.0170, 0.0093] m/yr. This data was obtained from Ben Perera in September 2021.",
+            "This data is for the Roach instrument - a different clock file is required for this instrument to accommodate recorded instrumental delays."
+        ]
+    },
+    "jbdfb": {
+        "clock_file": [
+            "jbdfb2jb.clk",
+            "jb2gps.clk"
+        ],
+        "clock_fmt": "tempo2",
+        "aliases": [
+            "jbodfb"
+        ],
+        "bogus_last_correction": true,
+        "itrf_xyz": [
+            3822625.769,
+            -154105.255,
+            5086486.256
+        ],
+        "origin": [
+            "The Lovell telescope at Jodrell Bank.",
+            "These are the coordinates used for VLBI as of March 2020 (MJD 58919). They are based on",
+            "a fiducial position at MJD 50449 plus a (continental) drift velocity of",
+            "[-0.0117, 0.0170, 0.0093] m/yr. This data was obtained from Ben Perera in September 2021.",
+            "This data is for the DFB instrument - a different clock file is required for this instrument to accommodate recorded instrumental delays."
+        ]
+    },
+    "jbafb": {
+        "clock_file": "",
+        "clock_fmt": "tempo2",
+        "aliases": [
+            "jboafb"
+        ],
+        "bogus_last_correction": true,
+        "itrf_xyz": [
+            3822625.769,
+            -154105.255,
+            5086486.256
+        ],
+        "origin": [
+            "The Lovell telescope at Jodrell Bank.",
+            "These are the coordinates used for VLBI as of March 2020 (MJD 58919). They are based on",
+            "a fiducial position at MJD 50449 plus a (continental) drift velocity of",
+            "[-0.0117, 0.0170, 0.0093] m/yr. This data was obtained from Ben Perera in September 2021.",
+            "This data is for the AFB instrument - This doesn't require any clock corrections."
+        ]
     },
     "jodrell_pre_2021": {
         "clock_file": "jb2gps.clk",

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -189,7 +189,7 @@ def test_can_try_to_compute_corrections(observatory):
 
 # Some of these now require TEMPO2 clock files
 # good_observatories = ["gbt", "ao", "vla", "jodrell", "wsrt", "parkes"]
-good_observatories = ["gbt", "ao", "vla", "jodrell"]
+good_observatories = ["gbt", "ao", "vla", "jodrell", "jbroach", "jbdfb"]
 
 
 @pytest.mark.parametrize("observatory", good_observatories)


### PR DESCRIPTION
The different Jodrell Bank instruments have different clock files to accommodate instrumental changes. This is encoded by using observatories `jbroach` or `jbdfb`, and PINT needs to support this.