### PR TITLE
Make the usage of TZR TOA explicit

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -16,4 +16,6 @@ the released changes.
 ### Fixed
 - Deleting JUMP1 from flag tables will not prevent fitting
 - Docstrings for `get_toas()` and `get_model_and_toas()`
+- Set `DelayComponent_list` and `NoiseComponent_list` to empty list if such components are absent
+- Fix invalid access of PLANET_SHAPIRO in models without Astrometry
 ### Removed

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -17,5 +17,5 @@ the released changes.
 - Deleting JUMP1 from flag tables will not prevent fitting
 - Docstrings for `get_toas()` and `get_model_and_toas()`
 - Set `DelayComponent_list` and `NoiseComponent_list` to empty list if such components are absent
-- Fix invalid access of PLANET_SHAPIRO in models without Astrometry
+- Fix invalid access of `PLANET_SHAPIRO` in models without `Astrometry`
 ### Removed

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -15,4 +15,5 @@ the released changes.
 - Options to add a TZR TOA (`AbsPhase`) during the creation of a `TimingModel` using `ModelBuilder.__call__`, `get_model`, and `get_model_and_toas`
 ### Fixed
 - Deleting JUMP1 from flag tables will not prevent fitting
+- Docstrings for `get_toas()` and `get_model_and_toas()`
 ### Removed

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -9,8 +9,10 @@ the released changes.
 
 ## Unreleased
 ### Changed
+- Made the addition of a TZR TOA (`AbsPhase`) in the `TimingModel` explicit in `Residuals` class.
 ### Added
 - Third-order Roemer delay terms to ELL1 model
+- Options to add a TZR TOA (`AbsPhase`) during the creation of a `TimingModel` using `ModelBuilder.__call__`, `get_model`, and `get_model_and_toas`
 ### Fixed
 - Deleting JUMP1 from flag tables will not prevent fitting
 ### Removed

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -16,8 +16,6 @@ you will find PINT sufficient for all your needs!
 .. _TEMPO: http://tempo.sourceforge.net/
 .. _TEMPO2: https://www.atnf.csiro.au/research/pulsar/tempo2/
 
-.. sectnum::
-
 Time
 ----
 

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -84,7 +84,14 @@ class ModelBuilder:
         self._validate_components()
         self.default_components = []
 
-    def __call__(self, parfile, allow_name_mixing=False, allow_tcb=False, **kwargs):
+    def __call__(
+        self,
+        parfile,
+        allow_name_mixing=False,
+        allow_tcb=False,
+        toas_for_tzr=None,
+        **kwargs,
+    ):
         """Callable object for making a timing model from .par file.
 
         Parameters
@@ -103,6 +110,10 @@ class ModelBuilder:
             error upon encountering TCB par files. If True, the par file will be
             converted to TDB upon read. If "raw", an unconverted malformed TCB
             TimingModel object will be returned.
+
+        toas_for_tzr : TOAs or None, optional
+            If this is not None, a TZR TOA (AbsPhase) will be created using the
+            given TOAs object.
 
         kwargs : dict
             Any additional parameter/value pairs that will add to or override those in the parfile.
@@ -175,6 +186,10 @@ class ModelBuilder:
                 getattr(tm, k).quantity = v
             else:
                 getattr(tm, k).value = v
+
+        # Explicitly add a TZR TOA from a given TOAs object.
+        if "AbsPhase" not in tm.components and toas_for_tzr is not None:
+            tm.add_tzr_toa(toas_for_tzr)
 
         return tm
 
@@ -606,7 +621,9 @@ class ModelBuilder:
             raise ComponentConflict(f"Can not decide the one component from: {cf_cps}")
 
 
-def get_model(parfile, allow_name_mixing=False, allow_tcb=False, **kwargs):
+def get_model(
+    parfile, allow_name_mixing=False, allow_tcb=False, toas_for_tzr=None, **kwargs
+):
     """A one step function to build model from a parfile.
 
     Parameters
@@ -626,6 +643,10 @@ def get_model(parfile, allow_name_mixing=False, allow_tcb=False, **kwargs):
         converted to TDB upon read. If "raw", an unconverted malformed TCB
         TimingModel object will be returned.
 
+    toas_for_tzr : TOAs or None, optional
+        If this is not None, a TZR TOA (AbsPhase) will be created using the
+        given TOAs object.
+
     kwargs : dict
         Any additional parameter/value pairs that will add to or override those in the parfile.
 
