### PR TITLE
Fix notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ docs/_autosummary
 
 # Jupyter notebooks should not be in git; they are built from md files
 docs/examples/*.ipynb
+
+# VSCode wants to put virtualenvs here
+.env

--- a/docs/examples/How_to_build_a_timing_model_component.py
+++ b/docs/examples/How_to_build_a_timing_model_component.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.13.8
+#       jupytext_version: 1.14.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/docs/examples/PINT_observatories.py
+++ b/docs/examples/PINT_observatories.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.13.8
+#       jupytext_version: 1.14.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/docs/examples/PINT_walkthrough.py
+++ b/docs/examples/PINT_walkthrough.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.13.8
+#       jupytext_version: 1.14.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/docs/examples/Simulate_and_make_MassMass.py
+++ b/docs/examples/Simulate_and_make_MassMass.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.13.8
+#       jupytext_version: 1.14.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/docs/examples/Wideband_TOA_walkthrough.py
+++ b/docs/examples/Wideband_TOA_walkthrough.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.13.8
+#       jupytext_version: 1.14.4
 #   kernelspec:
 #     display_name: Python 3
 #     language: python

--- a/docs/examples/build_model_from_scratch.py
+++ b/docs/examples/build_model_from_scratch.py
@@ -6,9 +6,9 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.13.8
+#       jupytext_version: 1.14.4
 #   kernelspec:
-#     display_name: Python 3
+#     display_name: .env
 #     language: python
 #     name: python3
 # ---
@@ -25,7 +25,12 @@
 # %%
 import astropy.units as u  # Astropy units is a very useful module.
 import pint.logging
-from IPython.core.display_functions import display
+
+try:
+    from IPython.display import display
+except ImportError:
+    # Older IPython
+    from IPython.core.display_functions import display
 
 # setup logging
 pint.logging.setup(level="INFO")

--- a/docs/examples/check_clock_corrections.py
+++ b/docs/examples/check_clock_corrections.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.13.8
+#       jupytext_version: 1.14.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/docs/examples/check_phase_connection.py
+++ b/docs/examples/check_phase_connection.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.13.8
+#       jupytext_version: 1.14.4
 #   kernelspec:
 #     display_name: Python 3
 #     language: python

--- a/docs/examples/fit_NGC6440E.py
+++ b/docs/examples/fit_NGC6440E.py
@@ -8,9 +8,9 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.13.8
+#       jupytext_version: 1.14.4
 #   kernelspec:
-#     display_name: Python 3 (ipykernel)
+#     display_name: .env
 #     language: python
 #     name: python3
 # ---
@@ -139,5 +139,7 @@ plt.show()
 # %%
 f.model.write_parfile("/tmp/output.par", "wt")
 print(f.model.as_parfile())
+
+# %%
 
 # %%

--- a/docs/examples/solar_wind.py
+++ b/docs/examples/solar_wind.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.13.8
+#       jupytext_version: 1.14.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/docs/examples/time_a_pulsar.py
+++ b/docs/examples/time_a_pulsar.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.13.8
+#       jupytext_version: 1.14.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/docs/examples/understanding_fitters.py
+++ b/docs/examples/understanding_fitters.py
@@ -7,7 +7,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.13.8
+#       jupytext_version: 1.14.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/docs/examples/understanding_parameters.py
+++ b/docs/examples/understanding_parameters.py
@@ -7,7 +7,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.13.8
+#       jupytext_version: 1.14.4
 #   kernelspec:
 #     display_name: Python 3
 #     language: python

--- a/docs/examples/understanding_timing_models.py
+++ b/docs/examples/understanding_timing_models.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.13.8
+#       jupytext_version: 1.14.4
 #   kernelspec:
 #     display_name: Python 3
 #     language: python


### PR DESCRIPTION
Currently I can't run `make notebooks`; see bug #1486. This PR is meant to fix this.

Currently outstanding problems:

- [ ] `Simulate_and_make_MassMass.ipynb` - `ValueError: UTC times during a leap second cannot be represented in pulsar_mjd format`
- [ ] `Wideband_TOA_walkthrough.ipynb` - `fitter.get_noise_covariancematrix()` doesn't work with a downhill fitter
- [ ] `understanding_fitters.ipynb` - `pwfit.plot()` produces a plot showing zero residuals
- [ ] `check_clock_corrections.ipynb` - doesn't actually list clock correction ending MJDs