### PR TITLE
WIP: persist pickles for TOAs loaded during a test run

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,12 @@
 import os
+import shutil
+import tempfile
+from pathlib import Path
+
 import hypothesis
 import pytest
-from astropy.utils.data import check_download_cache
 from astropy.config import paths
+from astropy.utils.data import check_download_cache
 
 # This setup is drawn from Astropy and might not be entirely relevant to us;
 # in particular we don't have a cron run for slow tests.
@@ -42,3 +46,9 @@ def temp_cache(tmpdir):
     with paths.set_temp_cache(tmpdir):
         yield None
         check_download_cache()
+
+
+@pytest.fixture(scope="session")
+def pickle_dir():
+    with tempfile.TemporaryDirectory(prefix="pytest-pickles-") as d:
+        yield Path(d)

--- a/tests/datafile/get_tempo_result.py
+++ b/tests/datafile/get_tempo_result.py
@@ -1,6 +1,8 @@
-import tempo_utils as t1u
-from pint.utils import longdouble2str
 import argparse
+
+import tempo_utils as t1u
+
+from pint.utils import longdouble2str
 
 
 def get_tempo_result(parfile, timfile):

--- a/tests/datafile/make_J1713_libstempo.py
+++ b/tests/datafile/make_J1713_libstempo.py
@@ -1,6 +1,7 @@
+import datetime
+
 import libstempo as T
 import numpy as np
-import datetime
 
 timJ1713 = "J1713+0747_NANOGrav_11yv0_short.tim"
 # one file in ICRS, one in ECL

--- a/tests/test_B1855.py
+++ b/tests/test_B1855.py
@@ -6,12 +6,12 @@ import unittest
 import astropy.units as u
 import numpy as np
 import pytest
+import test_derivative_utils as tdu
+from pinttestdata import datadir
 
 import pint.models.model_builder as mb
 import pint.toa as toa
-import test_derivative_utils as tdu
 from pint.residuals import Residuals
-from pinttestdata import datadir
 
 
 class TestB1855(unittest.TestCase):

--- a/tests/test_B1855_9yrs.py
+++ b/tests/test_B1855_9yrs.py
@@ -5,12 +5,12 @@ import unittest
 
 import astropy.units as u
 import numpy as np
+import test_derivative_utils as tdu
+from pinttestdata import datadir
 
 import pint.models.model_builder as mb
 import pint.toa as toa
-import test_derivative_utils as tdu
 from pint.residuals import Residuals
-from pinttestdata import datadir
 
 
 class TestB1855(unittest.TestCase):

--- a/tests/test_B1953.py
+++ b/tests/test_B1953.py
@@ -1,16 +1,16 @@
 """Various tests to assess the performance of the B1953+29."""
-from astropy import log
 import os
 import unittest
 
 import astropy.units as u
 import numpy as np
+import test_derivative_utils as tdu
+from astropy import log
+from pinttestdata import datadir
 
 import pint.models.model_builder as mb
 import pint.toa as toa
-import test_derivative_utils as tdu
 from pint.residuals import Residuals
-from pinttestdata import datadir
 
 
 class TestB1953(unittest.TestCase):

--- a/tests/test_Galactic.py
+++ b/tests/test_Galactic.py
@@ -2,19 +2,18 @@ import logging
 import os
 import unittest
 
+import astropy.coordinates
+import astropy.time
 import astropy.units as u
 import numpy as np
+import test_derivative_utils as tdu
+from pinttestdata import datadir
 
 import pint.models.model_builder as mb
 import pint.toa as toa
-import test_derivative_utils as tdu
-from pint.residuals import Residuals
-from pinttestdata import datadir
-from pint.pulsar_ecliptic import PulsarEcliptic
 from pint import utils
-
-import astropy.coordinates
-import astropy.time
+from pint.pulsar_ecliptic import PulsarEcliptic
+from pint.residuals import Residuals
 
 
 class TestGalactic(unittest.TestCase):

--- a/tests/test_J0613.py
+++ b/tests/test_J0613.py
@@ -5,12 +5,12 @@ import unittest
 
 import astropy.units as u
 import numpy as np
+import test_derivative_utils as tdu
+from pinttestdata import datadir
 
 import pint.models.model_builder as mb
 import pint.toa as toa
-import test_derivative_utils as tdu
 from pint.residuals import Residuals
-from pinttestdata import datadir
 
 
 class TestJ0613(unittest.TestCase):

--- a/tests/test_TDB_method.py
+++ b/tests/test_TDB_method.py
@@ -3,9 +3,9 @@ import os
 import unittest
 
 import numpy as np
+from pinttestdata import datadir
 
 import pint.toa as toa
-from pinttestdata import datadir
 
 
 class TestTDBMethod(unittest.TestCase):

--- a/tests/test_absphase.py
+++ b/tests/test_absphase.py
@@ -2,21 +2,22 @@
 import os
 import unittest
 
+import numpy as np
+from pinttestdata import datadir
+
 import pint.models
 import pint.toa
-from pinttestdata import datadir
 
 parfile = os.path.join(datadir, "NGC6440E.par")
 timfile = os.path.join(datadir, "zerophase.tim")
 
 
-class TestAbsPhase(unittest.TestCase):
-    def test_phase_zero(self):
-        # Check that model phase is 0.0 for a TOA at exactly the TZRMJD
-        model = pint.models.get_model(parfile)
-        toas = pint.toa.get_TOAs(timfile)
+def test_phase_zero(pickle_dir):
+    # Check that model phase is 0.0 for a TOA at exactly the TZRMJD
+    model = pint.models.get_model(parfile)
+    toas = pint.toa.get_TOAs(timfile, picklefilename=pickle_dir)
 
-        ph = model.phase(toas, abs_phase=True)
-        # Check that integer and fractional phase values are very close to 0.0
-        self.assertAlmostEqual(ph[0].value, 0.0)
-        self.assertAlmostEqual(ph[1].value, 0.0)
+    ph = model.phase(toas, abs_phase=True)
+    # Check that integer and fractional phase values are very close to 0.0
+    assert np.isclose(ph[0].value, 0.0)
+    assert np.isclose(ph[1].value, 0.0)

--- a/tests/test_all_component_and_model_builder.py
+++ b/tests/test_all_component_and_model_builder.py
@@ -1,25 +1,27 @@
 """Test model builder using variance input"""
 
-from collections import defaultdict
-import pytest
-import io
-from glob import glob
 import copy
+import io
+from collections import defaultdict
+from glob import glob
 from os.path import basename, join
-import numpy as np
+
 import astropy.units as u
+import numpy as np
+import pytest
+from pinttestdata import datadir
+
+from pint.models.model_builder import ComponentConflict, ModelBuilder, get_model
+from pint.models.parameter import floatParameter
 from pint.models.timing_model import (
-    TimingModel,
-    PhaseComponent,
-    Component,
-    AllComponents,
     AliasConflict,
+    AllComponents,
+    Component,
+    PhaseComponent,
+    TimingModel,
     UnknownBinaryModel,
 )
-from pint.models.model_builder import ModelBuilder, ComponentConflict, get_model
-from pint.models.parameter import floatParameter
-from pint.utils import split_prefixed_name, PrefixError
-from pinttestdata import datadir
+from pint.utils import PrefixError, split_prefixed_name
 
 
 class SimpleModel(PhaseComponent):

--- a/tests/test_astrometry.py
+++ b/tests/test_astrometry.py
@@ -5,9 +5,9 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.coordinates import Latitude, Longitude
+from pinttestdata import datadir
 
 from pint.models import get_model
-from pinttestdata import datadir
 
 
 @pytest.fixture

--- a/tests/test_astropyobservatory.py
+++ b/tests/test_astropyobservatory.py
@@ -1,6 +1,8 @@
 import logging
 import unittest
+
 import numpy as np
+
 import pint.observatory
 
 

--- a/tests/test_barytoa.py
+++ b/tests/test_barytoa.py
@@ -2,13 +2,13 @@
 import os
 
 import astropy.units as u
+from pinttestdata import datadir
 
 import pint.fitter
 import pint.models
-from pint.models.model_builder import get_model
 import pint.residuals
 import pint.toa
-from pinttestdata import datadir
+from pint.models.model_builder import get_model
 
 
 def test_barytoa():

--- a/tests/test_binary_generic.py
+++ b/tests/test_binary_generic.py
@@ -1,17 +1,17 @@
 """Tests of PINT generic binary model """
 
 import logging
-from os.path import basename, join
-from glob import glob
 import unittest
-import pytest
+from glob import glob
+from os.path import basename, join
 from warnings import warn
 
-from pint.models.model_builder import get_model
-from pint.models.timing_model import MissingParameter, TimingModel, Component
-from utils import verify_stand_alone_binary_parameter_updates
+import pytest
 from pinttestdata import datadir
+from utils import verify_stand_alone_binary_parameter_updates
 
+from pint.models.model_builder import get_model
+from pint.models.timing_model import Component, MissingParameter, TimingModel
 
 bad_trouble = ["J1923+2515_NANOGrav_9yv1.gls.par", "J1744-1134.basic.ecliptic.par"]
 

--- a/tests/test_clock_file.py
+++ b/tests/test_clock_file.py
@@ -8,14 +8,12 @@ from astropy.time import Time
 from numpy.testing import assert_allclose, assert_array_equal
 
 from pint.observatory import (
-    get_observatory,
-    bipm_default,
-    update_clock_files,
     ClockCorrectionOutOfRange,
+    bipm_default,
+    get_observatory,
+    update_clock_files,
 )
-from pint.observatory.clock_file import (
-    ClockFile,
-)
+from pint.observatory.clock_file import ClockFile
 from pint.observatory.topo_obs import export_all_clock_files
 
 

