### PR TITLE
WIP: Performance improvements

### DIFF
--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -203,10 +203,10 @@ class Astrometry(DelayComponent):
         rd = self.get_d_delay_quantities(toas)
 
         px_r = np.sqrt(rd["ssb_obs_r"] ** 2 - rd["in_psr_obs"] ** 2)
-        dd_dpx = 0.5 * (px_r**2 / (u.AU * const.c)) * (u.mas / u.radian)
+        dd_dpx = 0.5 * px_r**2 * ((u.mas / u.radian) / (u.AU * const.c))
 
         # We want to return sec / mas
-        return dd_dpx.decompose(u.si.bases) / u.mas
+        return dd_dpx.to(u.s) / u.mas
 
     def d_delay_astrometry_d_POSEPOCH(self, toas, param="", acc_delay=None):
         """Calculate the derivative wrt POSEPOCH"""
@@ -415,7 +415,7 @@ class AstrometryEquatorial(Astrometry):
         )
         dd_draj = rd["ssb_obs_r"] * geom / (const.c * u.radian)
 
-        return dd_draj.decompose(u.si.bases)
+        return dd_draj.to(u.s / u.rad)
 
     def d_delay_astrometry_d_DECJ(self, toas, param="", acc_delay=None):
         """Calculate the derivative wrt DECJ
@@ -432,7 +432,7 @@ class AstrometryEquatorial(Astrometry):
         ) - np.sin(rd["earth_dec"]) * np.cos(psr_dec)
         dd_ddecj = rd["ssb_obs_r"] * geom / (const.c * u.radian)
 
-        return dd_ddecj.decompose(u.si.bases)
+        return dd_ddecj.to(u.s / u.rad)
 
     def d_delay_astrometry_d_PMRA(self, toas, param="", acc_delay=None):
         """Calculate the derivative wrt PMRA
@@ -448,10 +448,9 @@ class AstrometryEquatorial(Astrometry):
         geom = np.cos(rd["earth_dec"]) * np.sin(psr_ra - rd["earth_ra"])
 
         deriv = rd["ssb_obs_r"] * geom * te / (const.c * u.radian)
-        dd_dpmra = deriv * u.mas / u.year
 
         # We want to return sec / (mas / yr)
-        return dd_dpmra.decompose(u.si.bases) / (u.mas / u.year)
+        return deriv.to(u.s * u.year / u.mas)
 
     def d_delay_astrometry_d_PMDEC(self, toas, param="", acc_delay=None):
         """Calculate the derivative wrt PMDEC
@@ -470,10 +469,9 @@ class AstrometryEquatorial(Astrometry):
         ) - np.cos(psr_dec) * np.sin(rd["earth_dec"])
 
         deriv = rd["ssb_obs_r"] * geom * te / (const.c * u.radian)
-        dd_dpmdec = deriv * u.mas / u.year
 
         # We want to return sec / (mas / yr)
-        return dd_dpmdec.decompose(u.si.bases) / (u.mas / u.year)
+        return deriv.to(u.s * u.year / u.mas)
 
     def change_posepoch(self, new_epoch):
         """Change POSEPOCH to a new value and update the position accordingly.
@@ -823,7 +821,7 @@ class AstrometryEcliptic(Astrometry):
         )
         dd_delong = rd["ssb_obs_r"] * geom / (const.c * u.radian)
 
-        return dd_delong.decompose(u.si.bases)
+        return dd_delong.to(u.s / u.rad)
 
     def d_delay_astrometry_d_ELAT(self, toas, param="", acc_delay=None):
         """Calculate the derivative wrt DECJ
@@ -840,7 +838,7 @@ class AstrometryEcliptic(Astrometry):
         ) - np.sin(rd["earth_elat"]) * np.cos(psr_elat)
         dd_delat = rd["ssb_obs_r"] * geom / (const.c * u.radian)
 
-        return dd_delat.decompose(u.si.bases)
+        return dd_delat.to(u.s / u.rad)
 
     def d_delay_astrometry_d_PMELONG(self, toas, param="", acc_delay=None):
         """Calculate the derivative wrt PMRA