@@ -640,13 +661,23 @@ def get_model(parfile, allow_name_mixing=False, allow_tcb=False, **kwargs):
         contents = None
     if contents is not None:
         return model_builder(
-            StringIO(contents), allow_name_mixing, allow_tcb=allow_tcb, **kwargs
+            StringIO(contents),
+            allow_name_mixing,
+            allow_tcb=allow_tcb,
+            toas_for_tzr=toas_for_tzr,
+            **kwargs,
         )
 
     # # parfile is a filename and can be handled by ModelBuilder
     # if _model_builder is None:
     #     _model_builder = ModelBuilder()
-    model = model_builder(parfile, allow_name_mixing, allow_tcb=allow_tcb, **kwargs)
+    model = model_builder(
+        parfile,
+        allow_name_mixing,
+        allow_tcb=allow_tcb,
+        toas_for_tzr=toas_for_tzr,
+        **kwargs,
+    )
     model.name = parfile
 
     return model
@@ -667,6 +698,7 @@ def get_model_and_toas(
     allow_name_mixing=False,
     limits="warn",
     allow_tcb=False,
+    add_tzr_to_model=True,
     **kwargs,
 ):
     """Load a timing model and a related TOAs, using model commands as needed
@@ -711,6 +743,9 @@ def get_model_and_toas(
         error upon encountering TCB par files. If True, the par file will be
         converted to TDB upon read. If "raw", an unconverted malformed TCB
         TimingModel object will be returned.
+    add_tzr_to_model: bool, optional
+        Create a TZR TOA in the timing model using the created TOAs object. Default is
+        True.
     kwargs : dict
         Any additional parameter/value pairs that will add to or override those in the parfile.
 
@@ -718,7 +753,9 @@ def get_model_and_toas(
     -------
     A tuple with (model instance, TOAs instance)
     """
+
     mm = get_model(parfile, allow_name_mixing, allow_tcb=allow_tcb, **kwargs)
