### PR TITLE
Added leap clock correction

### DIFF
--- a/src/pint/data/runtime/observatories.json
+++ b/src/pint/data/runtime/observatories.json
@@ -568,6 +568,11 @@
             486989.4,
             4900430.8
         ],
+        "clock_fmt": "tempo2",
+        "clock_file": [
+            "leap2effix.clk",
+            "effix2gps.clk"
+        ],
         "origin": "The Large European Array for Pulsars.\nThis is the same as the position of the Effelsberg radio telescope.\nImported from TEMPO2 observatories.dat 2021 June 7."
     },
     "jodrellm4": {


### PR DESCRIPTION
Closes #1478 

Here's the results of a quick test:

Pre-clock fix residuals:
![image](https://user-images.githubusercontent.com/60462875/209860025-05566d12-e1c8-46bf-869e-8601b08bd2a3.png)

Post-clock fix residuals:
<img width="990" alt="image" src="https://user-images.githubusercontent.com/60462875/209860275-6d518052-1352-42a1-a65f-f126677079f0.png">

