### PR TITLE
More realistic simulation of narrowband TOAs of multiple frequencies

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -20,6 +20,7 @@ the released changes.
 - Update CI tests for Python 3.12
 - Made `test_grid` routines faster
 - `pintk` uses downhill fitters by default
+- Optionally generate multi-frequency TOAs in an epoch using `make_fake_toas_uniform`
 ### Added
 - CHI2, CHI2R, TRES, DMRES now in postfit par files
 - Added `WaveX` model as a `DelayComponent` with Fourier amplitudes as fitted parameters

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -20,7 +20,6 @@ the released changes.
 - Update CI tests for Python 3.12
 - Made `test_grid` routines faster
 - `pintk` uses downhill fitters by default
-- Optionally generate multi-frequency TOAs in an epoch using `make_fake_toas_uniform`
 ### Added
 - CHI2, CHI2R, TRES, DMRES now in postfit par files
 - Added `WaveX` model as a `DelayComponent` with Fourier amplitudes as fitted parameters
@@ -43,6 +42,7 @@ the released changes.
 - `ScaleToaError.register_toasigma_deriv_funcs` method to populate derivatives of scaled TOA uncertainties.
 - `ScaleToaError.d_toasigma_d_EFAC` and `ScaleToaError.d_toasigma_d_EQUAD` methods.
 - Separate `.fullname` for all observatories
+- Optionally generate multi-frequency TOAs in an epoch using `make_fake_toas_uniform` and `make_fake_toas_fromMJDs`
 ### Fixed
 - Wave model `validate()` can correctly use PEPOCH to assign WAVEEPOCH parameter
 - Fixed RTD by specifying theme explicitly.

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -43,6 +43,7 @@ the released changes.
 - `ScaleToaError.d_toasigma_d_EFAC` and `ScaleToaError.d_toasigma_d_EQUAD` methods.
 - Separate `.fullname` for all observatories
 - Optionally generate multi-frequency TOAs in an epoch using `make_fake_toas_uniform` and `make_fake_toas_fromMJDs`
+- Documentation: Example notebook for simulations
 ### Fixed
 - Wave model `validate()` can correctly use PEPOCH to assign WAVEEPOCH parameter
 - Fixed RTD by specifying theme explicitly.

--- a/docs/examples/simulation_example.py
+++ b/docs/examples/simulation_example.py
@@ -111,10 +111,9 @@ plt.show()
 
 # %% [markdown]
 # The same thing can be achieved in the command line using
-# the following command::
+# the following command:
 #
-#       $ zima --startMJD 54000 --ntoa 100 --duration 2000 --obs gbt \
-#           --freq 1400 --error 1 --addnoise test.par test.tim
+#       $ zima --startMJD 54000 --ntoa 100 --duration 2000 --obs gbt --freq 1400 --error 1 --addnoise test.par test.tim
 
 # %% [markdown]
 # ## Multiple frequency example
@@ -213,11 +212,9 @@ plt.show()
 
 # %% [markdown]
 # The same thing can be achieved in the command line using
-# the following command::
+# the following command:
 #
-#       $ zima --startMJD 54000 --ntoa 100 --duration 2000 --obs gbt \
-#           --freq 1000 1333.33 1666.67 2000 --error 1 --addnoise --multifreq \
-#           test.par test.tim
+#       $ zima --startMJD 54000 --ntoa 100 --duration 2000 --obs gbt --freq 1000 1333.33 1666.67 2000 --error 1 --addnoise --multifreq test.par test.tim
 
 # %% [markdown]
 # ## Correlated noise simulation example
@@ -281,11 +278,9 @@ plt.show()
 
 # %% [markdown]
 # The same thing can be achieved in the command line using
-# the following command::
+# the following command:
 #
-#       $ zima --startMJD 54000 --ntoa 100 --duration 2000 --obs gbt \
-#           --freq 1400 --error 1 --addnoise --addcorrnoise \
-#           test.par test.tim
+#       $ zima --startMJD 54000 --ntoa 100 --duration 2000 --obs gbt --freq 1400 --error 1 --addnoise --addcorrnoise test.par test.tim
 
 # %% [markdown]
 # ## Wideband TOA simulation example
@@ -364,9 +359,7 @@ plt.show()
 # The same thing can be achieved in the command line using
 # the following command::
 #