+
     tt = get_TOAs(
         timfile,
         include_pn=include_pn,
@@ -733,4 +770,8 @@ def get_model_and_toas(
         picklefilename=picklefilename,
         limits=limits,
     )
+
+    if add_tzr_to_model:
+        mm.add_tzr_toa(tt)
+
     return mm, tt

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -189,6 +189,7 @@ class ModelBuilder:
 
         # Explicitly add a TZR TOA from a given TOAs object.
         if "AbsPhase" not in tm.components and toas_for_tzr is not None:
+            log.info("Creating a TZR TOA (AbsPhase) using the given TOAs object.")
             tm.add_tzr_toa(toas_for_tzr)
 
         return tm
@@ -772,6 +773,7 @@ def get_model_and_toas(
     )
 
     if "AbsPhase" not in mm.components and add_tzr_to_model:
+        log.info("Creating a TZR TOA (AbsPhase) using the given TOAs object.")
         mm.add_tzr_toa(tt)
 
     return mm, tt

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -192,6 +192,11 @@ class ModelBuilder:
             log.info("Creating a TZR TOA (AbsPhase) using the given TOAs object.")
             tm.add_tzr_toa(toas_for_tzr)
 
+        if not hasattr(tm, "DelayComponent_list"):
+            setattr(tm, "DelayComponent_list", [])
+        if not hasattr(tm, "NoiseComponent_list"):
+            setattr(tm, "NoiseComponent_list", [])
+
         return tm
 
     def _validate_components(self):

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -771,7 +771,7 @@ def get_model_and_toas(
         limits=limits,
     )
 
-    if add_tzr_to_model:
+    if "AbsPhase" not in mm.components and add_tzr_to_model:
         mm.add_tzr_toa(tt)
 
     return mm, tt

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -710,6 +710,9 @@ def get_model_and_toas(
         The parfile name, or a file-like object to read the parfile contents from
     timfile : str
         The timfile name, or a file-like object to read the timfile contents from
+    ephem : str, optional
+        If not None (default), this ephemeris will be used to create the TOAs object.
+        Default is to use the EPHEM parameter from the timing model.
     include_bipm : bool or None
         Whether to apply the BIPM clock correction. Defaults to True.
     bipm_version : string or None
@@ -744,7 +747,7 @@ def get_model_and_toas(
         error upon encountering TCB par files. If True, the par file will be
         converted to TDB upon read. If "raw", an unconverted malformed TCB
         TimingModel object will be returned.
-    add_tzr_to_model: bool, optional
+    add_tzr_to_model : bool, optional
         Create a TZR TOA in the timing model using the created TOAs object. Default is
         True.
     kwargs : dict

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1317,23 +1317,31 @@ class TimingModel:
         # False.  Of course, if you manually set it, it will use that setting.
         if abs_phase is None:
             abs_phase = "AbsPhase" in list(self.components.keys())
+
+        # This function gets called in `Residuals.calc_phase_resids()` with `abs_phase=True`
+        # by default. Hence, this branch is not run by default.
         if not abs_phase:
             return phase
+
         if "AbsPhase" not in list(self.components.keys()):
             # if no absolute phase (TZRMJD), add the component to the model and calculate it
-            from pint.models import absolute_phase
+            self.add_tzr_toa(toas)
 
-            self.add_component(absolute_phase.AbsPhase(), validate=False)
-            self.make_TZR_toa(
-                toas
-            )  # TODO:needs timfile to get all toas, but model doesn't have access to timfile. different place for this?
-            self.validate()
         tz_toa = self.get_TZR_toa(toas)
         tz_delay = self.delay(tz_toa)
         tz_phase = Phase(np.zeros(len(toas.table)), np.zeros(len(toas.table)))
         for pf in self.phase_funcs:
             tz_phase += Phase(pf(tz_toa, tz_delay))
         return phase - tz_phase
+
+    def add_tzr_toa(self, toas):
+        """Create a TZR TOA for the given TOAs object and add it to
+        the timing model. This corresponds to TOA closest to the PEPOCH."""
+        from pint.models.absolute_phase import AbsPhase
+
+        self.add_component(AbsPhase(), validate=False)
+        self.make_TZR_toa(toas)
+        self.validate()
 
     def total_dm(self, toas):
         """Calculate dispersion measure from all the dispersion type of components."""

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1324,6 +1324,8 @@ class TimingModel:
             return phase
 
         if "AbsPhase" not in list(self.components.keys()):
+            log.info("Creating a TZR TOA (AbsPhase) using the given TOAs object.")
+
             # if no absolute phase (TZRMJD), add the component to the model and calculate it
             self.add_tzr_toa(toas)
 

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -104,6 +104,7 @@ class Residuals:
         subtract_mean=True,
         use_weighted_mean=True,
         track_mode=None,
+        use_abs_phase=True,
     ):
         self.toas = toas
         self.model = model
@@ -114,6 +115,8 @@ class Residuals:
                 "Disabling implicit `subtract_mean` because `PhaseOffset` is present in the timing model."
             )
         self.subtract_mean = subtract_mean and "PhaseOffset" not in model.components
+
+        self.use_abs_phase = use_abs_phase
 
         self.use_weighted_mean = use_weighted_mean
         if track_mode is None:
@@ -139,6 +142,7 @@ class Residuals:
         else:
             self.phase_resids = None
             self.time_resids = None
+
         # delay chi-squared computation until needed to avoid infinite recursion
         # also it's expensive
         # only relevant if there are correlated errors
@@ -296,7 +300,9 @@ class Residuals:
         elif calctype.lower() == "numerical":
             return self.model.d_phase_d_toa(self.toas)
 
-    def calc_phase_resids(self, subtract_mean=None, use_weighted_mean=None):
+    def calc_phase_resids(
+        self, subtract_mean=None, use_weighted_mean=None, use_abs_phase=None
+    ):
         """Compute timing model residuals in pulse phase.
 
         if ``subtract_mean`` or ``use_weighted_mean`` is None, will use the values set for the object itself
@@ -304,7 +310,12 @@ class Residuals:
         Parameters
         ----------
         subtract_mean : bool or None, optional
+            Subtract the mean of the residuals. This is ignored if the `PhaseOffset` component
+            is present in the model. Default is to use the class attribute.
         use_weighted_mean : bool or None, optional
+            Whether to use weighted mean for mean subtraction. Default is to use the class attribute.
+        use_abs_phase : bool or None, optional
+            Whether to use absolute phase (w.r.t. the TZR TOA). Default is to use the class attribute.
 
         Returns
         -------
@@ -322,6 +333,10 @@ class Residuals:
 
         if use_weighted_mean is None:
             use_weighted_mean = self.use_weighted_mean
+
+        if use_abs_phase is None:
+            use_abs_phase = self.use_abs_phase
+
         # Read any delta_pulse_numbers that are in the TOAs table.
         # These are for PHASE statements, -padd flags, as well as user-inserted phase jumps
         # Check for the column, and if not there then create it as zeros
@@ -339,7 +354,8 @@ class Residuals:
             # we need absolute phases, since TZRMJD serves as the pulse
             # number reference.
             modelphase = (
-                self.model.phase(self.toas, abs_phase=True) + delta_pulse_numbers
+                self.model.phase(self.toas, abs_phase=use_abs_phase)
+                + delta_pulse_numbers
             )
             # First assign each TOA to the correct relative pulse number, including
             # and delta_pulse_numbers (from PHASE lines or adding phase jumps in GUI)
@@ -425,7 +441,11 @@ class Residuals:
         return mean
 
     def calc_time_resids(
-        self, calctype="taylor", subtract_mean=None, use_weighted_mean=None
+        self,
+        calctype="taylor",
+        subtract_mean=None,
+        use_weighted_mean=None,
+        use_abs_phase=None,
     ):
         """Compute timing model residuals in time (seconds).
 
@@ -442,8 +462,12 @@ class Residuals:
             If `calctype` == "numerical", then try a numerical derivative
             If `calctype` == "taylor", evaluate the frequency with a Taylor series
         subtract_mean : bool or None, optional
+            Subtract the mean of the residuals. This is ignored if the `PhaseOffset` component
+            is present in the model. Default is to use the class attribute.
         use_weighted_mean : bool or None, optional
-
+            Whether to use weighted mean for mean subtraction. Default is to use the class attribute.
+        use_abs_phase : bool or None, optional
+            Whether to use absolute phase (w.r.t. the TZR TOA). Default is to use the class attribute.
 
         Returns
         -------
@@ -458,12 +482,16 @@ class Residuals:
             # if we are using the defaults, save the calculation
             if self.phase_resids is None:
                 self.phase_resids = self.calc_phase_resids(
-                    subtract_mean=subtract_mean, use_weighted_mean=use_weighted_mean
+                    subtract_mean=subtract_mean,
+                    use_weighted_mean=use_weighted_mean,
+                    use_abs_phase=use_abs_phase,
                 )
             phase_resids = self.phase_resids
         else:
             phase_resids = self.calc_phase_resids(
-                subtract_mean=subtract_mean, use_weighted_mean=use_weighted_mean
+                subtract_mean=subtract_mean,
+                use_weighted_mean=use_weighted_mean,
+                use_abs_phase=use_abs_phase,
             )
         return (phase_resids / self.get_PSR_freq(calctype=calctype)).to(u.s)
 

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -343,6 +343,7 @@ class Residuals:
         if "delta_pulse_number" not in self.toas.table.colnames:
             self.toas.table["delta_pulse_number"] = np.zeros(len(self.toas.get_mjds()))
         delta_pulse_numbers = Phase(self.toas.table["delta_pulse_number"])
+
         # Track on pulse numbers, if requested
         if self.track_mode == "use_pulse_numbers":
             pulse_num = self.toas.get_pulse_numbers()
@@ -381,6 +382,7 @@ class Residuals:
             full = residualphase.int + residualphase.frac
         else:
             raise ValueError(f"Invalid track_mode '{self.track_mode}'")
+
         # If we are using pulse numbers, do we really want to subtract any kind of mean?
         if not subtract_mean:
             return full
@@ -395,6 +397,7 @@ class Residuals:
                 )
             w = 1.0 / (self.get_data_error().value ** 2)
             mean, err = weighted_mean(full, w)
