### PR TITLE
Autocorrelation check for event_optimize

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -16,6 +16,7 @@ the released changes.
 - Third-order Roemer delay terms to ELL1 model
 - Options to add a TZR TOA (`AbsPhase`) during the creation of a `TimingModel` using `ModelBuilder.__call__`, `get_model`, and `get_model_and_toas`
 - `pint.print_info()` function for bug reporting
+- Added an autocorrelation function to check for chain convergence in `event_optimize`
 ### Fixed
 - Deleting JUMP1 from flag tables will not prevent fitting
 - Simulating TOAs from tim file when PLANET_SHAPIRO is true now works

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -622,7 +622,7 @@ def main(argv=None):
         action="store_true",
     )
     parser.add_argument(
-        "--autocorr",
+        "--no-autocorr",
         help="Turn the autocorrelation check function off",
         default=True,
         action="store_false",

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -624,8 +624,9 @@ def main(argv=None):
     parser.add_argument(
         "--no-autocorr",
         help="Turn the autocorrelation check function off",
-        default=True,
-        action="store_false",
+        default=False,
+        action="store_true",
+        dest="noautocorr",
     )
 
     args = parser.parse_args(argv)
@@ -902,7 +903,7 @@ def main(argv=None):
                     pool=pool,
                     backend=backend,
                 )
-                if args.autocorr is False:
+                if args.noautocorr:
                     sampler.run_mcmc(pos, nsteps, progress=True)
                 else:
                     autocorr = autocorr_check(sampler, pos, nsteps, burnin)
@@ -913,7 +914,7 @@ def main(argv=None):
             sampler = emcee.EnsembleSampler(
                 nwalkers, ndim, ftr.lnposterior, blobs_dtype=dtype, backend=backend
             )
-            if args.autocorr is False:
+            if args.noautocorr:
                 sampler.run_mcmc(pos, nsteps, progress=True)
             else:
                 autocorr = autocorr_check(sampler, pos, nsteps, burnin)
@@ -921,7 +922,7 @@ def main(argv=None):
         sampler = emcee.EnsembleSampler(
             nwalkers, ndim, ftr.lnposterior, blobs_dtype=dtype, backend=backend
         )
-        if args.autocorr is False:
+        if args.noautocorr:
             sampler.run_mcmc(pos, nsteps, progress=True)
         else:
             autocorr = autocorr_check(sampler, pos, nsteps, burnin)

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -621,12 +621,6 @@ def main(argv=None):
         default=False,
         action="store_true",
     )
-    parser.add_argument(
-        "--autocorr",
-        help="Runs an autocorrelation check to stop the sampler once convergence is reached",
-        default=False,
-        action="store_true",
-    )
 
     args = parser.parse_args(argv)
     pint.logging.setup(

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -276,7 +276,7 @@ def autocorr_check(sampler, pos, nsteps, burnin, csteps=100, crit1=10):
     converged1 = False
     converged2 = False
     for sample in sampler.sample(pos, iterations=nsteps, progress=True):
-        if converged1 == False:
+        if not converged1:
             # Checks if the iteration is past the burnin and checks for convergence at 10% tau change
             if sampler.iteration >= burnin and sampler.iteration % csteps == 0:
                 tau = sampler.get_autocorr_time(tol=0, quiet=True)
@@ -299,7 +299,7 @@ def autocorr_check(sampler, pos, nsteps, burnin, csteps=100, crit1=10):
             else:
                 continue
         else:
-            if converged2 == False:
+            if not converged2:
                 # Checks for convergence at every 25 steps instead of 100 and tau change is 1%
                 if sampler.iteration % int(csteps / 4) == 0:
                     tau = sampler.get_autocorr_time(tol=0, quiet=True)

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -247,8 +247,8 @@ def get_fit_keyvals(model, phs=0.0, phserr=0.1):
     return fitkeys, np.asarray(fitvals), np.asarray(fiterrs)
 
 
-def autocorr_check(sampler, pos, nsteps, burnin, csteps=100, crit1=10):
-    """Return the converged sampler and the mean autocorrelation time per 100 steps
+def run_sampler_autocorr(sampler, pos, nsteps, burnin, csteps=100, crit1=10):
+    """Runs the sampler and checks for chain convergence. Return the converged sampler and the mean autocorrelation time per 100 steps
     Parameters
     ----------
     Sampler
@@ -906,7 +906,7 @@ def main(argv=None):
                 if args.noautocorr:
                     sampler.run_mcmc(pos, nsteps, progress=True)
                 else:
-                    autocorr = autocorr_check(sampler, pos, nsteps, burnin)
+                    autocorr = run_sampler_autocorr(sampler, pos, nsteps, burnin)
             pool.close()
             pool.join()
         except ImportError:
@@ -917,7 +917,7 @@ def main(argv=None):
             if args.noautocorr:
                 sampler.run_mcmc(pos, nsteps, progress=True)
             else:
-                autocorr = autocorr_check(sampler, pos, nsteps, burnin)
+                autocorr = run_sampler_autocorr(sampler, pos, nsteps, burnin)
     else:
         sampler = emcee.EnsembleSampler(
             nwalkers, ndim, ftr.lnposterior, blobs_dtype=dtype, backend=backend
@@ -925,7 +925,7 @@ def main(argv=None):
         if args.noautocorr:
             sampler.run_mcmc(pos, nsteps, progress=True)
         else:
-            autocorr = autocorr_check(sampler, pos, nsteps, burnin)
+            autocorr = run_sampler_autocorr(sampler, pos, nsteps, burnin)
 
     def chains_to_dict(names, sampler):
         samples = np.transpose(sampler.get_chain(), (1, 0, 2))

--- a/tests/test_event_optimize.py
+++ b/tests/test_event_optimize.py
@@ -14,8 +14,6 @@ import pickle
 import scipy.stats as stats
 from pint.scripts import event_optimize
 from pinttestdata import datadir
-from pathos.multiprocessing import Pool
-
 
 def test_result(tmp_path):
     parfile = datadir / "PSRJ0030+0451_psrcat.par"

--- a/tests/test_event_optimize.py
+++ b/tests/test_event_optimize.py
@@ -15,6 +15,7 @@ import scipy.stats as stats
 from pint.scripts import event_optimize
 from pinttestdata import datadir
 
+
 def test_result(tmp_path):
     parfile = datadir / "PSRJ0030+0451_psrcat.par"
     eventfile_orig = (

--- a/tests/test_event_optimize.py
+++ b/tests/test_event_optimize.py
@@ -146,7 +146,7 @@ def test_autocorr(tmp_path):
     sampler = emcee.EnsembleSampler(nwalkers, ndim, ln_prob)
 
     # Running the sampler with the autocorrelation check function from event_optimize
-    autocorr = event_optimize.autocorr_check(sampler, coords, nsteps, burnin=10)
+    autocorr = event_optimize.run_sampler_autocorr(sampler, coords, nsteps, burnin=10)
 
     # Extracting the samples and asserting that the autocorrelation check
     # stopped the sampler once convergence was reached


### PR DESCRIPTION
I have an autocorrelation routine for `event_optimize`. The routine runs the sampler and determines convergence of the chains by 2 criteria:

1.  The chain length is a specified ratio times the estimated autocorrelation time for each parameter.  (The default is set to 10 in `event_optimize`)
2. The change in estimated autocorrelation times is less than 1%

The check is conducted every 100 steps and then every 25 steps once 10% convergence is reached. 