### PR TITLE
Fix conversion from ICRS -> ECL when pm uncertainties are None

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -14,4 +14,5 @@ the released changes.
 - Fixed RTD by specifying theme explicitly.
 - `.value()` now works for pairParameters
 - Setting `model.PARAM1 = model.PARAM2` no longer overrides the name of `PARAM1`
+- Fix ICRS -> ECL conversion when parameter uncertainties are not set.
 ### Removed

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -550,12 +550,16 @@ class AstrometryEquatorial(Astrometry):
             ra=self.RAJ.quantity,
             dec=self.DECJ.quantity,
             obstime=self.POSEPOCH.quantity,
-            pm_ra_cosdec=self.RAJ.uncertainty * np.cos(self.DECJ.quantity) / dt
-            if self.RAJ.uncertainty is not None
-            else 0 * self.RAJ.units / dt,
-            pm_dec=self.DECJ.uncertainty / dt
-            if self.DECJ.uncertainty is not None
-            else 0 * self.DECJ.units / dt,
+            pm_ra_cosdec=(
+                self.RAJ.uncertainty * np.cos(self.DECJ.quantity) / dt
+                if self.RAJ.uncertainty is not None
+                else 0 * self.RAJ.units / dt
+            ),
+            pm_dec=(
+                self.DECJ.uncertainty / dt
+                if self.DECJ.uncertainty is not None
+                else 0 * self.DECJ.units / dt
+            ),
             frame=coords.ICRS,
         )
         c_ECL = c.transform_to(PulsarEcliptic(ecl=ecl))
@@ -567,12 +571,16 @@ class AstrometryEquatorial(Astrometry):
             ra=self.RAJ.quantity,
             dec=self.DECJ.quantity,
             obstime=self.POSEPOCH.quantity,
-            pm_ra_cosdec=self.PMRA.uncertainty
-            if self.PMRA.uncertainty is not None
-            else 0 * self.PMRA.units,
-            pm_dec=self.PMDEC.uncertainty
-            if self.PMDEC.uncertainty is not None
-            else 0 * self.PMDEC.units,
+            pm_ra_cosdec=(
+                self.PMRA.uncertainty
+                if self.PMRA.uncertainty is not None
+                else 0 * self.PMRA.units
+            ),
+            pm_dec=(
+                self.PMDEC.uncertainty
+                if self.PMDEC.uncertainty is not None
+                else 0 * self.PMDEC.units
+            ),
             frame=coords.ICRS,
         )
         c_ECL = c.transform_to(PulsarEcliptic(ecl=ecl))
@@ -951,8 +959,16 @@ class AstrometryEcliptic(Astrometry):
             lat=self.ELAT.quantity,
             obliquity=OBL[self.ECL.value],
             obstime=self.POSEPOCH.quantity,
-            pm_lon_coslat=self.ELONG.uncertainty * np.cos(self.ELAT.quantity) / dt,
-            pm_lat=self.ELAT.uncertainty / dt,
+            pm_lon_coslat=(
+                self.ELONG.uncertainty * np.cos(self.ELAT.quantity) / dt
+                if self.ELONG.uncertainty is not None
+                else 0 * self.ELONG.units / dt
+            ),
+            pm_lat=(
+                self.ELAT.uncertainty / dt
+                if self.ELAT.uncertainty is not None
+                else 0 * self.ELAT.units / dt
+            ),
             frame=PulsarEcliptic,
         )
         c_ECL = c.transform_to(PulsarEcliptic(ecl=ecl))
@@ -965,12 +981,16 @@ class AstrometryEcliptic(Astrometry):
             lat=self.ELAT.quantity,
             obliquity=OBL[self.ECL.value],
             obstime=self.POSEPOCH.quantity,
