### PR TITLE
Allow clock files that contain only sporadic updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - index.txt is only checked at most once a day
 - Moved observatories to JSON file.  Changed way observatories are loaded/overloaded
 - Split Jodrell Bank observatory based on backend to get correct clock files
+- Clock files can be marked as being valid past the end of the data they contain
 ### Added
 - delta_pulse_number column is now saved to -padd flag on TOA write
 ### Fixed

--- a/docs/examples/PINT_observatories.py
+++ b/docs/examples/PINT_observatories.py
@@ -44,7 +44,7 @@ print(gbt)
 # The observatory also includes info on things like the clock file:
 
 # %%
-print(f"GBT clock file is named '{gbt.clock_file}'")
+print(f"GBT clock file is named '{gbt.clock_files}'")
 
 # %% [markdown]
 # Some special locations are also present, like the solar system barycenter.  You can access explicitly through the `pint.observatory.special_locations` module, but if you just try to get one it will automatically import what is needed

--- a/src/pint/data/runtime/observatories.json
+++ b/src/pint/data/runtime/observatories.json
@@ -102,7 +102,10 @@
     },
     "jbroach": {
         "clock_file": [
-            "jbroach2jb.clk",
+            {
+                "name": "jbroach2jb.clk",
+                "valid_beyond_ends": true
+            },
             "jb2gps.clk"
         ],
         "clock_fmt": "tempo2",
@@ -125,7 +128,10 @@
     },
     "jbdfb": {
         "clock_file": [
-            "jbdfb2jb.clk",
+            {
+                "name": "jbdfb2jb.clk",
+                "valid_beyond_ends": true
+            },
             "jb2gps.clk"
         ],
         "clock_fmt": "tempo2",

--- a/src/pint/observatory/clock_file.py
+++ b/src/pint/observatory/clock_file.py
@@ -452,7 +452,9 @@ clkcorr_re = re.compile(
 )
 
 
-def read_tempo2_clock_file(filename, bogus_last_correction=False, friendly_name=None):
+def read_tempo2_clock_file(
+    filename, bogus_last_correction=False, friendly_name=None, valid_beyond_ends=False
+):
     """Read a TEMPO2-format clock file.
 
     This function can also be accessed through
@@ -469,6 +471,8 @@ def read_tempo2_clock_file(filename, bogus_last_correction=False, friendly_name=
     friendly_name : str or None
         A human-readable name for this file, for use in error reporting.
         If not provided, will default to ``filename``.
+    valid_beyond_ends : bool
+        Whether to consider the file valid past the ends of the data it contains.
     """
     log.debug(
         f"Loading TEMPO2-format observatory clock correction file {filename} with {bogus_last_correction=}"
@@ -547,6 +551,7 @@ def read_tempo2_clock_file(filename, bogus_last_correction=False, friendly_name=
         leading_comment=leading_comment,
         header=header,
         friendly_name=friendly_name,
+        valid_beyond_ends=valid_beyond_ends,
     )
 
 
@@ -573,6 +578,7 @@ def read_tempo_clock_file(
     bogus_last_correction=False,
     process_includes=True,
     friendly_name=None,
+    valid_beyond_ends=False,
 ):
     """Read a TEMPO-format clock file.
 
@@ -607,6 +613,8 @@ def read_tempo_clock_file(
     friendly_name : str or None
         A human-readable name for this file, for use in error reporting.
         If not provided, will default to ``filename``.
+    valid_beyond_ends : bool
+        Whether to consider the file valid past the ends of the data it contains.
     """
 
     leading_comment = None
@@ -765,6 +773,7 @@ def read_tempo_clock_file(
         comments=comments,
         leading_comment=leading_comment,
         friendly_name=friendly_name,
+        valid_beyond_ends=valid_beyond_ends,
     )
 
 

--- a/src/pint/observatory/global_clock_corrections.py
+++ b/src/pint/observatory/global_clock_corrections.py
@@ -14,7 +14,6 @@ to clear out old files you will want to do
 """
 import collections
 import time
-import warnings
 from pathlib import Path
 
 from astropy.utils.data import download_file
@@ -46,6 +45,9 @@ def get_file(
 ):
     """Obtain a local file pointing to a current version of name.
 
+    The mtime of the returned file will record when the data was last obtained
+    from the internet.
+
     Parameters
     ----------
     name : str
@@ -64,8 +66,12 @@ def get_file(
         Useful mostly for testing.
     invalid_if_older_than : astropy.time.Time or None
         Re-download the file if the cached version is older than this.
-    """
 
+    Returns
+    -------
+    pathlib.Path
+        The location of the file.
+    """
     log.trace(f"File {name} requested")
     if url_base is None:
         url_base = global_clock_correction_url_base
@@ -80,7 +86,7 @@ def get_file(
 
     if download_policy != "always":
         try:
-            local_file = download_file(remote_url, cache=True, sources=[])
+            local_file = Path(download_file(remote_url, cache=True, sources=[]))
             log.trace(f"file {remote_url} found in cache at path: {local_file}")
         except KeyError:
             log.trace(f"file {remote_url} not found in cache")
@@ -120,9 +126,10 @@ def get_file(
     # By this point we know we need a new file but we want it to wind up in
     # the cache
     log.info(
-        f"File {name} to be downloaded due to download policy {download_policy}: {remote_url}"
+        f"File {name} to be downloaded due to download policy "
+        f"{download_policy}: {remote_url}"
     )
-    return download_file(remote_url, cache="update", sources=mirror_urls)
+    return Path(download_file(remote_url, cache="update", sources=mirror_urls))
 
 
 IndexEntry = collections.namedtuple(

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -96,12 +96,6 @@ tempo_aliases = {
 }
 
 
-def _compute_hash(filename):
-    h = hashlib.sha256()
-    h.update(open(filename, "rb").read())
-    return h.digest()
-
-
 def get_TOAs(
     timfile,
     ephem=None,
@@ -270,7 +264,7 @@ def get_TOAs(
 
         files = [t.filename] if isinstance(t.filename, (str, Path)) else t.filename
         if files is not None:
-            t.hashes = {f: _compute_hash(f) for f in files}
+            t.hashes = {f: pint.utils.compute_hash(f) for f in files}
         recalc = True
 
     if all("clkcorr" not in f for f in t.table["flags"]):
@@ -1777,7 +1771,7 @@ class TOAs:
             return False
 
         for t, f in zip(timfiles, filenames):
-            if _compute_hash(t) != self.hashes[f]:
+            if pint.utils.compute_hash(t) != self.hashes[f]:
                 return False
         return True
 

--- a/tests/test_clock_file.py
+++ b/tests/test_clock_file.py
@@ -1,3 +1,4 @@
+import warnings
 from io import StringIO
 from textwrap import dedent
 
@@ -8,14 +9,12 @@ from astropy.time import Time
 from numpy.testing import assert_allclose, assert_array_equal
 
 from pint.observatory import (
-    get_observatory,
-    bipm_default,
-    update_clock_files,
     ClockCorrectionOutOfRange,
+    bipm_default,
+    get_observatory,
+    update_clock_files,
 )
-from pint.observatory.clock_file import (
-    ClockFile,
-)
+from pint.observatory.clock_file import ClockFile
 from pint.observatory.topo_obs import export_all_clock_files
 
 
@@ -439,12 +438,34 @@ def test_update_clock_files_str(tmp_path):
 
 
 def test_update_clock_files(tmp_path):
-    update_clock_files()
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=r".*dubious year.*")
+        update_clock_files()
     export_all_clock_files(tmp_path)
     assert (tmp_path / "wsrt2gps.clk").exists()
+
+
+def test_out_of_range_raises_exception(basic_clock):
+    with pytest.raises(ClockCorrectionOutOfRange) as excinfo:
+        basic_clock.evaluate(Time(60001, format="mjd"), limits="error")
 
 
 def test_out_of_range_message_has_helpful_name(basic_clock):
     with pytest.raises(ClockCorrectionOutOfRange) as excinfo:
         basic_clock.evaluate(Time(60001, format="mjd"), limits="error")
     assert "basic_clock" in str(excinfo.value)
+
+
+def test_out_of_range_emits_warning(basic_clock):
+    with pytest.warns(UserWarning, match="basic_clock"):
+        basic_clock.evaluate(Time(60001, format="mjd"))
+
+
+def test_out_of_range_allowed():
+    basic_clock = ClockFile(
+        mjd=np.array([50000, 55000, 60000]),
+        clock=np.array([1.0, 2.0, -1.0]) * u.us,
+        friendly_name="basic_clock",
+        valid_beyond_ends=True,
+    )
+    basic_clock.evaluate(Time(60001, format="mjd"), limits="error")

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -1,23 +1,24 @@
 #!/usr/bin/env python
 import io
 import os
-from pathlib import Path
 import unittest
+from pathlib import Path
 
+import astropy.units as u
 import numpy as np
 import pytest
-from pint.pulsar_mjd import Time
+from pinttestdata import datadir
 
 import pint.observatory
 import pint.observatory.topo_obs
+from pint.observatory import NoClockCorrections, Observatory, get_observatory
+from pint.observatory.special_locations import load_special_locations
 from pint.observatory.topo_obs import (
+    TopoObs,
     load_observatories,
     load_observatories_from_usual_locations,
-    TopoObs,
 )
-from pint.observatory.special_locations import load_special_locations
-from pint.observatory import get_observatory, Observatory, NoClockCorrections
-from pinttestdata import datadir
+from pint.pulsar_mjd import Time
 
 
 @pytest.fixture
@@ -228,7 +229,8 @@ def test_no_clock_means_no_corrections():
             "arecibo_bogus",
             itrf_xyz=[2390487.080, -5564731.357, 1994720.633],
         )
-        o.clock_corrections(Time(57600, format="mjd"), limits="error")
+        with pytest.raises(RuntimeError):
+            o.clock_corrections(Time(57600, format="mjd"), limits="error")
     finally:
         Observatory._registry = r
 
@@ -279,3 +281,9 @@ def test_observatory_override(sandbox, overwrite):
 
 def test_list_last_correction_mjds_runs():
     pint.observatory.list_last_correction_mjds()
+
+
+def test_valid_past_end():
+    o = pint.observatory.get_observatory("jbroach")
+    o.last_clock_correction_mjd()
+    o.clock_corrections(o._clock[0].time[-1] + 1 * u.d, limits="error")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
 """Test basic functionality of the :module:`pint.utils`."""
 import os
 from itertools import product
-from tempfile import NamedTemporaryFile
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import astropy.constants as c
 import astropy.units as u
@@ -12,6 +13,7 @@ from astropy.time import Time
 from hypothesis import assume, example, given
 from hypothesis.extra.numpy import array_shapes, arrays, scalar_dtypes
 from hypothesis.strategies import (
+    binary,
     composite,
     floats,
     integers,
@@ -19,6 +21,7 @@ from hypothesis.strategies import (
     one_of,
     sampled_from,
     slices,
+    tuples,
 )
 from numdifftools import Derivative
 from numpy.testing import assert_allclose, assert_array_equal
@@ -40,13 +43,14 @@ from pint.pulsar_mjd import (
 from pint.utils import (
     FTest,
     PosVel,
+    compute_hash,
     dmxparse,
     interesting_lines,
     lines_of,
+    list_parameters,
     open_or_use,
     taylor_horner,
     taylor_horner_deriv,
-    list_parameters,
 )
 
 
@@ -727,3 +731,37 @@ def test_taylor_horner_units_ok(x, result, n):
 
 def test_list_parameters():
     list_parameters()
+
+
+@given(
+    tuples(binary(max_size=1_000_000), binary(max_size=1_000_000)).filter(
+        lambda t: t[0] != t[1]
+    )
+)
+def test_compute_hash_detects_changes(a_b):
+    a, b = a_b
+    with TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+
+        f = tmp_path / "file"
+        f.write_bytes(a)
+        h_a = compute_hash(f)
+        f.write_bytes(b)
+        h_b = compute_hash(f)
+        assert h_a != h_b
+
+
+@given(binary(max_size=1_000_000))
+def test_compute_hash_accepts_no_change(a):
+    with TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+
+        f = tmp_path / "file"
+        f.write_bytes(a)
+        h_a = compute_hash(f)
+
+        g = tmp_path / "file2"
+        g.write_bytes(a)
+        h_b = compute_hash(g)
+
+    assert h_a == h_b


### PR DESCRIPTION
Previously we assumed any clock file was only valid as far as its last (real) entry. This is not the case for files like `jbroach2jb.clk`, which contain entries only when the instrumental delay changes, and so users will get inappropriate warnings about out-of-date clock files. This PR fixes that.

As a side effect, it needs to rewrite `observatories.json` to reflect a new format with room for individual clock files to have metadata. 

Closes #1326