### PR TITLE
Fixes dmxparse save=True exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 ## Unreleased
 ### Changed
 - global clock files now emit a warning instead of an exception if expired and the download fails
+### Added
+### Fixed
+- dmxparse outputs to dmxparse.out if save=True
 
 ## [0.9.1] 2022-08-12
 ### Changed

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -893,7 +893,7 @@ def dmxparse(fitter, save=False):
     fitter
         PINT fitter used to get timing residuals, must have already run a fit
     save : bool or str or file-like object, optional
-        If not False or None, saves output to specified file in the format of the TEMPO version.
+        If not False or None, saves output to specified file in the format of the TEMPO version.  If ``True``, assumes output file is ``dmxparse.out``
 
     Returns
     -------
@@ -988,6 +988,8 @@ def dmxparse(fitter, save=False):
 
     # Output the results'
     if save is not None and save:
+        if isinstance(save, bool):
+            save = "dmxparse.out"
         DMX = "DMX"
         lines = []
         lines.append("# Mean %s value = %+.6e \n" % (DMX, DMX_mean))
@@ -1010,6 +1012,8 @@ def dmxparse(fitter, save=False):
             )
         with open_or_use(save, mode="w") as dmxout:
             dmxout.writelines(lines)
+            if isinstance(save, (str, Path)):
+                log.debug(f"Wrote dmxparse output to '{save}'")
     # return the new mean subtracted values
     mean_sub_DMXs = DMXs - DMX_mean
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 """Test basic functionality of the :module:`pint.utils`."""
+import io
 import os
 from itertools import product
 from pathlib import Path
@@ -619,6 +620,30 @@ def test_dmxparse():
     f = fitter.WLSFitter(toas=t, model=m)
     f.fit_toas()
     dmx = dmxparse(f, save=False)
+
+
+def test_dmxparse_write():
+    # check output
+    m = tm.get_model(os.path.join(datadir, "B1855+09_NANOGrav_9yv1.gls.par"))
+    t = toa.get_TOAs(os.path.join(datadir, "B1855+09_NANOGrav_9yv1.tim"))
+    f = fitter.GLSFitter(toas=t, model=m)
+    f.fit_toas()
+    w = io.StringIO()
+    dmx = dmxparse(f, save=w)
+    w.seek(0)
+    assert len(w.read()) > 0
+
+
+def test_dmxparse_write_default():
+    # check output to default filename
+    m = tm.get_model(os.path.join(datadir, "B1855+09_NANOGrav_9yv1.gls.par"))
+    t = toa.get_TOAs(os.path.join(datadir, "B1855+09_NANOGrav_9yv1.tim"))
+    f = fitter.GLSFitter(toas=t, model=m)
+    f.fit_toas()
+    dmx = dmxparse(f, save=True)
+    with open("dmxparse.out") as r:
+        assert len(r.read()) > 0
+    # os.remove("dmxparse.out")
 
 
 def test_pmtot():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -643,7 +643,7 @@ def test_dmxparse_write_default():
     dmx = dmxparse(f, save=True)
     with open("dmxparse.out") as r:
         assert len(r.read()) > 0
-    # os.remove("dmxparse.out")
+    os.remove("dmxparse.out")
 
 
 def test_pmtot():


### PR DESCRIPTION
Fixes #1394 
Now if `save=True` will write to `dmxparse.out`.  

Also adds tests for writing to `StringIO` and default filename.