### PR TITLE
Make whitened residuals available

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -42,6 +42,7 @@ the released changes.
 - `ScaleToaError.register_toasigma_deriv_funcs` method to populate derivatives of scaled TOA uncertainties.
 - `ScaleToaError.d_toasigma_d_EFAC` and `ScaleToaError.d_toasigma_d_EQUAD` methods.
 - Separate `.fullname` for all observatories
+- `Residuals.calc_whitened_resids()` method
 ### Fixed
 - Wave model `validate()` can correctly use PEPOCH to assign WAVEEPOCH parameter
 - Fixed RTD by specifying theme explicitly.

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -500,6 +500,12 @@ class Residuals:
             )
         return (phase_resids / self.get_PSR_freq(calctype=calctype)).to(u.s)
 
+    def calc_whitened_resids(self):
+        r = self.calc_time_resids()
+        nr = sum(self.noise_resids.values())
+        sigma = self.get_data_error()
+        return (r - nr) / sigma
+
     def _calc_gls_chi2(self, lognorm=False):
         """Compute the chi2 when correlated noise is present in the timing model.
         If the system is not singular, it uses Cholesky factorization to evaluate this.

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -504,7 +504,7 @@ class Residuals:
         r = self.calc_time_resids()
         nr = sum(self.noise_resids.values())
         sigma = self.get_data_error()
-        return (r - nr) / sigma
+        return ((r - nr) / sigma).to(u.dimensionless_unscaled)
 
     def _calc_gls_chi2(self, lognorm=False):
         """Compute the chi2 when correlated noise is present in the timing model.

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -322,6 +322,12 @@ class Residuals:
         Returns
         -------
         Phase
+
+        See Also
+        --------
+        :meth:`pint.residuals.Residuals.get_PSR_freq`
+        :meth:`pint.residuals.Residuals.calc_time_resids`
+        :meth:`pint.residuals.Residuals.calc_whitened_resids`
         """
 
         if subtract_mean is None:
@@ -481,6 +487,8 @@ class Residuals:
         See Also
         --------
         :meth:`pint.residuals.Residuals.get_PSR_freq`
+        :meth:`pint.residuals.Residuals.calc_phase_resids`
+        :meth:`pint.residuals.Residuals.calc_whitened_resids`
         """
         assert calctype.lower() in ["modelf0", "taylor", "numerical"]
         if subtract_mean is None and use_weighted_mean is None:
@@ -501,6 +509,27 @@ class Residuals:
         return (phase_resids / self.get_PSR_freq(calctype=calctype)).to(u.s)
 
     def calc_whitened_resids(self):
+        """Compute whitened timing residuals (dimensionless).
+
+        Whitened residuals are computed by subtracting the correlated
+        noise realization from the time residuals and normalizes the
+        result using scaled TOA uncertainties.
+
+        This requires the `noise_resids` attribute to be set. This is
+        usually available in a post-fit residuals object.
+
+        Example usage::
+
+            >>> ftr = Fitter.auto(toas, model)
+            >>> ftr.fit_toas()
+            >>> res = ftr.resids
+            >>> white_res = res.calc_whitened_resids()
+
+        See Also
+        --------
+        :meth:`pint.residuals.Residuals.calc_time_resids`
+        :meth:`pint.residuals.Residuals.calc_phase_resids`
+        """
         r = self.calc_time_resids()
         nr = sum(self.noise_resids.values())
         sigma = self.get_data_error()


### PR DESCRIPTION
This partially overlaps with the stale PR #1000.

whitened_resids = (resids - noise_resids) / scaled_toa_error

If the fitting has been done properly, the whitened residuals should be normally distributed with unit variance.