+
         return full - mean
 
     def calc_phase_mean(self, weighted=True):

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -84,6 +84,7 @@ class Residuals:
         subtract_mean=True,
         use_weighted_mean=True,
         track_mode=None,
+        use_abs_phase=True,
     ):
         if cls is Residuals:
             try:

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -294,7 +294,7 @@ def make_fake_toas_uniform(
         include_bipm=clk_version["include_bipm"],
         bipm_version=clk_version["bipm_version"],
         include_gps=clk_version["include_gps"],
-        planets=model["PLANET_SHAPIRO"].value,
+        planets=model["PLANET_SHAPIRO"].value if "PLANET_SHAPIRO" in model else False,
     )
     ts.table["error"] = error
 

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -150,7 +150,8 @@ def get_TOAs(
     timfile : str or list of strings or file-like
         Filename, list of filenames, or file-like object containing the TOA data.
     ephem : str or None
-        The name of the solar system ephemeris to use; defaults to ``pint.toa.EPHEM_default`` if ``None``
+        The name of the solar system ephemeris to use; defaults to the EPHEM parameter
+        in the timing model (`model`) if it is given, otherwise defaults to ``pint.toa.EPHEM_default``.
     include_bipm : bool or None
         Whether to apply the BIPM clock correction. Defaults to True.
     bipm_version : str or None
@@ -167,7 +168,7 @@ def get_TOAs(
     model : pint.models.timing_model.TimingModel or None
         If a valid timing model is passed, model commands (such as BIPM version,
         planet shapiro delay, and solar system ephemeris) that affect TOA loading
-        are applied.
+        are applied. The solar system ephemeris is superseded by the `ephem` parameter.
     usepickle : bool
         Whether to try to use pickle-based caching of loaded clock-corrected TOAs objects.
     tdb_method : str

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -219,7 +219,11 @@ def get_TOAs(
                     f'CLOCK = {model["CLOCK"].value} is not implemented. '
                     f"Using TT({bipm_default}) instead."
                 )
-        if planets is None and model["PLANET_SHAPIRO"].value:
+        if (
+            planets is None
+            and "PLANET_SHAPIRO" in model
+            and model["PLANET_SHAPIRO"].value
+        ):
             planets = True
             log.debug("Using PLANET_SHAPIRO = True from the given model")
 

--- a/tests/test_explicit_absphase.py
+++ b/tests/test_explicit_absphase.py
@@ -1,0 +1,67 @@
+from pint.models import get_model, get_model_and_toas
+from pint.simulation import make_fake_toas_uniform
+from pint.residuals import Residuals
+from io import StringIO
+import pytest
+
+par = """
+F0      100
+PEPOCH  50000
+"""
+
+
+@pytest.fixture
+def fake_toas():
+    m = get_model(StringIO(par))
+    t = make_fake_toas_uniform(50000, 50100, 50, m, add_noise=True)
+    return t
+
+
+@pytest.fixture
+def model():
+    return get_model(StringIO(par))
+
+
+def test_add_tzr_toa(model, fake_toas):
+    assert "AbsPhase" not in model.components
+
+    model.add_tzr_toa(fake_toas)
+
+    assert "AbsPhase" in model.components
+    assert hasattr(model, "TZRMJD")
+    assert hasattr(model, "TZRSITE")
+    assert hasattr(model, "TZRFRQ")
+
+    with pytest.raises(ValueError):
+        model.add_tzr_toa(fake_toas)
+
+
+@pytest.mark.parametrize("use_abs_phase", [True, False])
+def test_residuals(model, fake_toas, use_abs_phase):
+    res = Residuals(fake_toas, model, use_abs_phase=use_abs_phase)
+    res.calc_phase_resids()
+    assert ("AbsPhase" in model.components) == use_abs_phase
+
+
+@pytest.mark.parametrize("use_abs_phase", [True, False])
+def test_residuals_2(model, fake_toas, use_abs_phase):
+    res = Residuals(fake_toas, model, use_abs_phase=False)
+    res.calc_phase_resids(use_abs_phase=use_abs_phase)
+    assert ("AbsPhase" in model.components) == use_abs_phase
+
+
+@pytest.mark.parametrize("add_tzr", [True, False])
+def test_get_model(fake_toas, add_tzr):
+    toas_for_tzr = fake_toas if add_tzr else None
+    m = get_model(StringIO(par), toas_for_tzr=toas_for_tzr)
+    assert ("AbsPhase" in m.components) == add_tzr
+
+
+@pytest.mark.parametrize("add_tzr", [True, False])
+def test_get_model_and_toas(fake_toas, add_tzr):
+    timfile = "fake_toas.tim"
+    fake_toas.write_TOA_file(timfile)
+
+    m, t = get_model_and_toas(StringIO(par), timfile, add_tzr_to_model=add_tzr)
+
+    assert ("AbsPhase" in m.components) == add_tzr


### PR DESCRIPTION
Related: #1585 

1. Move the TZR TOA creation from `TimingModel.phase()` to a new function `TimingModel.add_tzr_toa()`. This will throw an error if `AbsPhase` is already present in the model.
2. `Residuals.__init__()`, `Residuals.calc_phase_resids()` and `Residuals.calc_time_resids()` now have an explicit `use_abs_phase` option. The existing behavior is to implicitly use the absolute phase, and create a TZR TOA implicitly if not available in the timing model.
3. `ModelBuilder.__call__()` and `get_model()` have a new option `toas_for_tzr`. If a TOAs object is given, it creates a TZR TOA using that TOAs object if not already present and does nothing if the TZR TOA is already given in the model.
4. `get_model_and_toas` has a new option `add_tzr_to_model`. If True (default), this option will create a TZR TOA in the timing model using the created TOA object if not already present and does nothing otherwise.
5. Logs an info message every time a TZR TOA gets added to the model after its creation.
6. Fix docstrings for `get_model_and_toas()` and `get_toas()`.
7. Fix bug where `DelayComponent_list` is missing.
8. Fix bug where missing PLANET_SHAPIRO is accessed.