### PR TITLE
Disabled axes for pintk when not in timing model or data

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -49,4 +49,5 @@ the released changes.
 - `TimingModel.designmatrix()` method will fail with an informative error message if there are free unfittable parameters in the timing model.
 - `make_fake_toas_uniform` and `make_fake_toas_fromMJDs` respects units of errors
 - Robust access of EPHEM and PLANET_SHAPIRO in `make_fake_toas_fromtim`
+- `pintk` will not allow choices of axes that are not in timing model
 ### Removed

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -49,5 +49,6 @@ the released changes.
 - `TimingModel.designmatrix()` method will fail with an informative error message if there are free unfittable parameters in the timing model.
 - `make_fake_toas_uniform` and `make_fake_toas_fromMJDs` respects units of errors
 - Robust access of EPHEM and PLANET_SHAPIRO in `make_fake_toas_fromtim`
-- `pintk` will not allow choices of axes that are not in timing model
+- `pintk` will not allow choices of axes that are not in timing model/data
+- `pintk` correctly displays initial log level
 ### Removed

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -19,6 +19,7 @@ the released changes.
 - Only fittable parameters will be listed as check boxes in the `plk` interface.
 - Update CI tests for Python 3.12
 - Made `test_grid` routines faster
+- `pintk` uses downhill fitters by default
 ### Added
 - CHI2, CHI2R, TRES, DMRES now in postfit par files
 - Added `WaveX` model as a `DelayComponent` with Fourier amplitudes as fitted parameters

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -20,7 +20,6 @@ the released changes.
 - Update CI tests for Python 3.12
 - Made `test_grid` routines faster
 - `pintk` uses downhill fitters by default
-- `is_binary` attribute now uses component inheritance
 ### Added
 - CHI2, CHI2R, TRES, DMRES now in postfit par files
 - Added `WaveX` model as a `DelayComponent` with Fourier amplitudes as fitted parameters

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -20,6 +20,7 @@ the released changes.
 - Update CI tests for Python 3.12
 - Made `test_grid` routines faster
 - `pintk` uses downhill fitters by default
+- `is_binary` attribute now uses component inheritance
 ### Added
 - CHI2, CHI2R, TRES, DMRES now in postfit par files
 - Added `WaveX` model as a `DelayComponent` with Fourier amplitudes as fitted parameters

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -773,7 +773,10 @@ class TimingModel:
     @property_exists
     def is_binary(self):
         """Does the model describe a binary pulsar?"""
-        return any(x.startswith("Binary") for x in self.components.keys())
+        # need to import here to avoid circular imports
+        from pint.models.pulsar_binary import PulsarBinary
+
+        return any(isinstance(x, PulsarBinary) for x in self.components.keys())
 
     def orbital_phase(self, barytimes, anom="mean", radians=True):
         """Return orbital phase (in radians) at barycentric MJD times.

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -773,10 +773,7 @@ class TimingModel:
     @property_exists
     def is_binary(self):
         """Does the model describe a binary pulsar?"""
-        # need to import here to avoid circular imports
-        from pint.models.pulsar_binary import PulsarBinary
-
-        return any(isinstance(x, PulsarBinary) for x in self.components.keys())
+        return any(x.startswith("Binary") for x in self.components.keys())
 
     def orbital_phase(self, barytimes, anom="mean", radians=True):
         """Return orbital phase (in radians) at barycentric MJD times.

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -14,6 +14,8 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 
 import pint.pintk.pulsar as pulsar
 import pint.pintk.colormodes as cm
+from pint.models.pulsar_binary import PulsarBinary
+from pint.models.astrometry import Astrometry
 
 import tkinter as tk
 import tkinter.filedialog as tkFileDialog
@@ -529,14 +531,16 @@ class PlkXYChoiceWidget(tk.Frame):
                 if self.master.psr.fitted
                 else self.master.psr.prefit_model
             )
