### PR TITLE
Remove an undefined name

### DIFF
--- a/src/pint/models/tcb_conversion.py
+++ b/src/pint/models/tcb_conversion.py
@@ -9,7 +9,6 @@ __all__ = [
     "IFTE_K",
     "scale_parameter",
     "transform_mjd_parameter",
-    "convert_tcb_to_tdb",
 ]
 
 # These constants are taken from Irwin & Fukushima 1999.

--- a/src/pint/models/tcb_conversion.py
+++ b/src/pint/models/tcb_conversion.py
@@ -9,6 +9,7 @@ __all__ = [
     "IFTE_K",
     "scale_parameter",
     "transform_mjd_parameter",
+    "convert_tcb_tdb",
 ]
 
 # These constants are taken from Irwin & Fukushima 1999.


### PR DESCRIPTION
In file: tcb_conversion.py, the list named `__all__` contains an undefined name which can result in errors when this module is imported. I removed the undefined name from the list. For more information regarding `__all__`, please read about [importing fields from a package](https://docs.python.org/3/tutorial/modules.html#importing-from-a-package).  

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the Open Source Security Foundation (OpenSSF)(https://openssf.org/): Project Alpha-Omega(https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.