### PR TITLE
Fixed bug in dmxparse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - dmxparse outputs to dmxparse.out if save=True
 - Split the computation of correlated noise basis matrix and weights into two functions.
 - Fixed bug in combining design matrices
+- Fixed bug in dmxparse
 
 ## [0.9.1] 2022-08-12
 ### Changed

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -971,7 +971,7 @@ def dmxparse(fitter, save=False):
         mask_idxs[ii] = getattr(fitter.model, "DMX_{:}".format(epoch)).frozen
         DMX_Errs[ii] = getattr(fitter.model, "DMX_{:}".format(epoch)).uncertainty_value
         DMX_R1[ii] = getattr(fitter.model, "DMXR1_{:}".format(epoch)).value
-        DMX_R2[ii] = getattr(fitter.model, "DMXR1_{:}".format(epoch)).value
+        DMX_R2[ii] = getattr(fitter.model, "DMXR2_{:}".format(epoch)).value
     DMX_center_MJD = (DMX_R1 + DMX_R2) / 2
     # If any value need to be masked, do it
     if True in mask_idxs:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -614,6 +614,8 @@ def test_dmxparse():
     f = fitter.GLSFitter(toas=t, model=m)
     f.fit_toas()
     dmx = dmxparse(f, save=False)
+    # make sure the start and end are not the same
+    assert ((dmx["r2s"] - dmx["r1s"] > 0)).all()
     # Check exception handling
     m = tm.get_model(os.path.join(datadir, "B1855+09_NANOGrav_dfg+12_DMX.par"))
     t = toa.get_TOAs(os.path.join(datadir, "B1855+09_NANOGrav_dfg+12.tim"))


### PR DESCRIPTION
This fixes #1408, where the R1 and R2 times for dmxparse were the same.