### PR TITLE
fix NGC6440E.par

### DIFF
--- a/src/pint/data/examples/NGC6440E.par
+++ b/src/pint/data/examples/NGC6440E.par
@@ -8,10 +8,10 @@ POSEPOCH      53750.000000
 DM              223.9  1 0.3
 SOLARN0               0.00
 EPHEM               DE421
-CLK              UTC(NIST)
+CLK            	  TT(BIPM2021)
 UNITS               TDB
 TIMEEPH             FB90
-T2CMETHOD           TEMPO
+T2CMETHOD           IAU2000B
 CORRECT_TROPOSPHERE N
 PLANET_SHAPIRO      N
 DILATEFREQ          N

--- a/src/pint/data/examples/NGC6440E.par.good
+++ b/src/pint/data/examples/NGC6440E.par.good
@@ -10,10 +10,10 @@ FINISH           54187.588
 DM              224.113798  1            0.034939
 SOLARN0               0.00
 EPHEM               DE421
-CLK                 UTC(NIST)   
+CLK                 TT(BIPM2021)   
 UNITS               TDB
 TIMEEPH             FB90
-T2CMETHOD           TEMPO
+T2CMETHOD           IAU2000B
 CORRECT_TROPOSPHERE N
 PLANET_SHAPIRO      N
 DILATEFREQ          N

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -798,6 +798,11 @@ def read_toa_file(filename, process_includes=True, cdict=None, dir=None):
                 commands.extend(new_commands)
                 # re-set FORMAT
                 cdict["FORMAT"] = fmt
+            elif cmd == "MODE":
+                log.warning(
+                    "MODE command is not supported by PINT. 'MODE 0' does not invoke ordinary least squares fitting."
+                )
+                continue
             else:
                 log.warning(f"Unknown command {cmd} in line {line}")
                 continue


### PR DESCRIPTION
The example files `NGC6440E.par` and `NGC6440E.par.good` had unsupported `UNITS UTC(NIST)` and `T2CMETHOD TEMPO`. `PINT` was ignoring these lines with warnings and using `TT(BIPM2021)` and `IAU2000B` instead. I have changed these par files so that the warnings go away. This is the first step in addressing issue #1483. 

EDIT: I have also changed the warning for a "MODE" statement in the TOA file to be more informative.