### PR TITLE
Update author list

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -36,13 +36,30 @@ Other contributors (alphabetical)
 ---------------------------------
 
 * Bastian Beischer
+* Deven Bhakta
+* Thankful Cromartie
 * Chris Deil
 * Julia Deneva
 * Justin A. Ellis
+* Anthony Ford
 * Zac Hatfield-Dodds
+* Fabian Jankowski
+* David Kaplan
 * Maarten van Kerkwijk
+* Marcus D. Leech
+* Ruben Lopez-Coto
+* Nikhil Mahajan
+* Alex McEwen
+* Bradley Meyers
+* Patrick O'Neill
+* Tim Pennucci
 * Matt Pitkin
 * Ben Shapiro-Albert
 * Chris Sheehy
 * Renee Spiewak
+* Abhimanyu Susobhanan
+* Joe Swiggum
+* Jackson Taylor
 * Michele Vallisneri
+* @ktzhao
+* @physicsranger


### PR DESCRIPTION
I have updated AUTHORS.rst based on the contributor list (https://github.com/nanograv/PINT/graphs/contributors). I don't know who @ktzhao and @physicsranger are, so I have added their username instead. I hope this is OK.

No code changes are made.