### PR TITLE
Fix numerical slop reading in ASCII profiles, add tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 ### Added
 - method to identify mask parameters with no TOAs and optionally freeze them
 ### Fixed
+- corrected a precision issue with reading ASCII representations of pulse profiles
 ### Removed
 - termios import for solar_wind_dispersion
 

--- a/src/pint/templates/lcfitters.py
+++ b/src/pint/templates/lcfitters.py
@@ -405,6 +405,9 @@ class LCFitter:
 
         """
 
+        if not self.template.check_bounds():
+            raise ValueError("Template does not satisfy parameter bounds.")
+
         self._set_unbinned(unbinned)
         ph0 = self.template.get_location()
 


### PR DESCRIPTION
Julia reported a problem making NICER TOAs after updates to this template fitting code.  It was because I had begun to enforce strict parameter bounds, but profiles saved to ASCII templates can lose enough precision to fail the bounds check.  This PR:

(1) will no longer silently fail when the likelihood is nonsense (because of a failed parameter check)
(2) will check ASCII profiles and, if they're close enough to parameter bounds, silently skootch them up or down to the bound
(3) adds tests for both changes