### PR TITLE
Quality of life change for Fermi template code.

### DIFF
--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -106,7 +106,7 @@ def test_simple_fit_unbinned():
     # load in simulated phases
     ph = np.loadtxt(datadir / "template_phases.asc")
     lcf = lcfitters.LCFitter(lct, ph)
-    lcf.fit(unbinned=True, estimate_errors=True)
+    lcf.fit(unbinned=True, estimate_errors=True, quiet=True)
     expected_val = r"""
 Log Likelihood for fit: 1091.04
 
@@ -139,8 +139,8 @@ def test_simple_fit_binned():
 
     # load in simulated phases
     ph = np.loadtxt(datadir / "template_phases.asc")
-    lcf = lcfitters.LCFitter(lct, ph)
-    lcf.fit(unbinned=False, estimate_errors=True)
+    lcf = lcfitters.LCFitter(lct, ph, binned_bins=100)
+    lcf.fit(unbinned=False, estimate_errors=True, quiet=True)
     expected_val = r"""
 Log Likelihood for fit: 1080.31
 


### PR DESCRIPTION
This PR just adds a quiet kwarg for fitting Fermi pulse profiles.  It also changes the default binning to a higher resolution.

It is pretty trivial and (currently) only being used by me, propose it can be merged straightaway.