### PR TITLE
Raise exception for astropy <4 in __init__.py

### DIFF
--- a/src/pint/__init__.py
+++ b/src/pint/__init__.py
@@ -103,12 +103,3 @@ pint_units = {
     "pulse phase": u.dimensionless_unscaled,
     "hourangle_second": hourangle_second,
 }
-
-import astropy.version
-
-if astropy.version.major < 4:
-    log.warning(
-        "Using astropy version {}. To get most recent IERS data, upgrade to astropy >= 4.0".format(
-            astropy.__version__
-        )
-    )

--- a/src/pint/__init__.py
+++ b/src/pint/__init__.py
@@ -103,3 +103,10 @@ pint_units = {
     "pulse phase": u.dimensionless_unscaled,
     "hourangle_second": hourangle_second,
 }
+
+import astropy.version
+
+if astropy.version.major < 4:
+    raise ValueError(
+        f"astropy version must be >=4 (currently it is {astropy.version.major})"
+    )

--- a/tests/test_astropyversion.py
+++ b/tests/test_astropyversion.py
@@ -1,0 +1,33 @@
+import pytest
+import importlib
+import astropy
+import pint
+
+
+@pytest.fixture
+def sandbox():
+    class Sandbox:
+        pass
+
+    o = Sandbox()
+    import astropy
+
+    version = astropy.version.major
+
+    try:
+        yield o
+    finally:
+        astropy.version.major = version
+
+
+def test_astropy_version_raisesexception(sandbox):
+    # check this as a test
+    astropy.version.major = 3
+    with pytest.raises(ValueError):
+        importlib.reload(pint)
+
+
+def test_astropy_version(sandbox):
+    importlib.reload(pint)
+
+    assert astropy.version.major >= 4


### PR DESCRIPTION
Fixes #1354 

astropy >=4 is enforced by `requirements.txt`