### PR TITLE
Apply DMJUMP time delay for narrowband timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Moved `DMconst` from `pint.models.dispersion_model` to `pint` to avoid circular imports
 - Removed references to `astropy._erfa` (removed since `astropy` 4.2)
 - Refactor `Dre` method, fix expressions for Einstein delay and post-Keplerian parameters in DD model
+- Apply time delays from `DispersionJump` class when using narrowband ToAs
 - Updated contributor list (AUTHORS.rst)
 - Emit an informative warning for "MODE" statement in TOA file; Ignore "MODE 1" silently
 - Version of `sphinx-rtd-theme` updated in `requirements_dev.txt` 

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -757,7 +757,7 @@ class DispersionJump(Dispersion):
             )
         )
 
-        self.delay_funcs_component += [self.dmjump_dispersion_delay]
+        # self.delay_funcs_component += [self.dmjump_dispersion_delay]
 
     def setup(self):
         super().setup()
@@ -805,7 +805,7 @@ class DispersionJump(Dispersion):
         No delay for wideband timing.
         """
         if toas.is_wideband():
-            return []
+            return np.zeros(toas.ntoas) * u.s
         else:
             return self.dispersion_type_delay(toas)
 

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -736,8 +736,9 @@ class DispersionJump(Dispersion):
 
     Notes
     -----
-    This DM jump is only for modeling the DM values, and will not apply to the
-    dispersion time delay.
+    For wideband timing, this DM jump is only for modeling the DM values, and
+    will not apply to the dispersion time delay. For narrowband timing, this
+    will apply the usual dispersion time delay.
     """
 
     register = True
@@ -802,7 +803,7 @@ class DispersionJump(Dispersion):
     def dmjump_dispersion_delay(self, toas, acc_delay=None):
         """This is a wrapper function for interacting with the TimingModel class
 
-        No delay for wideband timing.
+        No delay for wideband timing, yes delay for narrowband.
         """
         if toas.is_wideband():
             return np.zeros(toas.ntoas) * u.s

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -758,7 +758,7 @@ class DispersionJump(Dispersion):
             )
         )
 
-        # self.delay_funcs_component += [self.dmjump_dispersion_delay]
+        self.delay_funcs_component += [self.dmjump_dispersion_delay]
 
     def setup(self):
         super().setup()


### PR DESCRIPTION
I was interested in correcting some DM offsets particular to certain datasets within the IPTA DR3 data combination, which can apparently result if a different initial DM value was used when fitting ToAs using frequency-resolved pulse portraits. It seemed that the `DispersionJump` class would be perfect for correcting this, except it looks like it's only set up to apply jumps to just the DM value used in wideband timing, but not to the time delay/residuals.

The following changes will apply the time delay from DMJUMPs given narrowband toas, but not apply any delay to wideband toas as originally set up. Let me know if this seems sensible or if anyone has suggestions for a better way to do this.

Here's also a comparison of some of the affected residuals from the DR3 data combination before and after the inclusion of a DMJUMP fit into the model to show the delay is being applied correctly:

Before:
![image](https://user-images.githubusercontent.com/60462875/224438605-12cef745-ea2d-4ec8-a3fc-e6649ebf8834.png)

After:
![image](https://user-images.githubusercontent.com/60462875/224438643-749e96af-7426-4362-9aa5-1ed5f94bcefa.png)