-#       $ zima --startMJD 54000 --ntoa 100 --duration 2000 --obs gbt \
-#           --freq 1400 --error 1 --addnoise --wideband --dmerror 1e-5 \
-#           test.par test.tim
+#       $ zima --startMJD 54000 --ntoa 100 --duration 2000 --obs gbt --freq 1400 --error 1 --addnoise --wideband --dmerror 1e-5 test.par test.tim
 
 # %% [markdown]
 # ## Simulating TOAs based on a tim file
@@ -400,5 +393,4 @@ plt.show()
 # The same thing can be achieved in the command line using
 # the following command::
 #
-#       $ zima --inputtim B1855+09_NANOGrav_9yv1.tim --addnoise \
-#           test.par test.tim
+#       $ zima --inputtim B1855+09_NANOGrav_9yv1.tim --addnoise test.par test.tim

--- a/docs/examples/simulation_example.py
+++ b/docs/examples/simulation_example.py
@@ -1,12 +1,11 @@
 # %% [markdown]
 # # Demonstrate TOA simulation using PINT
 
-# %% [markdown]
+# %%
 from pint.models import get_model
 from pint.simulation import (
     make_fake_toas_uniform,
     make_fake_toas_fromtim,
-    make_fake_toas_fromMJDs,
 )
 from pint.residuals import Residuals, WidebandTOAResiduals
 from pint.logging import setup as setup_log

