### PR TITLE
Rename basis and weights functions in EcorrNoise

### DIFF
--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -345,7 +345,7 @@ class EcorrNoise(NoiseComponent):
             ecorrs.append(getattr(self, ecorr))
         return ecorrs
 
-    def get_basis(self, toas):
+    def get_noise_basis(self, toas):
         """Return the quantization matrix for ECORR.
 
         A quantization matrix maps TOAs to observing epochs.
@@ -371,7 +371,7 @@ class EcorrNoise(NoiseComponent):
             nctot += nn
         return umat
 
-    def get_weights(self, toas, nweights=None):
+    def get_noise_weights(self, toas, nweights=None):
         """Return the ECORR weights
         The weights used are the square of the ECORR values.
         """
@@ -395,7 +395,7 @@ class EcorrNoise(NoiseComponent):
         A quantization matrix maps TOAs to observing epochs.
         The weights used are the square of the ECORR values.
         """
-        return (self.get_basis(toas), self.get_weights(toas))
+        return (self.get_noise_basis(toas), self.get_noise_weights(toas))
 
     def ecorr_cov_matrix(self, toas):
         """Full ECORR covariance matrix."""

--- a/tests/test_split_corrnoise_basis_weights.py
+++ b/tests/test_split_corrnoise_basis_weights.py
@@ -47,10 +47,10 @@ def test_covariance_matrix_relation(model_and_toas, component_label):
 
     model, toas = model_and_toas
     component = model.components[component_label]
-    basis_weight_func = component.basis_funcs[0]
+    basis_weights_func = component.basis_funcs[0]
     cov_func = component.covariance_matrix_funcs[0]
 
-    basis, weights = basis_weight_func(toas)
+    basis, weights = basis_weights_func(toas)
     cov = cov_func(toas)
     cov2 = np.dot(basis * weights[None, :], basis.T)
 
@@ -66,3 +66,18 @@ def test_ecorrnoise_basis_integer(model_and_toas):
     basis, weights = ecorrcomponent.ecorr_basis_weight_pair(toas)
 
     assert np.all(basis.astype(int) == basis) and np.all(basis >= 0)
+
+
+@pytest.mark.parametrize("component_label", ["EcorrNoise", "PLRedNoise"])
+def test_noise_basis_weights_funcs(model_and_toas, component_label):
+    model, toas = model_and_toas
+    component = model.components[component_label]
+
+    basis_weights_func = component.basis_funcs[0]
+
+    basis, weights = basis_weights_func(toas)
+
+    basis_ = component.get_noise_basis(toas)
+    weights_ = component.get_noise_weights(toas)
+
+    assert np.allclose(basis_, basis) and np.allclose(weights, weights_)

--- a/tests/test_split_corrnoise_basis_weights.py
+++ b/tests/test_split_corrnoise_basis_weights.py
@@ -93,7 +93,7 @@ def test_ecorrnoise_basis_integer(model_and_toas):
     assert np.all(basis.astype(int) == basis) and np.all(basis >= 0)
 
 
-@pytest.mark.parametrize("component_label", ["EcorrNoise", "PLRedNoise"])
+@pytest.mark.parametrize("component_label", noise_component_labels)
 def test_noise_basis_weights_funcs(model_and_toas, component_label):
     model, toas = model_and_toas
     component = model.components[component_label]


### PR DESCRIPTION
This should have been part of PR #1385. (Related to issue #1363)

The basis and weights functions for `PLRedNoise` and `EcorrNoise` should have been named `get_noise_basis` and `get_noise_weights`. Instead, these functions were not named correctly for `EcorrNoise`. This PR corrects that. I have also added a new test to make sure that this convention holds.