### PR TITLE
Fix import for longdouble2str in get_tempo_result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 ### Fixed
 - Broken notebooks CI test
 - BIPM correction for simulated TOAs
+- Import for `longdouble2str` in `get_tempo_result`
 ### Removed
 
 ## [0.9.3] 2022-12-16

--- a/tests/datafile/get_tempo_result.py
+++ b/tests/datafile/get_tempo_result.py
@@ -1,5 +1,5 @@
 import tempo_utils as t1u
-from pint.utils import longdouble2str
+from pint.pulsar_mjd import longdouble2str
 import argparse
 
 


### PR DESCRIPTION
The import for `longdoubl2str` needed to be changed.