--- a/docs/examples/simulation_example.py
+++ b/docs/examples/simulation_example.py
@@ -1,0 +1,405 @@
+# %% [markdown]
+# # Demonstrate TOA simulation using PINT
+
+# %% [markdown]
+from pint.models import get_model
+from pint.simulation import (
+    make_fake_toas_uniform,
+    make_fake_toas_fromtim,
+    make_fake_toas_fromMJDs,
+)
+from pint.residuals import Residuals, WidebandTOAResiduals
+from pint.logging import setup as setup_log
+from pint import dmu
+from pint.config import examplefile
+
+import numpy as np
+import matplotlib.pyplot as plt
+import astropy.units as u
+import io
+
+# Turn logging level to warnings and above
+setup_log(level="WARNING")
+
+# %% [markdown]
+# ## Basic example
+
+# %%
+# First, let us create a simple model from which we will simulate TOAs.
+m = get_model(
+    io.StringIO(
+        """
+        RAJ             05:00:00
+        DECJ            20:00:00
+        PEPOCH          55000
+        F0              100
+        F1              -1e-14
+        DM              15
+        PHOFF           0
+        EFAC tel gbt    1.5
+        TZRMJD          55000
+        TZRFRQ          1400
+        TZRSITE         gbt
+        EPHEM           DE440
+        CLOCK           TT(BIPM2019)
+        UNITS           TDB
+        """
+    )
+)
+
+# %%
+# The simplest type of simulation we can do is narrowband TOAs with uniformly
+# spaced epochs (one TOA per epoch) with a single frequency and equal TOA uncertainties.
+tsim = make_fake_toas_uniform(
+    model=m,
+    startMJD=54000,
+    endMJD=56000,
+    ntoas=100,
+    freq=1400 * u.MHz,
+    obs="gbt",
+    error=1 * u.us,
+    include_bipm=True,
+    include_gps=True,
+)
+
+# %%
+# Let us try plotting the residuals
+res = Residuals(tsim, m)
+
+plt.errorbar(
+    tsim.get_mjds(),
+    res.time_resids.to_value("us"),
+    res.get_data_error().to_value("us"),
+    marker="+",
+    ls="",
+)
+plt.xlabel("MJD")
+plt.ylabel("Residuals (us)")
+plt.show()
+
+# %% [markdown]
+# Here we see that the TOAs don't have the expected white
+# noise. The noise should be 1.5 us, including the EFAC.
+# The noise can be included by using the `add_noise` option.
+
+# %%
+tsim = make_fake_toas_uniform(
+    model=m,
+    startMJD=54000,
+    endMJD=56000,
+    ntoas=100,
+    freq=1400 * u.MHz,
+    obs="gbt",
+    error=1 * u.us,
+    include_bipm=True,
+    include_gps=True,
+    add_noise=True,
+)
+
+# %%
+res = Residuals(tsim, m)
+
+plt.errorbar(
+    tsim.get_mjds(),
+    res.time_resids.to_value("us"),
+    res.get_data_error().to_value("us"),
+    marker="+",
+    ls="",
+)
+plt.xlabel("MJD")
+plt.ylabel("Residuals (us)")
+plt.show()
+
+# %% [markdown]
+# The same thing can be achieved in the command line using
+# the following command::
+#
+#       $ zima --startMJD 54000 --ntoa 100 --duration 2000 --obs gbt \
+#           --freq 1400 --error 1 --addnoise test.par test.tim
+
+# %% [markdown]
+# ## Multiple frequency example
+#
+# Multiple frequency TOAs can be simulated by passing an array of frequencies
+# into the `freq` parameter.
+
+# %%
+freqs = np.linspace(1000, 2000, 4) * u.MHz
+tsim = make_fake_toas_uniform(
+    model=m,
+    startMJD=54000,
+    endMJD=56000,
+    ntoas=100,
+    freq=freqs,
+    obs="gbt",
+    error=1 * u.us,
+    include_bipm=True,
+    include_gps=True,
+    add_noise=True,
+)
+
+# %%
+res = Residuals(tsim, m)
+
+plt.subplot(211)
+plt.errorbar(
+    tsim.get_mjds(),
+    res.time_resids.to_value("us"),
+    res.get_data_error().to_value("us"),
+    marker="+",
+    ls="",
+)
+plt.xlabel("MJD")
+plt.ylabel("Residuals (us)")
+
+plt.subplot(212)
+plt.errorbar(
+    tsim.get_freqs(),
+    res.time_resids.to_value("us"),
+    res.get_data_error().to_value("us"),
+    marker="+",
+    ls="",
+)
+plt.xlabel("Freq (MHz)")
+plt.ylabel("Residuals (us)")
+plt.show()
+
+# %% [markdown]
+# We see that the frequencies are distributed amongst epochs such that
+# there is only one TOA per epoch. To distribute the TOAs such that each
+# epoch contains all frequencies, use the `multi_freqs_in_epoch` option.
+# Note that this option doesn't change the total number of TOAs.
+
+# %%
+freqs = np.linspace(1000, 2000, 4) * u.MHz
+tsim = make_fake_toas_uniform(
+    model=m,
+    startMJD=54000,
+    endMJD=56000,
+    ntoas=100,
+    freq=freqs,
+    obs="gbt",
+    error=1 * u.us,
+    include_bipm=True,
+    include_gps=True,
+    add_noise=True,
+    multi_freqs_in_epoch=True,
+)
+
+# %%
+res = Residuals(tsim, m)
+
+plt.subplot(211)
+plt.errorbar(
+    tsim.get_mjds(),
+    res.time_resids.to_value("us"),
+    res.get_data_error().to_value("us"),
+    marker="+",
+    ls="",
+)
+plt.xlabel("MJD")
+plt.ylabel("Residuals (us)")
+
+plt.subplot(212)
+plt.errorbar(
+    tsim.get_freqs(),
+    res.time_resids.to_value("us"),
+    res.get_data_error().to_value("us"),
+    marker="+",
+    ls="",
+)
+plt.xlabel("Freq(MHz)")
+plt.ylabel("Residuals (us)")
+plt.show()
+
+# %% [markdown]
+# The same thing can be achieved in the command line using
+# the following command::
+#
+#       $ zima --startMJD 54000 --ntoa 100 --duration 2000 --obs gbt \
+#           --freq 1000 1333.33 1666.67 2000 --error 1 --addnoise --multifreq \
+#           test.par test.tim
+
+# %% [markdown]
+# ## Correlated noise simulation example
+#
+# If there is a correlated noise component in the timing model,
+# an instance of that noise can be injected into the TOAs using
+# the `add_correlated_noise` option.
+
+# %%
+m1 = get_model(
+    io.StringIO(
+        """
+        RAJ             05:00:00
+        DECJ            20:00:00
+        PEPOCH          55000
+        F0              100
+        F1              -1e-14
+        DM              15
+        PHOFF           0
+        EFAC tel gbt    1.5
+        TNREDAMP        -13
+        TNREDGAM        4
+        TZRMJD          55000
+        TZRFRQ          1400
+        TZRSITE         gbt
+        EPHEM           DE440
+        CLOCK           TT(BIPM2019)
+        UNITS           TDB
+        """
+    )
+)
+
+tsim = make_fake_toas_uniform(
+    model=m1,
+    startMJD=54000,
+    endMJD=56000,
+    ntoas=100,
+    freq=1400 * u.MHz,
+    obs="gbt",
+    error=1 * u.us,
+    include_bipm=True,
+    include_gps=True,
+    add_noise=True,
+    add_correlated_noise=True,
+)
+
+
+# %%
+res = Residuals(tsim, m1)
+
+plt.errorbar(
+    tsim.get_mjds(),
+    res.time_resids.to_value("us"),
+    res.get_data_error().to_value("us"),
+    marker="+",
+    ls="",
+)
+plt.xlabel("MJD")
+plt.ylabel("Residuals (us)")
+plt.show()
+
+# %% [markdown]
+# The same thing can be achieved in the command line using
+# the following command::
+#
+#       $ zima --startMJD 54000 --ntoa 100 --duration 2000 --obs gbt \
+#           --freq 1400 --error 1 --addnoise --addcorrnoise \
+#           test.par test.tim
+
+# %% [markdown]
+# ## Wideband TOA simulation example
+#
+# Wideband TOAs can be simulated using the `wideband` option.
+# The white noise RMS for the wideband DMs is controlled using
+# the `wideband_dm_error` parameter.
+
+# %%
+m2 = get_model(
+    io.StringIO(
+        """
+        RAJ             05:00:00
+        DECJ            20:00:00
+        PEPOCH          55000
+        F0              100
+        F1              -1e-14
+        DMEPOCH         55000
+        DM              15
+        DM1             1
+        DM2             0.5
+        PHOFF           0
+        EFAC tel gbt    1.5
+        TZRMJD          55000
+        TZRFRQ          1400
+        TZRSITE         gbt
+        EPHEM           DE440
+        CLOCK           TT(BIPM2019)
+        UNITS           TDB
+        """
+    )
+)
+
+tsim = make_fake_toas_uniform(
+    model=m2,
+    startMJD=54000,
+    endMJD=56000,
+    ntoas=100,
+    freq=1400 * u.MHz,
+    obs="gbt",
+    error=1 * u.us,
+    include_bipm=True,
+    include_gps=True,
+    wideband=True,
+    wideband_dm_error=1e-5 * dmu,
+    add_noise=True,
+)
+
+# %%
+res = WidebandTOAResiduals(tsim, m2)
+
+plt.subplot(211)
+plt.errorbar(
+    tsim.get_mjds(),
+    res.toa.time_resids.to_value("us"),
+    res.toa.get_data_error().to_value("us"),
+    marker="+",
+    ls="",
+)
+plt.xlabel("MJD")
+plt.ylabel("Residuals (us)")
+
+plt.subplot(212)
+plt.errorbar(
+    tsim.get_mjds(),
+    tsim.get_dms().to_value(dmu),
+    res.dm.get_data_error().to_value(dmu),
+    marker="+",
+    ls="",
+)
+plt.xlabel("MJD")
+plt.ylabel("Wideband DM (dmu)")
+plt.show()
+
+# %% [markdown]
+# The same thing can be achieved in the command line using
+# the following command::
+#
+#       $ zima --startMJD 54000 --ntoa 100 --duration 2000 --obs gbt \
+#           --freq 1400 --error 1 --addnoise --wideband --dmerror 1e-5 \
+#           test.par test.tim
+
+# %% [markdown]
+# ## Simulating TOAs based on a tim file
+#
+# TOAs can be simulated to match the configuration of an existing tim file
+# (e.g. epochs, TOA uncertainties, frequencies, flags, etc.) using the
+# `make_fake_toas_fromtim` function. This also works with wideband tim files.
+
+# %%
+tsim = make_fake_toas_fromtim(
+    timfile=examplefile("B1855+09_NANOGrav_9yv1.tim"),
+    model=m,
+    add_noise=True,
+)
+
+# %%
+res = Residuals(tsim, m)
+
+plt.errorbar(
+    tsim.get_mjds(),
+    res.time_resids.to_value("us"),
+    res.get_data_error().to_value("us"),
+    marker="+",
+    ls="",
+)
+plt.xlabel("MJD")
+plt.ylabel("Residuals (us)")
+plt.show()
+
+# %% [markdown]
+# The same thing can be achieved in the command line using
+# the following command::
+#
+#       $ zima --inputtim B1855+09_NANOGrav_9yv1.tim --addnoise \
+#           test.par test.tim

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -69,6 +69,7 @@ are not included in the default build because they take too long, but you can do
    examples/solar_wind.ipynb
    examples/bayesian-example-NGC6440E.py
    examples/bayesian-wideband-example.py
