### PR TITLE
Allow merging a list of TOAs objects with only one element

### DIFF
--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -2692,7 +2692,7 @@ def merge_TOAs(TOAs_list, strict=False):
     """
     # don't duplicate code: just use the existing method
     t = copy.deepcopy(TOAs_list[0])
-    if len(TOAs_list > 1):
+    if len(TOAs_list) > 1:
         t.merge(*TOAs_list[1:], strict=strict)
     return t
 

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -3,7 +3,7 @@
 In particular, single TOAs are represented by :class:`pint.toa.TOA` objects, and if you
 want to manage a collection of these we recommend you use a :class:`pint.toa.TOAs` object
 as this makes certain operations much more convenient. You probably want to load one with
-:func:`pint.toa.get_TOAs` (from a ``.tim`` file) or :func:`pint.toa.get_TOAs_array` (from a 
+:func:`pint.toa.get_TOAs` (from a ``.tim`` file) or :func:`pint.toa.get_TOAs_array` (from a
 :class:`numpy.ndarray` or :class:`astropy.time.Time` object).
 
 Warning
@@ -2692,7 +2692,8 @@ def merge_TOAs(TOAs_list, strict=False):
     """
     # don't duplicate code: just use the existing method
     t = copy.deepcopy(TOAs_list[0])
-    t.merge(*TOAs_list[1:], strict=strict)
+    if len(TOAs_list > 1):
+        t.merge(*TOAs_list[1:], strict=strict)
     return t
 
 


### PR DESCRIPTION
@dlakaplan did some code cleanup in PR #1511 that inadvertently broke the `merge_TOAs()` function in the case when a list of length 1 is passed (it currently raises a `TypeError` in this case). Trying to merge such a list might seem like an odd thing to want to do, but it is something we ran across in doing IPTA "combination" using PINT Pal for a pulsar with only NANOGrav data, where we had a configuration file that only included a single .tim file.

The simplest solution seemed to be to change PINT to handle this case more sensibly, by just returning the single TOAs object rather than raising an exception, so this is what this PR does.