### PR TITLE
Explicit deep copy of flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Moved observatories to JSON file.  Changed way observatories are loaded/overloaded
 ### Added
 ### Fixed
+- TOA flags are properly deepcopy'd when desired
 
 ## [0.9.0] 2022-06-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Moved observatories to JSON file.  Changed way observatories are loaded/overloaded
 ### Added
 ### Fixed
-- TOA flags are properly deepcopy'd when desired
+- TOA flags are properly deepcopy'd when desired (to deal with [astropy bug](https://github.com/astropy/astropy/issues/13435))
 
 ## [0.9.0] 2022-06-24
 ### Changed

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1508,6 +1508,17 @@ class TOAs:
         if not hasattr(self, "max_index"):
             self.max_index = np.maximum.reduce(self.table["index"])
 
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            setattr(result, k, copy.deepcopy(v, memo))
+        # need to explicitly add in the flags
+        for i in range(len(self)):
+            result.table[i]["flags"] = copy.deepcopy(self.table[i]["flags"])
+        return result
+
     @property
     def ntoas(self):
         """The number of TOAs. Also available as len(toas)."""

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -11,6 +11,7 @@ import astropy.units as u
 from pint.models import get_model
 from pint.fitter import WidebandTOAFitter
 import pint.fitter
+import pint.residuals
 from pint.toa import get_TOAs
 from pinttestdata import datadir
 
@@ -34,28 +35,36 @@ def toas():
 def test_copy_toa_object(toas):
     toa_copy = copy.deepcopy(toas)
 
-    assert sys.getsizeof(toas) == sys.getsizeof(toa_copy)
-    assert id(toas) != id(toa_copy)
+    assert toas == toa_copy
+    assert toas is not toa_copy
     assert toas.ntoas == toa_copy.ntoas
     assert all(toas.table["mjd"] == toa_copy.table["mjd"])
-    assert not (toas.table is toa_copy.table)
-    assert not (toas.table[0]["flags"] is toa_copy.table[0]["flags"])
+    assert toas.table is not toa_copy.table
+    assert toas.table[0]["flags"] is not toa_copy.table[0]["flags"]
+    for c in toas.table.colnames:
+        assert toas.table[c] is not toa_copy.table[c]
 
 
 def test_copy_model_object(model):
     model_copy = copy.deepcopy(model)
 
-    assert sys.getsizeof(model) == sys.getsizeof(model_copy)
-    assert id(model) != id(model_copy)
+    assert model is not model_copy
     assert len(model.params) == len(model_copy.params)
-    assert list(model.components.keys()) == list(model_copy.components.keys())
+    assert (model.components.keys()) == (model_copy.components.keys())
+    for p in model.params:
+        assert getattr(model, p) is not getattr(model_copy, p)
+
+
+def test_copy_residuals(model, toas):
+    r = pint.residuals.Residuals(toas, model)
+    r_copy = copy.deepcopy(r)
+    assert r is not r_copy
 
 
 def test_copy_fitter_object(model, toas):
     fitter = pint.fitter.Fitter(toas, model)
     fitter_copy = copy.deepcopy(fitter)
-    assert sys.getsizeof(fitter) == sys.getsizeof(fitter_copy)
-    assert not (fitter is fitter_copy)
+    assert fitter is not fitter_copy
 
 
 def test_copy_wideband_fitter_object():
@@ -64,8 +73,7 @@ def test_copy_wideband_fitter_object():
     fitter = WidebandTOAFitter([toas], model, additional_args={})
     fitter_copy = copy.deepcopy(fitter)
 
