### PR TITLE
Tools for dealing with limited precision

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,7 @@ import hypothesis
 import pytest
 from astropy.utils.data import check_download_cache
 from astropy.config import paths
+import pint.utils
 
 # This setup is drawn from Astropy and might not be entirely relevant to us;
 # in particular we don't have a cron run for slow tests.
@@ -42,3 +43,7 @@ def temp_cache(tmpdir):
     with paths.set_temp_cache(tmpdir):
         yield None
         check_download_cache()
+
+
+# Refuse to run test suite if precision not available
+pint.utils.require_longdouble_precision()

--- a/src/pint/pulsar_mjd.py
+++ b/src/pint/pulsar_mjd.py
@@ -44,6 +44,7 @@ except AttributeError:
     from string import maketrans
 
 
+# This check is implemented in pint.utils, but we want to avoid circular imports
 if np.finfo(np.longdouble).eps > 2e-19:
     import warnings
 

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -86,7 +86,7 @@ def zero_residuals(ts, model, maxiter=10, tolerance=None):
 
 
 def update_fake_toa_clock(ts, model, include_bipm=False, include_gps=True):
-    """Update the clock s:qettings (corrections, etc) for fake TOAs
+    """Update the clock settings (corrections, etc) for fake TOAs
 
     Parameters
     ----------

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -86,6 +86,9 @@ __all__ = [
     "colorize",
     "group_iterator",
     "compute_hash",
+    "PINTPrecisionError",
+    "check_longdouble_precision",
+    "require_longdouble_precision",
 ]
 
 COLOR_NAMES = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]
@@ -101,6 +104,34 @@ TEXT_ATTRIBUTES = [
 ]
 
 # Actual exported tools
+
+
+class PINTPrecisionError(RuntimeError):
+    pass
+
+
+# A warning is emitted in pint.pulsar_mjd if sufficient precision is not available
+
+
+def check_longdouble_precision():
+    """Check whether long doubles have adequate precision.
+
+    Returns True if long doubles have enough precision to use PINT
+    for sub-microsecond timing on this machine.
+    """
+    return np.finfo(np.longdouble).eps < 2e-19
+
+
+def require_longdouble_precision():
+    """Raise an exception if long doubles do not have enough precision.
+
+    Raises RuntimeError if PINT cannot be run with high precision on this
+    machine.
+    """
+    if not check_longdouble_precision():
+        raise PINTPrecisionError(
+            f"PINT needs higher precision floating point than you have available. PINT uses the numpy longdouble type to represent modified Julian days, and this machine does not have sufficient numerical precision to represent sub-microsecond times with np.longdouble. On an M1 Mac you will need to use a Rosetta environment, or on a Windows machine you will need to us a different Python interpreter. Some PINT operations can work with reduced precision, but you have requested one that cannot."
+        )
 
 
 class PosVel:


### PR DESCRIPTION
As we see in #1389, users can miss or ignore the "limited precision" warning when trying to run PINT with 64-bit longdouble values. This PR tries to make PINT run less badly and signal more loudly in this setting.

- The test suite will not run and will emit an error message about precision.
- `pint.simulation` will make fake TOAs but only good to a few microseconds.
- Functions that require full precision to run can call `require_longdouble_precision()` to do the test and get an informative exception. I haven't identified any such functions yet (do Fitters work okay, for some values of "okay"?)

I would appreciate additional testing in a 64-bit-only environment (M1 macs, Windows MSVC).