### PR TITLE
Extract single TOA as table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project, at least loosely, adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Can extract single TOAs as length=1 table
+### Added
+### Fixed
+
 ## [0.9.1] 2022-08-12
 ### Changed
 - No tests now change based on $TEMPO or $TEMPO2

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1337,7 +1337,7 @@ class TOAs:
 
         Parameter
         ---------
-        index : str or pair or list or array or slice
+        index : str or pair or list or array or slice or int
             How to choose what to select.
 
         Returns
@@ -1347,8 +1347,8 @@ class TOAs:
 
         Note
         ----
-        This function does not currently support extracting a single :class:`~pint.toa.TOA` object,
-        to use integer indexing a column must be selected.
+        This function does not currently support extracting a single :class:`~pint.toa.TOA` object.
+        To use integer indexing a column must be selected, or a table with length 1 will be returned.
         """
         column = None
         subset = None
@@ -1383,7 +1383,12 @@ class TOAs:
                 r.table = r.table[index]
                 return r
             elif isinstance(index, int):
-                raise ValueError("TOAs do not support extraction of TOA objects (yet?)")
+                log.warning(
+                    "TOAs do not support extraction of single TOA objects.  Returning TOAs of length 1"
+                )
+                r = copy.deepcopy(self)
+                r.table = r.table[[index]]
+                return r
             else:
                 raise ValueError("Unable to index TOAs with {}".format(index))
         elif column in self.table.columns:

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1383,7 +1383,7 @@ class TOAs:
                 r.table = r.table[index]
                 return r
             elif isinstance(index, int):
-                log.warning(
+                log.info(
                     "TOAs do not support extraction of single TOA objects.  Returning TOAs of length 1"
                 )
                 r = copy.deepcopy(self)

--- a/tests/test_toa_indexing.py
+++ b/tests/test_toa_indexing.py
@@ -59,14 +59,19 @@ def test_getitem_boolean(c):
     one_of(
         arrays(int, array_shapes(max_dims=1), elements=integers(0, n_tim - 1)),
         lists(integers(0, n_tim - 1)),
+        integers(0, n_tim - 1),
     )
 )
 def test_getitem_where(a):
     toas = get_TOAs(StringIO(tim), ephem="de421")
     m = toas.get_mjds()
     s = toas[a]
-    assert len(s) == len(a)
-    assert set(s.get_mjds()) == set(m[a])
+    if not isinstance(a, int):
+        assert len(s) == len(a)
+        assert set(s.get_mjds()) == set(m[a])
+    else:
+        assert len(s) == 1
+        assert set(s.get_mjds()) == set(m[[a]])
     if len(s) > 0:
         toas.get_summary()
 


### PR DESCRIPTION
Extracting a single TOA as a `TOA` object does not work.  But is there a reason we shouldn't enable a length=1 `TOAs` object?  This allows that, and updates the docs slightly.

Addresses #1352 

If this is a bad idea happy to shelve.