@@ -857,10 +855,9 @@ class AstrometryEcliptic(Astrometry):
         geom = np.cos(rd["earth_elat"]) * np.sin(psr_elong - rd["earth_elong"])
 
         deriv = rd["ssb_obs_r"] * geom * te / (const.c * u.radian)
-        dd_dpmelong = deriv * u.mas / u.year
 
         # We want to return sec / (mas / yr)
-        return dd_dpmelong.decompose(u.si.bases) / (u.mas / u.year)
+        return deriv.to(u.s * u.year / u.mas)
 
     def d_delay_astrometry_d_PMELAT(self, toas, param="", acc_delay=None):
         """Calculate the derivative wrt PMDEC
@@ -879,10 +876,9 @@ class AstrometryEcliptic(Astrometry):
         ) - np.cos(psr_elat) * np.sin(rd["earth_elat"])
 
         deriv = rd["ssb_obs_r"] * geom * te / (const.c * u.radian)
-        dd_dpmelat = deriv * u.mas / u.year
 
         # We want to return sec / (mas / yr)
-        return dd_dpmelat.decompose(u.si.bases) / (u.mas / u.year)
+        return deriv.to(u.s * u.year / u.mas)
 
     def print_par(self, format="pint"):
         result = ""

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -1973,6 +1973,9 @@ class maskParameter(floatParameter):
         return select_idx[self.name]
 
     def cache_toa_mask(self, toas):
+        """Cache the TOA mask for this parameter. This will lead to exceptions and/or
+        wrong results if the TOAs object is mutated after this.
+        """
         self.__cache_mask = self.select_toa_mask(toas)
         self.__cache_toas = toas
 

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -1977,6 +1977,9 @@ class maskParameter(floatParameter):
         wrong results if the TOAs object is mutated after this. This can be undone using
         the `clear_toa_mask_cache()` method.
         """
+        assert self.select_toa_mask(
+            toas
+        ).any(), f"Empty TOA mask found for {self.name}. Will not cache this."
         self.__cache_mask = self.select_toa_mask(toas)
         self.__cache_toas = toas
 

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -1974,10 +1974,16 @@ class maskParameter(floatParameter):
 
     def cache_toa_mask(self, toas):
         """Cache the TOA mask for this parameter. This will lead to exceptions and/or
-        wrong results if the TOAs object is mutated after this.
+        wrong results if the TOAs object is mutated after this. This can be undone using
+        the `clear_toa_mask_cache()` method.
         """
         self.__cache_mask = self.select_toa_mask(toas)
         self.__cache_toas = toas
+
+    def clear_toa_mask_cache(self):
+        """Clear the TOA mask cache. This will undo a `cache_toa_mask()` call."""
+        self.__cache_mask = None
+        self.__cache_toas = None
 
     def compare_key_value(self, other_param):
         """Compare if the key and value are the same with the other parameter.

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -1739,6 +1739,9 @@ class maskParameter(floatParameter):
         self.is_prefix = True
         self._parfile_name = self.origin_name
 
+        self.__cache_mask = None
+        self.__cache_toas = None
+
     def __repr__(self):
         out = f"{self.__class__.__name__}({self.name}"
         if self.key is not None:
@@ -1931,6 +1934,9 @@ class maskParameter(floatParameter):
         array
             An array of TOA indices selected by the mask.
         """
+        if self.__cache_mask is not None and self.__cache_toas is toas:
+            return self.__cache_mask
+
         if len(self.key_value) == 1:
             if not hasattr(self, "toa_selector"):
                 self.toa_selector = TOASelect(is_range=False, use_hash=True)
@@ -1965,6 +1971,10 @@ class maskParameter(floatParameter):
             col = tbl[column_match[key.lower()]]
         select_idx = self.toa_selector.get_select_index(condition, col)
         return select_idx[self.name]
+
+    def cache_toa_mask(self, toas):
+        self.__cache_mask = self.select_toa_mask(toas)
+        self.__cache_toas = toas
 
     def compare_key_value(self, other_param):
         """Compare if the key and value are the same with the other parameter.

--- a/src/pint/models/stand_alone_psr_binaries/DD_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/DD_model.py
@@ -370,7 +370,7 @@ class DDmodel(PSR_BINARY):
            de/dECC = 1
         """
         eTheta = self.eTheta()