--- a/tests/test_clockcorr.py
+++ b/tests/test_clockcorr.py
@@ -1,12 +1,12 @@
-import unittest
-
-import pytest
 import os
+import unittest
+from os import path
+
 import astropy.units as u
 import numpy
-from pinttestdata import datadir
-from os import path
+import pytest
 from astropy.time import Time
+from pinttestdata import datadir
 
 from pint.observatory import Observatory
 from pint.observatory.clock_file import ClockFile

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,13 +1,15 @@
-import numpy as np
+import io
+import os
 import unittest
+from copy import deepcopy as cp
+
 import astropy
 import astropy.units as u
+import numpy as np
+from pinttestdata import datadir
+
 import pint
 import pint.models as mod
-import os
-import io
-from copy import deepcopy as cp
-from pinttestdata import datadir
 
 
 class TestCompare(unittest.TestCase):

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,17 +1,18 @@
 """ Test for pint object copying
 """
 
-import os
-import pytest
-import numpy as np
 import copy
+import os
 import sys
 
 import astropy.units as u
-from pint.models import get_model
-from pint.fitter import WidebandTOAFitter
-from pint.toa import get_TOAs
+import numpy as np
+import pytest
 from pinttestdata import datadir
+
+from pint.fitter import WidebandTOAFitter
+from pint.models import get_model
+from pint.toa import get_TOAs
 
 os.chdir(datadir)
 

--- a/tests/test_covariance_matrix.py
+++ b/tests/test_covariance_matrix.py
@@ -1,14 +1,14 @@
 """ Various of tests for the pint covariance.
 """
 
-import pytest
 import os
 
-import numpy as np
 import astropy.units as u
-from pint.pint_matrix import CovarianceMatrix, combine_covariance_matrix
-
+import numpy as np
+import pytest
 from pinttestdata import datadir
+
+from pint.pint_matrix import CovarianceMatrix, combine_covariance_matrix
 
 os.chdir(datadir)
 

--- a/tests/test_d_phase_d_toa.py
+++ b/tests/test_d_phase_d_toa.py
@@ -8,10 +8,11 @@ try:
 except ImportError:
     from astropy._erfa import DJM0
 
+from pinttestdata import datadir, testdir
+
 import pint.toa as toa
 from pint.models import model_builder as mb
 from pint.polycos import Polycos
-from pinttestdata import datadir, testdir
 
 
 class TestD_phase_d_toa(unittest.TestCase):

--- a/tests/test_datafiles.py
+++ b/tests/test_datafiles.py
@@ -1,8 +1,10 @@
 """Test installation of PINT data files"""
 import os
-import pytest
-import pint.config
 import tempfile
+
+import pytest
+
+import pint.config
 
 
 @pytest.fixture

--- a/tests/test_dd.py
+++ b/tests/test_dd.py
@@ -4,12 +4,12 @@ import unittest
 
 import astropy.units as u
 import numpy as np
+from pinttestdata import datadir
+from utils import verify_stand_alone_binary_parameter_updates
 
 import pint.models.model_builder as mb
 import pint.toa as toa
-from utils import verify_stand_alone_binary_parameter_updates
 from pint.residuals import Residuals
-from pinttestdata import datadir
 
 
 class TestDD(unittest.TestCase):

--- a/tests/test_ddk.py
+++ b/tests/test_ddk.py
@@ -4,26 +4,26 @@ import logging
 import os
 import re
 import unittest
-from io import StringIO
 import warnings
+from io import StringIO
 
 import astropy.units as u
 import numpy as np
 import pytest
 import test_derivative_utils as tdu
 from astropy.time import Time
+from loguru import logger as log
 from pinttestdata import datadir
 from utils import verify_stand_alone_binary_parameter_updates
-from loguru import logger as log
 
+import pint.fitter
 import pint.models.model_builder as mb
-from pint.models import get_model
 import pint.simulation
 import pint.toa as toa
+from pint.models import get_model
 from pint.models.parameter import boolParameter
 from pint.models.timing_model import MissingParameter, TimingModelError
 from pint.residuals import Residuals
-import pint.fitter
 
 temp_par_str = """
     PSR  J1713+0747

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -1,13 +1,15 @@
-import numpy as np
-import astropy.units as u
-from astropy.time import Time
-import matplotlib.pyplot as plt
-import pint.toa as toa
-import pint.simulation as simulation
-from pint.models import get_model
-from copy import deepcopy
 import io
+from copy import deepcopy
+
+import astropy.units as u
+import matplotlib.pyplot as plt
+import numpy as np
 import pytest
+from astropy.time import Time
+
+import pint.simulation as simulation
+import pint.toa as toa
+from pint.models import get_model
 
 
 @pytest.mark.parametrize("ndays", [7 * u.d, 20 * u.d])

--- a/tests/test_derived_quantities.py
+++ b/tests/test_derived_quantities.py
@@ -28,17 +28,17 @@ import pint
 from pint.derived_quantities import (
     a1sini,
     companion_mass,
+    gamma,
     mass_funct,
     mass_funct2,
+    omdot,
+    omdot_to_mtot,
+    pbdot,
     pulsar_age,
     pulsar_B,
     pulsar_B_lightcyl,
     pulsar_edot,
     pulsar_mass,
-    omdot,
-    pbdot,
-    gamma,
-    omdot_to_mtot,
 )
 
 

--- a/tests/test_design_matrix.py
+++ b/tests/test_design_matrix.py
@@ -1,17 +1,18 @@
 """ Test for pint design matrix"""
 import os
-import pytest
+
+import astropy.units as u
 import numpy as np
+import pytest
+from pinttestdata import datadir
 
 from pint.models import get_model
-from pint.toa import get_TOAs
 from pint.pint_matrix import (
     DesignMatrixMaker,
-    combine_design_matrices_by_quantity,
     combine_design_matrices_by_param,
+    combine_design_matrices_by_quantity,
 )
-import astropy.units as u
-from pinttestdata import datadir
+from pint.toa import get_TOAs
 
 
 class TestDesignMatrix:

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -5,6 +5,7 @@ import emcee
 import numpy as np
 import numpy.random
 from numpy.testing import assert_array_equal
+from pinttestdata import datadir, testdir
 
 import pint.fermi_toas as fermi
 import pint.models
@@ -12,7 +13,6 @@ import pint.toa as toa
 from pint.mcmc_fitter import MCMCFitter, MCMCFitterBinnedTemplate
 from pint.sampler import EmceeSampler
 from pint.scripts.event_optimize import marginalize_over_phase, read_gaussfitfile
-from pinttestdata import datadir, testdir
 
 
 def test_sampler():

--- a/tests/test_dmefac_dmequad.py
+++ b/tests/test_dmefac_dmequad.py
@@ -2,13 +2,12 @@
 """
 from io import StringIO
 
+import astropy.units as u
 import numpy as np
 import pytest
-import astropy.units as u
 
-from pint.toa import get_TOAs
 from pint.models.noise_model import ScaleDmError
-
+from pint.toa import get_TOAs
 
 tim = """FORMAT 1
 fake 1400 54000 1.0 gbt -pp_dm 57.0 -pp_dme 0.01 -fe Rcvr_800

--- a/tests/test_dmx.py
+++ b/tests/test_dmx.py
@@ -4,11 +4,11 @@ import unittest
 
 import astropy.units as u
 import numpy as np
+from pinttestdata import datadir
 
 import pint.toa as toa
 from pint import residuals
 from pint.models import model_builder as mb
-from pinttestdata import datadir
 
 
 class TestDMX(unittest.TestCase):

--- a/tests/test_dmxrange_add_sub.py
+++ b/tests/test_dmxrange_add_sub.py
@@ -1,8 +1,10 @@
 """Test functions for adding and removing DMX ranges."""
 
-import pytest
 import io
+
 import numpy as np
+import pytest
+
 from pint.models import get_model
 from pint.models.dispersion_model import DispersionDM, DispersionDMX
 from pint.utils import PrefixError

--- a/tests/test_downhill_fitter.py
+++ b/tests/test_downhill_fitter.py
@@ -13,8 +13,8 @@ from scipy.linalg import block_diag, cho_factor, cho_solve, cholesky
 import pint.fitter
 from pint.models import get_model
 from pint.models.timing_model import MissingTOAs
-from pint.toa import merge_TOAs
 from pint.simulation import make_fake_toas_uniform
+from pint.toa import merge_TOAs
 
 par_eccentric = """
 PSR J1234+5678

--- a/tests/test_early_chime_data.py
+++ b/tests/test_early_chime_data.py
@@ -5,11 +5,11 @@ import unittest
 import astropy.units as u
 import numpy as np
 from astropy.tests.helper import assert_quantity_allclose
+from pinttestdata import datadir, testdir
 
 import pint.models.model_builder as mb
 import pint.toa as toa
 from pint.residuals import Residuals
-from pinttestdata import datadir, testdir
 
 
 class Test_CHIME_data(unittest.TestCase):

--- a/tests/test_ell1h.py
+++ b/tests/test_ell1h.py
@@ -2,22 +2,21 @@
 import logging
 import os
 import unittest
-import pytest
+from io import StringIO
 from warnings import warn
 
 import astropy.units as u
 import numpy as np
+import pytest
+import test_derivative_utils as tdu
+from pinttestdata import datadir
+from utils import verify_stand_alone_binary_parameter_updates
 
 import pint.fitter as ff
+import pint.toa as toa
 from pint.models import get_model
 from pint.models.timing_model import TimingModelError
-import pint.toa as toa
-import test_derivative_utils as tdu
-from utils import verify_stand_alone_binary_parameter_updates
 from pint.residuals import Residuals
-from pinttestdata import datadir
-from io import StringIO
-
 
 os.chdir(datadir)
 

--- a/tests/test_event_optimize.py
+++ b/tests/test_event_optimize.py
@@ -9,9 +9,9 @@ from io import StringIO
 from pathlib import Path
 
 import pytest
