### PR TITLE
Fail more gracefully if download fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project, at least loosely, adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- global clock files now emit a warning instead of an exception if expired and the download fails
+
 ## [0.9.1] 2022-08-12
 ### Changed
 - No tests now change based on $TEMPO or $TEMPO2


### PR DESCRIPTION
Disconnected operation currently runs into a snag if `index.txt` is out of date - an exception occurs and clock corrections are not available. This softens that to a warning.