-            pm_lon_coslat=self.PMELONG.uncertainty
-            if self.PMELONG.uncertainty is not None
-            else 0 * self.PMELONG.units,
-            pm_lat=self.PMELAT.uncertainty
-            if self.PMELAT.uncertainty is not None
-            else 0 * self.PMELAT.units,
+            pm_lon_coslat=(
+                self.PMELONG.uncertainty
+                if self.PMELONG.uncertainty is not None
+                else 0 * self.PMELONG.units
+            ),
+            pm_lat=(
+                self.PMELAT.uncertainty
+                if self.PMELAT.uncertainty is not None
+                else 0 * self.PMELAT.units
+            ),
             frame=PulsarEcliptic,
         )
         c_ECL = c.transform_to(PulsarEcliptic(ecl=ecl))

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -550,8 +550,12 @@ class AstrometryEquatorial(Astrometry):
             ra=self.RAJ.quantity,
             dec=self.DECJ.quantity,
             obstime=self.POSEPOCH.quantity,
-            pm_ra_cosdec=self.RAJ.uncertainty * np.cos(self.DECJ.quantity) / dt,
-            pm_dec=self.DECJ.uncertainty / dt,
+            pm_ra_cosdec=self.RAJ.uncertainty * np.cos(self.DECJ.quantity) / dt
+            if self.RAJ.uncertainty is not None
+            else 0 * self.RAJ.units / dt,
+            pm_dec=self.DECJ.uncertainty / dt
+            if self.DECJ.uncertainty is not None
+            else 0 * self.DECJ.units / dt,
             frame=coords.ICRS,
         )
         c_ECL = c.transform_to(PulsarEcliptic(ecl=ecl))
@@ -563,8 +567,12 @@ class AstrometryEquatorial(Astrometry):
             ra=self.RAJ.quantity,
             dec=self.DECJ.quantity,
             obstime=self.POSEPOCH.quantity,
-            pm_ra_cosdec=self.PMRA.uncertainty,
-            pm_dec=self.PMDEC.uncertainty,
+            pm_ra_cosdec=self.PMRA.uncertainty
+            if self.PMRA.uncertainty is not None
+            else 0 * self.PMRA.units,
+            pm_dec=self.PMDEC.uncertainty
+            if self.PMDEC.uncertainty is not None
+            else 0 * self.PMDEC.units,
             frame=coords.ICRS,
         )
         c_ECL = c.transform_to(PulsarEcliptic(ecl=ecl))

--- a/tests/test_modelconversions.py
+++ b/tests/test_modelconversions.py
@@ -73,10 +73,10 @@ def test_ECL_to_ICRS():
 def test_ICRS_to_ECL_nouncertainties():
     # start with ICRS model with no pm uncertainties, get residuals with ECL model, compare
     model_ICRS = get_model(io.StringIO(modelstring_ICRS))
-    for p in ["PMRA", "PMDEC"]:
-        getattr(model_ICRS, p).frozen = True
-        getattr(model_ICRS, p).uncertainties = None
-
+    model_ICRS.PMRA._uncertainty = None
+    model_ICRS.PMRA.frozen = True
+    model_ICRS.PMDEC._uncertainty = None
+    model_ICRS.PMDEC.frozen = True
     toas = pint.simulation.make_fake_toas_uniform(
         MJDStart, MJDStop, NTOA, model=model_ICRS, error=1 * u.us, add_noise=True
     )
@@ -89,10 +89,10 @@ def test_ICRS_to_ECL_nouncertainties():
 def test_ECL_to_ICRS_nouncertainties():
     # start with ECL model with no pm uncertainties, get residuals with ICRS model, compare
     model_ECL = get_model(io.StringIO(modelstring_ECL))
-    for p in ["PMELONG", "PMELAT"]:
-        getattr(model_ECL, p).frozen = True
-        getattr(model_ECL, p).uncertainties = None
-
+    model_ECL.PMELONG._uncertainty = None
+    model_ECL.PMELONG.frozen = True
+    model_ECL.PMELAT._uncertainty = None
+    model_ECL.PMELAT.frozen = True
     toas = pint.simulation.make_fake_toas_uniform(
         MJDStart, MJDStop, NTOA, model=model_ECL, error=1 * u.us, add_noise=True
     )


### PR DESCRIPTION
This should have been fixed by #1598 , but that only handled ECL -> ICRS and not the inverse.  I had put in tests there but they actually didn't work (you can't assign uncertainties to `None` with the normal methods). So I fixed the conversion and fixed the tests.