-            if choice == "elongation":
-                if not any(x.startswith("Astrometry") for x in model.components):
-                    self.xbuttons[ii].configure(state="disabled")
-                    self.ybuttons[ii].configure(state="disabled")
-            if choice == "orbital phase":
-                if not any(x.startswith("Binary") for x in model.components):
-                    self.xbuttons[ii].configure(state="disabled")
-                    self.ybuttons[ii].configure(state="disabled")
+            if choice == "elongation" and not any(
+                isinstance(x, Astrometry) for x in model.components
+            ):
+                self.xbuttons[ii].configure(state="disabled")
+                self.ybuttons[ii].configure(state="disabled")
+            elif choice == "orbital phase" and not any(
+                isinstance(x, PulsarBinary) for x in model.components
+            ):
+                self.xbuttons[ii].configure(state="disabled")
+                self.ybuttons[ii].configure(state="disabled")
             if choice == "frequency" and (
                 (len(np.unique(self.master.psr.all_toas["freq"])) <= 1)
                 or np.any(np.isinf(self.master.psr.all_toas["freq"]))

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -524,31 +524,18 @@ class PlkXYChoiceWidget(tk.Frame):
             if choice.lower() == yid:
                 self.ybuttons[ii].select()
 
+            model = (
+                self.master.psr.postfit_model
+                if self.master.psr.fitted
+                else self.master.psr.prefit_model
+            )
             if choice == "elongation":
-                if not any(
-                    x.startswith("Astrometry")
-                    for x in self.master.psr.prefit_model.components
-                ):
+                if not any(x.startswith("Astrometry") for x in model.components):
                     self.xbuttons[ii].configure(state="disabled")
-                    if not self.master.psr.fitted:
-                        self.ybuttons[ii].configure(state="disabled")
-                if self.master.psr.fitted and not any(
-                    x.startswith("Astrometry")
-                    for x in self.master.psr.pstfit_model.components
-                ):
                     self.ybuttons[ii].configure(state="disabled")
             if choice == "orbital phase":
-                if not any(
-                    x.startswith("Binary")
-                    for x in self.master.psr.prefit_model.components
-                ):
+                if not any(x.startswith("Binary") for x in model.components):
                     self.xbuttons[ii].configure(state="disabled")
-                    if not self.master.psr.fitted:
-                        self.ybuttons[ii].configure(state="disabled")
-                if self.master.psr.fitted and not any(
-                    x.startswith("Binary")
-                    for x in self.master.psr.prefit_model.components
-                ):
                     self.ybuttons[ii].configure(state="disabled")
             if choice == "frequency" and (
                 (len(np.unique(self.master.psr.all_toas["freq"])) <= 1)

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -524,6 +524,38 @@ class PlkXYChoiceWidget(tk.Frame):
             if choice.lower() == yid:
                 self.ybuttons[ii].select()
 
+            if choice == "elongation":
+                if not any(
+                    x.startswith("Astrometry")
+                    for x in self.master.psr.prefit_model.components
+                ):
+                    self.xbuttons[ii].configure(state="disabled")
+                    if not self.master.psr.fitted:
+                        self.ybuttons[ii].configure(state="disabled")
+                if self.master.psr.fitted and not any(
+                    x.startswith("Astrometry")
+                    for x in self.master.psr.pstfit_model.components
+                ):
+                    self.ybuttons[ii].configure(state="disabled")
+            if choice == "orbital phase":
+                if not any(
+                    x.startswith("Binary")
+                    for x in self.master.psr.prefit_model.components
+                ):
+                    self.xbuttons[ii].configure(state="disabled")
+                    if not self.master.psr.fitted:
+                        self.ybuttons[ii].configure(state="disabled")
+                if self.master.psr.fitted and not any(
+                    x.startswith("Binary")
+                    for x in self.master.psr.prefit_model.components
+                ):
+                    self.ybuttons[ii].configure(state="disabled")
+            if choice == "frequency" and (
+                len(np.unique(self.master.psr.all_toas["frequency"])) <= 1
+            ):
+                self.xbuttons[ii].configure(state="disabled")
+                self.ybuttons[ii].configure(state="disabled")
+
     def setCallbacks(self, updatePlot):
         """
         Set the callback functions

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -551,7 +551,8 @@ class PlkXYChoiceWidget(tk.Frame):
                 ):
                     self.ybuttons[ii].configure(state="disabled")
             if choice == "frequency" and (
-                len(np.unique(self.master.psr.all_toas["frequency"])) <= 1
+                (len(np.unique(self.master.psr.all_toas["freq"])) <= 1)
+                or np.any(np.isinf(self.master.psr.all_toas["freq"]))
             ):
                 self.xbuttons[ii].configure(state="disabled")
                 self.ybuttons[ii].configure(state="disabled")

--- a/src/pint/pintk/plk.py
+++ b/src/pint/pintk/plk.py
@@ -14,7 +14,6 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 
 import pint.pintk.pulsar as pulsar
 import pint.pintk.colormodes as cm
-from pint.models.pulsar_binary import PulsarBinary
 from pint.models.astrometry import Astrometry
 
 import tkinter as tk
@@ -536,9 +535,7 @@ class PlkXYChoiceWidget(tk.Frame):
             ):
                 self.xbuttons[ii].configure(state="disabled")
                 self.ybuttons[ii].configure(state="disabled")
-            elif choice == "orbital phase" and not any(
-                isinstance(x, PulsarBinary) for x in model.components
-            ):
+            elif choice == "orbital phase" and not model.is_binary:
                 self.xbuttons[ii].configure(state="disabled")
                 self.ybuttons[ii].configure(state="disabled")
             if choice == "frequency" and (

--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -104,7 +104,7 @@ class Pulsar:
         )
         # Set of indices from original list that are deleted
         self.deleted = set([])
-        if fitter == "auto":
+        if fitter == "notdownhill":
             self.fit_method = self.getDefaultFitter(downhill=False)
             log.info(
                 f"Since wideband={self.all_toas.wideband} and correlated={self.prefit_model.has_correlated_errors}, selecting fitter={self.fit_method}"

--- a/src/pint/scripts/pintk.py
+++ b/src/pint/scripts/pintk.py
@@ -270,7 +270,7 @@ def main(argv=None):
             timfile=args.timfile,
             fitter=args.fitter,
             ephem=args.ephem,
-            loglevel=args.loglevel,
+            loglevel=pint.logging.get_level(args.loglevel, args.verbosity, args.quiet),
         )
         root.protocol("WM_DELETE_WINDOW", root.destroy)
         img = tk.Image("photo", file=pint.pintk.plk.icon_img)

--- a/src/pint/scripts/pintk.py
+++ b/src/pint/scripts/pintk.py
@@ -223,7 +223,7 @@ def main(argv=None):
         "--fitter",
         type=str,
         choices=(
-            "auto",
+            "notdownhill",
             "downhill",
             "WLSFitter",
             "GLSFitter",
@@ -234,8 +234,8 @@ def main(argv=None):
             "WidebandDownhillFitter",
             "WidebandLMFitter",
         ),
-        default="auto",
-        help="PINT Fitter to use [default='auto'].  'auto' will choose WLS/GLS/WidebandTOA depending on TOA/model properties.  'downhill' will do the same for Downhill versions.",
+        default="downhill",
+        help="PINT Fitter to use [default='downhill'].  'notdownhill' will choose WLS/GLS/WidebandTOA depending on TOA/model properties.  'downhill' will do the same for Downhill versions.",
     )
     parser.add_argument(
         "--version",

--- a/src/pint/scripts/pintk.py
+++ b/src/pint/scripts/pintk.py
@@ -33,7 +33,7 @@ class PINTk:
         master,
         parfile=None,
         timfile=None,
-        fitter="auto",
+        fitter="downhill",
         ephem=None,
         loglevel=None,
         **kwargs,
@@ -151,7 +151,7 @@ class PINTk:
                 self.mainFrame.grid_columnconfigure(col, weight=1)
                 visible += 1
 
-    def openPulsar(self, parfile, timfile, fitter="auto", ephem=None):
+    def openPulsar(self, parfile, timfile, fitter="downhill", ephem=None):
         self.psr = Pulsar(parfile, timfile, ephem, fitter=fitter)
         self.widgets["plk"].setPulsar(
             self.psr,


### PR DESCRIPTION
* Disabled "elongation" axes when no Astrometry component present
* Disabled "orbital phase" axes when no Binary component present
* Disabled "frequency" axes when <=1 frequency value present or when frequencies are not finite
* Also changed default `pintk` fitters to downhill versions (#1665)
* Also changed general `is_binary` property to rely on class inheritance rather than component name

Example on a barycentered dataset (so no Astrometry or Binary component and all event data):
<img width="141" alt="Screen Shot 2023-10-23 at 12 43 27 PM" src="https://github.com/nanograv/PINT/assets/5092062/b17e18a2-b6e7-4340-8eca-b9c302292bb5">
