### PR TITLE
Update of #1165 (add site clock to simulation) to fix BIPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project, at least loosely, adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+### Added
+### Fixed
+- Creating fake TOAs properly handles site clock corrections
+### Removed
+
 ## [0.9.2] 2022-11-30
 ### Changed
 - Minimum supported versions updated to numpy 1.18.5, matplotlib 3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project, at least loosely, adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.9.2] 2022-11-30
 ### Changed
 - Minimum supported versions updated to numpy 1.18.5, matplotlib 3.2.0
 - `introduces_correlated_errors` is now a class attribute of `NoiseComponent`s
@@ -22,6 +22,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - New tests to improve test coverage
 - Documentation: Instructions to checkout development branch
 - Clock file for effix
+- Added energy dependent templates to the lctemplates utilities and added tests
 ### Fixed
 - global clock files now emit a warning instead of an exception if expired and the download fails
 - dmxparse outputs to dmxparse.out if save=True
@@ -32,6 +33,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Fixed bug in photonphase with polycos
 - Made clock file loading log entries a little friendlier
 - Typo fixes in documentation
+- Fixed failing HealthCheck in tests/test_precision.py
 ### Removed
 - Removed obsolete `ltinterface` module
 - Removed old and WIP functions from `gridutils` module

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -64,10 +64,7 @@ def zero_residuals(ts, model, maxiter=10, tolerance=None):
     ts.compute_pulse_numbers(model)
     maxresid = None
     if tolerance is None:
-        if pint.utils.check_longdouble_precision():
-            tolerance = 1 * u.ns
-        else:
-            tolerance = 5 * u.us
+        tolerance = 1 * u.ns if pint.utils.check_longdouble_precision() else 5 * u.us
     for i in range(maxiter):
         r = pint.residuals.Residuals(ts, model, track_mode="use_pulse_numbers")
         resids = r.calc_time_resids(calctype="taylor")
@@ -109,7 +106,6 @@ def get_fake_toa_clock_versions(model, include_bipm=False, include_gps=True):
             if len(clk) == 2:
                 ctype, cvers = clk
                 if ctype == "TT" and cvers.startswith("BIPM"):
-                    include_bipm = True
                     if bipm_version is None:
                         bipm_version = cvers
                         log.info(f"Using CLOCK = {bipm_version} from the given model")
@@ -118,11 +114,14 @@ def get_fake_toa_clock_versions(model, include_bipm=False, include_gps=True):
                         f'CLOCK = {model["CLOCK"].value} is not implemented. '
                         f"Using TT({bipm_default}) instead."
                     )
+                include_bipm = True
         else:
             log.warning(
                 f'CLOCK = {model["CLOCK"].value} is not implemented. '
                 f"Using TT({bipm_default}) instead."
             )
+            include_bipm = True
+
     return {
         "include_bipm": include_bipm,
         "bipm_version": bipm_version,

--- a/tests/test_fake_toas.py
+++ b/tests/test_fake_toas.py
@@ -22,6 +22,26 @@ def roundtrip(toas, model):
     return toas2
 
 
+def test_roundtrip():
+    # test for roundtrip accuracy at high precision
+    parfile = os.path.join(datadir, "NGC6440E.par")
+    model = get_model(parfile)
+
+    toas = pint.simulation.make_fake_toas_uniform(
+        startMJD=56000,
+        endMJD=56400,
+        ntoas=100,
+        model=model,
+        obs="gbt",
+        error=1 * u.microsecond,
+        freq=1400 * u.MHz,
+    )
+    res = pint.residuals.Residuals(toas, model)
+    toas2 = roundtrip(toas, model)
+    res2 = pint.residuals.Residuals(toas2, model)
+    assert np.allclose(res.time_resids, res2.time_resids)
+
+
 def test_noise_addition():
     # basic model, no EFAC or EQUAD
     model = get_model(

--- a/tests/test_fitter_error_checking.py
+++ b/tests/test_fitter_error_checking.py
@@ -221,6 +221,7 @@ def test_update_model_sets_things(Fitter):
     fitter = Fitter(toas, model)
     fitter.fit_toas()
     par_out = fitter.model.as_parfile()
+    print(par_out)
     assert re.search(r"CLOCK *TT\(TAI\)", par_out)
     assert re.search(r"TIMEEPH *FB90", par_out)
     assert re.search(r"T2CMETHOD *IAU2000B", par_out)
@@ -232,4 +233,4 @@ def test_update_model_sets_things(Fitter):
     assert re.search(r"EPHEM *DE421", par_out)
     assert re.search(r"DMDATA *N", par_out)
     assert re.search(r"START *58000.0", par_out)
-    assert re.search(r"FINISH *59000.0", par_out)
+    assert re.search(r"FINISH *58999.9+", par_out)

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
-from hypothesis import assume, example, given
+from hypothesis import assume, example, given, settings, HealthCheck
 from hypothesis.strategies import (
     booleans,
     composite,
@@ -605,6 +605,7 @@ def test_pulsar_mjd_proceeds_at_normal_rate_on_leap_second_days(i_f):
 
 
 @given(leap_sec_day_mjd())
+@settings(suppress_health_check=[HealthCheck.filter_too_much])
 def test_mjd_proceeds_slower_on_leap_second_days(i_f):
     i, f = i_f
     assume(0.2 < f < 1)


### PR DESCRIPTION
This updates #1165 to fix #1464 and #1161.  That separately implemented a check as to whether the clock was OK, but didn't set `include_bipm` correctly when needed.  This updates that and adds a check of residuals roundtrip through a file at higher precision.