-    assert sys.getsizeof(fitter) == sys.getsizeof(fitter_copy)
-    assert id(fitter) != id(fitter_copy)
+    assert fitter is not fitter_copy
     assert len(fitter.designmatrix_makers) == len(fitter_copy.designmatrix_makers)
     for ii in range(len(fitter.designmatrix_makers)):
         assert (

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -10,46 +10,69 @@ import sys
 import astropy.units as u
 from pint.models import get_model
 from pint.fitter import WidebandTOAFitter
+import pint.fitter
 from pint.toa import get_TOAs
 from pinttestdata import datadir
 
-os.chdir(datadir)
+parfile = os.path.join(datadir, "NGC6440E.par")
+timfile = os.path.join(datadir, "NGC6440E.tim")
 
 
-class TestObjectCopy:
-    def test_copy_toa_object(self):
-        toa = get_TOAs("J1614-2230_NANOGrav_12yv3.wb.tim")
-        toa_copy = copy.deepcopy(toa)
+@pytest.fixture
+def model():
+    return get_model(parfile)
 
-        assert sys.getsizeof(toa) == sys.getsizeof(toa_copy)
-        assert id(toa) != id(toa_copy)
-        assert toa.ntoas == toa_copy.ntoas
-        assert all(toa.table["mjd"] == toa_copy.table["mjd"])
 
-    def test_copy_model_object(self):
-        model = get_model("J1614-2230_NANOGrav_12yv3.wb.gls.par")
-        model_copy = copy.deepcopy(model)
+@pytest.fixture
+def toas():
+    # The scope="module" setting ensures the TOAs object will be created
+    # only once for the whole module, which will save time but might
+    # allow accidental modifications done in one test to affect other tests.
+    return get_TOAs(timfile)
 
-        assert sys.getsizeof(model) == sys.getsizeof(model_copy)
-        assert id(model) != id(model_copy)
-        assert len(model.params) == len(model_copy.params)
-        assert list(model.components.keys()) == list(model_copy.components.keys())
 
-    def test_copy_wideband_fitter_object(self):
-        model = get_model("J1614-2230_NANOGrav_12yv3.wb.gls.par")
-        toas = get_TOAs("J1614-2230_NANOGrav_12yv3.wb.tim")
-        fitter = WidebandTOAFitter([toas], model, additional_args={})
-        fitter_copy = copy.deepcopy(fitter)
+def test_copy_toa_object(toas):
+    toa_copy = copy.deepcopy(toas)
 
-        assert sys.getsizeof(fitter) == sys.getsizeof(fitter_copy)
-        assert id(fitter) != id(fitter_copy)
-        assert len(fitter.designmatrix_makers) == len(fitter_copy.designmatrix_makers)
-        for ii in range(len(fitter.designmatrix_makers)):
-            assert (
-                fitter.designmatrix_makers[ii].derivative_quantity
-                == fitter_copy.designmatrix_makers[ii].derivative_quantity
-            )
-            assert (
-                fitter.designmatrix_makers[ii].quantity_unit
-                == fitter_copy.designmatrix_makers[ii].quantity_unit
-            )
+    assert sys.getsizeof(toas) == sys.getsizeof(toa_copy)
+    assert id(toas) != id(toa_copy)
+    assert toas.ntoas == toa_copy.ntoas
+    assert all(toas.table["mjd"] == toa_copy.table["mjd"])
+    assert not (toas.table is toa_copy.table)
+    assert not (toas.table[0]["flags"] is toa_copy.table[0]["flags"])
+
+
+def test_copy_model_object(model):
+    model_copy = copy.deepcopy(model)
+
+    assert sys.getsizeof(model) == sys.getsizeof(model_copy)
+    assert id(model) != id(model_copy)
+    assert len(model.params) == len(model_copy.params)
+    assert list(model.components.keys()) == list(model_copy.components.keys())
+
+
+def test_copy_fitter_object(model, toas):
+    fitter = pint.fitter.Fitter(toas, model)
+    fitter_copy = copy.deepcopy(fitter)
+    assert sys.getsizeof(fitter) == sys.getsizeof(fitter_copy)
+    assert not (fitter is fitter_copy)
+
+
+def test_copy_wideband_fitter_object():
+    model = get_model(os.path.join(datadir, "J1614-2230_NANOGrav_12yv3.wb.gls.par"))
+    toas = get_TOAs(os.path.join(datadir, "J1614-2230_NANOGrav_12yv3.wb.tim"))
+    fitter = WidebandTOAFitter([toas], model, additional_args={})
+    fitter_copy = copy.deepcopy(fitter)
+
+    assert sys.getsizeof(fitter) == sys.getsizeof(fitter_copy)
+    assert id(fitter) != id(fitter_copy)
+    assert len(fitter.designmatrix_makers) == len(fitter_copy.designmatrix_makers)
+    for ii in range(len(fitter.designmatrix_makers)):
+        assert (
+            fitter.designmatrix_makers[ii].derivative_quantity
+            == fitter_copy.designmatrix_makers[ii].derivative_quantity
+        )
+        assert (
+            fitter.designmatrix_makers[ii].quantity_unit
+            == fitter_copy.designmatrix_makers[ii].quantity_unit
+        )


### PR DESCRIPTION
Fixes #1328.  Explicitly implements deepcopy of flags since they were left as a shallow copy.  Adds test for that (and other minor updates to `test_copy.py`).