### PR TITLE
Update requirements for oldestdeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project, at least loosely, adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Changed minimum supported version of scipy to 1.4.1
+### Added
+### Fixed
+### Removed
+
 ## [0.9.3] 2022-12-16
 ### Changed
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,14 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 ## Unreleased
 ### Changed
 - Changed minimum supported version of scipy to 1.4.1
-### Added
-### Fixed
-### Removed
-
-## [0.9.3] 2022-12-16
-### Changed
 - Moved DMconst from `pint.models.dispersion_model` to `pint` to avoid circular imports
 ### Added
 - Documentation: Explanation for DM
 - Methods to compute dispersion slope and to convert DM using the CODATA value of DMconst
 - `TimingModel.total_dispersion_slope` method
 - Explicit discussion of DT92 convention to DDK model
+### Fixed
+### Removed
 
 ## [0.9.3] 2022-12-16
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.18.5
 astropy>=4.0,!=4.0.1,!=4.0.1.post1
 pyerfa
-scipy>=0.18.1
+scipy>=1.4.1
 jplephem>=2.6
 matplotlib>=3.2.0
 emcee>=3.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,16 +28,19 @@ package_dir =
     = src
 include_package_data = True
 python_requires = >=3.8
+# These should match requirements.txt
 install_requires =
+    numpy>=1.18.5
     astropy>=4.0,!=4.0.1,!=4.0.1.post1
-    numpy>=1.17.0
-    scipy>=0.18.1
+    pyerfa
+    scipy>=1.4.1
     jplephem>=2.6
-    matplotlib>=1.5.3
-    emcee>=3.0
-    uncertainties
+    matplotlib>=3.2.0
+    emcee>=3.0.1
     corner>=2.0.1
+    uncertainties
     loguru
+    nestle>=0.2.0
 
 [options.packages.find]
 where = src

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@
 envlist =
     clean
     ephemeris_connection
+    oldestdeps
     notebooks
     docs
     report
@@ -62,6 +63,7 @@ deps =
     numdifftools==0.9.39
     astropy==4.0
     matplotlib==3.2.0
+    scipy==1.4.1
     pytest
     coverage
     hypothesis


### PR DESCRIPTION
I updated the version of scipy used for the oldestdeps tests to a version released just before our numpy version 1.18.5. This constraint keeps it from installing a very new scipy, which pulls in a new numpy that causes crashes in the oldestdeps tests. So this bumps up the scipy minimum required version to 1.4.1.
