### PR TITLE
Event optimize update errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Added try/except to `test_pldmnoise.py`/`test_PLRedNoise_recovery` to avoid exceptions during CI
 - Import for `longdouble2str` in `get_tempo_result`
 - Plotting orbital phase in `pintk` when FB0 is used instead of PB
+- Added 1 sigma errors to update the postfit parfile errors in `event_optimize`
 ### Removed
 
 ## [0.9.3] 2022-12-16

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -863,8 +863,10 @@ def main(argv=None):
     f.close()
 
     # Write out the par file for the best MCMC parameter est
-    lower, upper = np.percentile(samples, [16, 84], axis=0)
-    errors = (upper - lower) / 2
+    centered_samples = [
+        samples[:, i] - ftr.maxpost_fitvals[i] for i in range(samples.shape[1])
+    ]
+    errors = (np.percentile(np.abs(centered_samples), 68)) / 2
     ftr.set_param_uncertainties(dict(zip(ftr.fitkeys[:-1], errors[:-1])))
 
     f = open(ftr.model.PSR.value + "_post.par", "w")

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -863,6 +863,10 @@ def main(argv=None):
     f.close()
 
     # Write out the par file for the best MCMC parameter est
+    lower, upper = np.percentile(samples, [16, 84], axis=0)
+    errors = (upper - lower) / 2
+    ftr.set_param_uncertainties(dict(zip(ftr.fitkeys[:-1], errors[:-1])))
+
     f = open(ftr.model.PSR.value + "_post.par", "w")
     f.write(ftr.model.as_parfile())
     f.close()

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -923,8 +923,7 @@ def main(argv=None):
         samples[:, i] - ftr.maxpost_fitvals[i] for i in range(len(ftr.fitkeys))
     ]
     errors = [
-        np.percentile(np.abs(centered_samples[i]), 68) / 2
-        for i in range(len(ftr.fitkeys))
+        np.percentile(np.abs(centered_samples[i]), 68) for i in range(len(ftr.fitkeys))
     ]
     ftr.set_param_uncertainties(dict(zip(ftr.fitkeys[:-1], errors[:-1])))
 


### PR DESCRIPTION
Addresses issue #1529 where event optimize is not updating the errors in the post fit par file. This calculates an error for each parameter from the 68% confidence interval and updates the model within the fitter. 