### PR TITLE
Changed hypothesis version for oldestdeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 - Version of `sphinx-rtd-theme` updated in `requirements_dev.txt` 
 - Updated `black` version to 23.x
 - Older event loading functions now use newer functions to create TOAs and then convert to list of TOA objects
+- Limited hypothesis to <= 6.72.0 to avoid numpy problems in oldestdeps
 ### Added
 - Documentation: Explanation for DM
 - Methods to compute dispersion slope and to convert DM using the CODATA value of DMconst

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ deps =
     scipy==1.4.1
     pytest
     coverage
-    hypothesis
+    hypothesis<=6.72.0
 commands = {posargs:pytest}
 
 [testenv:report]


### PR DESCRIPTION
CI failure due to `hypothesis` updates.  Pin it to an older version instead.