### PR TITLE
Fix simulate mass-mass notebook and update doc/nb envs to python 3.10

### DIFF
--- a/docs/examples/Simulate_and_make_MassMass.py
+++ b/docs/examples/Simulate_and_make_MassMass.py
@@ -27,7 +27,6 @@ import astropy.time
 import numpy as np
 from matplotlib import pyplot as plt
 import matplotlib.cm as cm
-import copy
 import io
 
 import pint.fitter
@@ -54,7 +53,7 @@ def plot_contour(mp, mc, quantity, target, uncertainty, color, nsigma=3, **kwarg
     mc : astropy.units.Quantity
         array of companion masses (y-axis)
     quantity : astropy.units.Quantity
-        2D array of the prediction as a function of mp,mc.  Shape is (len(mc),len(mp))
+        2D array of the prediction as a function of mp and mc.  Shape is (len(mc), len(mp))
     target : astropy.units.Quantity
         best-fit value of the prediction (say from a PINT fit).
     uncertainty : astropy.units.Quantity
@@ -72,7 +71,7 @@ def plot_contour(mp, mc, quantity, target, uncertainty, color, nsigma=3, **kwarg
     return plt.contour(
         mp.value,
         mc.value,
-        quantity,
+        quantity.value,
         [(target - nsigma * uncertainty).value, (target + nsigma * uncertainty).value],
         colors=color,
         **kwargs,

--- a/docs/examples/Simulate_and_make_MassMass.py
+++ b/docs/examples/Simulate_and_make_MassMass.py
@@ -204,7 +204,7 @@ m = get_model(f)
 
 # %%
 # roughly the parameters from Fonseca, Stairs, Thorsett (2014)
-tstart = astropy.time.Time(1990, format="jyear")
+tstart = astropy.time.Time(1990.25, format="jyear")
 tstop = astropy.time.Time(2014, format="jyear")
 # this is the error on each TOA
 error = 5 * u.us

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ commands =
 
 [testenv:notebooks]
 description = update the notebooks
-basepython = python3.8
+basepython = python3.10
 deps =
     traitlets
     sphinx >= 2.2, != 5.1.0
@@ -105,7 +105,7 @@ commands = coverage erase
 [testenv:docs]
 changedir = {toxinidir}/docs
 description = invoke sphinx-build to build the HTML docs
-basepython = python3.8
+basepython = python3.10
 deps =
     traitlets
     sphinx >= 2.2, != 5.1.0


### PR DESCRIPTION
Trying to fix notebook build errors based on missing python 3.8.  Not sure why that is happening there (and not in `oldestdeps` which also uses 3.8) but I think this fixes it.