-        a1 = (self.a1()).decompose()
+        a1 = (self.a1()).to(u.m)
         sinOmg = np.sin(self.omega())
         cosOmg = np.cos(self.omega())
         with u.set_enabled_equivalencies(u.dimensionless_angles()):
@@ -392,7 +392,7 @@ class DDmodel(PSR_BINARY):
            de/dEDOT = tt0
         """
         eTheta = self.eTheta()
-        a1 = (self.a1()).decompose()
+        a1 = (self.a1()).to(u.m)
         sinOmg = np.sin(self.omega())
         cosOmg = np.cos(self.omega())
         with u.set_enabled_equivalencies(u.dimensionless_angles()):
@@ -642,7 +642,7 @@ class DDmodel(PSR_BINARY):
                 + 1.0 / 2 * nHat**2 * Dre * Drepp
                 - 1.0 / 2 * e * sinE / (1 - e * cosE) * nHat**2 * Dre * Drep
             )
-        ).decompose()
+        ).to(u.s)
 
     def d_delayI_d_par(self, par):
         """Derivative on delay inverse."""

--- a/src/pint/models/stand_alone_psr_binaries/ELL1_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/ELL1_model.py
@@ -106,7 +106,9 @@ class ELL1BaseModel(PSR_BINARY):
         PB = (self.pb()).to("second")
         PBDOT = self.pbdot()
         ttasc = self.ttasc()
-        return (ttasc / PB - 0.5 * PBDOT * (ttasc / PB) ** 2).decompose()
+        return (ttasc / PB - 0.5 * PBDOT * (ttasc / PB) ** 2).to(
+            u.dimensionless_unscaled
+        )
 
     def d_Phi_d_TASC(self):
         """dPhi/dTASC"""
@@ -162,7 +164,7 @@ class ELL1BaseModel(PSR_BINARY):
         return (
             Dre
             * (1 - nhat * Drep + (nhat * Drep) ** 2 + 1.0 / 2 * nhat**2 * Dre * Drepp)
-        ).decompose()
+        ).to(u.s)
 
     def nhat(self):
         return 2 * np.pi / self.pb()
@@ -319,7 +321,7 @@ class ELL1BaseModel(PSR_BINARY):
         Zhu et al. (2019), Eqn. 1
         Fiore et al. (2023), Eqn. 4
         """
-        return ((self.a1() / c.c) * self.d_delayR_da1()).decompose()
+        return ((self.a1() / c.c) * self.d_delayR_da1()).to(u.s)
 
     def d_Dre_d_par(self, par):
         """Derivative computation.

--- a/src/pint/models/stand_alone_psr_binaries/ELL1k_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/ELL1k_model.py
@@ -130,7 +130,7 @@ class ELL1kmodel(ELL1model):
                 + 0.5
                 * (self.eps2() * np.sin(2 * Phi) - self.eps1() * (np.cos(2 * Phi) + 3))
             )
-        ).decompose()
+        ).to(u.s)
 
     def d_Dre_d_par(self, par):
         """Derivative computation.

--- a/src/pint/models/stand_alone_psr_binaries/binary_generic.py
+++ b/src/pint/models/stand_alone_psr_binaries/binary_generic.py
@@ -381,7 +381,7 @@ class PSR_BINARY:
     def ecc(self):
         """Calculate eccentricity with EDOT"""
         if hasattr(self, "_tt0"):
-            return self.ECC + (self.tt0 * self.EDOT).decompose()
+            return self.ECC + (self.tt0 * self.EDOT).to(u.dimensionless_unscaled)
         return self.ECC
 
     def d_ecc_d_T0(self):

--- a/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
+++ b/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
@@ -100,9 +100,9 @@ class OrbitPB(Orbit):
         PB = self.PB.to("second")
         PBDOT = self.PBDOT
         XPBDOT = self.XPBDOT