+   examples/simulation-example.py
    examples-rendered/paper_validation_example.ipynb
 
 .. _`Time a Pulsar`: examples/time_a_pulsar.html

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -69,7 +69,7 @@ are not included in the default build because they take too long, but you can do
    examples/solar_wind.ipynb
    examples/bayesian-example-NGC6440E.py
    examples/bayesian-wideband-example.py
-   examples/simulation-example.py
+   examples/simulation_example.py
    examples-rendered/paper_validation_example.ipynb
 
 .. _`Time a Pulsar`: examples/time_a_pulsar.html

--- a/src/pint/scripts/zima.py
+++ b/src/pint/scripts/zima.py
@@ -54,6 +54,12 @@ def main(argv=None):
         default=1400.0,
     )
     parser.add_argument(
+        "--multifreq",
+        help="Simulate multiple frequency TOAs per epoch",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
         "--error",
         help="Random error to apply to each TOA (us)",
         type=float,
@@ -136,6 +142,7 @@ def main(argv=None):
             add_correlated_noise=args.addcorrnoise,
             wideband=args.wideband,
             wideband_dm_error=args.dmerror * pint.dmu,
+            multi_freqs_in_epoch=args.multifreq,
         )
     else:
         log.info(f"Reading initial TOAs from {args.inputtim}")

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -189,7 +189,7 @@ def make_fake_toas_uniform(
     name="fake",
     include_bipm=False,
     include_gps=True,
-    multi_freqs_in_epoch=True,
+    multi_freqs_in_epoch=False,
 ):
     """Make evenly spaced toas
 
@@ -316,7 +316,7 @@ def make_fake_toas_fromMJDs(
     name="fake",
     include_bipm=False,
     include_gps=True,
-    multi_freqs_in_epoch=True,
+    multi_freqs_in_epoch=False,
 ):
     """Make toas from a list of MJDs
 

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -316,6 +316,7 @@ def make_fake_toas_fromMJDs(
     name="fake",
     include_bipm=False,
     include_gps=True,
+    multi_freqs_in_epoch=True,
 ):
     """Make toas from a list of MJDs
 
@@ -351,6 +352,8 @@ def make_fake_toas_fromMJDs(
     include_gps : bool, optional
         Whether or not to disable UTC(GPS)->UTC clock correction
         (see :class:`pint.observatory.topo_obs.TopoObs`)
+    multi_freqs_in_epoch : bool, optional
+        Whether to generate multiple frequency TOAs for the same epoch.
 
     Returns
     -------
@@ -373,14 +376,17 @@ def make_fake_toas_fromMJDs(
         raise TypeError(
             f"Do not know how to interpret input times of type '{type(MJDs)}'"
         )
-    times = MJDs
 
     if freq is None or np.isinf(freq).all():
         freq = np.inf * u.MHz
-
     freqs = np.atleast_1d(freq)
-    freq_array = np.tile(freqs, len(times) // len(freqs) + 1)[: len(times)]
-    # freq_array = _get_freq_array(np.atleast_1d(freq), len(times))
+
+    if not multi_freqs_in_epoch:
+        times = MJDs
+        freq_array = np.tile(freqs, len(MJDs) // len(freqs) + 1)[: len(times)]
+    else:
+        times = np.repeat(MJDs, len(freqs))
+        freq_array = np.tile(freqs, len(MJDs))
 
     clk_version = get_fake_toa_clock_versions(
         model, include_bipm=include_bipm, include_gps=include_gps

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -235,6 +235,7 @@ def make_fake_toas_uniform(
         (see :class:`pint.observatory.topo_obs.TopoObs`)
     multi_freqs_in_epoch : bool, optional
         Whether to generate multiple frequency TOAs for the same epoch.
+
     Returns
     -------
     TOAs : pint.toa.TOAs
@@ -249,6 +250,10 @@ def make_fake_toas_uniform(
        without adding the measurement noise to the simulated DM values.
     3. The simulated DM measurement noise respects ``DMEFAC`` and ``DMEQUAD``
        values in the `model`.
+    4. If `multi_freqs_in_epoch` is True, each epoch will contain TOAs for all
+       frequencies given in the `freq` argument. Otherwise, each epoch will have
+       only one TOA, and the frequencies are distributed amongst TOAs in an
+       alternating manner. In either case, the total number of TOAs will be `ntoas`.
 
     See Also
     --------
@@ -362,7 +367,17 @@ def make_fake_toas_fromMJDs(
 
     Notes
     -----
-    `add_noise` respects any ``EFAC`` or ``EQUAD`` present in the `model`
+    1. `add_noise` respects any ``EFAC`` or ``EQUAD`` present in the `model`
+    2. When `wideband` is set, wideband DM measurement noise will be included
+       only if `add_noise` is set. Otherwise, the `-pp_dme` flags will be set
+       without adding the measurement noise to the simulated DM values.
+    3. The simulated DM measurement noise respects ``DMEFAC`` and ``DMEQUAD``
+       values in the `model`.
+    4. If `multi_freqs_in_epoch` is True, each epoch will contain TOAs for all
+       frequencies given in the `freq` argument, and the total number of
+       TOAs will be `len(MJDs)*len(freq)`. Otherwise, each epoch will have
+       only one TOA, and the frequencies are distributed amongst TOAs in an
+       alternating manner, and the total number of TOAs will be `len(MJDs)`.
 
     See Also
     --------

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -385,7 +385,11 @@ def make_fake_toas_fromMJDs(
         times = MJDs
         freq_array = np.tile(freqs, len(MJDs) // len(freqs) + 1)[: len(times)]
     else:
-        times = np.repeat(MJDs, len(freqs))
+        times = (
+            time.Time(np.repeat(MJDs, len(freqs)))
+            if isinstance(MJDs, time.Time)
+            else np.repeat(MJDs, len(freqs))
+        )
         freq_array = np.tile(freqs, len(MJDs))
 
     clk_version = get_fake_toa_clock_versions(

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -191,10 +191,7 @@ def make_fake_toas_uniform(
     include_gps=True,
     multi_freqs_in_epoch=False,
 ):
-    """Make evenly spaced toas
-
-    Can include alternating frequencies if fed an array of frequencies,
-    only works with one observatory at a time
+    """Simulate uniformly spaced TOAs.
 
     Parameters
     ----------
@@ -209,7 +206,8 @@ def make_fake_toas_uniform(
     fuzz : astropy.units.Quantity, optional
         Standard deviation of 'fuzz' distribution to be applied to TOAs
     freq : astropy.units.Quantity, optional
-        frequency of the fake toas, default 1400 MHz
+        Frequency (or array of frequencies) for the fake TOAs,
+        default is 1400 MHz
     obs : str, optional
         observatory for fake toas, default GBT
     error : astropy.units.Quantity
@@ -254,6 +252,7 @@ def make_fake_toas_uniform(
        frequencies given in the `freq` argument. Otherwise, each epoch will have
        only one TOA, and the frequencies are distributed amongst TOAs in an
        alternating manner. In either case, the total number of TOAs will be `ntoas`.
+    5. Currently supports simulating only one observatory.
 
     See Also
     --------
@@ -323,10 +322,7 @@ def make_fake_toas_fromMJDs(
     include_gps=True,
     multi_freqs_in_epoch=False,
 ):
-    """Make toas from a list of MJDs
-
-    Can include alternating frequencies if fed an array of frequencies,
-    only works with one observatory at a time
+    """Simulate TOAs from a list of MJDs
 
     Parameters
     ----------
@@ -335,7 +331,8 @@ def make_fake_toas_fromMJDs(
     model : pint.models.timing_model.TimingModel
         current model
     freq : astropy.units.Quantity, optional
-        frequency of the fake toas, default 1400 MHz
+        Frequency (or array of frequencies) for the fake toas,
+        default is 1400 MHz
     obs : str, optional
         observatory for fake toas, default GBT
     error : astropy.units.Quantity
@@ -343,7 +340,7 @@ def make_fake_toas_fromMJDs(
     add_noise : bool, optional
         Add noise to the TOAs (otherwise `error` just populates the column)
     add_correlated_noise : bool, optional
-        Add correlated noise to the TOAs if it's present in the timing mode.
+        Add correlated noise to the TOAs if it's present in the timing model.
     wideband : astropy.units.Quantity, optional
         Whether to include wideband DM values with each TOA; default is
         not to include any DM information
@@ -378,6 +375,7 @@ def make_fake_toas_fromMJDs(
        TOAs will be `len(MJDs)*len(freq)`. Otherwise, each epoch will have
        only one TOA, and the frequencies are distributed amongst TOAs in an
        alternating manner, and the total number of TOAs will be `len(MJDs)`.
+    5. Currently supports simulating only one observatory.
 
     See Also
     --------
@@ -439,10 +437,7 @@ def make_fake_toas_fromMJDs(
 def make_fake_toas_fromtim(
     timfile, model, add_noise=False, add_correlated_noise=False, name="fake"
 ):
-    """Make fake toas with the same times as an input tim file
-
-    Can include alternating frequencies if fed an array of frequencies,
-    only works with one observatory at a time
+    """Simulate fake TOAs with the same times as an input tim file
 
     Parameters
     ----------

--- a/tests/test_fake_toas.py
+++ b/tests/test_fake_toas.py
@@ -9,7 +9,7 @@ import numpy as np
 import tempfile
 import os
 import pint.config
-from pint.fitter import GLSFitter
+from pint.fitter import GLSFitter, DownhillGLSFitter
 from pinttestdata import datadir
 import pytest
 
@@ -357,3 +357,73 @@ def test_fake_wb_toas():
     )
     assert len(tfu) == 100
     assert all("pp_dm" in f and "pp_dme" in f for f in tfu.get_flags())
+
+
+def test_simulate_corrnoise(tmp_path):
+    parfile = datadir / "B1855+09_NANOGrav_9yv1.gls.par"
+
+    m = get_model(parfile)
+
+    # Simulated TOAs won't have the correct flags for some of these to work.
+    m.remove_component("ScaleToaError")
+    m.remove_component("EcorrNoise")
+    m.remove_component("DispersionDMX")
+    m.remove_component("PhaseJump")
+    m.remove_component("FD")
+    m.PLANET_SHAPIRO.value = False
+
+    t = pint.simulation.make_fake_toas_uniform(
+        m.START.value,
+        m.FINISH.value,
+        1000,
+        m,
+        add_noise=True,
+        add_correlated_noise=True,
+    )
+
+    # Check if the created TOAs can be whitened using
+    # the original timing model. This won't work if the
+    # noise is not realized correctly.
+    ftr = DownhillGLSFitter(t, m)
+    ftr.fit_toas()
+    rc = sum(ftr.resids.noise_resids.values())
+    r = ftr.resids.time_resids
+    rw = r - rc
+    sigma = ftr.resids.get_data_error()
+
+    # This should be independent and standard-normal distributed.
+    x = (rw / sigma).to_value("")
+    assert np.isclose(np.std(x), 1, atol=0.2)
+    assert np.isclose(np.mean(x), 0, atol=0.01)
+
+
+@pytest.mark.parametrize("multifreq", [True, False])
+def test_simulate_uniform_multifreq(multifreq):
+    parfile = os.path.join(datadir, "NGC6440E.par")
+    m = get_model(parfile)
+
+    ntoas = 100
+
+    freqs = np.array([500, 1400]) * u.MHz
+    t = pint.simulation.make_fake_toas_uniform(
+        50000,
+        51000,
+        ntoas,
+        m,
+        add_noise=True,
+        freq=freqs,
+        multi_freqs_in_epoch=multifreq,
+    )
+    assert len(t) == ntoas
+
+    freqs = np.array([500, 750, 1400]) * u.MHz
+    t = pint.simulation.make_fake_toas_uniform(
+        50000,
+        51000,
+        ntoas,
+        m,
+        add_noise=True,
+        freq=freqs,
+        multi_freqs_in_epoch=multifreq,
+    )
+    assert len(t) == ntoas

--- a/tests/test_fake_toas.py
+++ b/tests/test_fake_toas.py
@@ -241,13 +241,13 @@ def test_fake_uniform(t1, t2):
     model = get_model(
         io.StringIO(
             """
