### PR TITLE
Fix clock selection for random models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Added try/except to `test_pldmnoise.py`/`test_PLRedNoise_recovery` to avoid exceptions during CI
 - Import for `longdouble2str` in `get_tempo_result`
 - Plotting orbital phase in `pintk` when FB0 is used instead of PB
+- Selection of BIPM for random models
 ### Removed
 
 ## [0.9.3] 2022-12-16

--- a/src/pint/models/stand_alone_psr_binaries/binary_generic.py
+++ b/src/pint/models/stand_alone_psr_binaries/binary_generic.py
@@ -355,7 +355,6 @@ class PSR_BINARY:
             e = np.longdouble(eccentricity).value
         else:
             e = eccentricity
-        print(f"e: {e}")
         if any(e < 0) or any(e >= 1):
             raise ValueError("Eccentricity should be in the range of [0,1).")
 

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -106,9 +106,8 @@ def get_fake_toa_clock_versions(model, include_bipm=False, include_gps=True):
             if len(clk) == 2:
                 ctype, cvers = clk
                 if ctype == "TT" and cvers.startswith("BIPM"):
-                    if bipm_version is None:
-                        bipm_version = cvers
-                        log.info(f"Using CLOCK = {bipm_version} from the given model")
+                    bipm_version = cvers
+                    log.info(f"Using CLOCK = {bipm_version} from the given model")
                 else:
                     log.warning(
                         f'CLOCK = {model["CLOCK"].value} is not implemented. '

--- a/tests/test_random_models.py
+++ b/tests/test_random_models.py
@@ -72,3 +72,18 @@ def test_random_models_wb(fitter):
     # this is a bit stochastic, but I see typically < 1e-4 cycles for this
     # for the uncertainty at 59000
     assert np.all(dphase.std(axis=0) < 1e-4)
+
+
+@pytest.mark.parametrize("clock", ["UTC(NIST)", "TT(BIPM2021)", "TT(BIPM2015)"])
+def test_random_model_clock(clock):
+    m, t = get_model_and_toas(
+        os.path.join(datadir, "NGC6440E.par"), os.path.join(datadir, "NGC6440E.tim")
+    )
+    m.CLOCK.value = clock
+    if "BIPM" in clock:
+        assert simulation.get_fake_toa_clock_versions(m)[
+            "bipm_version"
+        ] == m.CLOCK.value.replace("TT(", "").replace(")", "")
+        assert simulation.get_fake_toa_clock_versions(m)["include_bipm"]
+    else:
+        assert ~simulation.get_fake_toa_clock_versions(m)["include_bipm"]


### PR DESCRIPTION
The BIPM selection for fake TOAs had a bug.  That prevented merging with existing TOAs in some situations.  That should be fixed here.