### PR TITLE
Simplify pyerfa use 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,8 @@ de-403-masses.tpc
 .idea
 .cache
 .vscode
+.venv
+.mypy_cache
 
 # Test output/intermediate files
 # tests/datafile/fake_testzima.tim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 ## Unreleased
 ### Changed
 - Moved DMconst from `pint.models.dispersion_model` to `pint` to avoid circular imports
+- Ensured we require `pyerfa` and remove the obsolete `astropy._erfa`
 ### Added
 - Documentation: Explanation for DM
 - Methods to compute dispersion slope and to convert DM using the CODATA value of DMconst

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     uncertainties
     corner>=2.0.1
     loguru
+    pyerfa
 
 [options.packages.find]
 where = src

--- a/src/pint/erfautils.py
+++ b/src/pint/erfautils.py
@@ -1,10 +1,6 @@
 """Observatory position and velocity calculation."""
 
-try:
-    import erfa
-except ImportError:
-    import astropy._erfa as erfa
-
+import erfa
 import numpy as np
 from astropy import table
 from loguru import logger as log

--- a/src/pint/fits_utils.py
+++ b/src/pint/fits_utils.py
@@ -2,11 +2,7 @@
 
 import numpy as np
 from loguru import logger as log
-
-try:
-    from erfa import DAYSEC as SECS_PER_DAY
-except ImportError:
-    from astropy._erfa import DAYSEC as SECS_PER_DAY
+from erfa import DAYSEC as SECS_PER_DAY
 
 from pint.pulsar_mjd import fortran_float
 

--- a/src/pint/logging.py
+++ b/src/pint/logging.py
@@ -55,10 +55,7 @@ import sys
 import warnings
 from loguru import logger as log
 
-try:
-    from erfa import ErfaWarning
-except ImportError:
-    from astropy._erfa import ErfaWarning
+from erfa import ErfaWarning
 
 __all__ = ["LogFilter", "setup", "format", "levels", "get_level"]
 
@@ -128,7 +125,8 @@ def showwarning(message, category, filename, lineno, file=None, line=None):
 class LogFilter:
     """Custom logging filter for ``loguru``.
     Define some messages that are never seen (e.g., Deprecation Warnings).
-    Others that will only be seen once.  Filtering of those is done on the basis of regular expressions."""
+    Others that will only be seen once.  Filtering of those is done on the basis of regular expressions.
+    """
 
     def __init__(self, onlyonce=None, never=None, onlyonce_level="INFO"):
         """

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -8,13 +8,8 @@ import astropy.coordinates as coords
 import astropy.units as u
 import numpy as np
 from astropy.time import Time
-
 from loguru import logger as log
-
-try:
-    from erfa import ErfaWarning
-except ImportError:
-    from astropy._erfa import ErfaWarning
+from erfa import ErfaWarning
 
 from pint import ls
 from pint.models.parameter import (

--- a/src/pint/models/stand_alone_psr_binaries/binary_generic.py
+++ b/src/pint/models/stand_alone_psr_binaries/binary_generic.py
@@ -3,13 +3,8 @@
 import astropy.constants as c
 import astropy.units as u
 import numpy as np
-
 from loguru import logger as log
-
-try:
-    from erfa import DAYSEC as SECS_PER_DAY
-except ImportError:
-    from astropy._erfa import DAYSEC as SECS_PER_DAY
+from erfa import DAYSEC as SECS_PER_DAY
 
 from pint import Tsun, ls
 from pint.models.stand_alone_psr_binaries.binary_orbits import OrbitPB

--- a/src/pint/pulsar_mjd.py
+++ b/src/pint/pulsar_mjd.py
@@ -27,10 +27,7 @@ was observing the sky at the moment a leap second was introduced.
 .. _leap_smear: https://developers.google.com/time/smear
 """
 
-try:
-    import erfa
-except ImportError:
-    import astropy._erfa as erfa
+import erfa
 import astropy.time
 import astropy.units as u
 import numpy as np

--- a/tests/test_d_phase_d_toa.py
+++ b/tests/test_d_phase_d_toa.py
@@ -2,11 +2,7 @@ import os
 import unittest
 
 import numpy as np
-
-try:
-    from erfa import DJM0
-except ImportError:
-    from astropy._erfa import DJM0
+from erfa import DJM0
 
 import pint.toa as toa
 from pint.models import model_builder as mb

--- a/tests/test_erfautils.py
+++ b/tests/test_erfautils.py
@@ -10,15 +10,6 @@ from pint import erfautils
 from pint.observatory import Observatory
 
 
-def test_simpler_erfa_import():
-    try:
-        import erfa
-    except ImportError:
-        import astropy._erfa as erfa
-
-    erfa
-
-
 @pytest.mark.xfail(
     reason="astropy doesn't include up-to-date IERS B - "
     "if this starts passing we can ditch the "
@@ -36,7 +27,7 @@ def test_compare_erfautils_astropy():
     dvel = np.sqrt((dopv.vel**2).sum(axis=0))
     assert len(dpos) == len(mjds)
     # This is just above the level of observed difference
-    assert dpos.max() < 0.05 * u.m, "position difference of %s" % dpos.max().to(u.m)
+    assert dpos.max() < 0.05 * u.m, f"position difference of {dpos.max().to(u.m)}"
     # This level is what is permitted as a velocity difference from tempo2 in test_times.py
     assert dvel.max() < 0.02 * u.mm / u.s, "velocity difference of %s" % dvel.max().to(
         u.mm / u.s

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -4,10 +4,7 @@ import sys
 from datetime import datetime
 from decimal import Decimal
 
-try:
-    import erfa
-except ImportError:
-    import astropy._erfa as erfa
+import erfa
 import astropy.units as u
 import numpy as np
 import pytest

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -47,37 +47,35 @@ from pint.utils import PosVel
 time_eps = (np.finfo(float).eps * u.day).to(u.ns)
 
 
-leap_sec_mjds = set(
-    [
-        41499,
-        41683,
-        42048,
-        42413,
-        42778,
-        43144,
-        43509,
-        43874,
-        44239,
-        44786,
-        45151,
-        45516,
-        46247,
-        47161,
-        47892,
-        48257,
-        48804,
-        49169,
-        49534,
-        50083,
-        50630,
-        51179,
-        53736,
-        54832,
-        56109,
-        57204,
-        57754,
-    ]
-)
+leap_sec_mjds = {
+    41499,
+    41683,
+    42048,
+    42413,
+    42778,
+    43144,
+    43509,
+    43874,
+    44239,
+    44786,
+    45151,
+    45516,
+    46247,
+    47161,
+    47892,
+    48257,
+    48804,
+    49169,
+    49534,
+    50083,
+    50630,
+    51179,
+    53736,
+    54832,
+    56109,
+    57204,
+    57754,
+}
 leap_sec_days = set([d - 1 for d in leap_sec_mjds])
 near_leap_sec_days = list(
     sorted([d - 1 for d in leap_sec_days] + [d + 1 for d in leap_sec_days])
@@ -98,7 +96,7 @@ def possible_leap_sec_days(draw):
 @composite
 def leap_sec_day_mjd(draw):
     i = draw(sampled_from(sorted(leap_sec_days)))
-    f = draw(floats(0, 1, allow_nan=False))
+    f = draw(floats(1, 2, allow_nan=False)) - 1
     return (i, f)
 
 


### PR DESCRIPTION
This ensures that `pyerfa` is actually installed, and it drops the `astropy._erfa` (which has disappeared in the most recent version).