### PR TITLE
Update of #1165 (add site clock to simulation) to fix BIPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 ## Unreleased
 ### Changed
 ### Added
-- method to identify mask parameters with no TOAs and optionally freeze them
 ### Fixed
+- Creating fake TOAs properly handles site clock corrections
 ### Removed
 
 ## [0.9.2] 2022-11-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 ## Unreleased
 ### Changed
 ### Added
+- method to identify mask parameters with no TOAs and optionally freeze them
 ### Fixed
 - Creating fake TOAs properly handles site clock corrections
 - corrected a precision issue with reading ASCII representations of pulse profiles

--- a/tests/test_fake_toas.py
+++ b/tests/test_fake_toas.py
@@ -10,6 +10,7 @@ import os
 import pint.config
 from pint.fitter import GLSFitter
 from pinttestdata import datadir
+import pytest
 
 
 def roundtrip(toas, model):
@@ -20,10 +21,43 @@ def roundtrip(toas, model):
     return toas2
 
 
-def test_roundtrip():
+NGC6440E = """
+PSR              1748-2021E
+RAJ       17:48:52.75  1
+DECJ      -20:21:29.0  1
+F0       61.485476554  1
+F1         -1.181D-15  1
+PEPOCH        53750.000000
+POSEPOCH      53750.000000
+DM              223.9  1
+SOLARN0               0.00
+EPHEM               DE421
+UNITS               TDB
+TIMEEPH             FB90
+T2CMETHOD           TEMPO
+CORRECT_TROPOSPHERE N
+DILATEFREQ          N
+TZRMJD  53801.38605118223
+TZRFRQ            1949.609
+TZRSITE                  1
+"""
+
+
+@pytest.mark.parametrize(
+    "clock, planet",
+    [
+        ("UTC(NIST)", "Y"),
+        ("UTC(NIST)", "N"),
+        ("TT(BIPM2021)", "Y"),
+        ("TT(BIPM2021)", "N"),
+        ("TT(TAI)", "Y"),
+        ("TT(TAI)", "N"),
+    ],
+)
+def test_roundtrip(clock, planet):
     # test for roundtrip accuracy at high precision
-    parfile = os.path.join(datadir, "NGC6440E.par")
-    model = get_model(parfile)
+    partext = f"{NGC6440E}\nCLK {clock}\nPLANET_SHAPIRO {planet}"
+    model = get_model(io.StringIO(partext))
 
     toas = pint.simulation.make_fake_toas_uniform(
         startMJD=56000,

--- a/tests/test_fitter_error_checking.py
+++ b/tests/test_fitter_error_checking.py
@@ -232,4 +232,6 @@ def test_update_model_sets_things(Fitter):
     assert re.search(r"EPHEM *DE421", par_out)
     assert re.search(r"DMDATA *N", par_out)
     assert re.search(r"START *58000.0", par_out)
-    assert re.search(r"FINISH *59000.0", par_out)
+    assert re.search(r"FINISH *59000.0", par_out) or re.search(
+        r"FINISH *58999.9+", par_out
+    )


### PR DESCRIPTION
This updates #1165 to fix #1464 and #1161. That separately implemented a check as to whether the clock was OK, but didn't set `include_bipm` correctly when needed. This updates that and adds a check of residuals roundtrip through a file at higher precision.