### PR TITLE
Correction to docstring for pbprime functions

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -14,4 +14,5 @@ the released changes.
 - Fixed RTD by specifying theme explicitly.
 - `.value()` now works for pairParameters
 - Setting `model.PARAM1 = model.PARAM2` no longer overrides the name of `PARAM1`
+- Fixed an incorrect docstring in pbprime() functions. 
 ### Removed

--- a/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
+++ b/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
@@ -29,7 +29,7 @@ class Orbit:
         return (orbits - norbits) * 2 * np.pi * u.rad
 
     def pbprime(self):
-        """Derivative of binary period with respect to time."""
+        """Instantaneous binary period as a function of time."""
         raise NotImplementedError
 
     def pbdot_orbit(self):
@@ -105,7 +105,7 @@ class OrbitPB(Orbit):
         ).decompose()
 
     def pbprime(self):
-        """Derivative of binary period with respect to time."""
+        """Instantaneous binary period as a function of time."""
         return self.PB + self.PBDOT * self.tt0
 
     def pbdot_orbit(self):
@@ -186,7 +186,7 @@ class OrbitFBX(Orbit):
         return orbits.decompose()
 
     def pbprime(self):
-        """Derivative of binary period with respect to time."""
+        """Instantaneous binary period as a function of time."""
         orbit_freq = taylor_horner_deriv(self.tt0, self._FBXs(), 1)
         return 1.0 / orbit_freq
 


### PR DESCRIPTION
While going through the binary orbit classes to implement a new model, I found that the docstrings for the `pbprime()` methods had an incorrect description. These should calculate the orbital period as a function of time, but the docstrings said that they compute the time-derivative of the orbital period (this is actually computed in `pbdot_orbit()`).