-        return (
-            self.tt0 / PB - 0.5 * (PBDOT + XPBDOT) * (self.tt0 / PB) ** 2
-        ).decompose()
+        return (self.tt0 / PB - 0.5 * (PBDOT + XPBDOT) * (self.tt0 / PB) ** 2).to(
+            u.dimensionless_unscaled
+        )
 
     def pbprime(self):
         """Instantaneous binary period as a function of time."""
@@ -183,7 +183,7 @@ class OrbitFBX(Orbit):
     def orbits(self):
         """Orbital phase (number of orbits since T0)."""
         orbits = taylor_horner(self.tt0, self._FBXs())
-        return orbits.decompose()
+        return orbits.to(u.dimensionless_unscaled)
 
     def pbprime(self):
         """Instantaneous binary period as a function of time."""
@@ -213,8 +213,7 @@ class OrbitFBX(Orbit):
                 FBXs.append(1.0 * getattr(self, f"FB{ii}").unit)
                 break
             ii += 1
-        d_orbits = taylor_horner(self.tt0, FBXs) / par.unit
-        return d_orbits.decompose() * 2 * np.pi * u.rad
+        return taylor_horner(self.tt0, FBXs) * 2 * np.pi * (u.rad / par.unit)
 
     def d_pbprime_d_FBX(self, FBX):
         par = getattr(self, FBX)

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -489,10 +489,16 @@ class TimingModel:
     #    return result
 
     def lock(self, toas):
+        """Lock a timing model object for a given TOAs object by caching parameter masks. This can
+        provide significant performance gains when mask parameters are present. However, mutating the
+        TOAs object after calling this function can lead to exceptions or wrong results down the line.
+        """
+
         log.warning(
-            "Locking the TimingModel object for the given TOAs. Mutating this TOAs object or using a "
-            "different TOAs object with this model will lead to undefined behavior."
+            "Locking the TimingModel object for the given TOAs object. This is will lead to "
+            "undefined behavior if the TOAs object is mutated after this."
         )
+
         self.__locked = True
         self.__lock_toas = toas
 

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -489,9 +489,10 @@ class TimingModel:
     #    return result
 
     def lock(self, toas):
-        """Lock a timing model object for a given TOAs object by caching parameter masks. This can
-        provide significant performance gains when mask parameters are present. However, mutating the
-        TOAs object after calling this function can lead to exceptions or wrong results down the line.
+        """Lock a timing model object for a given TOAs object by caching parameter masks. This also
+        allows us to do other optimizations such as skipping TOA error checks. This can provide significant
+        performance gains when mask parameters are present. However, mutating the TOAs object after calling
+        this function can lead to exceptions or wrong results down the line.
         """
 
         log.warning(
@@ -517,6 +518,7 @@ class TimingModel:
         return self.__locked
 
     def unlock(self):
+        """Undo the lock() call."""
         self.__locked = False
         self.__lock_toas = None
 

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -349,6 +349,9 @@ class TimingModel:
         for cp in components:
             self.add_component(cp, setup=False, validate=False)
 
+        self.__locked = False
+        self.__lock_toas = None
+
     def __repr__(self):
         return "{}(\n  {}\n)".format(
             self.__class__.__name__,
@@ -484,6 +487,19 @@ class TimingModel:
     #        for pp in cp.params:
     #            result += str(getattr(cp, pp)) + "\n"
     #    return result
+
+    def lock(self, toas):
+        log.warning(
+            "Locking the TimingModel object for the given TOAs. Mutating this TOAs object or using a "
+            "different TOAs object with this model will lead to undefined behavior."
+        )
+        self.__locked = True
+        self.__lock_toas = toas
+
+        for mp in self.get_params_of_type_top("maskParameter"):
+            mpar = getattr(self, mp)
+            if mpar.key is not None:
+                mpar.cache_toa_mask(toas)
 
     def __getattr__(self, name):
         if name in ["components", "component_types", "search_cmp_attr"]:

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -506,7 +506,7 @@ class Residuals:
         If the system is singular, it uses singular value decomposition instead."""
         self.update()
 
-        residuals = self.time_resids.to(u.s).value
+        residuals = self.time_resids.to_value(u.s)
 
         M = self.model.noise_model_designmatrix(self.toas)
         phi = self.model.noise_model_basis_weight(self.toas)