-        PSRJ J1234+5678
-        ELAT 0
-        ELONG 0
-        DM 10
-        F0 1
-        PEPOCH 58000
-        """
+            PSRJ J1234+5678
+            ELAT 0
+            ELONG 0
+            DM 10
+            F0 1
+            PEPOCH 58000
+            """
         )
     )
     toas = pint.simulation.make_fake_toas_uniform(

--- a/tests/test_zima.py
+++ b/tests/test_zima.py
@@ -97,71 +97,15 @@ def test_zima_fuzzdays(tmp_path):
         sys.stdout = saved_stdout
 
 
-def test_simulate_corrnoise(tmp_path):
-    parfile = datadir / "B1855+09_NANOGrav_9yv1.gls.par"
+def test_zima_multifreq(tmp_path):
+    matplotlib.use("Agg")
 
-    m = get_model(parfile)
-
-    # Simulated TOAs won't have the correct flags for some of these to work.
-    m.remove_component("ScaleToaError")
-    m.remove_component("EcorrNoise")
-    m.remove_component("DispersionDMX")
-    m.remove_component("PhaseJump")
-    m.remove_component("FD")
-    m.PLANET_SHAPIRO.value = False
-
-    t = make_fake_toas_uniform(
-        m.START.value,
-        m.FINISH.value,
-        1000,
-        m,
-        add_noise=True,
-        add_correlated_noise=True,
-    )
-
-    # Check if the created TOAs can be whitened using
-    # the original timing model. This won't work if the
-    # noise is not realized correctly.
-    ftr = DownhillGLSFitter(t, m)
-    ftr.fit_toas()
-    rc = sum(ftr.resids.noise_resids.values())
-    r = ftr.resids.time_resids
-    rw = r - rc
-    sigma = ftr.resids.get_data_error()
-
-    # This should be independent and standard-normal distributed.
-    x = (rw / sigma).to_value("")
-    assert np.isclose(np.std(x), 1, atol=0.2)
-    assert np.isclose(np.mean(x), 0, atol=0.01)
-
-
-@pytest.mark.parametrize("multifreq", [True, False])
-def test_simulate_uniform_multifreq(multifreq):
     parfile = os.path.join(datadir, "NGC6440E.par")
-    m = get_model(parfile)
-
-    ntoas = 100
-
-    freqs = np.array([500, 1400]) * u.MHz
-    t = make_fake_toas_uniform(
-        50000,
-        51000,
-        ntoas,
-        m,
-        add_noise=True,
-        freq=freqs,
-        multi_freqs_in_epoch=multifreq,
-    )
-    assert len(t) == ntoas
-
-    freqs = np.array([500, 750, 1400]) * u.MHz
-    t = make_fake_toas_uniform(
-        50000,
-        51000,
-        ntoas,
-        m,
-        add_noise=True,
-        freq=freqs,
-        multi_freqs_in_epoch=multifreq,
-    )
-    assert len(t) == ntoas
+    output_timfile = tmp_path / "fake_testzima.tim"
+    saved_stdout, sys.stdout = sys.stdout, StringIO("_")
+    try:
+        cmd = f"--freq 1400 500 --multifreq {parfile} {output_timfile}"
+        zima.main(cmd.split())
+        lines = sys.stdout.getvalue()
+    finally:
+        sys.stdout = saved_stdout

--- a/tests/test_zima.py
+++ b/tests/test_zima.py
@@ -12,6 +12,7 @@ from pint.models import get_model_and_toas, get_model
 from pint.simulation import make_fake_toas_uniform
 from pint.residuals import Residuals
 from pint.fitter import DownhillGLSFitter
+from astropy import units as u
 
 
 @pytest.mark.parametrize("addnoise", ["", "--addnoise"])
@@ -132,3 +133,35 @@ def test_simulate_corrnoise(tmp_path):
     x = (rw / sigma).to_value("")
     assert np.isclose(np.std(x), 1, atol=0.2)
     assert np.isclose(np.mean(x), 0, atol=0.01)
+
+
+@pytest.mark.parametrize("multifreq", [True, False])
+def test_simulate_uniform_multifreq(multifreq):
+    parfile = os.path.join(datadir, "NGC6440E.par")
+    m = get_model(parfile)
+
+    ntoas = 100
+
+    freqs = np.array([500, 1400]) * u.MHz
+    t = make_fake_toas_uniform(
+        50000,
+        51000,
+        ntoas,
+        m,
+        add_noise=True,
+        freq=freqs,
+        multi_freqs_in_epoch=multifreq,
+    )
+    assert len(t) == ntoas
+
+    freqs = np.array([500, 750, 1400]) * u.MHz
+    t = make_fake_toas_uniform(
+        50000,
+        51000,
+        ntoas,
+        m,
+        add_noise=True,
+        freq=freqs,
+        multi_freqs_in_epoch=multifreq,
+    )
+    assert len(t) == ntoas


### PR DESCRIPTION
`multi_freqs_in_epoch` option in `make_fake_toas_uniform` and `make_fake_toas_fromMJDs`.
`--multifreq` option in `zima`
Moved some tests from `test_zima.py` to `test_fake_toas.py`

Note that the default behavior doesn't change.