+from pinttestdata import datadir
 
 from pint.scripts import event_optimize
-from pinttestdata import datadir
 
 
 def test_result(tmp_path):

--- a/tests/test_event_optimize_MCMCFitter.py
+++ b/tests/test_event_optimize_MCMCFitter.py
@@ -3,7 +3,6 @@
 # to get the fftfit module.  It can be run manually by people who have PRESTO
 import os
 import unittest
-
 from io import StringIO
 
 from pinttestdata import datadir

--- a/tests/test_event_optimize_multiple.py
+++ b/tests/test_event_optimize_multiple.py
@@ -4,7 +4,6 @@
 import os
 import sys
 import unittest
-
 from io import StringIO
 
 from pinttestdata import datadir

--- a/tests/test_event_toas.py
+++ b/tests/test_event_toas.py
@@ -1,9 +1,13 @@
 import os
-import pytest
 
-from pint.event_toas import read_mission_info_from_heasoft, create_mission_config
-from pint.event_toas import load_fits_TOAs
+import pytest
 from pinttestdata import datadir
+
+from pint.event_toas import (
+    create_mission_config,
+    load_fits_TOAs,
+    read_mission_info_from_heasoft,
+)
 
 
 def test_xselect_mdb_is_found_headas(monkeypatch, tmp_path):

--- a/tests/test_eventstats.py
+++ b/tests/test_eventstats.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
+import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 import pint.eventstats as es
-import numpy as np
 
 
 def test_sig2sigma():

--- a/tests/test_fake_toas.py
+++ b/tests/test_fake_toas.py
@@ -1,15 +1,17 @@
+import io
+import os
+import tempfile
+
 import astropy.units as u
+import numpy as np
+from pinttestdata import datadir, testdir
+
+import pint.config
+import pint.residuals
 import pint.simulation
+from pint.fitter import GLSFitter
 from pint.models.model_builder import get_model, get_model_and_toas
 from pint.toa import get_TOAs
-import pint.residuals
-import io
-import numpy as np
-import tempfile
-import os
-import pint.config
-from pint.fitter import GLSFitter
-from pinttestdata import datadir, testdir
 
 
 def test_noise_addition():

--- a/tests/test_fd.py
+++ b/tests/test_fd.py
@@ -2,15 +2,15 @@
 import copy
 import os
 import unittest
-import pytest
 
 import astropy.units as u
 import numpy as np
+import pytest
+from pinttestdata import datadir
 
 import pint.models.model_builder as mb
 import pint.residuals
 import pint.toa as toa
-from pinttestdata import datadir
 
 
 class TestFD(unittest.TestCase):

--- a/tests/test_fermiphase.py
+++ b/tests/test_fermiphase.py
@@ -5,15 +5,14 @@ from io import StringIO
 from pathlib import Path
 
 import pytest
-
 from astropy.io import fits
+from pinttestdata import datadir
 
 import pint.models
 import pint.scripts.fermiphase as fermiphase
 import pint.toa as toa
 from pint.fermi_toas import load_Fermi_TOAs
 from pint.observatory.satellite_obs import get_satellite_observatory
