### PR TITLE
Adding PLDMNoise model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Can initialize observatories with lat/lon/altitude
 - Can output observatories as JSON
 - Can extract single TOAs as length=1 table
+- Added PLDMNoise component which allows modeling of stochastic DM variations as red noise with a power law spectrum
 ### Fixed
 - global clock files now emit a warning instead of an exception if expired and the download fails
 - dmxparse outputs to dmxparse.out if save=True

--- a/tests/test_pldmnoise.py
+++ b/tests/test_pldmnoise.py
@@ -4,7 +4,10 @@ component properly.
 Tests that PLDMNoise reproduces same results as PLRedNoise using
 monochromatic data
 
-To do: Add test that fits out DM noise correctly in toy simulated dataset
+To do:
+    Add test that fits out DM noise correctly in toy simulated dataset
+    Add test that checks for same results between PINT and Tempo2/TempoNest
+    Add test that checks for same results between PINT and enterprise
 """
 
 import astropy.units as u

--- a/tests/test_pldmnoise.py
+++ b/tests/test_pldmnoise.py
@@ -1,0 +1,73 @@
+"""Tests to ensure that ModelBuilder is able to read PLDMNoise 
+component properly.
+
+To do:
+    - Add check that PLDMNoise reproduces same results as PLRedNoise given
+    monochromatic data
+    - Add test that fits out DM noise correctly in toy simulated dataset
+"""
+
+import io
+import pytest
+
+import pint.models.model_builder as mb
+
+parfile_contents = """
+    PSRJ           J0023+0923
+    RAJ             00:23:16.8790858         1  0.00002408141295805134   
+    DECJ           +09:23:23.86936           1  0.00082010713730773120   
+    F0             327.84702062954047136     1  0.00000000000295205483   
+    F1             -1.2278326306812866375e-15 1  3.8219244605614075223e-19
+    PEPOCH         56199.999797564144902       
+    POSEPOCH       56199.999797564144902       
+    DMEPOCH        56200                       
+    DM             14.327978186774068347     1  0.00006751663559857748   
+    BINARY         ELL1
+    PB             0.13879914244858396754    1  0.00000000003514075083   
+    A1             0.034841158415224894973   1  0.00000012173038389247   
+    TASC           56178.804891768506529     1  0.00000007765191894742   
+    EPS1           1.6508830631753595232e-05 1  0.00000477568412215803   
+    EPS2           3.9656838708709247373e-06 1  0.00000458951091435993   
+    CLK            TT(BIPM2015)
+    MODE 1
+    UNITS          TDB
+    TIMEEPH        FB90
+    DILATEFREQ     N
+    PLANET_SHAPIRO N
+    CORRECT_TROPOSPHERE  N
+    EPHEM          DE436
+    JUMP -fe 430 0 0
+    TNEF -group 430_ASP 1.0389
+    TNEQ -group 430_ASP -8.77109
+    TNECORR -group 430_PUPPI 0.00490558
+    TNRedAmp -13.3087
+    TNRedGam 0.125393
+    TNRedC 14
+    TNDMAMP -14.2
+    TNDMGAM 0.624
+    TNDMC 70
+"""
+
+
+@pytest.fixture()
+def modelJ0023p0923():
+    return mb.get_model(io.StringIO(parfile_contents))
+
+
+def test_read_PLDMNoise_component(modelJ0023p0923):
+    assert "PLDMNoise" in modelJ0023p0923.components
+
+
+def test_read_PLDMNoise_component_type(modelJ0023p0923):
+    assert (
+        modelJ0023p0923.components["PLDMNoise"] in modelJ0023p0923.NoiseComponent_list
+    )
+
+
+def test_read_PLDMNoise_params(modelJ0023p0923):
+    params = ["TNDMAMP", "TNDMGAM", "TNDMC"]
+    for param in params:
+        assert (
+            hasattr(modelJ0023p0923, param)
+            and getattr(modelJ0023p0923, param).quantity is not None
+        )

--- a/tests/test_split_corrnoise_basis_weights.py
+++ b/tests/test_split_corrnoise_basis_weights.py
@@ -8,7 +8,15 @@ from pint.models import get_model_and_toas
 from pint.models.timing_model import Component
 
 
-component_labels = [c for c in list(Component.component_types.keys()) if "Noise" in c]
+# get list of correlated noise components
+noise_component_labels = []
+for key in list(Component.component_types.keys()):
+    component_instance = Component.component_types[key]()
+    try:
+        if component_instance.introduces_correlated_errors:
+            noise_component_labels.append(key)
+    except:
+        pass
 
 
 def add_DM_noise_to_model(model):
@@ -32,7 +40,7 @@ def model_and_toas():
     return model, toas
 
 
-@pytest.mark.parametrize("component_label", component_labels)
+@pytest.mark.parametrize("component_label", noise_component_labels)
 def test_noise_basis_shape(model_and_toas, component_label):
     """Test shape of basis matrix."""
 
@@ -45,7 +53,7 @@ def test_noise_basis_shape(model_and_toas, component_label):
     assert basis.shape == (len(toas), len(weights))
 
 
-@pytest.mark.parametrize("component_label", component_labels)
+@pytest.mark.parametrize("component_label", noise_component_labels)
 def test_noise_weights_sign(model_and_toas, component_label):
     """Weights should be positive."""
 
@@ -58,7 +66,7 @@ def test_noise_weights_sign(model_and_toas, component_label):
     assert np.all(weights >= 0)
 
 
-@pytest.mark.parametrize("component_label", component_labels)
+@pytest.mark.parametrize("component_label", noise_component_labels)
 def test_covariance_matrix_relation(model_and_toas, component_label):
     """Consistency between basis and weights and covariance matrix"""
 

--- a/tests/test_split_corrnoise_basis_weights.py
+++ b/tests/test_split_corrnoise_basis_weights.py
@@ -8,10 +8,10 @@ from pint.models import get_model_and_toas
 from pint.models.timing_model import Component
 
 
-components = ["EcorrNoise", "PLRedNoise", "PLDMNoise"]
+component_labels = [c for c in list(Component.component_types.keys()) if "Noise" in c]
 
 
-def inject_DM_noise(model):
+def add_DM_noise_to_model(model):
     all_components = Component.component_types
     noise_class = all_components["PLDMNoise"]
     noise = noise_class()  # Make the DM noise instance.
@@ -28,11 +28,11 @@ def model_and_toas():
     parfile = examplefile("B1855+09_NANOGrav_9yv1.gls.par")
     timfile = examplefile("B1855+09_NANOGrav_9yv1.tim")
     model, toas = get_model_and_toas(parfile, timfile)
-    model = inject_DM_noise(model)
+    model = add_DM_noise_to_model(model)
     return model, toas
 
 
-@pytest.mark.parametrize("component_label", components)
+@pytest.mark.parametrize("component_label", component_labels)
 def test_noise_basis_shape(model_and_toas, component_label):
     """Test shape of basis matrix."""
 
@@ -45,7 +45,7 @@ def test_noise_basis_shape(model_and_toas, component_label):
     assert basis.shape == (len(toas), len(weights))
 
 
-@pytest.mark.parametrize("component_label", components)
+@pytest.mark.parametrize("component_label", component_labels)
 def test_noise_weights_sign(model_and_toas, component_label):
     """Weights should be positive."""
 
@@ -58,7 +58,7 @@ def test_noise_weights_sign(model_and_toas, component_label):
     assert np.all(weights >= 0)
 
 
-@pytest.mark.parametrize("component_label", components)
+@pytest.mark.parametrize("component_label", component_labels)
 def test_covariance_matrix_relation(model_and_toas, component_label):
     """Consistency between basis and weights and covariance matrix"""
 


### PR DESCRIPTION
Adding a `PLDMNoise` model which models stochastic DM variations using a powerlaw spectrum. This model shares most of the same code as the `PLRedNoise` model. This new model uses the parameters `TNDMAMP`, `TNDMGAM`, and `TNDMC` as well as a reference frequency of 1400 MHz to match the conventions used in `enterprise` and `TempoNest`.