### PR TITLE
`pintk` can swap inputs

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -29,6 +29,7 @@ the released changes.
 - Piecewise orbital model (`BinaryBTPiecewise`)
 - `TimingModel.fittable_params` property
 - Simulate correlated noise using `pint.simulation` (also available via the `zima` script)
+- `pintk` will recognize when timfile and parfile inputs are switched and swap them
 ### Fixed
 - Wave model `validate()` can correctly use PEPOCH to assign WAVEEPOCH parameter
 - Fixed RTD by specifying theme explicitly.

--- a/src/pint/scripts/pintk.py
+++ b/src/pint/scripts/pintk.py
@@ -3,11 +3,13 @@
 import argparse
 
 import sys
+import os
 
 import tkinter as tk
 import tkinter.filedialog as tkFileDialog
 import tkinter.messagebox as tkMessageBox
 import matplotlib as mpl
+from loguru import logger as log
 
 import pint.logging
 
@@ -260,6 +262,24 @@ def main(argv=None):
     pint.logging.setup(
         level=pint.logging.get_level(args.loglevel, args.verbosity, args.quiet)
     )
+    # see if the arguments were flipped
+    if (
+        os.path.splitext(args.parfile)[1] == ".tim"
+        and os.path.splitext(args.timfile)[1] == ".par"
+    ):
+        log.debug(
+            f"Swapping inputs: parfile='{args.timfile}' and timfile='{args.parfile}'"
+        )
+        args.parfile, args.timfile = args.timfile, args.parfile
+    else:
+        if os.path.splitext(args.timfile)[1] != ".tim":
+            log.info(
+                f"Input timfile '{args.timfile}' has unusual extension '{os.path.splitext(args.timfile)[1]}': is this intended?"
+            )
+        if os.path.splitext(args.parfile)[1] != ".par":
+            log.info(
+                f"Input parfile '{args.parfile}' has unusual extension '{os.path.splitext(args.parfile)[1]}': is this intended?"
+            )
 
     root = tk.Tk()
     root.minsize(1000, 800)


### PR DESCRIPTION
Previously if you fed `pintk` the timfile and parfile in the wrong order, it would fail with an opaque message:
```
(pintdev) kaplan@plock[~/pythonpackages/PINT_dlakaplan] (master) % pintk tests/datafile/NGC6440E.tim tests/datafile/NGC6440E.par -vv
INFO     (pint.pintk.pulsar             ): Loading pulsar parfile: tests/datafile/NGC6440E.tim                                      
Traceback (most recent call last):
  File "/Users/kaplan/opt/anaconda3/envs/pintdev/bin/pintk", line 33, in <module>
    sys.exit(load_entry_point('pint-pulsar', 'console_scripts', 'pintk')())
  File "/Users/kaplan/pythonpackages/PINT_dlakaplan/src/pint/scripts/pintk.py", line 267, in main
    app = PINTk(
  File "/Users/kaplan/pythonpackages/PINT_dlakaplan/src/pint/scripts/pintk.py", line 51, in __init__
    self.openPulsar(
  File "/Users/kaplan/pythonpackages/PINT_dlakaplan/src/pint/scripts/pintk.py", line 153, in openPulsar
    self.psr = Pulsar(parfile, timfile, ephem, fitter=fitter)
  File "/Users/kaplan/pythonpackages/PINT_dlakaplan/src/pint/pintk/pulsar.py", line 74, in __init__
    self.prefit_model = pint.models.get_model(self.parfile)
  File "/Users/kaplan/pythonpackages/PINT_dlakaplan/src/pint/models/model_builder.py", line 708, in get_model
    model = model_builder(
  File "/Users/kaplan/pythonpackages/PINT_dlakaplan/src/pint/models/model_builder.py", line 187, in __call__
    self._setup_model(
  File "/Users/kaplan/pythonpackages/PINT_dlakaplan/src/pint/models/model_builder.py", line 646, in _setup_model
    timing_model.validate(allow_tcb=allow_tcb)
  File "/Users/kaplan/pythonpackages/PINT_dlakaplan/src/pint/models/timing_model.py", line 433, in validate
    self.validate_component_types()
  File "/Users/kaplan/pythonpackages/PINT_dlakaplan/src/pint/models/timing_model.py", line 456, in validate_component_types
    assert (
AssertionError: Model must have one and only one spindown component (Spindown or another subclass of SpindownBase).
```
Now it will look and if the extensions are flipped, it will swap the inputs:
```
(pintdev) kaplan@plock[~/pythonpackages/PINT_dlakaplan] (pintkargs) % pintk tests/datafile/NGC6440E.tim tests/datafile/NGC6440E.par -vv
DEBUG    (pint.scripts.pintk            ): Swapping inputs: parfile='tests/datafile/NGC6440E.par' and timfile='tests/datafile/NGC6440E.tim'
```
If the extensions otherwise don't match the expected values it will note that as `log.INFO` but still try to proceed.  This could still be used as a clue that there is something wrong if `pintk` fails.