### PR TITLE
Made clock file loading log entries a little friendlier

### DIFF
--- a/src/pint/observatory/clock_file.py
+++ b/src/pint/observatory/clock_file.py
@@ -458,7 +458,7 @@ def read_tempo2_clock_file(
         Whether to consider the file valid past the ends of the data it contains.
     """
     log.debug(
-        f"Loading TEMPO2-format observatory clock correction file {filename} with {bogus_last_correction=}"
+        f"Loading TEMPO2-format observatory clock correction file {friendly_name} ({filename}) with {bogus_last_correction=}"
     )
     try:
         mjd = []
@@ -600,9 +600,15 @@ def read_tempo_clock_file(
     """
 
     leading_comment = None
-    log.debug(
-        f"Loading TEMPO observatory ({obscode}) clock correction file {filename} with {bogus_last_correction=}"
-    )
+    if obscode is None:
+        log.debug(
+            f"Loading TEMPO-format observatory clock correction file {friendly_name} ({filename}) with {bogus_last_correction=}"
+        )
+    else:
+        log.debug(
+            f"Loading TEMPO-format observatory ({obscode}) clock correction file {friendly_name} ({filename}) with {bogus_last_correction=}"
+        )
+
     mjds = []
     clkcorrs = []
     comments = []


### PR DESCRIPTION
Including the `friendly_name` in the log entries, and also not including `obscode` if it's `None`

Entries now look like:
```
...
DEBUG    (pint.observatory.clock_file   ): Loading TEMPO2-format observatory clock correction file gps2utc.clk (/Users/kaplan/.astropy/cache/download/url/d3c81b5766f4bfb84e65504c8a453085/contents) with bogus_last_correction=False
...
DEBUG    (pint.observatory.clock_file   ): Loading TEMPO2-format observatory clock correction file tai2tt_bipm2021.clk (/Users/kaplan/.astropy/cache/download/url/e00edeef4edde217d65207a9abeb6a8c/contents) with bogus_last_correction=False
...
DEBUG    (pint.observatory.clock_file   ): Loading TEMPO-format observatory clock correction file time_ao.dat (/Users/kaplan/.astropy/cache/download/url/36fe8d7a16ab23eeb27a998de5b7eea4/contents) with bogus_last_correction=False
```