### PR TITLE
Removed import of termios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - method to identify mask parameters with no TOAs and optionally freeze them
 ### Fixed
 ### Removed
+- termios import for solar_wind_dispersion
 
 ## [0.9.2] 2022-11-30
 ### Changed

--- a/src/pint/models/solar_wind_dispersion.py
+++ b/src/pint/models/solar_wind_dispersion.py
@@ -1,5 +1,4 @@
 """Dispersion due to the solar wind."""
-from termios import B300
 from warnings import warn
 
 import astropy.constants as const


### PR DESCRIPTION
Somehow:
```
from termios import B300
```
made it in to `solar_wind_dispersion` when I was working on that module.  I don't know why.  I couldn't see it used anywhere.  Possibly a rogue auto-complete.  

In any case, this removes it.