-from pinttestdata import datadir
 
 parfile = datadir / "PSRJ0030+0451_psrcat.par"
 eventfile = (

--- a/tests/test_fitter.py
+++ b/tests/test_fitter.py
@@ -2,17 +2,17 @@
 import os
 from copy import deepcopy
 
+import astropy.units as u
+
 # import matplotlib
 # matplotlib.use('TKAgg')
 import matplotlib.pyplot as plt
 import pytest
-import astropy.units as u
+from pinttestdata import datadir
 
 import pint.models as tm
-from pint import fitter, toa, simulation
-from pinttestdata import datadir
 import pint.models.parameter as param
-from pint import ls
+from pint import fitter, ls, simulation, toa
 from pint.models import get_model, get_model_and_toas
 
 

--- a/tests/test_fitter_compare.py
+++ b/tests/test_fitter_compare.py
@@ -1,29 +1,29 @@
 #! /usr/bin/env python
+import copy
 import os
 import unittest
-from os.path import join
 from io import StringIO
-import copy
-import numpy as np
+from os.path import join
 
 import astropy.units as u
+import numpy as np
 import pytest
 from pinttestdata import datadir
 
 import pint
 from pint.fitter import (
     ConvergenceFailure,
-    MaxiterReached,
     DownhillGLSFitter,
     DownhillWLSFitter,
     GLSFitter,
+    MaxiterReached,
     WidebandDownhillFitter,
     WidebandTOAFitter,
     WLSFitter,
 )
 from pint.models.model_builder import get_model
-from pint.toa import get_TOAs
 from pint.simulation import make_fake_toas_uniform
+from pint.toa import get_TOAs
 
 
 @pytest.fixture

--- a/tests/test_fitter_error_checking.py
+++ b/tests/test_fitter_error_checking.py
@@ -1,10 +1,10 @@
 #! /usr/bin/env python
 import io
-
-import numpy as np
-import astropy.units as u
-import pytest
 import re
+
+import astropy.units as u
+import numpy as np
+import pytest
 
 import pint.fitter
 from pint.models import get_model

--- a/tests/test_flagging_clustering.py
+++ b/tests/test_flagging_clustering.py
@@ -1,35 +1,41 @@
 """Tests for clustering and flagging"""
+import copy
 import logging
 import os
 import unittest
-import pytest
-import copy
 
 import astropy.units as u
 import numpy as np
+import pytest
+from pinttestdata import datadir
 
 import pint.models.model_builder as mb
 import pint.toa as toa
+from pint.models import PhaseJump, parameter as p
 from pint.residuals import Residuals
-from pinttestdata import datadir
-from pint.models import parameter as p
-from pint.models import PhaseJump
 
 
 class SimpleSetup:
-    def __init__(self, par, tim):
+    def __init__(self, par, tim, pickle_dir):
         self.par = par
         self.tim = tim
         self.m = mb.get_model(self.par)
         self.t = toa.get_TOAs(
-            self.tim, ephem="DE405", planets=False, include_bipm=False
+            self.tim,
+            ephem="DE405",
+            planets=False,
+            include_bipm=False,
+            usepickle=True,
+            picklefilename=pickle_dir,
         )
 
 
 @pytest.fixture
-def setup_NGC6440E():
+def setup_NGC6440E(pickle_dir):
     return SimpleSetup(
-        os.path.join(datadir, "NGC6440E.par"), os.path.join(datadir, "NGC6440E.tim")
+        os.path.join(datadir, "NGC6440E.par"),
+        os.path.join(datadir, "NGC6440E.tim"),
+        pickle_dir,
     )
 
 

--- a/tests/test_glitch.py
+++ b/tests/test_glitch.py
@@ -5,12 +5,12 @@ import unittest
 import astropy.units as u
 import numpy as np
 import pytest
+from pinttestdata import datadir
 
 import pint.fitter
 import pint.models
 import pint.residuals
 import pint.toa
-from pinttestdata import datadir
 
 parfile = os.path.join(datadir, "prefixtest.par")
 timfile = os.path.join(datadir, "prefixtest.tim")

--- a/tests/test_gls_fitter.py
+++ b/tests/test_gls_fitter.py
@@ -5,11 +5,11 @@ import unittest
 
 import astropy.units as u
 import numpy as np
+from pinttestdata import datadir
 
 import pint.models.model_builder as mb
 from pint import toa
 from pint.fitter import GLSFitter
-from pinttestdata import datadir
 
 
 class TestGLS(unittest.TestCase):

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -3,15 +3,15 @@ import concurrent.futures
 import io
 import multiprocessing
 import os
-import pytest
 
 import astropy.units as u
 import numpy as np
+import pytest
 
 import pint.config
 import pint.gridutils
 import pint.models.parameter as param
-from pint.fitter import GLSFitter, WLSFitter, DownhillWLSFitter, DownhillGLSFitter
+from pint.fitter import DownhillGLSFitter, DownhillWLSFitter, GLSFitter, WLSFitter
 from pint.models.model_builder import get_model_and_toas
 
 # for multi-core tests, don't use all available CPUs

--- a/tests/test_infostrings.py
+++ b/tests/test_infostrings.py
@@ -1,20 +1,20 @@
 """Tests for adding info strings to parfiles and tim files"""
-import logging
-import os
-import unittest
-import pytest
 import copy
 import io
+import logging
+import os
 import platform
+import unittest
 
 import astropy.units as u
 import numpy as np
+import pytest
+from pinttestdata import datadir
 
+import pint
 import pint.models.model_builder as mb
 import pint.toa as toa
 from pint.residuals import Residuals
-from pinttestdata import datadir
-import pint
 
 
 class SimpleSetup:

--- a/tests/test_jump.py
+++ b/tests/test_jump.py
@@ -1,19 +1,18 @@
 """Tests for jump model component """
+import copy
 import logging
 import os
 import unittest
-import pytest
-import copy
 
 import astropy.units as u
 import numpy as np
+import pytest
+from pinttestdata import datadir
 
 import pint.models.model_builder as mb
 import pint.toa as toa
+from pint.models import PhaseJump, parameter as p
 from pint.residuals import Residuals
-from pinttestdata import datadir
-from pint.models import parameter as p
-from pint.models import PhaseJump
 
 
 class SimpleSetup:

--- a/tests/test_mask_parameter.py
+++ b/tests/test_mask_parameter.py
@@ -1,19 +1,19 @@
 """Various tests for the maskParameter"""
 
+import copy
 import os
-import pytest
 from io import StringIO
+
 import astropy
 import astropy.time as time
 import astropy.units as u
 import numpy as np
+import pytest
+from pinttestdata import datadir
 
 from pint.models.model_builder import get_model
 from pint.models.parameter import maskParameter
 from pint.toa import get_TOAs
-from pinttestdata import datadir
-
-import copy
 
 
 @pytest.fixture

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6,11 +6,11 @@ import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
 from astropy import log
+from pinttestdata import datadir
 
 import pint.models as tm
 from pint import toa
 from pint.residuals import Residuals
-from pinttestdata import datadir
 
 
 def test_model():

--- a/tests/test_model_derivatives.py
+++ b/tests/test_model_derivatives.py
@@ -8,13 +8,13 @@ from glob import glob
 import numdifftools
 import numpy as np
 import pytest
+from astropy import units as u
 from hypothesis import HealthCheck, Verbosity, assume, given, settings
 from hypothesis.strategies import composite, floats, integers, sampled_from
 from numpy.testing import assert_allclose
-from astropy import units as u
 
-import pint.toa
 import pint.simulation
+import pint.toa
 from pint.models import get_model
 
 

--- a/tests/test_model_ifunc.py
+++ b/tests/test_model_ifunc.py
@@ -3,12 +3,12 @@ import os
 import unittest
 
 import astropy.units as u
+from pinttestdata import datadir
 
+import pint.fitter
 import pint.models
 import pint.residuals
 import pint.toa
-import pint.fitter
-from pinttestdata import datadir
 
 # Not included in the test here, but as a sanity check I used this same
 # ephemeris to phase up Fermi data, and it looks good.

--- a/tests/test_model_manual.py
+++ b/tests/test_model_manual.py
@@ -1,22 +1,23 @@
 """Test model building and structure for simple models."""
 
+from collections import defaultdict
 from glob import glob
 from os.path import basename, join
-from collections import defaultdict
-import pytest
 
 import astropy.units as u
+import pytest
+from pinttestdata import datadir
+
 from pint.models.astrometry import AstrometryEquatorial
 from pint.models.dispersion_model import DispersionDM, DispersionDMX
-from pint.models.spindown import Spindown
 from pint.models.model_builder import get_model
+from pint.models.spindown import Spindown
 from pint.models.timing_model import (
+    Component,
     MissingParameter,
     TimingModel,
-    Component,
     UnknownBinaryModel,
 )
-from pinttestdata import datadir
 
 
 @pytest.fixture

--- a/tests/test_model_wave.py
+++ b/tests/test_model_wave.py
@@ -1,15 +1,15 @@
 #! /usr/bin/env python
 import os
 import unittest
-import pytest
 
 import astropy.units as u
+import pytest
+from pinttestdata import datadir
 
 import pint.fitter
 import pint.models
 import pint.residuals
 import pint.toa
-from pinttestdata import datadir
 
 # Not included in the test here, but as a sanity check I used this same
 # ephemeris to phase up Fermi data, and it looks good.

--- a/tests/test_modelconversions.py
+++ b/tests/test_modelconversions.py
@@ -1,16 +1,16 @@
 import io
 import os
-import pytest
 
 import astropy.units as u
 import numpy as np
+import pytest
 
 import pint.residuals
 import pint.simulation
 from pint.fitter import WLSFitter
 from pint.models.model_builder import get_model, get_model_and_toas
-from pint.toa import get_TOAs
 from pint.pulsar_ecliptic import OBL, PulsarEcliptic
+from pint.toa import get_TOAs
 
 modelstring_ECL = """
 PSR              B1855+09

--- a/tests/test_modelutils.py
+++ b/tests/test_modelutils.py
@@ -4,13 +4,12 @@ import unittest
 
 import astropy.units as u
 import numpy as np
+from pinttestdata import datadir
 
 import pint.toa as toa
 from pint.models import get_model
+from pint.modelutils import model_ecliptic_to_equatorial, model_equatorial_to_ecliptic
 from pint.residuals import Residuals
-from pinttestdata import datadir
-
-from pint.modelutils import model_equatorial_to_ecliptic, model_ecliptic_to_equatorial
 
 
 class TestEcliptic(unittest.TestCase):

--- a/tests/test_new_observatories.py
+++ b/tests/test_new_observatories.py
@@ -1,14 +1,14 @@
+import os
+import os.path
 from io import StringIO
 
 import numpy as np
-import os
-import os.path
 import pytest
+from pinttestdata import datadir
 
-from pint.toa import get_TOAs
 from pint.models import get_model
 from pint.observatory import get_observatory
-from pinttestdata import datadir
+from pint.toa import get_TOAs
 
 parfile = os.path.join(datadir, "NGC6440E.par")
 

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python
 import io
 import os
-from pathlib import Path
 import unittest
+from pathlib import Path
 
 import numpy as np
 import pytest
-from pint.pulsar_mjd import Time
+from pinttestdata import datadir
 
 import pint.observatory
 import pint.observatory.topo_obs
+from pint.observatory import NoClockCorrections, Observatory, get_observatory
+from pint.observatory.special_locations import load_special_locations
 from pint.observatory.topo_obs import (
+    TopoObs,
     load_observatories,
     load_observatories_from_usual_locations,
-    TopoObs,
 )
-from pint.observatory.special_locations import load_special_locations
-from pint.observatory import get_observatory, Observatory, NoClockCorrections
-from pinttestdata import datadir
+from pint.pulsar_mjd import Time
 
 
 @pytest.fixture

--- a/tests/test_observatory_envar.py
+++ b/tests/test_observatory_envar.py
@@ -1,11 +1,12 @@
+import importlib
 import os
 import sys
-import pytest
-import importlib
 
-import pint.observatory.topo_obs
-import pint.observatory.special_locations
+import pytest
+
 import pint.observatory
+import pint.observatory.special_locations
+import pint.observatory.topo_obs
 
 
 @pytest.fixture

--- a/tests/test_observatory_metadata.py
+++ b/tests/test_observatory_metadata.py
@@ -1,7 +1,9 @@
 import logging
 import os
 import unittest
+
 import numpy as np
+
 import pint.observatory
 
 

--- a/tests/test_orbit_phase.py
+++ b/tests/test_orbit_phase.py
@@ -5,10 +5,10 @@ import unittest
 import astropy.time as time
 import astropy.units as u
 import numpy as np
-
-import pint.toa as t
-import pint.models as m
 from pinttestdata import datadir
+
+import pint.models as m
+import pint.toa as t
 
 
 class TestOrbitPhase(unittest.TestCase):

--- a/tests/test_parametercovariancematrix.py
+++ b/tests/test_parametercovariancematrix.py
@@ -1,9 +1,9 @@
-import numpy as np
 import os
 import unittest
 from os.path import join
 
 import astropy.units as u
+import numpy as np
 import pytest
 from pinttestdata import datadir
 
@@ -12,13 +12,13 @@ from pint.fitter import (
     DownhillGLSFitter,
     DownhillWLSFitter,
     GLSFitter,
-    WLSFitter,
     WidebandDownhillFitter,
     WidebandTOAFitter,
+    WLSFitter,
 )
 from pint.models.model_builder import get_model
-from pint.toa import get_TOAs
 from pint.simulation import make_fake_toas_uniform
+from pint.toa import get_TOAs
 
 
 @pytest.fixture

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,8 +1,8 @@
 import copy
+import io
 import os
 import pickle
 import unittest
-import io
 
 import astropy.time as time
 import astropy.units as u

--- a/tests/test_parfile.py
+++ b/tests/test_parfile.py
@@ -3,9 +3,9 @@ import os
 import tempfile
 
 import pytest
+from pinttestdata import datadir, testdir
 
 import pint.models as tm
-from pinttestdata import testdir, datadir
 
 parfile = datadir / "J1744-1134.basic.par"
 

--- a/tests/test_parfile_writing.py
+++ b/tests/test_parfile_writing.py
@@ -2,16 +2,16 @@
 import numbers
 import os
 from io import StringIO
-import pytest
 
 import astropy.units as u
 import numpy as np
+import pytest
+from pinttestdata import datadir
 
 import pint.models.model_builder as mb
 import pint.models.parameter as mp
 import pint.toa as toa
 from pint.residuals import Residuals
-from pinttestdata import datadir
 
 
 def test_parfile_write(tmp_path):

--- a/tests/test_parfile_writing_format.py
+++ b/tests/test_parfile_writing_format.py
@@ -1,15 +1,14 @@
 import os
 import unittest
-import pytest
 from io import StringIO
 
 import pytest
 from hypothesis import given
 from hypothesis.strategies import sampled_from
-
-from pint.models import get_model, get_model_and_toas
-from pint import fitter
 from pinttestdata import datadir
+
+from pint import fitter
+from pint.models import get_model, get_model_and_toas
 
 
 def test_SWM():

--- a/tests/test_phase.py
+++ b/tests/test_phase.py
@@ -1,10 +1,13 @@
 # Test for phase.py
 
-import pytest
-import numpy as np
-import astropy.units as u
-from pint.phase import Phase
 import math
+
+import astropy.units as u
+import numpy as np
+import pytest
+
+from pint.phase import Phase
+
 
 # modified from @mhvk's test_phase_class.py
 def assert_equal(first, second):

--- a/tests/test_phase_commands.py
+++ b/tests/test_phase_commands.py
@@ -2,12 +2,13 @@
 import os
 import unittest
 
+import astropy.units as u
+import numpy as np
+from pinttestdata import datadir
+
 import pint.models
 import pint.toa
 from pint.residuals import Residuals
-from pinttestdata import datadir
-import astropy.units as u
-import numpy as np
 
 parfile = os.path.join(datadir, "NGC6440E_PHASETEST.par")
 timfile = os.path.join(datadir, "NGC6440E_PHASETEST.tim")

--- a/tests/test_photonphase.py
+++ b/tests/test_photonphase.py
@@ -2,12 +2,12 @@
 import os
 import unittest
 
+import numpy as np
 import pytest
+from astropy.io import fits
+from pinttestdata import datadir
 
 import pint.scripts.photonphase as photonphase
-from pinttestdata import datadir
-from astropy.io import fits
-import numpy as np
 
 parfile = datadir / "J1513-5908_PKS_alldata_white.par"
 eventfile = datadir / "B1509_RXTE_short.fits"

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,13 +1,14 @@
 """Test pickle-ability of timing models"""
+import os
+import pickle
+
 import astropy.units as u
 import numpy as np
-import os
+from pinttestdata import datadir
 
 import pint.config
 import pint.models.parameter as param
 from pint.models.model_builder import get_model
-from pinttestdata import datadir
-import pickle
 
 
 def test_pickle_prefixparameter():

--- a/tests/test_piecewise.py
+++ b/tests/test_piecewise.py
@@ -5,14 +5,14 @@ import unittest
 import astropy.units as u
 import numpy as np
 import pytest
+from pinttestdata import datadir
 
 import pint.fitter
 import pint.models
 import pint.residuals
 import pint.toa
-from pinttestdata import datadir
-from pint.models.timing_model import MissingParameter
 from pint import fitter, toa
+from pint.models.timing_model import MissingParameter
 
 parfile = os.path.join(datadir, "piecewise.par")
 parfile2 = os.path.join(datadir, "piecewise_twocomps.par")

--- a/tests/test_pintbary.py
+++ b/tests/test_pintbary.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 import sys
 import unittest
+from io import StringIO
 
 import numpy as np
-from io import StringIO
 
 import pint.scripts.pintbary as pintbary
 

--- a/tests/test_pintempo.py
+++ b/tests/test_pintempo.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 import os
 import sys
-
 from io import StringIO
 
-from pint.scripts import pintempo
 from pinttestdata import datadir
+
+from pint.scripts import pintempo
 
 parfile = os.path.join(datadir, "NGC6440E.par")
 timfile = os.path.join(datadir, "NGC6440E.tim")

--- a/tests/test_pintk.py
+++ b/tests/test_pintk.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 import os
 import unittest
+from io import StringIO
 
 import numpy as np
 import pytest
-from io import StringIO
+from pinttestdata import datadir
 
 import pint.scripts.pintk as pintk
-from pinttestdata import datadir
 
 parfile = os.path.join(datadir, "NGC6440E.par")
 timfile = os.path.join(datadir, "NGC6440E.tim")

--- a/tests/test_plk_widget.py
+++ b/tests/test_plk_widget.py
@@ -1,7 +1,9 @@
+from tkinter import Frame
+
 import astropy.units as u
 import pytest
+
 from pint.pintk.plk import PlkWidget
-from tkinter import Frame
 
 
 @pytest.fixture

--- a/tests/test_polycos.py
+++ b/tests/test_polycos.py
@@ -1,12 +1,14 @@
 """Test polycos."""
 
-import pytest
-import numpy as np
-from pint.polycos import Polycos
-from pint.models import get_model
-import pint.toa as toa
-from pinttestdata import datadir
 from pathlib import Path
+
+import numpy as np
+import pytest
+from pinttestdata import datadir
+
+import pint.toa as toa
+from pint.models import get_model
+from pint.polycos import Polycos
 
 
 @pytest.fixture

--- a/tests/test_prefixparaminheritance.py
+++ b/tests/test_prefixparaminheritance.py
@@ -1,5 +1,5 @@
-import unittest
 import io
+import unittest
 
 from pint.models import get_model
 

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -3,18 +3,18 @@ import os
 import unittest
 
 import numpy as np
+from pinttestdata import datadir
 from scipy.stats import norm
 
 import pint.models
 
 # from pint.models.priors import *
 from pint.models.priors import (
-    Prior,
-    UniformBoundedRV,
     GaussianBoundedRV,
+    Prior,
     RandomInclinationPrior,
+    UniformBoundedRV,
 )
-from pinttestdata import datadir
 
 
 class TestPriors(unittest.TestCase):

--- a/tests/test_process_parfile.py
+++ b/tests/test_process_parfile.py
@@ -3,13 +3,12 @@
 """
 import os
 import tempfile
-
-import pytest
 from io import StringIO
 
-from pint.models.model_builder import ModelBuilder, parse_parfile, TimingModelError
+import pytest
 
 from pint.models import get_model
+from pint.models.model_builder import ModelBuilder, TimingModelError, parse_parfile
 
 base_par = """
 PSR J1234+5678

--- a/tests/test_pulsar_mjd.py
+++ b/tests/test_pulsar_mjd.py
@@ -3,9 +3,9 @@ import os
 import unittest
 
 import numpy as np
-from pint.pulsar_mjd import Time
-
 from pinttestdata import datadir
+
+from pint.pulsar_mjd import Time
 
 
 class TestPsrMjd(unittest.TestCase):

--- a/tests/test_pulsar_position.py
+++ b/tests/test_pulsar_position.py
@@ -4,9 +4,9 @@ import os
 import unittest
 
 import numpy as np
+from pinttestdata import datadir
 
 import pint.models.model_builder as mb
-from pinttestdata import datadir
 
 
 class TestPulsarPosition(unittest.TestCase):

--- a/tests/test_pulse_number.py
+++ b/tests/test_pulse_number.py
@@ -1,19 +1,19 @@
 #!/usr/bin/python
-from io import StringIO
 import os
-import pytest
 from copy import deepcopy
+from io import StringIO
 
 import numpy as np
+import pytest
 from astropy import units as u
 from numpy.testing import assert_almost_equal
-
-from pint.residuals import Residuals
 from pinttestdata import datadir
+
 import pint.fitter
 from pint.models import get_model
-from pint.toa import get_TOAs
+from pint.residuals import Residuals
 from pint.simulation import make_fake_toas_uniform
+from pint.toa import get_TOAs
 
 parfile = os.path.join(datadir, "withpn.par")
 timfile = os.path.join(datadir, "withpn.tim")
@@ -25,11 +25,11 @@ def model():
 
 
 @pytest.fixture
-def toas():
+def toas(pickle_dir):
     # The scope="module" setting ensures the TOAs object will be created
     # only once for the whole module, which will save time but might
     # allow accidental modifications done in one test to affect other tests.
-    return get_TOAs(timfile)
+    return get_TOAs(timfile, usepickle=True, picklefilename=pickle_dir)
 
 
 @pytest.fixture

--- a/tests/test_random_models.py
+++ b/tests/test_random_models.py
@@ -1,21 +1,20 @@
 import os
 from copy import deepcopy
 
+import astropy.units as u
+
 # import matplotlib
 # matplotlib.use('TKAgg')
 import matplotlib.pyplot as plt
-import pytest
 import numpy as np
-import astropy.units as u
+import pytest
+from pinttestdata import datadir
 
+import pint.fitter
+import pint.models.parameter as param
+from pint import ls, simulation, toa, utils
 from pint.models import get_model, get_model_and_toas
 from pint.toa import get_TOAs
-import pint.fitter
-from pint import toa, simulation
-from pinttestdata import datadir
-import pint.models.parameter as param
-from pint import ls
-from pint import utils
 
 
 @pytest.mark.parametrize(

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -16,8 +16,8 @@ from pint.fitter import GLSFitter, WidebandTOAFitter, WLSFitter
 from pint.models import get_model
 from pint.models.dispersion_model import Dispersion
 from pint.residuals import CombinedResiduals, Residuals, WidebandTOAResiduals
-from pint.toa import get_TOAs
 from pint.simulation import make_fake_toas_uniform
+from pint.toa import get_TOAs
 from pint.utils import weighted_mean
 
 os.chdir(datadir)

--- a/tests/test_satobs.py
+++ b/tests/test_satobs.py
@@ -1,11 +1,11 @@
 import os
-import pytest
 
-from astropy.time import Time
 import numpy as np
+import pytest
+from astropy.time import Time
+from pinttestdata import datadir
 
 from pint.observatory.satellite_obs import get_satellite_observatory
-from pinttestdata import datadir
 
 
 def test_good_calls():

--- a/tests/test_solar_system_body.py
+++ b/tests/test_solar_system_body.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 import os
 import unittest
-import pytest
 
 import astropy.time as time
 import numpy as np
+import pytest
 from astropy.coordinates import solar_system_ephemeris
+from pinttestdata import datadir
 
 import pint.config
 from pint.solar_system_ephemerides import objPosVel, objPosVel_wrt_SSB
-from pinttestdata import datadir
 
 # Hack to support FileNotFoundError in Python 2
 try:

--- a/tests/test_solar_wind.py
+++ b/tests/test_solar_wind.py
@@ -1,21 +1,22 @@
 """ Test for pint solar wind module
 """
 
-import os
-from io import StringIO
-import pytest
-import numpy as np
-from numpy.testing import assert_allclose
 import copy
+import os
 import sys
+from io import StringIO
 
 import astropy.units as u
+import numpy as np
+import pytest
 from astropy.time import Time
-from pint.models import get_model
-from pint.fitter import WidebandTOAFitter
-from pint.toa import get_TOAs
-from pint.simulation import make_fake_toas_uniform
+from numpy.testing import assert_allclose
 from pinttestdata import datadir
+
+from pint.fitter import WidebandTOAFitter
+from pint.models import get_model
+from pint.simulation import make_fake_toas_uniform
+from pint.toa import get_TOAs
 
 os.chdir(datadir)
 

--- a/tests/test_stigma.py
+++ b/tests/test_stigma.py
@@ -1,19 +1,18 @@
+import io
 import logging
 import os
-import io
+import tempfile
 
 import astropy.units as u
 import numpy as np
 import pytest
-import tempfile
-
-from pint.models import get_model
-import pint.toa as toa
-import pint.simulation as simulation
 import test_derivative_utils as tdu
-from pint.residuals import Residuals
 from pinttestdata import datadir
 
+import pint.simulation as simulation
+import pint.toa as toa
+from pint.models import get_model
+from pint.residuals import Residuals
 
 stigma_template = """
 PSR              FAKE

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,8 +1,8 @@
 import logging
 
 import numpy as np
-
 from pinttestdata import datadir
+
 from pint.templates import lcfitters, lcprimitives, lctemplate
 
 

--- a/tests/test_tempox_compatibility.py
+++ b/tests/test_tempox_compatibility.py
@@ -1,11 +1,12 @@
-from io import StringIO
 import re
+from io import StringIO
 
 import astropy.units as u
 import numpy as np
 import pytest
-from pint.models import get_model
+
 import pint.toa
+from pint.models import get_model
 
 par_basic = """
 PSR J1234+5678

--- a/tests/test_tim_writing.py
+++ b/tests/test_tim_writing.py
@@ -1,11 +1,12 @@
-from io import StringIO
 import re
+from io import StringIO
 
 import astropy.units as u
 import numpy as np
 import pytest
 from hypothesis import given, settings
-from hypothesis.strategies import lists, tuples, one_of, from_regex, just
+from hypothesis.strategies import from_regex, just, lists, one_of, tuples
+
 from pint.toa import get_TOAs
 
 basic_tim_header = "FORMAT 1\n"

--- a/tests/test_times.py
+++ b/tests/test_times.py
@@ -16,7 +16,7 @@ from pint.utils import PosVel
 @pytest.mark.xfail(
     reason="PINT has a newer version of the Arecibo position than TEMPO2"
 )
-def test_times_against_tempo2():
+def test_times_against_tempo2(pickle_dir):
     log.setLevel("ERROR")
     # for nice output info, set the following instead
     # log.setLevel('INFO')
@@ -24,7 +24,12 @@ def test_times_against_tempo2():
     ls = u.def_unit("ls", const.c * 1.0 * u.s)
 
     log.info("Reading TOAs into PINT")
-    ts = toa.get_TOAs(datadir + "/testtimes.tim", include_bipm=False, usepickle=False)
+    ts = toa.get_TOAs(
+        datadir + "/testtimes.tim",
+        include_bipm=False,
+        usepickle=True,
+        picklefilename=pickle_dir,
+    )
     if log.level < 25:
         ts.print_summary()
     ts.table.sort("index")

--- a/tests/test_timing_model.py
+++ b/tests/test_timing_model.py
@@ -2,19 +2,19 @@ import io
 import os
 import sys
 import warnings
-from copy import deepcopy
 from contextlib import redirect_stdout
+from copy import deepcopy
 
 import astropy.units as u
 import numpy as np
 import pytest
 from hypothesis import given
-from hypothesis.strategies import permutations, composite
+from hypothesis.strategies import composite, permutations
 from numpy.testing import assert_allclose
-from pint import toa
-from pint.observatory import compare_t2_observatories_dat
 from pinttestdata import datadir
 
+import pint.residuals
+from pint import toa
 from pint.models import (
     DEFAULT_ORDER,
     AstrometryEquatorial,
@@ -26,9 +26,9 @@ from pint.models import (
     get_model,
     parameter as p,
 )
+from pint.observatory import compare_t2_observatories_dat
 from pint.simulation import make_fake_toas_uniform
 from pint.toa import get_TOAs
-import pint.residuals
 
 
 @pytest.fixture

--- a/tests/test_toa.py
+++ b/tests/test_toa.py
@@ -9,8 +9,8 @@ from pinttestdata import datadir
 
 from pint.models import get_model
 from pint.observatory import get_observatory
-from pint.toa import TOA, TOAs
 from pint.simulation import make_fake_toas_uniform
+from pint.toa import TOA, TOAs
 
 
 class TestTOA(unittest.TestCase):

--- a/tests/test_toa_flag.py
+++ b/tests/test_toa_flag.py
@@ -4,8 +4,9 @@
 import os
 import unittest
 
-import pint.toa as toa
 from pinttestdata import datadir
+
+import pint.toa as toa
 
 
 class TestToaFlag(unittest.TestCase):

--- a/tests/test_toa_indexing.py
+++ b/tests/test_toa_indexing.py
@@ -2,9 +2,9 @@ from io import StringIO
 
 import numpy as np
 import pytest
-from hypothesis import given, assume
-from hypothesis.strategies import slices, integers, booleans, one_of, lists
-from hypothesis.extra.numpy import arrays, array_shapes
+from hypothesis import assume, given
+from hypothesis.extra.numpy import array_shapes, arrays
+from hypothesis.strategies import booleans, integers, lists, one_of, slices
 
 from pint.toa import get_TOAs
 

--- a/tests/test_toa_selection.py
+++ b/tests/test_toa_selection.py
@@ -5,14 +5,14 @@ import unittest
 
 import astropy.units as u
 import numpy as np
+from pinttestdata import datadir
+
+import pint.models.model_builder as mb
+import pint.toa as toa
 
 # import matplotlib
 # matplotlib.use('TKAgg')
 # import matplotlib.pyplot as plt
-
-import pint.models.model_builder as mb
-import pint.toa as toa
-from pinttestdata import datadir
 
 
 class TestTOAselection(unittest.TestCase):

--- a/tests/test_toa_shuffle.py
+++ b/tests/test_toa_shuffle.py
@@ -1,22 +1,17 @@
 import io
 import os
+import time
 from copy import deepcopy
 
 import numpy as np
 import pytest
-import time
-
-from hypothesis import given
-from hypothesis.strategies import (
-    composite,
-    permutations,
-)
 from astropy import units as u
-
+from hypothesis import given
+from hypothesis.strategies import composite, permutations
 from pinttestdata import datadir
 
-from pint import simulation, toa
 import pint.residuals
+from pint import simulation, toa
 from pint.models import get_model, get_model_and_toas
 
 shuffletoas = """FORMAT 1

--- a/tests/test_toa_writer.py
+++ b/tests/test_toa_writer.py
@@ -1,14 +1,15 @@
-from io import StringIO
 import os
 import os.path
-import pytest
+from io import StringIO
 
-from pint.models import get_model
-from pint import toa, simulation
-from pinttestdata import datadir
-from astropy.time import Time
-import numpy as np
 import astropy.units as u
+import numpy as np
+import pytest
+from astropy.time import Time
+from pinttestdata import datadir
+
+from pint import simulation, toa
+from pint.models import get_model
 
 
 def test_roundtrip_bary_toa_Tempo2format(tmpdir):

--- a/tests/test_troposphere_model.py
+++ b/tests/test_troposphere_model.py
@@ -1,90 +1,106 @@
 #!/usr/bin/env python
 
 import os
-import unittest
+import warnings
 
 import astropy.units as u
 import numpy as np
+import pytest
+from astropy.coordinates import AltAz, SkyCoord
+from astropy.time import Time
+from pinttestdata import datadir, testdir
+
 import pint.models as models
 import pint.observatory
 import pint.toa as toa
-from astropy.coordinates import AltAz, SkyCoord
-from astropy.time import Time
 from pint.observatory import get_observatory
 
-from pinttestdata import testdir, datadir
+
+@pytest.fixture
+def setup(pickle_dir):
+    class Setup:
+        pass
+
+    s = Setup()
+
+    s.MIN_ALT = 5  # the minimum altitude in degrees for testing the delay model
+
+    s.FLOAT_THRESHOLD = 1e-12  #
+
+    # parfile = os.path.join(datadir, "J1744-1134.basic.par")
+    # ngc = os.path.join(datadir, "NGC6440E")
+
+    s.toas = toa.get_TOAs(
+        os.path.join(datadir, "NGC6440E.tim"), picklefilename=pickle_dir
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        s.model = pint.models.get_model(os.path.join(datadir, "NGC6440E.par"))
+        s.modelWithTD = pint.models.get_model(os.path.join(datadir, "NGC6440E.par"))
+        s.modelWithTD.CORRECT_TROPOSPHERE.value = True
+
+    s.toasInvalid = toa.get_TOAs(
+        os.path.join(datadir, "NGC6440E.tim"), picklefilename=pickle_dir
+    )
+
+    for i in range(len(s.toasInvalid.table)):
+        # adjust the timing by half a day to make them invalid
+        s.toasInvalid.table["mjd"][i] += 0.5 * u.d
+
+    s.testAltitudes = np.arange(s.MIN_ALT, 90, 100) * u.deg
+    s.testHeights = np.array([10, 100, 1000, 5000]) * u.m
+
+    s.td = s.modelWithTD.components["TroposphereDelay"]
+    return s
 
 
-class TestTroposphereDelay(unittest.TestCase):
+def test_altitudes(setup):
+    # the troposphere delay should strictly decrease with increasing altitude above horizon
+    delays = setup.td.delay_model(setup.testAltitudes, 0, 1000 * u.m, 0)
 
-    MIN_ALT = 5  # the minimum altitude in degrees for testing the delay model
+    for i in range(1, len(delays)):
+        assert delays[i] < delays[i - 1]
 
-    FLOAT_THRESHOLD = 1e-12  #
 
-    def setUp(self):
+def test_heights(setup):
+    # higher elevation observatories should have less troposphere delay
+    heightDelays = []  # list of the delays at each height
+    for h in setup.testHeights:
+        heightDelays.append(setup.td.delay_model(setup.testAltitudes, 0, h, 0))
+    for i in range(1, len(setup.testHeights)):
+        print(heightDelays[i], heightDelays[i - 1])
+        assert np.all(np.less(heightDelays[i], heightDelays[i - 1]))
 
-        # parfile = os.path.join(datadir, "J1744-1134.basic.par")
-        # ngc = os.path.join(datadir, "NGC6440E")
 
-        self.toas = toa.get_TOAs(os.path.join(datadir, "NGC6440E.tim"))
-        self.model = pint.models.get_model(os.path.join(datadir, "NGC6440E.par"))
-        self.modelWithTD = pint.models.get_model(os.path.join(datadir, "NGC6440E.par"))
-        self.modelWithTD.CORRECT_TROPOSPHERE.value = True
+def test_model_access(setup):
+    # make sure that the model components are linked correctly to the troposphere delay
+    assert hasattr(setup.model, "CORRECT_TROPOSPHERE")
+    assert "TroposphereDelay" in setup.modelWithTD.components.keys()
 
-        self.toasInvalid = toa.get_TOAs(os.path.join(datadir, "NGC6440E.tim"))
+    # the model should have the sky coordinates defined
+    assert setup.td._get_target_skycoord() is not None
 
-        for i in range(len(self.toasInvalid.table)):
-            # adjust the timing by half a day to make them invalid
-            self.toasInvalid.table["mjd"][i] += 0.5
 
-        self.testAltitudes = np.arange(self.MIN_ALT, 90, 100) * u.deg
-        self.testHeights = np.array([10, 100, 1000, 5000]) * u.m
-
-        self.td = self.modelWithTD.components["TroposphereDelay"]
-
-    def test_altitudes(self):
-        # the troposphere delay should strictly decrease with increasing altitude above horizon
-        delays = self.td.delay_model(self.testAltitudes, 0, 1000 * u.m, 0)
-
-        for i in range(1, len(delays)):
-            assert delays[i] < delays[i - 1]
-
-    def test_heights(self):
-        # higher elevation observatories should have less troposphere delay
-        heightDelays = []  # list of the delays at each height
-        for h in self.testHeights:
-            heightDelays.append(self.td.delay_model(self.testAltitudes, 0, h, 0))
-        for i in range(1, len(self.testHeights)):
-            print(heightDelays[i], heightDelays[i - 1])
-            assert np.all(np.less(heightDelays[i], heightDelays[i - 1]))
-
-    def test_model_access(self):
-        # make sure that the model components are linked correctly to the troposphere delay
-        assert hasattr(self.model, "CORRECT_TROPOSPHERE")
-        assert "TroposphereDelay" in self.modelWithTD.components.keys()
-
-        # the model should have the sky coordinates defined
-        assert self.td._get_target_skycoord() is not None
-
-    def test_invalid_altitudes(self):
-        assert np.all(
-            np.less_equal(
-                np.abs(self.td.troposphere_delay(self.toasInvalid)),
-                self.FLOAT_THRESHOLD * u.s,
-            )
+def test_invalid_altitudes(setup):
+    assert np.all(
+        np.less_equal(
+            np.abs(setup.td.troposphere_delay(setup.toasInvalid)),
+            setup.FLOAT_THRESHOLD * u.s,
         )
+    )
 
-    def test_latitude_index(self):
-        # the code relies on finding the neighboring latitudes to any site
-        # for atmospheric constants defined at every 15 degrees
-        # so I will test the nearest neighbors function
 
-        l1 = self.td._find_latitude_index(20 * u.deg)
-        l2 = self.td._find_latitude_index(-80 * u.deg)
-        l3 = self.td._find_latitude_index(0 * u.deg)
-        l4 = self.td._find_latitude_index(-90 * u.deg)
+def test_latitude_index(setup):
+    # the code relies on finding the neighboring latitudes to any site
+    # for atmospheric constants defined at every 15 degrees
+    # so I will test the nearest neighbors function
 
-        assert self.td.LAT[l1] <= 20 * u.deg < self.td.LAT[l1 + 1]
-        assert self.td.LAT[l2] <= 80 * u.deg <= self.td.LAT[l2 + 1]
-        assert self.td.LAT[l3] <= 0 * u.deg <= self.td.LAT[l3 + 1]
-        assert self.td.LAT[l4] <= 90 * u.deg <= self.td.LAT[l4 + 1]
+    l1 = setup.td._find_latitude_index(20 * u.deg)
+    l2 = setup.td._find_latitude_index(-80 * u.deg)
+    l3 = setup.td._find_latitude_index(0 * u.deg)
+    l4 = setup.td._find_latitude_index(-90 * u.deg)
+
+    assert setup.td.LAT[l1] <= 20 * u.deg < setup.td.LAT[l1 + 1]
+    assert setup.td.LAT[l2] <= 80 * u.deg <= setup.td.LAT[l2 + 1]
+    assert setup.td.LAT[l3] <= 0 * u.deg <= setup.td.LAT[l3 + 1]
+    assert setup.td.LAT[l4] <= 90 * u.deg <= setup.td.LAT[l4 + 1]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,10 +43,10 @@ from pint.utils import (
     dmxparse,
     interesting_lines,
     lines_of,
+    list_parameters,
     open_or_use,
     taylor_horner,
     taylor_horner_deriv,
-    list_parameters,
 )
 
 
@@ -602,19 +602,33 @@ def test_time_from_mjd_string_rejects_other_formats():
         time_from_mjd_string("58000", format="cxcsec")
 
 
-def test_dmxparse():
+def test_dmxparse_runs(pickle_dir):
     """Test for dmxparse function."""
+    # FIXME: what does this actually check?
     m = tm.get_model(os.path.join(datadir, "B1855+09_NANOGrav_9yv1.gls.par"))
-    t = toa.get_TOAs(os.path.join(datadir, "B1855+09_NANOGrav_9yv1.tim"))
+    t = toa.get_TOAs(
+        os.path.join(datadir, "B1855+09_NANOGrav_9yv1.tim"),
+        usepickle=True,
+        picklefilename=pickle_dir,
+    )
     f = fitter.GLSFitter(toas=t, model=m)
     f.fit_toas()
-    dmx = dmxparse(f, save=False)
+    dmxparse(f, save=False)
+
+
+def test_dmxparse_runs_wls(pickle_dir):
+    """Test for dmxparse function."""
     # Check exception handling
+    # FIXME: what does this actually check?
     m = tm.get_model(os.path.join(datadir, "B1855+09_NANOGrav_dfg+12_DMX.par"))
-    t = toa.get_TOAs(os.path.join(datadir, "B1855+09_NANOGrav_dfg+12.tim"))
+    t = toa.get_TOAs(
+        os.path.join(datadir, "B1855+09_NANOGrav_dfg+12.tim"),
+        usepickle=True,
+        picklefilename=pickle_dir,
+    )
     f = fitter.WLSFitter(toas=t, model=m)
     f.fit_toas()
-    dmx = dmxparse(f, save=False)
+    dmxparse(f, save=False)
 
 
 def test_pmtot():

--- a/tests/test_variety_parfiles.py
+++ b/tests/test_variety_parfiles.py
@@ -1,16 +1,16 @@
 """Various test for the bad par files"""
-import pytest
-from io import StringIO
 import warnings
+from io import StringIO
 
+import pytest
+
+from pint.models.model_builder import get_model
 from pint.models.timing_model import (
-    TimingModelError,
-    UnknownBinaryModel,
     MissingBinaryError,
     MissingParameter,
+    TimingModelError,
+    UnknownBinaryModel,
 )
-from pint.models.model_builder import get_model
-
 
 base_par = """
 PSR J1234+5678

--- a/tests/test_widebandTOA_fitting.py
+++ b/tests/test_widebandTOA_fitting.py
@@ -1,101 +1,114 @@
 """ Various of tests for the general data fitter using wideband TOAs.
 """
 
-import pytest
-import os
-
-import numpy as np
 import astropy.units as u
-from pint.models import get_model
-from pint.toa import get_TOAs
-from pint.fitter import WidebandTOAFitter
+import numpy as np
+import pytest
 from pinttestdata import datadir
 
-os.chdir(datadir)
+from pint.fitter import WidebandTOAFitter
+from pint.models import get_model
+from pint.toa import get_TOAs
 
 
-class TestWidebandTOAFitter:
-    def setup(self):
-        self.model = get_model("J1614-2230_NANOGrav_12yv3.wb.gls.par")
-        self.toas = get_TOAs(
-            "J1614-2230_NANOGrav_12yv3.wb.tim", ephem="DE436", bipm_version="BIPM2015"
-        )
-        self.fit_data_name = ["toa", "dm"]
-        self.fit_params_lite = ["F0", "F1", "ELONG", "ELAT", "DMJUMP1", "DMX_0022"]
-        self.tempo_res = np.genfromtxt(
-            "J1614-2230_NANOGrav_12yv3.wb.tempo_test", comments="#"
-        )
+@pytest.fixture
+def setup(pickle_dir):
+    class Setup:
+        pass
 
-    def test_fitter_init(self):
-        fitter = WidebandTOAFitter([self.toas], self.model, additional_args={})
+    s = Setup()
+    s.model = get_model(datadir / "J1614-2230_NANOGrav_12yv3.wb.gls.par")
+    s.toas = get_TOAs(
+        datadir / "J1614-2230_NANOGrav_12yv3.wb.tim",
+        ephem="DE436",
+        bipm_version="BIPM2015",
+        picklefilename=pickle_dir,
+    )
+    s.fit_data_name = ["toa", "dm"]
+    s.fit_params_lite = ["F0", "F1", "ELONG", "ELAT", "DMJUMP1", "DMX_0022"]
+    s.tempo_res = np.genfromtxt(
+        datadir / "J1614-2230_NANOGrav_12yv3.wb.tempo_test", comments="#"
+    )
+    return s
 
-        # test making residuals
-        assert len(fitter.resids._combined_resids) == 2 * self.toas.ntoas
-        # test additional args
-        add_args = {}
-        add_args["toa"] = {"subtract_mean": False}
-        fitter2 = WidebandTOAFitter([self.toas], self.model, additional_args=add_args)
 
-        assert fitter2.resids.toa.subtract_mean == False
+def test_fitter_init(setup):
+    fitter = WidebandTOAFitter([setup.toas], setup.model, additional_args={})
 
-    def test_fitter_designmatrix(self):
-        fitter = WidebandTOAFitter([self.toas], self.model, additional_args={})
-        fitter.model.free_params = self.fit_params_lite
-        assert set(fitter.model.free_params) == set(self.fit_params_lite)
-        # test making design matrix
-        d_matrix = fitter.get_designmatrix()
-        assert d_matrix.shape == (2 * self.toas.ntoas, len(self.fit_params_lite) + 1)
-        assert [lb[0] for lb in d_matrix.labels[0]] == ["toa", "dm"]
-        assert d_matrix.derivative_params == (["Offset"] + fitter.model.free_params)
+    # test making residuals
+    assert len(fitter.resids._combined_resids) == 2 * setup.toas.ntoas
+    # test additional args
+    add_args = {}
+    add_args["toa"] = {"subtract_mean": False}
+    fitter2 = WidebandTOAFitter([setup.toas], setup.model, additional_args=add_args)
 
-    def test_fitting_no_full_cov(self):
-        fitter = WidebandTOAFitter([self.toas], self.model, additional_args={})
-        time_rms_pre = fitter.resids_init.toa.rms_weighted()
-        dm_rms_pre = fitter.resids_init.dm.rms_weighted()
-        fitter.fit_toas()
-        dm_rms_post = fitter.resids.dm.rms_weighted()
+    assert fitter2.resids.toa.subtract_mean == False
 
-        prefit_pint = fitter.resids_init.toa.time_resids
-        prefit_tempo = self.tempo_res[:, 0] * u.us
-        diff_prefit = (prefit_pint - prefit_tempo).to(u.ns)
-        # 50 ns is the difference of PINT tempo precession and nautation model.
-        assert np.abs(diff_prefit - diff_prefit.mean()).max() < 50 * u.ns
-        postfit_pint = fitter.resids.toa.time_resids
-        postfit_tempo = self.tempo_res[:, 1] * u.us
-        diff_postfit = (postfit_pint - postfit_tempo).to(u.ns)
-        assert np.abs(diff_postfit - diff_postfit.mean()).max() < 50 * u.ns
-        assert np.abs(dm_rms_pre - dm_rms_post) < 5e-8 * dm_rms_pre.unit
 
-    def test_fitting_full_cov(self):
-        fitter2 = WidebandTOAFitter([self.toas], self.model, additional_args={})
-        time_rms_pre = fitter2.resids_init.toa.rms_weighted()
-        dm_rms_pre = fitter2.resids_init.dm.rms_weighted()
-        fitter2.fit_toas(full_cov=True)
-        time_rms_post = fitter2.resids.toa.rms_weighted()
-        dm_rms_post = fitter2.resids.dm.rms_weighted()
+def test_fitter_designmatrix(setup):
+    fitter = WidebandTOAFitter([setup.toas], setup.model, additional_args={})
+    fitter.model.free_params = setup.fit_params_lite
+    assert set(fitter.model.free_params) == set(setup.fit_params_lite)
+    # test making design matrix
+    d_matrix = fitter.get_designmatrix()
+    assert d_matrix.shape == (2 * setup.toas.ntoas, len(setup.fit_params_lite) + 1)
+    assert [lb[0] for lb in d_matrix.labels[0]] == ["toa", "dm"]
+    assert d_matrix.derivative_params == (["Offset"] + fitter.model.free_params)
 
-        prefit_pint = fitter2.resids_init.toa.time_resids
-        prefit_tempo = self.tempo_res[:, 0] * u.us
-        diff_prefit = (prefit_pint - prefit_tempo).to(u.ns)
-        # 50 ns is the difference of PINT tempo precession and nautation model.
-        assert np.abs(diff_prefit - diff_prefit.mean()).max() < 50 * u.ns
-        postfit_pint = fitter2.resids.toa.time_resids
-        postfit_tempo = self.tempo_res[:, 1] * u.us
-        diff_postfit = (postfit_pint - postfit_tempo).to(u.ns)
-        assert np.abs(diff_postfit - diff_postfit.mean()).max() < 50 * u.ns
-        assert np.abs(dm_rms_pre - dm_rms_post) < 5e-8 * dm_rms_pre.unit
 
-    def test_noise_design_matrix_index(self):
-        model = get_model("B1855+09_NANOGrav_12yv3.wb.gls.par")
-        toas = get_TOAs(
-            "B1855+09_NANOGrav_12yv3.wb.tim", ephem="DE436", bipm_version="BIPM2015"
-        )
-        fitter = WidebandTOAFitter(toas, model, additional_args={})
-        fitter.fit_toas(full_cov=False, debug=True)
-        # Test red noise basis
-        pl_rd = fitter.model.pl_rn_basis_weight_pair(fitter.toas)[0]
-        p0, p1 = fitter.resids.pl_red_noise_M_index
-        pl_rd_backwards = (
-            fitter.resids.pl_red_noise_M[0] * fitter.resids.norm[p0:p1][np.newaxis, :]
-        )
-        assert np.all(np.isclose(pl_rd, pl_rd_backwards[0:313, :]))
+def test_fitting_no_full_cov(setup):
+    fitter = WidebandTOAFitter([setup.toas], setup.model, additional_args={})
+    time_rms_pre = fitter.resids_init.toa.rms_weighted()
+    dm_rms_pre = fitter.resids_init.dm.rms_weighted()
+    fitter.fit_toas()
+    dm_rms_post = fitter.resids.dm.rms_weighted()
+
+    prefit_pint = fitter.resids_init.toa.time_resids
+    prefit_tempo = setup.tempo_res[:, 0] * u.us
+    diff_prefit = (prefit_pint - prefit_tempo).to(u.ns)
+    # 50 ns is the difference of PINT tempo precession and nautation model.
+    assert np.abs(diff_prefit - diff_prefit.mean()).max() < 50 * u.ns
+    postfit_pint = fitter.resids.toa.time_resids
+    postfit_tempo = setup.tempo_res[:, 1] * u.us
+    diff_postfit = (postfit_pint - postfit_tempo).to(u.ns)
+    assert np.abs(diff_postfit - diff_postfit.mean()).max() < 50 * u.ns
+    assert np.abs(dm_rms_pre - dm_rms_post) < 5e-8 * dm_rms_pre.unit
+
+
+def test_fitting_full_cov(setup):
+    fitter2 = WidebandTOAFitter([setup.toas], setup.model, additional_args={})
+    time_rms_pre = fitter2.resids_init.toa.rms_weighted()
+    dm_rms_pre = fitter2.resids_init.dm.rms_weighted()
+    fitter2.fit_toas(full_cov=True)
+    time_rms_post = fitter2.resids.toa.rms_weighted()
+    dm_rms_post = fitter2.resids.dm.rms_weighted()
+
+    prefit_pint = fitter2.resids_init.toa.time_resids
+    prefit_tempo = setup.tempo_res[:, 0] * u.us
+    diff_prefit = (prefit_pint - prefit_tempo).to(u.ns)
+    # 50 ns is the difference of PINT tempo precession and nautation model.
+    assert np.abs(diff_prefit - diff_prefit.mean()).max() < 50 * u.ns
+    postfit_pint = fitter2.resids.toa.time_resids
+    postfit_tempo = setup.tempo_res[:, 1] * u.us
+    diff_postfit = (postfit_pint - postfit_tempo).to(u.ns)
+    assert np.abs(diff_postfit - diff_postfit.mean()).max() < 50 * u.ns
+    assert np.abs(dm_rms_pre - dm_rms_post) < 5e-8 * dm_rms_pre.unit
+
+
+def test_noise_design_matrix_index(pickle_dir):
+    model = get_model(datadir / "B1855+09_NANOGrav_12yv3.wb.gls.par")
+    toas = get_TOAs(
+        datadir / "B1855+09_NANOGrav_12yv3.wb.tim",
+        ephem="DE436",
+        bipm_version="BIPM2015",
+        picklefilename=pickle_dir,
+    )
+    fitter = WidebandTOAFitter(toas, model, additional_args={})
+    fitter.fit_toas(full_cov=False, debug=True)
+    # Test red noise basis
+    pl_rd = fitter.model.pl_rn_basis_weight_pair(fitter.toas)[0]
+    p0, p1 = fitter.resids.pl_red_noise_M_index
+    pl_rd_backwards = (
+        fitter.resids.pl_red_noise_M[0] * fitter.resids.norm[p0:p1][np.newaxis, :]
+    )
+    assert np.all(np.isclose(pl_rd, pl_rd_backwards[0:313, :]))

--- a/tests/test_zima.py
+++ b/tests/test_zima.py
@@ -2,12 +2,12 @@
 import os
 import sys
 import unittest
-
-import numpy as np
 from io import StringIO
 
-import pint.scripts.zima as zima
+import numpy as np
 from pinttestdata import datadir, testdir
+
+import pint.scripts.zima as zima
 
 
 def test_result(tmp_path):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,10 +1,11 @@
 """Utililty functions for the tests"""
 import logging
 import os
-from io import StringIO
 import unittest
-import pytest
 import warnings
+from io import StringIO
+
+import pytest
 
 
 def verify_stand_alone_binary_parameter_updates(m):


### PR DESCRIPTION
Currently many of our tests load TOAs from files in `tests/datafile/`. Some of these files are quite large. PINT has a facility for making re-loading of tim files much faster: saving a pickle in which clock corrections and similar data have already been computed. This PR is intended to make the test suite use this facility, where appropriate, by creating these pickles in a temporary directory that persists for the duration of a test run.

This PR also add the ability to easily specify a directory in which pickles should be kept, named according to the name of the .tim files they are made from. This may be useful in other contexts.

This PR needs to convert many old `unittest`-style test cases so that they can use `pytest` fixtures. Minor test cleanups may also happen.