### PR TITLE
Allow docs build without examples (much faster)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
+  version: 3.11
   install:
     - requirements: requirements_dev.txt
     - requirements: requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.11
+  version: 3.8
   install:
     - requirements: requirements_dev.txt
     - requirements: requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,22 +1,30 @@
-
-# .readthedocs.yml
+# .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+   configuration: docs/conf.py
 
-# Doc formats that will be built. Can add pdf, epub if wanted. 
+# If using Sphinx, optionally build your docs in additional formats such as PDF
 formats:
-  - htmlzip
+   - htmlzip
 
-# Optionally set the version of Python and requirements required to build your docs
+# Optionally declare the Python requirements required to build your docs
 python:
-  version: 3.8
   install:
     - requirements: requirements_dev.txt
     - requirements: requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Refactor `Dre` method, fix expressions for Einstein delay and post-Keplerian parameters in DD model
 - Updated contributor list (AUTHORS.rst)
 - Emit an informative warning for "MODE" statement in TOA file; Ignore "MODE 1" silently
+- Version of sphinx-rtd-them updated in requirements_dev.txt 
 ### Added
 - Documentation: Explanation for DM
 - Methods to compute dispersion slope and to convert DM using the CODATA value of DMconst

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -53,6 +53,7 @@ clean:
 cleaner:
 	rm -rf $(BUILDDIR)/*
 	rm -rf _autosummary/*.rst
+	rm -rf examples/*.ipynb
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,6 +24,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"
+	@echo "  htmlnoexamples   to make standalone HTML files without the example files (faster)"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
 	@echo "  pickle     to make pickle files"
@@ -49,10 +50,21 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 
+cleaner:
+	rm -rf $(BUILDDIR)/*
+	rm -rf _autosummary/*.rst
+
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+
+htmlnoexamples:
+	$(SPHINXBUILD) -b html -t noexamples $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "pint"
-copyright = "2017-2021 PINT Developers"
+copyright = "2017-2023 PINT Developers"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -203,7 +203,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 # The name of an image file (relative to this directory) to place at the
 # top of the sidebar.
-# html_logo = None
+html_logo = "logo/PINT_LOGO_64trans.png"
 
 # The name of an image file (within the static path) to use as favicon
 # of the docs.  This file should be a Windows icon file (.ico) being

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,6 +123,9 @@ exclude_patterns = [
     "_ext",
 ]
 
+if tags.has("noexamples"):
+    exclude_patterns.append("examples/*.py")
+
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
 # default_role = None

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -50,7 +50,6 @@ are not included in the default build because they take too long, but you can do
 .. Using the exclude_patterns list in conf.py
 
 .. toctree::
-.. only:: not noexamples
 
    basic-installation
    examples/time_a_pulsar.ipynb

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -50,6 +50,7 @@ are not included in the default build because they take too long, but you can do
 .. Using the exclude_patterns list in conf.py
 
 .. toctree::
+.. only:: not noexamples
 
    basic-installation
    examples/time_a_pulsar.ipynb

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ traitlets
 Sphinx>=2.2,!=5.1.0
 astropy>=4.0,!=4.0.1,!=4.0.1.post1
 #astropy-helpers>=1.3
-sphinx-rtd-theme>=0.1.9
+sphinx-rtd-theme>=1.1.1
 coveralls>=1.1
 wheel>=0.29.0
 pytest>=4.3


### PR DESCRIPTION
Standard RTD builds take a long time.  About 6 min on my system.  Much of that time is spent running the example notebooks.  This gives a new build target for the docs that excludes them.  It takes about 90s on my system:
```
(pintdev) kaplan@plock[~/pythonpackages/PINT_dlakaplan/docs] (docsnoexamples) % make cleaner; time make html >& ../html.out
rm -rf _build/*
rm -rf _autosummary/*.rst
make html >&../html.out  367.42s user 15.96s system 96% cpu 6:35.46 total
```
vs.
```
(pintdev) kaplan@plock[~/pythonpackages/PINT_dlakaplan/docs] (docsnoexamples) % make cleaner; time make htmlnoexamples >& ../htmlnoexamples.out
rm -rf _build/*
rm -rf _autosummary/*.rst
make htmlnoexamples >&../htmlnoexamples.out  78.49s user 10.44s system 89% cpu 1:39.79 total
```
So you would run `make htmlnoexamples`

I also added `cleaner` which removes not only the files in `_build/` (done by standard `make clean`) but `_autosummary/`, since those may need to be regenerated when modules are added/removed.  Note that this directory is hard-coded since I couldn't find that it was set at the top level.

Finally, I updated the version of `sphinx-rtd-theme` so that search seems to work again,  and added the logo (back?) to the RTD page.