### PR TITLE
Add import to fix pintk with matplotlib 3.6

### DIFF
--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -9,6 +9,7 @@ from astropy.time import Time
 import astropy.units as u
 import matplotlib as mpl
 import numpy as np
+import matplotlib.figure
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 
 import pint.pintk.pulsar as pulsar


### PR DESCRIPTION
@scottransom was seeing an error when trying to run `pintk` on Python 3.10:

```
pintk NGC6440E.par NGC6440E.tim                                                      12:09:19
Traceback (most recent call last):
  File "/home/sransom/python_venvs/py3/bin/pintk", line 33, in <module>
    sys.exit(load_entry_point('pint-pulsar', 'console_scripts', 'pintk')())
  File "/home/sransom/git/PINT/src/pint/scripts/pintk.py", line 267, in main
    app = PINTk(
  File "/home/sransom/git/PINT/src/pint/scripts/pintk.py", line 49, in __init__
    self.createWidgets()
  File "/home/sransom/git/PINT/src/pint/scripts/pintk.py", line 131, in createWidgets
    "plk": PlkWidget(master=self.mainFrame, loglevel=self.loglevel),
  File "/home/sransom/git/PINT/src/pint/pintk/plk.py", line 673, in __init__
    self.initPlk()
  File "/home/sransom/git/PINT/src/pint/pintk/plk.py", line 700, in initPlk
    self.plkFig = mpl.figure.Figure(dpi=self.plkDpi)
  File "/home/sransom/python_venvs/py3/lib/python3.10/site-packages/matplotlib/_api/__init__.py", line 224, in __getattr__
    raise AttributeError(
AttributeError: module 'matplotlib' has no attribute 'figure'
```

This seems to have been caused by a change in matplotlib 3.6, which makes it so that `mpl.figure` isn't accessible unless it is explicitly imported. This PR adds the explicit import and so avoids the error.