### PR TITLE
Fix sign of y coordinate for Pico Veleta so it's no longer in the sea

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -55,4 +55,5 @@ the released changes.
 - Robust access of EPHEM and PLANET_SHAPIRO in `make_fake_toas_fromtim`
 - `pintk` will not allow choices of axes that are not in timing model/data
 - `pintk` correctly displays initial log level
+- Fixed sign of y coordinate for Pico Veleta observatory (also being fixed in tempo2)
 ### Removed

--- a/src/pint/data/runtime/observatories.json
+++ b/src/pint/data/runtime/observatories.json
@@ -1261,11 +1261,11 @@
         "itoa_code": "PV",
         "itrf_xyz": [
             5088964.0,
-            301689.8,
+            -301689.8,
             3825017.0
         ],
         "fullname": "Observatorio Pico Veleta",
-        "origin": "Imported from TEMPO2 observatories.dat 2021 June 7. As of 2023-11-01 this appears to be somewhere in the sea."
+        "origin": "Imported from TEMPO2 observatories.dat 2021 June 7. Fixed signed of y coordinate on 2023 Nov 6 along with M. Keith in tempo2 to make location sensible."
     },
     "iar1": {
         "itrf_xyz": [


### PR DESCRIPTION
Fixes part of #1669. Same fix is also going in to tempo2.