### PR TITLE
Can ignore pulse_number column on TOA read/write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Can extract single TOAs as length=1 table
 ### Added
 - Can ignore pulse_number column on TOA read or write (to help merging)
+- Can add in missing columns when merging unless told not to
 ### Fixed
 - global clock files now emit a warning instead of an exception if expired and the download fails
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 ### Changed
 - Can extract single TOAs as length=1 table
 ### Added
+- Can ignore pulse_number column on TOA read or write (to help merging)
 ### Fixed
 - global clock files now emit a warning instead of an exception if expired and the download fails
 ### Added

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -593,6 +593,7 @@ def get_model_and_toas(
     planets=None,
     usepickle=False,
     tdb_method="default",
+    include_pn=True,
     picklefilename=None,
     allow_name_mixing=False,
     limits="warn",
@@ -621,6 +622,8 @@ def get_model_and_toas(
     tdb_method : str
         Which method to use for the clock correction to TDB. See
         :func:`pint.observatory.Observatory.get_TDBs` for details.
+    include_pn : bool, optional
+        Whether or not to read in the 'pn' column (``pulse_number``)
     picklefilename : str or None
         Filename to use for caching loaded file. Defaults to adding ``.pickle.gz`` to the
         filename of the timfile, if there is one and only one. If no filename is available,
@@ -640,6 +643,7 @@ def get_model_and_toas(
     mm = get_model(parfile, allow_name_mixing)
     tt = get_TOAs(
         timfile,
+        include_pn=include_pn,
         model=mm,
         ephem=ephem,
         include_bipm=include_bipm,

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1228,6 +1228,7 @@ class TOAs:
            :func:`pint.toa.TOAs.compute_pulse_numbers` or extracted from the
            ``pn`` entry in ``flags`` with
            :func:`pint.toa.TOAs.phase_columns_from_flags`.
+           If it is present for some TOAs but not all, missing values are filled with ``NaN``.
        * - ``delta_pulse_number``
          - number of turns to adjust pulse number by, compared to the model;
            ``PHASE`` statements in the ``.tim`` file or the ``padd`` entry in

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -2478,8 +2478,8 @@ def merge_TOAs(TOAs_list):
     # but it should be more helpful
     columns = tables[0].colnames
     for i, tt in enumerate(tables[1:]):
-        extra_columns = [x for x in tt.table.colnames if not x in columns]
-        missing_columns = [x for x in columns if not x in tt.table.colnames]
+        extra_columns = [x for x in tt.colnames if not x in columns]
+        missing_columns = [x for x in columns if not x in tt.colnames]
         if len(extra_columns) > 0:
             log.warning(f"File {i+1} has extra column(s): {','.join(extra_columns)}")
         if len(missing_columns) > 0:

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -310,7 +310,7 @@ def get_TOAs(
         save_pickle(t, picklefilename=picklefilename)
     if "pulse_number" in t.table.colnames and not include_pn:
         log.warning(f"'pulse_number' column exists but not being read in")
-        del t.table["pulse_number"]
+        t.remove_pulse_numbers()
     return t
 
 
@@ -1893,6 +1893,16 @@ class TOAs:
         phases = model.phase(self, abs_phase=True) + delta_pulse_numbers
         self.table["pulse_number"] = phases.int
         self.table["pulse_number"].unit = u.dimensionless_unscaled
+
+    def remove_pulse_numbers(self):
+        """Delete pulse numbers from TOA data"""
+
+        if "pulse_number" in self.table.colnames:
+            del self.table["pulse_number"]
+        else:
+            log.warning(
+                f"Requested deleting of pulse numbers, but they are not present"
+            )
 
     def adjust_TOAs(self, delta):
         """Apply a time delta to TOAs.

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -2404,7 +2404,7 @@ class TOAs:
         self.table.add_column(col)
 
 
-def merge_TOAs(TOAs_list):
+def merge_TOAs(TOAs_list, strict=False):
     """Merge a list of TOAs instances and return a new combined TOAs instance
 
     In order for a merge to work, each TOAs instance needs to have
@@ -2413,9 +2413,14 @@ def merge_TOAs(TOAs_list):
     .planets (i.e. whether planetary PosVel columns are in the tables
     or not).
 
+    If ``pulse_number``, [``ssb_obs_pos``, ``ssb_obs_vel``, ``obs_sun_pos``], [``tdb``, ``tdbld``]
+    columns are present in some but not all data try to put them in unless ``strict=True``
+
     Parameters
     ----------
     TOAs_list : list of TOAs instances
+    strict : bool, optional
+        If ``strict``, do not add in missing columns to facilitate merging
 
     Returns
     -------
@@ -2444,23 +2449,66 @@ def merge_TOAs(TOAs_list):
     planets = [tt.planets for tt in TOAs_list]
     if len(set(planets)) > 1:
         raise TypeError(f"merge_TOAs() cannot merge. Inconsistent planets: {planets}")
-    num_cols = [len(tt.table.columns) for tt in TOAs_list]
-    if len(set(num_cols)) > 1:
-        columns = TOAs_list[0].table.colnames
-        for i, tt in enumerate(TOAs_list[1:]):
-            extra_columns = [x for x in tt.table.colnames if not x in columns]
-            missing_columns = [x for x in columns if not x in tt.table.colnames]
-            if len(extra_columns) > 0:
-                log.warning(
-                    f"File {i+1} has extra column(s): {','.join(extra_columns)}"
-                )
-            if len(missing_columns) > 0:
-                log.warning(
-                    f"File {i+1} has missing column(s): {','.join(missing_columns)}"
-                )
-        raise TypeError(
-            f"merge_TOAs() cannot merge. Inconsistent numbers of table columns: {num_cols}"
-        )
+    # check for the presence of various computable columns
+    #   pulse_number
+    #   ssb_obs_pos, ssb_obs_vel, obs_sun_pos
+    #   tdb, tdbld
+    # if one file has these and the others don't, try to add them if strict=False
+    all_colnames = [tt.table.colnames for tt in TOAs_list]
+    has_pulse_number = np.array(
+        ["pulse_number" in colnames for colnames in all_colnames]
+    )
+    has_posvel = np.array(
+        [
+            ("ssb_obs_pos" in colnames)
+            and ("ssb_obs_vel" in colnames)
+            and ("obs_sun_pos" in colnames)
+            for colnames in all_colnames
+        ]
+    )
+    has_tdb = np.array(
+        [("tdb" in colnames) and ("tdbld" in colnames) for colnames in all_colnames]
+    )
+    has_posvel_ecl = np.array(
+        ["ssb_obs_vel_ecl" in colnames for colnames in all_colnames]
+    )
+    if has_pulse_number.any() and not has_pulse_number.all():
+        if strict:
+            log.warning("Not all data have 'pulse_number' columns but strict=True")
+        else:
+            # some data have pulse_numbers but not all
+            # put in NaN
+            for i, tt in enumerate(TOAs_list):
+                if not "pulse_number" in tt.table.colnames:
+                    log.warning(
+                        f"'pulse_number' not present in data set {i}: inserting NaNs"
+                    )
+                    tt.table.add_column(np.ones(len(tt)) * np.nan, name="pulse_number")
+    if has_posvel.any() and not has_posvel.all():
+        if strict:
+            log.warning("Not all data have position/velocity columns but strict=True")
+        else:
+            # some data have positions/velocities but not all
+            # compute as needed
+            for i, tt in enumerate(TOAs_list):
+                if not (
+                    ("ssb_obs_pos" in tt.table.colnames)
+                    and ("ssb_obs_vel" in tt.table.colnames)
+                    and ("obs_sun_pos" in tt.table.colnames)
+                ):
+                    tt.compute_posvels()
+    if has_tdb.any() and not has_tdb.all():
+        if strict:
+            log.warning("Not all data have TDB columns but strict=True")
+        else:
+            # some data have TDBs but not all
+            # compute as needed
+            for i, tt in enumerate(TOAs_list):
+                if not (
+                    ("tdb" in tt.table.colnames) and ("tdbld" in tt.table.colnames)
+                ):
+                    tt.compute_TDBs()
+
     # Use a copy of the first TOAs instance as the base for the joined object
     nt = copy.deepcopy(TOAs_list[0])
     # The following ensures that the filename list is flat
@@ -2481,23 +2529,30 @@ def merge_TOAs(TOAs_list):
         t["index"] += start_index
         start_index += tt.max_index + 1
         tables.append(t)
-    # the astropy vstack will enforce having the same columns throughout
-    # but the error messages aren't very useful.
-    # This isn't an exhaustive check
-    # (it just checks everything against the first observation)
-    # but it should be more helpful
-    columns = tables[0].colnames
-    for i, tt in enumerate(tables[1:]):
-        extra_columns = [x for x in tt.colnames if not x in columns]
-        missing_columns = [x for x in columns if not x in tt.colnames]
-        if len(extra_columns) > 0:
-            log.warning(f"File {i+1} has extra column(s): {','.join(extra_columns)}")
-        if len(missing_columns) > 0:
-            log.warning(
-                f"File {i+1} has missing column(s): {','.join(missing_columns)}"
-            )
-    nt.table = table.vstack(tables, join_type="exact", metadata_conflicts="silent")
-    # Fix the table meta data about filenames
+    try:
+        nt.table = table.vstack(tables, join_type="exact", metadata_conflicts="silent")
+    except table.np_utils.TableMergeError as e:
+        # the astropy vstack will enforce having the same columns throughout
+        # but the error messages aren't very useful.
+        # This isn't an exhaustive check
+        # (it just checks everything against the first observation)
+        # but it should be more helpful
+        message = []
+        for i, colnames in enumerate(all_colnames[1:]):
+            extra_columns = [x for x in colnames if not x in all_colnames[0]]
+            missing_columns = [x for x in all_colnames[0] if not x in colnames]
+            if len(extra_columns) > 0:
+                message.append(
+                    f"File {i+1} has extra column(s): {','.join(extra_columns)}"
+                )
+
+            if len(missing_columns) > 0:
+                message.append(
+                    f"File {i+1} has missing column(s): {','.join(missing_columns)}"
+                )
+        raise table.np_utils.TableMergeError(", ".join(message)) from e
+
+        # Fix the table meta data about filenames
     nt.table.meta["filename"] = nt.filename
     nt.max_index = start_index - 1
     nt.hashes = {}

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -2023,6 +2023,9 @@ class TOAs:
         if "pulse_number" in toacopy.table.colnames:
             if include_pn:
                 toacopy["pn"] = toacopy.table["pulse_number"]
+                # but delete those that are NaN
+                for i in np.where(np.isnan(self["pulse_number"]))[0]:
+                    del toacopy.table["flags"][i]["pn"]
             else:
                 log.warning(
                     f"'pulse_number' column exists but it is not being written out"

--- a/tests/test_pulse_number.py
+++ b/tests/test_pulse_number.py
@@ -64,6 +64,12 @@ def test_pulse_number(model, toas):
     assert "pulse_number" in toas.table.colnames
 
 
+def test_remove_pulse_number(model, toas):
+    assert "pulse_number" in toas.table.colnames
+    toas.remove_pulse_numbers()
+    assert "pulse_number" not in toas.table.colnames
+
+
 @pytest.mark.parametrize("obs", ["GBT", "AO", "@", "coe"])
 def test_make_fake_toas(obs, model):
     t = make_fake_toas_uniform(56000, 59000, 10, model, obs=obs)

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -248,7 +248,7 @@ def test_toa_merge_different_columns():
         nt = toa.merge_TOAs(toas)
 
 
-def test_toa_merge_different_columns_ignorepn():
+def test_toa_merge_different_columns_ignorepn_onread():
     filenames = [
         datadir / "NGC6440E.tim",
         datadir / "testtimes.tim",
@@ -261,6 +261,22 @@ def test_toa_merge_different_columns_ignorepn():
     t.write_TOA_file(f)
     f.seek(0)
     toas = [toa.get_TOAs(fname, include_pn=False) for fname in [f, filenames[1]]]
+    nt = toa.merge_TOAs(toas)
+
+
+def test_toa_merge_different_columns_ignorepn_onwrite():
+    filenames = [
+        datadir / "NGC6440E.tim",
+        datadir / "testtimes.tim",
+    ]
+    model = get_model(datadir / "NGC6440E.par")
+    # read and add pulse numbers
+    t = toa.get_TOAs(filenames[0], model=model)
+    t.compute_pulse_numbers(model)
+    f = StringIO()
+    t.write_TOA_file(f, include_pn=False)
+    f.seek(0)
+    toas = [toa.get_TOAs(fname, include_pn=True) for fname in [f, filenames[1]]]
     nt = toa.merge_TOAs(toas)
 
 

--- a/tests/test_toa_reader.py
+++ b/tests/test_toa_reader.py
@@ -4,6 +4,7 @@ import unittest
 from glob import glob
 from io import StringIO
 from pathlib import Path
+from webbrowser import get
 
 import numpy as np
 import pytest
@@ -232,6 +233,35 @@ def test_toa_merge_different_ephem():
     toas[0].ephem = "DE436"
     with pytest.raises(TypeError):
         nt = toa.merge_TOAs(toas)
+
+
+def test_toa_merge_different_columns():
+    filenames = [
+        datadir / "NGC6440E.tim",
+        datadir / "testtimes.tim",
+    ]
+    model = get_model(datadir / "NGC6440E.par")
+    # add a pulse_number column.  then the merge should fail
+    toas = [toa.get_TOAs(ff, model=model) for ff in filenames]
+    toas[0].compute_pulse_numbers(model)
+    with pytest.raises(TypeError):
+        nt = toa.merge_TOAs(toas)
+
+
+def test_toa_merge_different_columns_ignorepn():
+    filenames = [
+        datadir / "NGC6440E.tim",
+        datadir / "testtimes.tim",
+    ]
+    model = get_model(datadir / "NGC6440E.par")
+    # read and add pulse numbers
+    t = toa.get_TOAs(filenames[0], model=model)
+    t.compute_pulse_numbers(model)
+    f = StringIO()
+    t.write_TOA_file(f)
+    f.seek(0)
+    toas = [toa.get_TOAs(fname, include_pn=False) for fname in [f, filenames[1]]]
+    nt = toa.merge_TOAs(toas)
 
 
 def test_bipm_default():

--- a/tests/test_toa_writer.py
+++ b/tests/test_toa_writer.py
@@ -118,6 +118,23 @@ def test_roundtrip_ncyobs_toa_TEMPOformat(tmp_path):
         ts.write_TOA_file(tmp_path / "testncyobs.tim", format="TEMPO")
 
 
+def test_write_pn_nan():
+    # NaN should not get written as flag in tim file
+    model = get_model(datadir / "NGC6440E.par")
+    # read and add pulse numbers
+    t = toa.get_TOAs(datadir / "NGC6440E.tim", model=model)
+    t.compute_pulse_numbers(model)
+    t["pulse_number"][10] = np.nan
+    f = StringIO()
+    t.write_TOA_file(f)
+    f.seek(0)
+    contents = f.read()
+    assert "nan" not in contents
+    f.seek(0)
+    t2 = toa.get_TOAs(f)
+    assert np.isnan(t2["pulse_number"][10])
+
+
 simplepar = """
 PSR              1748-2021E
 RAJ       17:48:52.75  1


### PR DESCRIPTION
Reading or writing TOAs with `include_pn=False` will ignore the `pulse_number` column. It will issue a warning that this is happening.  This may make it easier to merge TOA files, but in general it may also be dangerous.  So I'm not convinced that this is overall a good idea but it will address #1397 

The error message when failing to merge is also a little more informative.