### PR TITLE
More flexible read/write for polycos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Moved observatories to JSON file.  Changed way observatories are loaded/overloaded
 - Split Jodrell Bank observatory based on backend to get correct clock files
 - Clock files can be marked as being valid past the end of the data they contain
+- Polycos can be written/read from Path or Stream objects
+- Polyco format registration now done once as a class method
+- Polyco reading/generation from timing model done as class methods
 ### Added
 - delta_pulse_number column is now saved to -padd flag on TOA write
 - command-line utility to compare parfiles

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,8 @@ import sys
 from packaging.version import parse
 
 import jupytext
-#import sphinx.ext.apidoc
+
+# import sphinx.ext.apidoc
 
 
 # If extensions (or modules to document with autodoc) are in another
@@ -76,7 +77,7 @@ autodoc_inherit_docstrings = True
 templates_path = ["_templates"]
 
 # The suffix of source filenames.
-#source_suffix = ".rst"
+# source_suffix = ".rst"
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
@@ -85,8 +86,8 @@ templates_path = ["_templates"]
 master_doc = "index"
 
 # General information about the project.
-project = u"pint"
-copyright = u"2017-2021 PINT Developers"
+project = "pint"
+copyright = "2017-2021 PINT Developers"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -109,7 +110,18 @@ release = pint.__version__
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build", "examples/.ipynb_checkpoints", "conf.py", "_ext"]
+# exclude some notebooks that take too long to run and are not needed for the docs bulid
+exclude_patterns = [
+    "_build",
+    "examples/.ipynb_checkpoints",
+    "examples/fit_NGC6440E_MCMC.py",
+    "examples/compare_tempo2_B1855.py",
+    "examples/compare_tempo2_B1855.py",
+    "examples/example_dmx_ranges.py",
+    "examples/example_pulse_numbers.py",
+    "conf.py",
+    "_ext",
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -262,7 +274,7 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass
 # [howto/manual]).
 latex_documents = [
-    ("index", "pint.tex", u"pint Documentation", u"PINT Developers", "manual")
+    ("index", "pint.tex", "pint Documentation", "PINT Developers", "manual")
 ]
 
 # The name of an image file (relative to this directory) to place at
@@ -290,7 +302,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [("index", "pint", u"pint Documentation", [u"PINT Developers"], 1)]
+man_pages = [("index", "pint", "pint Documentation", ["PINT Developers"], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -305,8 +317,8 @@ texinfo_documents = [
     (
         "index",
         "pint",
-        u"pint Documentation",
-        u"PINT Developers",
+        "pint Documentation",
+        "PINT Developers",
         "pint",
         "One line description of project.",
         "Miscellaneous",

--- a/docs/examples/example_dmx_ranges.py
+++ b/docs/examples/example_dmx_ranges.py
@@ -43,7 +43,7 @@ glsfit.fit_toas(maxiter=1)
 glsfit.print_summary()
 
 # You can print some statistics on the DMXs like this:
-pint.utils.dmxstats(glsfit)
+pint.utils.dmxstats(glsfit.model, glsfit.toas)
 
 # dmxparse will pull out the DMX values and compute correct errors from the covariance matrix, which we can easily plot
 dmx = pint.utils.dmxparse(glsfit)

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -35,15 +35,19 @@ For example, the file ``NGC6440E.par`` from the
 Examples
 --------
 
-We don't really have any proper tutorials yet. But for the moment, we
-have a few examples that may be useful.  These tutorials examples are
-in the form of Jupyter notebooks, downloadable from a link at the top
+These tutorials examples are
+in the form of `Jupyter <https://jupyter.org>`_ notebooks, downloadable from a link at the top
 of each page. (Also available in the same place is a plain-python
 script version, in case this is more convenient.) You should be able
 to download these files and run them from anywhere convenient
 (provided ``PINT`` is installed). Finally, there are additional
 notebooks you can download from the `PINT Wiki
-<https://github.com/nanograv/PINT/wiki>`_.
+<https://github.com/nanograv/PINT/wiki>`_ or the 
+`GitHub examples <https://github.com/nanograv/PINT/tree/master/docs/examples>`_ directory: these 
+are not included in the default build because they take too long, but you can download and run them yourself.
+
+.. The list below is just those that are built.  Other notebooks are excluded from the build
+.. Using the exclude_patterns list in conf.py
 
 .. toctree::
 

--- a/src/pint/mcmc_fitter.py
+++ b/src/pint/mcmc_fitter.py
@@ -276,7 +276,7 @@ class MCMCFitter(Fitter):
         """
         Return pulse phases based on the current model
         """
-        phases = self.model.phase(self.toas)[1]
+        phases = self.model.phase(self.toas).frac
         # ensure all positive
         return np.where(phases < 0.0, phases + 1.0, phases)
 

--- a/src/pint/phase.py
+++ b/src/pint/phase.py
@@ -23,7 +23,6 @@ class Phase(namedtuple("Phase", "int frac")):
         >>> p = Phase(np.arange(10),np.random.random(10))
         >>> print(p.int)
         >>> print(p.frac[:5])
-        >>> print(p[::2])
         >>> i,f = p
         >>> q = p.quantity
 
@@ -107,9 +106,10 @@ class Phase(namedtuple("Phase", "int frac")):
     def __rmul__(self, num):
         return self.__mul__(num)
 
-    def __getitem__(self, key):
-        return Phase(self.int[key], self.frac[key])
-
     @property
     def quantity(self):
         return self.int + self.frac
+
+    @property
+    def value(self):
+        return self.quantity.value

--- a/src/pint/phase.py
+++ b/src/pint/phase.py
@@ -91,3 +91,6 @@ class Phase(namedtuple("Phase", "int frac")):
 
     def __rmul__(self, num):
         return self.__mul__(num)
+
+    def __getitem__(self, key):
+        return Phase(self.int[key], self.frac[key])

--- a/src/pint/phase.py
+++ b/src/pint/phase.py
@@ -97,3 +97,7 @@ class Phase(namedtuple("Phase", "int frac")):
 
     def __getitem__(self, key):
         return Phase(self.int[key], self.frac[key])
+
+    @property
+    def quantity(self):
+        return self.int + self.frac

--- a/src/pint/phase.py
+++ b/src/pint/phase.py
@@ -8,7 +8,7 @@ class Phase(namedtuple("Phase", "int frac")):
     """
     Class representing pulse phase as integer (.int) and fractional (.frac) parts.
 
-    The phase values are dimensionless :class:`~astropy.quantity.Quantity` (``u.dimensionless_unscaled == u.Unit("") == Unit(dimensionless)``)
+    The phase values are dimensionless :class:`~astropy.units.Quantity` (``u.dimensionless_unscaled == u.Unit("") == Unit(dimensionless)``)
 
     Ensures that the fractional part stays in [-0.5, 0.5)
 
@@ -23,22 +23,23 @@ class Phase(namedtuple("Phase", "int frac")):
         """Create new Phase object
 
         Constructs a Phase object.
-        Can be initialized with arrays or a scalar :class:`~astropy.quantity.Quantity` (dimensionless).
+        Can be initialized with arrays or a scalar :class:`~astropy.units.Quantity` (dimensionless).
 
         Accepts either floating point argument (``arg1``) or pair of arguments with integer (``arg1``) and fractional (``arg2``) parts separate
-        Scalars are converted to length 1 arrays so `Phase.int` and `Phase.frac` are always arrays
+        Scalars are converted to length 1 arrays so ``Phase.int`` and ``Phase.frac`` are always arrays
 
         Parameters
         ----------
-        arg1 : array or astropy.quantity.Quantity
+        arg1 : np.ndarray or astropy.units.Quantity
             Quantity should be dimensionless
-        arg2 : array or astropy.quantity.Quantity
+        arg2 : np.ndarray or astropy.units.Quantity
             Quantity should be dimensionless
 
         Returns
         -------
         Phase
-            pulse phase object with arrays of dimensionless :class:`~astropy.quantity.Quantity` objects as the int and frac parts
+            pulse phase object with arrays of dimensionless :class:`~astropy.units.Quantity`
+            objects as the ``int`` and ``frac`` parts
         """
         if not hasattr(arg1, "unit"):
             arg1 = u.Quantity(arg1)

--- a/src/pint/phase.py
+++ b/src/pint/phase.py
@@ -15,6 +15,18 @@ class Phase(namedtuple("Phase", "int frac")):
     SUGGESTION(@paulray): How about adding some documentation here
     describing why the fractional part is reduced to [-0.5,0.5) instead of [0,1).
 
+    Examples
+    --------
+
+        >>> from pint.phase import Phase
+        >>> import numpy as np
+        >>> p = Phase(np.arange(10),np.random.random(10))
+        >>> print(p.int)
+        >>> print(p.frac[:5])
+        >>> print(p[::2])
+        >>> i,f = p
+        >>> q = p.quantity
+
     """
 
     __slots__ = ()

--- a/src/pint/phase.py
+++ b/src/pint/phase.py
@@ -8,7 +8,7 @@ class Phase(namedtuple("Phase", "int frac")):
     """
     Class representing pulse phase as integer (.int) and fractional (.frac) parts.
 
-    The phase values are dimensionless Quantitys (u.dimensionless_unscaled == u.Unit("") == Unit(dimensionless))
+    The phase values are dimensionless :class:`~astropy.quantity.Quantity` (``u.dimensionless_unscaled == u.Unit("") == Unit(dimensionless)``)
 
     Ensures that the fractional part stays in [-0.5, 0.5)
 
@@ -23,19 +23,22 @@ class Phase(namedtuple("Phase", "int frac")):
         """Create new Phase object
 
         Constructs a Phase object.
-        Can be initialized with arrays or a scalar Quantity.
-        Can take inputs as plain numerical types, or dimensionless Quantitys
-        Accepts either floating point argument (arg1) or pair of arguments with integer (arg1) and fractional (arg2) parts separate
+        Can be initialized with arrays or a scalar :class:`~astropy.quantity.Quantity` (dimensionless).
+
+        Accepts either floating point argument (``arg1``) or pair of arguments with integer (``arg1``) and fractional (``arg2``) parts separate
         Scalars are converted to length 1 arrays so `Phase.int` and `Phase.frac` are always arrays
 
         Parameters
         ----------
-        arg1 : array or dimensionless Quantity
-        arg2 : array or dimensionless Quantity
+        arg1 : array or astropy.quantity.Quantity
+            Quantity should be dimensionless
+        arg2 : array or astropy.quantity.Quantity
+            Quantity should be dimensionless
 
         Returns
         -------
-        Phase : pulse phase object with arrays of dimensionless Quantitys as the int and frac parts
+        Phase
+            pulse phase object with arrays of dimensionless :class:`~astropy.quantity.Quantity` objects as the int and frac parts
         """
         if not hasattr(arg1, "unit"):
             arg1 = u.Quantity(arg1)

--- a/src/pint/phase.py
+++ b/src/pint/phase.py
@@ -6,7 +6,7 @@ import numpy
 
 class Phase(namedtuple("Phase", "int frac")):
     """
-    Class representing pulse phase as integer (.int) and fractional (.frac) parts.
+    Class representing pulse phase as integer (``.int``) and fractional (``.frac``) parts.
 
     The phase values are dimensionless :class:`~astropy.units.Quantity` (``u.dimensionless_unscaled == u.Unit("") == Unit(dimensionless)``)
 
@@ -22,7 +22,6 @@ class Phase(namedtuple("Phase", "int frac")):
     def __new__(cls, arg1, arg2=None):
         """Create new Phase object
 
-        Constructs a Phase object.
         Can be initialized with arrays or a scalar :class:`~astropy.units.Quantity` (dimensionless).
 
         Accepts either floating point argument (``arg1``) or pair of arguments with integer (``arg1``) and fractional (``arg2``) parts separate
@@ -30,9 +29,9 @@ class Phase(namedtuple("Phase", "int frac")):
 
         Parameters
         ----------
-        arg1 : np.ndarray or astropy.units.Quantity
+        arg1 : numpy.ndarray or astropy.units.Quantity
             Quantity should be dimensionless
-        arg2 : np.ndarray or astropy.units.Quantity
+        arg2 : numpy.ndarray or astropy.units.Quantity
             Quantity should be dimensionless
 
         Returns

--- a/src/pint/polycos.py
+++ b/src/pint/polycos.py
@@ -405,7 +405,7 @@ def tempo_polyco_table_writer(polycoTable, filename="polyco.dat"):
     ----------
     polycoTable: astropy.table.Table
         Polycos style table
-    filename : str or pathlib.Path or file-like
+    filename : str or ~pathlib.Path or file-like
         Destination for the output polyco file. Default is 'polyco.dat'.
 
     References
@@ -521,7 +521,7 @@ class Polycos:
 
         Parameters
         ---------
-        filename : str or pathlib.Path or file-like
+        filename : str or ~pathlib.Path or file-like
             The name of the input polyco file.
         format : str, optional
             The format of the file. Default is 'tempo'.
@@ -550,7 +550,7 @@ class Polycos:
 
         Parameters
         ---------
-        filename : str or pathlib.Path or file-like
+        filename : str or ~pathlib.Path or file-like
             The name of the input polyco file.
         format : str, optional
             The format of the file. Default is 'tempo'.
@@ -642,7 +642,7 @@ class Polycos:
 
         Parameters
         ---------
-        filename : str or pathlib.Path or file-like
+        filename : str or ~pathlib.Path or file-like
             The name of the input polyco file.
         format : str, optional
             The format of the file. Default is 'tempo'.
@@ -709,7 +709,7 @@ class Polycos:
             Observing frequency [MHz]
         maxha : float, optional.
             Maximum hour angle. Default 12.0. Only 12.0 is supported for now.
-        method : string, optional
+        method : str, optional
             Method to generate polycos. Only the ``TEMPO`` method is supported for now.
         numNodes : int, optional
             Number of nodes for fitting. It cannot be less then the number of

--- a/src/pint/polycos.py
+++ b/src/pint/polycos.py
@@ -530,7 +530,7 @@ class Polycos:
         self.fileName = filename
 
         if filename is not None:
-            log.debug(f"Reading polycos from '{filename}'")
+            log.info(f"Reading polycos from '{filename}'")
             if format not in [f["format"] for f in self.polycoFormats]:
                 raise ValueError(
                     "Unknown polyco file format '" + format + "'\n"

--- a/src/pint/polycos.py
+++ b/src/pint/polycos.py
@@ -323,8 +323,8 @@ def tempo_polyco_table_writer(polycoTable, filename="polyco.dat"):
     ---------
     polycoTable: astropy table
         Polycos style table
-    filename : str
-        Name of the output poloco file. Default is 'polyco.dat'.
+    filename : str or Path or file-like
+        Destination for the output polyco file. Default is 'polyco.dat'.
 
     References
     ----------
@@ -660,14 +660,14 @@ class Polycos:
 
         Parameters
         ---------
-        filename : str
-            The name of the polyco file.
+        filename : str or Path or file-like
+            The name of the input polyco file.
         format : str
             The format of the file. Default is 'tempo'.
 
         Return
         ---------
-        Polycos Table with read_in data.
+        Polycos
 
         """
         self.fileName = filename

--- a/src/pint/polycos.py
+++ b/src/pint/polycos.py
@@ -638,7 +638,7 @@ class Polycos:
     def read_polyco_file(self, filename, format="tempo"):
         """Read polyco file to a table.
 
-        Included for backward compatibility.  It is better to use :meth:`pint.polycos.Polyco.read`.
+        Included for backward compatibility.  It is better to use :meth:`pint.polycos.Polycos.read`.
 
         Parameters
         ---------

--- a/src/pint/polycos.py
+++ b/src/pint/polycos.py
@@ -25,7 +25,7 @@ Or, to generate polycos from a timing model:
 
     >>> from pint.models import get_model
     >>> from pint.polycos import Polycos
-    >>> m = get_model(filename)
+    >>> model = get_model(filename)
     >>> p = Polycos.generate_polycos(model, 50000, 50001, "AO", 144, 12, 1400)
   
 References

--- a/src/pint/polycos.py
+++ b/src/pint/polycos.py
@@ -234,8 +234,8 @@ def tempo_polyco_table_reader(filename):
                 52-72   DM
                 74-79   Doppler shift due to earth motion (10^-4)
                 80-86   Log_10 of fit rms residual in periods
-         2       1-20   Reference Phase (RPHASE)
-                21-38   Reference rotation frequency (F0)
+         2       1-20   Reference Phase (RPHASE or :math:`\\phi_0`)
+                21-38   Reference rotation frequency (:math:`f_0`)
                 39-43   Observatory number
                 44-49   Data span (minutes)
                 50-54   Number of coefficients
@@ -251,10 +251,13 @@ def tempo_polyco_table_reader(filename):
 
     The pulse phase and frequency at time T are then calculated as::
 
+    .. math::
 
-        DT = (T-TMID)*1440
-        PHASE = RPHASE + DT*60*F0 + COEFF(1) + DT*COEFF(2) + DT^2*COEFF(3) + ....
-        FREQ(Hz) = F0 + (1/60)*(COEFF(2) + 2*DT*COEFF(3) + 3*DT^2*COEFF(4) + ....)
+        \\Delta T = 1440(T-T_{\\rm mid})
+
+        \\phi = \\phi_0 + 60 \Delta T f_0 + COEFF[1] + COEFF[2] \\Delta T + COEFF[3] \\Delta T^2 + \\ldots
+
+        f({\\rm Hz}) = f_0 + \\frac{1}{60}\\left( COEFF[2] + 2 COEFF[3] \Delta T + 3 COEFF[4] \Delta T^2  + \\ldots \\right)
 
     Parameters
     ----------
@@ -361,8 +364,8 @@ def tempo_polyco_table_writer(polycoTable, filename="polyco.dat"):
                 52-72   DM
                 74-79   Doppler shift due to earth motion (10^-4)
                 80-86   Log_10 of fit rms residual in periods
-         2       1-20   Reference Phase (RPHASE)
-                21-38   Reference rotation frequency (F0)
+         2       1-20   Reference Phase (RPHASE or :math:`\\phi_0`)
+                21-38   Reference rotation frequency (:math:`f_0`)
                 39-43   Observatory number
                 44-49   Data span (minutes)
                 50-54   Number of coefficients
@@ -377,9 +380,13 @@ def tempo_polyco_table_writer(polycoTable, filename="polyco.dat"):
 
     The pulse phase and frequency at time T are then calculated as::
 
-        DT = (T-TMID)*1440
-        PHASE = RPHASE + DT*60*F0 + COEFF(1) + DT*COEFF(2) + DT^2*COEFF(3) + ....
-        FREQ(Hz) = F0 + (1/60)*(COEFF(2) + 2*DT*COEFF(3) + 3*DT^2*COEFF(4) + ....)
+    .. math::
+
+        \\Delta T = 1440(T-T_{\\rm mid})
+
+        \\phi = \\phi_0 + 60 \Delta T f_0 + COEFF[1] + COEFF[2] \\Delta T + COEFF[3] \\Delta T^2 + \\ldots
+
+        f({\\rm Hz}) = f_0 + \\frac{1}{60}\\left( COEFF[2] + 2 COEFF[3] \Delta T + 3 COEFF[4] \Delta T^2  + \\ldots \\right)
 
     Parameters
     ---------
@@ -554,15 +561,19 @@ class Polycos:
         formatName : str
             The name for the format.
         methodMood : str
-            ['r','w','rw']. 'r'  represent as reading
-                            'w'  represent as writting
-                            'rw' represent as reading and writting
-        readMethod : method
+            One of ['r','w','rw'].
+        readMethod : function
             The method for reading the file format.
-        writeMethod : method
+        writeMethod : function
             The method for writting the file to disk.
 
+        Notes
+        -----
+        The read/write methods should correspond to what are needed by :meth:`astropy.io.registry.register_reader` and
+        :meth:`astropy.io.registry.register_writer`, respectively
+
         """
+        assert methodMood.lower() in ["r", "w", "rw"]
         # Check if the format already exist.
         if (
             formatName in [f["format"] for f in cls.polycoFormats]

--- a/src/pint/polycos.py
+++ b/src/pint/polycos.py
@@ -1,10 +1,20 @@
 """Polynomial coefficients for phase prediction
 
 Polycos designed to predict the pulsar's phase and pulse-period over a
-given interval using polynomial expansions. 
+given interval using polynomial expansions.   
 
-Example
--------
+The pulse phase and frequency at time T are then calculated as::
+
+.. math::
+
+    \\Delta T = 1440(T-T_{\\rm mid})
+
+    \\phi = \\phi_0 + 60 \Delta T f_0 + COEFF[1] + COEFF[2] \\Delta T + COEFF[3] \\Delta T^2 + \\ldots
+
+    f({\\rm Hz}) = f_0 + \\frac{1}{60}\\left( COEFF[2] + 2 COEFF[3] \Delta T + 3 COEFF[4] \Delta T^2  + \\ldots \\right)
+
+Examples
+--------
 Read in polycos, predict phases:
 
     >>> from pint.polycos import Polycos
@@ -134,7 +144,7 @@ class PolycoEntry:
 
         Parameters
         ----------
-        t : float or np.ndarray
+        t : float or numpy.ndarray
             Input times
 
         Returns
@@ -161,7 +171,7 @@ class PolycoEntry:
 
         Parameters
         ----------
-        t : float or np.ndarray
+        t : float or numpy.ndarray
             Input times
 
         Returns
@@ -175,12 +185,12 @@ class PolycoEntry:
 
         Parameters
         ----------
-        t : float or np.ndarray
+        t : float or numpy.ndarray
             Input times
 
         Returns
         -------
-        np.ndarray
+        numpy.ndarray
             Frequency (in Hz)
         """
         dt = (data2longdouble(t) - self.tmid.value) * MIN_PER_DAY
@@ -195,12 +205,12 @@ class PolycoEntry:
 
         Parameters
         ----------
-        t : float or np.ndarray
+        t : float or numpy.ndarray
             Input times
 
         Returns
         -------
-        np.ndarray
+        numpy.ndarray
             Frequency derivative (in Hz/s)
         """
         dt = (data2longdouble(t) - self.tmid.value) * MIN_PER_DAY
@@ -234,8 +244,8 @@ def tempo_polyco_table_reader(filename):
                 52-72   DM
                 74-79   Doppler shift due to earth motion (10^-4)
                 80-86   Log_10 of fit rms residual in periods
-         2       1-20   Reference Phase (RPHASE or :math:`\\phi_0`)
-                21-38   Reference rotation frequency (:math:`f_0`)
+         2       1-20   Reference Phase (RPHASE)
+                21-38   Reference rotation frequency (F0)
                 39-43   Observatory number
                 44-49   Data span (minutes)
                 50-54   Number of coefficients
@@ -364,8 +374,8 @@ def tempo_polyco_table_writer(polycoTable, filename="polyco.dat"):
                 52-72   DM
                 74-79   Doppler shift due to earth motion (10^-4)
                 80-86   Log_10 of fit rms residual in periods
-         2       1-20   Reference Phase (RPHASE or :math:`\\phi_0`)
-                21-38   Reference rotation frequency (:math:`f_0`)
+         2       1-20   Reference Phase (RPHASE)
+                21-38   Reference rotation frequency (F0)
                 39-43   Observatory number
                 44-49   Data span (minutes)
                 50-54   Number of coefficients
@@ -389,7 +399,7 @@ def tempo_polyco_table_writer(polycoTable, filename="polyco.dat"):
         f({\\rm Hz}) = f_0 + \\frac{1}{60}\\left( COEFF[2] + 2 COEFF[3] \Delta T + 3 COEFF[4] \Delta T^2  + \\ldots \\right)
 
     Parameters
-    ---------
+    ----------
     polycoTable: astropy.table.Table
         Polycos style table
     filename : str or Path or file-like
@@ -693,7 +703,7 @@ class Polycos:
             Observing frequency [MHz]
         maxha : float, optional.
             Maximum hour angle. Default 12.0. Only 12.0 is supported for now.
-        method : str, optional
+        method : string, optional
             Method to generate polycos. Only the ``TEMPO`` method is supported for now.
         numNodes : int, optional
             Number of nodes for fitting. It cannot be less then the number of
@@ -862,12 +872,12 @@ class Polycos:
 
         Parameters
         ---------
-        t: numpy.ndarray or float
+        t: numpy.ndarray or a single number.
            An time array in MJD. Time sample should be in order
 
         Returns
         ---------
-        np.ndarray
+        numpy.ndarray
              Fractional phase
         """
         if not isinstance(t, np.ndarray) and not isinstance(t, list):
@@ -880,7 +890,7 @@ class Polycos:
 
         Parameters
         ---------
-        t: numpy.ndarray or float
+        t: numpy.ndarray or a single number.
            An time array in MJD. Time sample should be in order
 
         Returns
@@ -890,9 +900,11 @@ class Polycos:
 
         Notes
         -----
+        Calculates phase according to:
+
         .. math::
 
-            \\phi = \\phi_0 + 60 \\Delta T f_0 + COEFF[1] + COEFF[2] \\Delta T + COEFF[3] \\Delta T^2 + \\ldots
+            \\phi = \\phi_0 + 60 \\Delta T f_0 + COEFF[1] + COEFF[2] \Delta T + COEFF[3] \Delta T^2 + \\ldots
 
         """
         if not isinstance(t, (np.ndarray, list)):
@@ -929,14 +941,16 @@ class Polycos:
 
         Returns
         ---------
-        np.ndarray
+        numpy.ndarray
              Polyco evaluated spin frequency [Hz] at time t.
 
         Notes
         -----
+        Calculates frequency according to:
+
         .. math::
 
-            f({\\rm Hz}) = f_0 + \\frac{1}{60}\\left(COEFF[2] + 2 \\Delta T COEFF[3] + 3 \\Delta T^2 COEFF[4] + \\ldots\\right)
+            f({\\rm Hz}) = f_0 + \\frac{1}{60}\\left(COEFF[2] + 2 \\delta T COEFF[3] + 3 \\Delta T^2 COEFF[4] + \\ldots\\right)
         """
         if not isinstance(t, np.ndarray) and not isinstance(t, list):
             t = np.array([t])

--- a/src/pint/polycos.py
+++ b/src/pint/polycos.py
@@ -16,7 +16,7 @@ Or, to generate polycos from a timing model:
     >>> from pint.models import get_model
     >>> from pint.polycos import Polycos
     >>> m = get_model(filename)
-    >>> p =Polycos.generate_polycos(model, 50000, 50001, "AO", 144, 12, 1400)
+    >>> p = Polycos.generate_polycos(model, 50000, 50001, "AO", 144, 12, 1400)
 
 """
 import astropy.table as table
@@ -130,7 +130,17 @@ class PolycoEntry:
         )
 
     def evalabsphase(self, t):
-        """Return the phase at time t, computed with this polyco entry"""
+        """Return the phase at time t, computed with this polyco entry
+
+        Parameters
+        ----------
+        t : float or np.ndarray
+            Input times
+
+        Returns
+        -------
+        pint.phase.Phase
+        """
         dt = (data2longdouble(t) - self.tmid.value) * MIN_PER_DAY
         # Compute polynomial by factoring out the dt's
         phase = Phase(
@@ -147,11 +157,32 @@ class PolycoEntry:
         return phase
 
     def evalphase(self, t):
-        """Return the phase at time t, computed with this polyco entry"""
+        """Return the phase at time t, computed with this polyco entry
+
+        Parameters
+        ----------
+        t : float or np.ndarray
+            Input times
+
+        Returns
+        -------
+        pint.phase.Phase
+        """
         return self.evalabsphase(t).frac
 
     def evalfreq(self, t):
-        """Return the freq at time t, computed with this polyco entry"""
+        """Return the freq at time t, computed with this polyco entry
+
+        Parameters
+        ----------
+        t : float or np.ndarray
+            Input times
+
+        Returns
+        -------
+        np.ndarray
+            Frequency (in Hz)
+        """
         dt = (data2longdouble(t) - self.tmid.value) * MIN_PER_DAY
         s = data2longdouble(0.0)
         for i in range(1, self.ncoeff):
@@ -160,7 +191,18 @@ class PolycoEntry:
         return freq
 
     def evalfreqderiv(self, t):
-        """Return the frequency derivative at time t."""
+        """Return the frequency derivative at time t.
+
+        Parameters
+        ----------
+        t : float or np.ndarray
+            Input times
+
+        Returns
+        -------
+        np.ndarray
+            Frequency derivative (in Hz/s)
+        """
         dt = (data2longdouble(t) - self.tmid.value) * MIN_PER_DAY
         s = data2longdouble(0.0)
         for i in range(2, self.ncoeff):
@@ -208,6 +250,7 @@ def tempo_polyco_table_reader(filename):
     One polyco file could include more then one entry.
 
     The pulse phase and frequency at time T are then calculated as::
+
 
         DT = (T-TMID)*1440
         PHASE = RPHASE + DT*60*F0 + COEFF(1) + DT*COEFF(2) + DT^2*COEFF(3) + ....
@@ -624,37 +667,26 @@ class Polycos:
         Parameters
         ----------
         model : TimingModel
-            TimingModel to generate the Polycos with parameters
-            setup.
-
+            TimingModel to generate the Polycos
         mjdStart : float, np.longdouble
             Start time of polycos in mjd
-
         mjdEnd : float, np.longdouble
             Ending time of polycos in mjd
-
         obs : str
             Observatory code
-
         segLength : int
             Length of polyco segement [minutes]
-
         ncoeff : int
             Number of coefficents
-
         obsFreq : float
             Observing frequency [MHz]
-
         maxha : float, optional.
-            Maximum hour angle. Default 12.0 Only 12.0 is supported for now.
-
+            Maximum hour angle. Default 12.0. Only 12.0 is supported for now.
         method : string, optional
             Method to generate polycos. Only the ``TEMPO`` method is supported for now.
-
         numNodes : int, optional
             Number of nodes for fitting. It cannot be less then the number of
             coefficents. Default: 20
-
         progress : bool, optional
             Whether or not to show the progress bar during calculation
 
@@ -815,6 +847,18 @@ class Polycos:
         return start_idx
 
     def eval_phase(self, t):
+        """Polyco evaluation of fractional phase
+
+        Parameters
+        ---------
+        t: numpy.ndarray or a single number.
+           An time array in MJD. Time sample should be in order
+
+        Returns
+        ---------
+        np.ndarray
+             Fractional phase
+        """
         if not isinstance(t, np.ndarray) and not isinstance(t, list):
             t = np.array([t])
         return self.eval_abs_phase(t).frac
@@ -830,7 +874,7 @@ class Polycos:
 
         Returns
         ---------
-        out: pint.phase.Phase
+        pint.phase.Phase
              Polyco evaluated absolute phase for t.
 
         Notes
@@ -870,11 +914,11 @@ class Polycos:
         Parameters
         ---------
         t: numpy.ndarray, float
-           An time array in MJD. Time sample should be in order
+           An time array in MJD. Time samples should be in order
 
         Returns
         ---------
-        out: np.array
+        np.ndarray
              Polyco evaluated spin frequency [Hz] at time t.
 
         Notes

--- a/src/pint/polycos.py
+++ b/src/pint/polycos.py
@@ -652,6 +652,9 @@ class Polycos:
         Polycos
 
         """
+        raise DeprecationWarning(
+            "Use `p=pint.polycos.Polycos.read()` rather than `p.read_polyco_file()`"
+        )
         self.fileName = filename
 
         if format not in [f["format"] for f in self.polycoFormats]:

--- a/src/pint/polycos.py
+++ b/src/pint/polycos.py
@@ -402,7 +402,7 @@ def tempo_polyco_table_writer(polycoTable, filename="polyco.dat"):
     ----------
     polycoTable: astropy.table.Table
         Polycos style table
-    filename : str or Path or file-like
+    filename : str or pathlib.Path or file-like
         Destination for the output polyco file. Default is 'polyco.dat'.
 
     References
@@ -518,7 +518,7 @@ class Polycos:
 
         Parameters
         ---------
-        filename : str or Path or file-like
+        filename : str or pathlib.Path or file-like
             The name of the input polyco file.
         format : str, optional
             The format of the file. Default is 'tempo'.
@@ -546,7 +546,7 @@ class Polycos:
 
         Parameters
         ---------
-        filename : str or Path or file-like
+        filename : str or pathlib.Path or file-like
             The name of the input polyco file.
         format : str, optional
             The format of the file. Default is 'tempo'.
@@ -571,7 +571,7 @@ class Polycos:
         formatName : str
             The name for the format.
         methodMood : str
-            One of ['r','w','rw'].
+            One of ['r', 'w', 'rw'].
         readMethod : function
             The method for reading the file format.
         writeMethod : function
@@ -632,11 +632,11 @@ class Polycos:
     def read_polyco_file(self, filename, format="tempo"):
         """Read polyco file to a table.
 
-        Included for backward compatibility.  It is better to use :meth:`pint.polyco.Polyco.read()`.
+        Included for backward compatibility.  It is better to use :meth:`pint.polycos.Polyco.read`.
 
         Parameters
         ---------
-        filename : str or Path or file-like
+        filename : str or pathlib.Path or file-like
             The name of the input polyco file.
         format : str, optional
             The format of the file. Default is 'tempo'.

--- a/src/pint/polycos.py
+++ b/src/pint/polycos.py
@@ -503,12 +503,15 @@ class Polycos:
         """
         for fmt in formatlist:
             if fmt["read_method"] is not None and fmt["write_method"] is None:
+                log.debug(f"Registering Polyco format '{fmt['format']}' with mode='r'")
                 cls.add_polyco_file_format(fmt["format"], "r", fmt["read_method"], None)
             elif fmt["read_method"] is None and fmt["write_method"] is not None:
+                log.debug(f"Registering Polyco format '{fmt['format']}' with mode='w'")
                 cls.add_polyco_file_format(
                     fmt["format"], "w", None, fmt["write_method"]
                 )
             elif fmt["read_method"] is not None and fmt["write_method"] is not None:
+                log.debug(f"Registering Polyco format '{fmt['format']}' with mode='rw'")
                 cls.add_polyco_file_format(
                     fmt["format"], "rw", fmt["read_method"], fmt["write_method"]
                 )
@@ -527,6 +530,7 @@ class Polycos:
         self.fileName = filename
 
         if filename is not None:
+            log.debug(f"Reading polycos from '{filename}'")
             if format not in [f["format"] for f in self.polycoFormats]:
                 raise ValueError(
                     "Unknown polyco file format '" + format + "'\n"
@@ -599,6 +603,7 @@ class Polycos:
 
             pFormat["read_method"] = readMethod
             pFormat["write_method"] = writeMethod
+            log.debug(f"Registering Polyco format '{formatName}' with mode='r'")
             registry.register_reader(
                 pFormat["format"], table.Table, pFormat["read_method"]
             )
@@ -608,6 +613,7 @@ class Polycos:
 
             pFormat["read_method"] = readMethod
             pFormat["write_method"] = writeMethod
+            log.debug(f"Registering Polyco format '{formatName}' with mode='w'")
             registry.register_writer(
                 pFormat["format"], table.Table, pFormat["write_method"]
             )
@@ -619,7 +625,7 @@ class Polycos:
 
             pFormat["read_method"] = readMethod
             pFormat["write_method"] = writeMethod
-
+            log.debug(f"Registering Polyco format '{formatName}' with mode='rw'")
             registry.register_reader(
                 pFormat["format"], table.Table, pFormat["read_method"]
             )

--- a/src/pint/polycos.py
+++ b/src/pint/polycos.py
@@ -693,7 +693,7 @@ class Polycos:
             Observing frequency [MHz]
         maxha : float, optional.
             Maximum hour angle. Default 12.0. Only 12.0 is supported for now.
-        method : string, optional
+        method : str, optional
             Method to generate polycos. Only the ``TEMPO`` method is supported for now.
         numNodes : int, optional
             Number of nodes for fitting. It cannot be less then the number of
@@ -862,7 +862,7 @@ class Polycos:
 
         Parameters
         ---------
-        t: numpy.ndarray or a single number.
+        t: numpy.ndarray or float
            An time array in MJD. Time sample should be in order
 
         Returns
@@ -880,7 +880,7 @@ class Polycos:
 
         Parameters
         ---------
-        t: numpy.ndarray or a single number.
+        t: numpy.ndarray or float
            An time array in MJD. Time sample should be in order
 
         Returns
@@ -892,7 +892,7 @@ class Polycos:
         -----
         .. math::
 
-            \\phi = \\phi_0 + 60 \\Delta T f_0 + COEFF[1] + COEFF[2] \Delta T + COEFF[3] \Delta T^2 + \\ldots
+            \\phi = \\phi_0 + 60 \\Delta T f_0 + COEFF[1] + COEFF[2] \\Delta T + COEFF[3] \\Delta T^2 + \\ldots
 
         """
         if not isinstance(t, (np.ndarray, list)):
@@ -936,7 +936,7 @@ class Polycos:
         -----
         .. math::
 
-            f({\\rm Hz}) = f_0 + \\frac{1}{60}\\left(COEFF[2] + 2 \\delta T COEFF[3] + 3 \\Delta T^2 COEFF[4] + \\ldots\\right)
+            f({\\rm Hz}) = f_0 + \\frac{1}{60}\\left(COEFF[2] + 2 \\Delta T COEFF[3] + 3 \\Delta T^2 COEFF[4] + \\ldots\\right)
         """
         if not isinstance(t, np.ndarray) and not isinstance(t, list):
             t = np.array([t])

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -276,7 +276,7 @@ class emcee_fitter(Fitter):
         """
         Return pulse phases based on the current model
         """
-        phss = self.model.phase(self.toas)[1]
+        phss = self.model.phase(self.toas).frac
         return phss.value % 1
 
     def lnprior(self, theta):

--- a/tests/test_absphase.py
+++ b/tests/test_absphase.py
@@ -18,5 +18,5 @@ class TestAbsPhase(unittest.TestCase):
 
         ph = model.phase(toas, abs_phase=True)
         # Check that integer and fractional phase values are very close to 0.0
-        self.assertAlmostEqual(ph[0].value, 0.0)
-        self.assertAlmostEqual(ph[1].value, 0.0)
+        self.assertAlmostEqual(ph.int.value, 0.0)
+        self.assertAlmostEqual(ph.frac.value, 0.0)

--- a/tests/test_d_phase_d_toa.py
+++ b/tests/test_d_phase_d_toa.py
@@ -25,8 +25,7 @@ class TestD_phase_d_toa(unittest.TestCase):
         )
         self.modelB1855 = mb.get_model(self.parfileB1855)
         # Read tempo style polycos.
-        self.plc = Polycos()
-        self.plc.read_polyco_file("B1855_polyco.dat", "tempo")
+        self.plc = Polycos().read("B1855_polyco.dat", "tempo")
 
     def testD_phase_d_toa(self):
         pint_d_phase_d_toa = self.modelB1855.d_phase_d_toa(self.toasB1855)

--- a/tests/test_polycos.py
+++ b/tests/test_polycos.py
@@ -67,9 +67,8 @@ def test_read_write_round_trip(tmpdir, polyco_file):
 
 def test_generate_polycos_maxha_error(par_file):
     model = get_model(str(par_file))
-    p = Polycos()
     with pytest.raises(ValueError):
-        p.generate_polycos(model, 55000, 55002, "ao", 144, 12, 400.0, maxha=8)
+        p = Polycos.generate_polycos(model, 55000, 55002, "ao", 144, 12, 400.0, maxha=8)
 
 
 @pytest.mark.parametrize("obs", ["ao", "gbt", "@", "coe"])
@@ -81,8 +80,7 @@ def test_generate_polycos(tmpdir, par_file, obs, obsfreq, nspan, ncoeff):
 
     model = get_model(str(par_file))
 
-    p = Polycos()
-    p.generate_polycos(model, mjd_start, mjd_end, obs, nspan, ncoeff, obsfreq)
+    p = Polycos.generate_polycos(model, mjd_start, mjd_end, obs, nspan, ncoeff, obsfreq)
     p.write_polyco_file(str(output_polyco))
     q = Polycos(str(output_polyco))
 

--- a/tests/test_polycos.py
+++ b/tests/test_polycos.py
@@ -1,6 +1,7 @@
 """Test polycos."""
 
 import pytest
+import io
 import numpy as np
 from pint.polycos import Polycos
 from pint.models import get_model
@@ -24,8 +25,7 @@ def test_polycos_basic(polyco_file):
 
     Except the ones that should.
     """
-    p = Polycos()
-    p.read_polyco_file(polyco_file)
+    p = Polycos.read(polyco_file)
     table = p.polycoTable
     entry = table["entry"][0]
     print(entry)
@@ -39,8 +39,7 @@ def test_polycos_basic(polyco_file):
 
 def test_find_entry(polyco_file):
     """Check polycos find the correct entry and out of bounds throws an error."""
-    p = Polycos()
-    p.read_polyco_file(polyco_file)
+    p = Polycos.read(polyco_file)
 
     assert np.all(p.find_entry(55000) == 0)
     assert np.all(p.find_entry(55001) == 4)
@@ -58,10 +57,8 @@ def test_read_write_round_trip(tmpdir, polyco_file):
         p1 = f.read()
 
     output_polyco = tmpdir / "B1855_polyco_round_trip.dat"
-    p = Polycos()
-    p.read_polyco_file(polyco_file)
-    p.write_polyco_file(output_polyco)
-
+    p = Polycos.read(polyco_file)
+    p.write_polyco_file(str(output_polyco))
     with open(output_polyco, "r") as f:
         p2 = f.read()
 
@@ -86,9 +83,8 @@ def test_generate_polycos(tmpdir, par_file, obs, obsfreq, nspan, ncoeff):
 
     p = Polycos()
     p.generate_polycos(model, mjd_start, mjd_end, obs, nspan, ncoeff, obsfreq)
-    p.write_polyco_file(output_polyco)
-    q = Polycos()
-    q.read_polyco_file(output_polyco)
+    p.write_polyco_file(str(output_polyco))
+    q = Polycos(str(output_polyco))
 
     mjds = np.linspace(mjd_start, mjd_end, 51)
 


### PR DESCRIPTION
Changes:
* Can now read/write from/to a `Path` object or a stream (like `io.StringIO`).
* Registering formats done as a class method.  Done once on import for default formats (just tempo), can be done later if needed.
* Read polycos and generate from timing model now done as class methods that return new objects
* Documentation cleanup/improvements.
* implemented `len()`, `__getitem__` for polycos
* implemented `__getitem__` for Phase objects

