### PR TITLE
Replace a test expression to remove a logical short circuit

### DIFF
--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -1506,11 +1506,7 @@ class PlkWidget(tk.Frame):
                 self.psr.selected_toas = self.psr.all_toas[cluster_bool]
                 jump_name = self.psr.add_jump(cluster_bool)
                 self.updateJumped(jump_name)
-            if (
-                self.selected is not None
-                and self.selected != []
-                and all(self.selected)
-            ):
+            if self.selected is not None and self.selected != [] and all(self.selected):
                 self.psr.selected_toas = self.all_toas[self.selected]
             self.fitboxesWidget.addFitCheckBoxes(self.psr.prefit_model)
             self.randomboxWidget.addRandomCheckbox(self)

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -1508,7 +1508,7 @@ class PlkWidget(tk.Frame):
                 self.updateJumped(jump_name)
             if (
                 self.selected is not None
-                and self.selected is not []
+                and self.selected != []
                 and all(self.selected)
             ):
                 self.psr.selected_toas = self.all_toas[self.selected]


### PR DESCRIPTION
In file: plk.py, method: `canvasKeyEvent`, a logical expression uses the identity operator. A new object is created inside the identity check operation and then used for matching identity. Since this is a distinct, new object, it will not have identity and it will match with anything else. As a result, the identity check will have a logical short circuit and the program may have unintended behavior. In this case, the identity check will always evaluate to true. I updated the logical operation to remove the logical short circuit. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): Project [Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.