### PR TITLE
Fixed failing tests on oldestdeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 
 ## Unreleased
 ### Changed
+- Minimum supported versions updated to numpy 1.18.5, matplotlib 3.2.0
 ### Added
 - Can ignore pulse_number column on TOA read or write (to help merging)
 - Can add in missing columns when merging unless told not to
@@ -19,6 +20,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Split the computation of correlated noise basis matrix and weights into two functions.
 - Fixed bug in combining design matrices
 - Fixed bug in dmxparse
+- Fixed bug in photonphase with polycos
 
 ## [0.9.1] 2022-08-12
 ### Changed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-numpy>=1.17.0
+numpy>=1.18.5
 astropy>=4.0,!=4.0.1,!=4.0.1.post1
 pyerfa
 scipy>=0.18.1
 jplephem>=2.6
-matplotlib>=1.5.3
+matplotlib>=3.2.0
 emcee>=3.0.1
 corner>=2.0.1
 uncertainties

--- a/src/pint/scripts/photonphase.py
+++ b/src/pint/scripts/photonphase.py
@@ -227,7 +227,7 @@ def main(argv=None):
 
         # Calculate phases
         log.debug("Evaluating polycos")
-        phases = p.eval_phase(mjds)
+        phases = ptable.eval_phase(mjds)
         phases[phases < 0] += 1.0
         h = float(hm(phases))
         print("Htest : {0:.2f} ({1:.2f} sigma)".format(h, h2sig(h)))

--- a/tests/test_photonphase.py
+++ b/tests/test_photonphase.py
@@ -14,9 +14,6 @@ eventfile = datadir / "B1509_RXTE_short.fits"
 orbfile = datadir / "FPorbit_Day6223"
 
 
-@pytest.mark.skipif(
-    "DISPLAY" not in os.environ, reason="Needs an X server, xvfb counts"
-)
 def test_rxte_result(capsys, tmp_path):
     "Test that processing RXTE data with orbit file gives correct result"
 
@@ -38,9 +35,6 @@ parfile_nicerbad = datadir / "ngc300nicernoTZR.par"
 eventfile_nicer = datadir / "ngc300nicer_bary.evt"
 
 
-#@pytest.mark.skipif(
-#    "DISPLAY" not in os.environ, reason="Needs an X server, xvfb counts"
-#)
 def test_nicer_result_bary(capsys):
     "Check that barycentered NICER data is processed correctly."
     cmd = f" {eventfile_nicer} {parfile_nicer}"
@@ -72,9 +66,6 @@ def test_nicer_result_topo(capsys):
     assert abs(v - 183.21) < 1
 
 
-@pytest.mark.skipif(
-    "DISPLAY" not in os.environ, reason="Needs an X server, xvfb counts"
-)
 def test_AbsPhase_exception():
     "Verify that passing par file with no TZR* parameters raises exception"
     with pytest.raises(ValueError):
@@ -82,9 +73,6 @@ def test_AbsPhase_exception():
         photonphase.main(cmd.split())
 
 
-@pytest.mark.skipif(
-    "DISPLAY" not in os.environ, reason="Needs an X server, xvfb counts"
-)
 def test_OrbPhase_exception():
     "Verify that trying to add ORBIT_PHASE column with no BINARY parameter in the par file raises exception"
     with pytest.raises(ValueError):
@@ -96,9 +84,6 @@ parfile_nicer_binary = datadir / "PSR_J0218+4232.par"
 eventfile_nicer_binary = datadir / "J0218_nicer_2070030405_cleanfilt_cut_bary.evt"
 
 
-@pytest.mark.skipif(
-    "DISPLAY" not in os.environ, reason="Needs an X server, xvfb counts"
-)
 def test_OrbPhase_column(tmp_path):
     "Verify that the ORBIT_PHASE column is calculated and added correctly"
 
@@ -123,9 +108,6 @@ def test_OrbPhase_column(tmp_path):
     os.remove(outfile)
 
 
-@pytest.mark.skipif(
-    "DISPLAY" not in os.environ, reason="Needs an X server, xvfb counts"
-)
 def test_nicer_result_bary_polyco(capsys, tmp_path):
     "Check that barycentered NICER data is processed correctly with --polyco."
     outfile = tmp_path / "polycos-photonphase-test.evt"

--- a/tests/test_photonphase.py
+++ b/tests/test_photonphase.py
@@ -38,9 +38,9 @@ parfile_nicerbad = datadir / "ngc300nicernoTZR.par"
 eventfile_nicer = datadir / "ngc300nicer_bary.evt"
 
 
-@pytest.mark.skipif(
-    "DISPLAY" not in os.environ, reason="Needs an X server, xvfb counts"
-)
+#@pytest.mark.skipif(
+#    "DISPLAY" not in os.environ, reason="Needs an X server, xvfb counts"
+#)
 def test_nicer_result_bary(capsys):
     "Check that barycentered NICER data is processed correctly."
     cmd = f" {eventfile_nicer} {parfile_nicer}"

--- a/tox.ini
+++ b/tox.ini
@@ -58,12 +58,13 @@ description =
     Run tests on Python 3 with minimum supported versions of astropy, numpy
 basepython = python3.8
 deps =
-    numpy==1.17.*
+    numpy==1.18.5
+    numdifftools==0.9.39
     astropy==4.0
+    matplotlib==3.2.0
     pytest
     coverage
     hypothesis
-    numdifftools
 commands = {posargs:pytest}
 
 [testenv:report]


### PR DESCRIPTION
Attempt to fix #1401 

Required updating the oldest version of numpy and pinning the versions of scipy and matplotlib to keep it from automatically updating numpy to the most recent.