@@ -520,7 +520,7 @@ class Residuals:
         M, norm = normalize_designmatrix(M, None)
 
         phiinv /= norm**2
-        Nvec = self.model.scaled_toa_uncertainty(self.toas).to(u.s).value ** 2
+        Nvec = self.model.scaled_toa_uncertainty(self.toas).to_value(u.s) ** 2
         cinv = 1 / Nvec
         mtcm = np.dot(M.T, cinv[:, None] * M)
         mtcm += np.diag(phiinv)
@@ -763,10 +763,11 @@ class WidebandDMResiduals(Residuals):
         data_errors = self.get_data_error()
         if (data_errors == 0.0).any():
             return np.inf
-        try:
-            return ((self.resids / data_errors) ** 2.0).sum().decompose().value
-        except ValueError:
-            return ((self.resids / data_errors) ** 2.0).sum().decompose()
+        return (
+            ((self.resids / data_errors) ** 2.0)
+            .sum()
+            .to_value(u.dimensionless_unscaled)
+        )
 
     def rms_weighted(self):
         """Compute weighted RMS of the residuals in time."""

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -582,10 +582,11 @@ class Residuals:
 
             # This the fastest way, but highly depend on the assumption of time_resids and
             # error units. Ensure only a pure number is returned.
-            try:
-                return ((self.time_resids / toa_errors.to(u.s)) ** 2.0).sum().value
-            except ValueError:
-                return ((self.time_resids / toa_errors.to(u.s)) ** 2.0).sum()
+            return (
+                ((self.time_resids / toa_errors) ** 2.0)
+                .sum()
+                .to_value(u.dimensionless_unscaled)
+            )
 
     def ecorr_average(self, use_noise_model=True):
         """Uses the ECORR noise model time-binning to compute "epoch-averaged" residuals.

--- a/tests/test_mask_cache.py
+++ b/tests/test_mask_cache.py
@@ -1,0 +1,19 @@
+from pinttestdata import datadir
+from pint.models import get_model_and_toas
+from pint.residuals import Residuals
+
+
+def test_mask_cache():
+    model, toas = get_model_and_toas(
+        datadir / "J1713+0747_small.gls.par", datadir / "J1713+0747_small.tim"
+    )
+
+    res1 = Residuals(toas, model)
+    chi2_1 = res1.calc_chi2()
+
+    model.lock(toas)
+
+    res2 = Residuals(toas, model)
+    chi2_2 = res2.calc_chi2()
+
+    assert chi2_1 == chi2_2

--- a/tests/test_mask_cache.py
+++ b/tests/test_mask_cache.py
@@ -1,6 +1,7 @@
 from pinttestdata import datadir
 from pint.models import get_model_and_toas
 from pint.residuals import Residuals
+import pytest
 
 
 def test_mask_cache():
@@ -12,8 +13,14 @@ def test_mask_cache():
     chi2_1 = res1.calc_chi2()
 
     model.lock(toas)
-
     res2 = Residuals(toas, model)
     chi2_2 = res2.calc_chi2()
-
     assert chi2_1 == chi2_2
+
+    model.unlock()
+    chi2_3 = res1.calc_chi2()
+    assert chi2_1 == chi2_3
+
+    toas.table["error"][0] = 0
+    with pytest.raises(ValueError):
+        model.lock(toas)


### PR DESCRIPTION
1. Change `Quantity.decompose()` to `Quantity.to()` --- see #1641 
2. Optionally cache parameter masks.
3. Minimize Quantity operations in `ScaleToaError.scale_toa_sigma`

Item 1 gives a slight performance advantage (~5%) overall.

Item 2 gives almost 10x improvement in timing models where maskParameters (e.g. JUMPs) are present. The caching is of course turned off by default, and can be enabled by calling `model.lock(toas)`. Mutating the `toas` object after calling `model.lock(toas)` leads to undefined behavior (in practice, some unhelpful exception down the line in the best case scenario, and wrong result in the worst case scenario).

Item 3 gives around 40% improvement in models where ScaleToaError is present.

These performance improvements are important for Bayesian timing & noise analysis (#1407) and frequentist noise estimation (#1639).