### PR TITLE
Add site clock to simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project, at least loosely, adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+### Added
+### Fixed
+- Creating fake TOAs properly handles site clock corrections
+### Removed
+
 ## [0.9.2] 2022-11-30
 ### Changed
 - Minimum supported versions updated to numpy 1.18.5, matplotlib 3.2.0

--- a/tests/test_fitter_error_checking.py
+++ b/tests/test_fitter_error_checking.py
@@ -221,6 +221,7 @@ def test_update_model_sets_things(Fitter):
     fitter = Fitter(toas, model)
     fitter.fit_toas()
     par_out = fitter.model.as_parfile()
+    print(par_out)
     assert re.search(r"CLOCK *TT\(TAI\)", par_out)
     assert re.search(r"TIMEEPH *FB90", par_out)
     assert re.search(r"T2CMETHOD *IAU2000B", par_out)
@@ -232,4 +233,4 @@ def test_update_model_sets_things(Fitter):
     assert re.search(r"EPHEM *DE421", par_out)
     assert re.search(r"DMDATA *N", par_out)
     assert re.search(r"START *58000.0", par_out)
-    assert re.search(r"FINISH *59000.0", par_out)
+    assert re.search(r"FINISH *58999.9+", par_out)


### PR DESCRIPTION
This updates #1165 to fix #1464 and #1161. That separately implemented a check as to whether the clock was OK, but didn't set include_bipm correctly when needed. This updates that and adds a check of residuals roundtrip through a file at higher precision.

(I am resubmitting a PR since was getting weird RTD failures)