### PR TITLE
Fix examples

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -57,4 +57,5 @@ the released changes.
 - `pintk` will not allow choices of axes that are not in timing model/data
 - `pintk` correctly displays initial log level
 - Fixed sign of y coordinate for Pico Veleta observatory (also being fixed in tempo2)
+- Minor bug fixes in example notebooks
 ### Removed

--- a/docs/examples/How_to_build_a_timing_model_component.py
+++ b/docs/examples/How_to_build_a_timing_model_component.py
@@ -34,8 +34,6 @@
 # ## Import the necessary modules
 
 # %%
-import numpy as np  # Numpy is a widely used package
-
 # PINT uses astropy units in the internal calculation and is highly recommended for a new component
 import astropy.units as u
 

--- a/docs/examples/PINT_walkthrough.py
+++ b/docs/examples/PINT_walkthrough.py
@@ -33,7 +33,6 @@
 
 # %%
 import tempfile
-import numpy as np
 import astropy.units as u
 from pprint import pprint
 from glob import glob

--- a/docs/examples/Wideband_TOA_walkthrough.py
+++ b/docs/examples/Wideband_TOA_walkthrough.py
@@ -19,15 +19,12 @@
 # Traditional pulsar timing involved measuring only the arrival time of each pulse. But as receivers have covered wider and wider contiguous bandwidths, it became necessary to generate many TOAs for each time interval, covering different subbands. This frequency coverage allowed better handling of changing dispersion measures, but resulted in a large number of TOAs and had certain limitations. A new approach measures the pulse arrival time and the dispersion measure simultaneously from a frequency-resolved data cube. This produces TOAs, each of which has an associated dispersion measure and uncertainty. Working with this data requires different handling from PINT. This notebook demonstrates that.
 
 # %%
-import os
-
 import astropy.units as u
 import matplotlib.pyplot as plt
 from astropy.visualization import quantity_support
 
 from pint.fitter import Fitter
 from pint.models import get_model_and_toas
-from pint.toa import get_TOAs
 import pint.config
 import pint.logging
 

--- a/docs/examples/check_phase_connection.py
+++ b/docs/examples/check_phase_connection.py
@@ -27,7 +27,7 @@ import astropy.units as u
 
 import pint.fitter, pint.toa, pint.simulation
 from pint.models import get_model_and_toas
-from pint import utils, simulation
+from pint import simulation
 import pint.config
 import pint.logging
 

--- a/docs/examples/compare_tempo2_B1855.py
+++ b/docs/examples/compare_tempo2_B1855.py
@@ -1,4 +1,8 @@
 """Various tests to assess the performance of the B1855+09."""
+
+# This example requires `tempo2_utils`. It is available at
+# https://github.com/demorest/tempo_utils.
+
 import pint.models.model_builder as mb
 import pint.toa as toa
 import pint.logging

--- a/docs/examples/compare_tempo2_J0613.py
+++ b/docs/examples/compare_tempo2_J0613.py
@@ -1,5 +1,8 @@
 """Various tests to assess the performance of the J0623-0200."""
 
+# This example requires `tempo2_utils`. It is available at
+# https://github.com/demorest/tempo_utils.
+
 import pint.models.model_builder as mb
 import pint.toa as toa
 import pint.logging

--- a/docs/examples/covariance.py
+++ b/docs/examples/covariance.py
@@ -19,7 +19,6 @@
 # The results of a fit consist of best-fit parameter values and uncertainties, and residuals; these are conventional data products from pulsar timing. Additional information can be useful though: we can describe the correlations between model parameters in a matrix, and we can compute the derivatives of the residuals with respect to the model parameters. Both of these additional pieces of information can be obtained from a Fitter object in PINT; this notebook will demonstrate how to do this efficiently.
 # %%
 import contextlib
-import os
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -27,7 +26,6 @@ import numpy as np
 import scipy.linalg
 import scipy.stats
 
-import astropy.units as u
 import matplotlib.pyplot as plt
 from astropy.visualization import quantity_support
 

--- a/docs/examples/example_dmx_ranges.py
+++ b/docs/examples/example_dmx_ranges.py
@@ -1,4 +1,7 @@
-from __future__ import print_function, division
+# %% [markdown]
+# ## DMX ranges demonstration
+
+# %%
 import astropy.units as u
 
 import pint.toa
@@ -12,41 +15,51 @@ from astropy.visualization import quantity_support
 
 quantity_support()
 
+# %% [markdown]
 # This example shows how to construct and add a set of DMX components to a model.
 # In this case the model we load already has a DMX component, so we remove it first
 # and replace it with one we construct.
 
+# %%
 m1855 = pint.models.get_model(pint.config.examplefile("B1855+09_NANOGrav_9yv1.gls.par"))
 ts1855 = pint.toa.get_TOAs(
     pint.config.examplefile("B1855+09_NANOGrav_9yv1.tim"), usepickle=True
 )
 ts1855.print_summary()
 
+# %%
 # Remove and build a new DMX component
 m1855.remove_component("DispersionDMX")
 
+# %%
 # Build the new component with maximum DMX bin of 15 days ensuring that there are TOAs above and below 1000 MHz in each gin
 mask, dmx_comp = pint.utils.dmx_ranges(
     ts1855, binwidth=15.0 * u.d, divide_freq=1000.0 * u.MHz
 )
 
+# %%
 # Mask out any TOAs that couldn't be included in a DMX range
 ts1855.select(mask)
 
+# %%
 # Add it to the model
 m1855.add_component(dmx_comp, validate=True)
 
+# %%
 # Now run the fit with the new DMX component
 glsfit = pint.fitter.GLSFitter(toas=ts1855, model=m1855)
 glsfit.fit_toas(maxiter=1)
 glsfit.print_summary()
 
+# %%
 # You can print some statistics on the DMXs like this:
 pint.utils.dmxstats(glsfit.model, glsfit.toas)
 
+# %%
 # dmxparse will pull out the DMX values and compute correct errors from the covariance matrix, which we can easily plot
 dmx = pint.utils.dmxparse(glsfit)
 
+# %%
 fig, ax = plt.subplots(figsize=(16, 9))
 ax.errorbar(dmx["dmxeps"], dmx["dmxs"], yerr=dmx["dmx_verrs"], fmt="s", label="NRT DMX")
 ax.grid(True)

--- a/docs/examples/example_dmx_ranges.py
+++ b/docs/examples/example_dmx_ranges.py
@@ -1,5 +1,4 @@
 from __future__ import print_function, division
-import numpy as np
 import astropy.units as u
 
 import pint.toa

--- a/docs/examples/example_pulse_numbers.py
+++ b/docs/examples/example_pulse_numbers.py
@@ -1,4 +1,7 @@
-#!/usr/bin/env python
+# %% [markdown]
+# ## Pulse numbers demonstration
+
+# %%
 from copy import deepcopy
 import pint.models
 import astropy.units as u
@@ -9,12 +12,14 @@ from astropy.visualization import quantity_support
 from astropy import log
 import pint.config
 import pint.logging
+import pint.fitter as fit
 
 # setup logging
 pint.logging.setup(level="INFO")
 
 quantity_support()
 
+# %%
 modelin = pint.models.get_model(pint.config.examplefile("waves.par"))
 model2 = deepcopy(modelin)
 component, order, from_list, comp_type = model2.map_component("Wave")
@@ -22,10 +27,12 @@ from_list.remove(component)
 # modelin.TRACK.value = "0"
 # model2.TRACK.value = "0"
 
+# %%
 realtoas = pint.toa.get_TOAs(pint.config.examplefile("waves_withpn.tim"))
 res = Residuals(realtoas, modelin)
 res2 = Residuals(realtoas, model2)
 
+# %%
 fig, ax = plt.subplots(figsize=(16, 9))
 ax.set_title("Residuals using PN from .tim file")
 ax.errorbar(
@@ -45,11 +52,12 @@ ax.errorbar(
 ax.legend()
 ax.grid(True)
 
-
+# %%
 realtoas.compute_pulse_numbers(modelin)
 res = Residuals(realtoas, modelin)
 res2 = Residuals(realtoas, model2)
 
+# %%
 fig, ax = plt.subplots(figsize=(16, 9))
 ax.set_title("Residuals using PN from compute_pulse_numbers")
 ax.errorbar(
@@ -71,8 +79,7 @@ ax.grid(True)
 
 plt.show()
 
-import pint.fitter as fit
-
+# %%
 modelin.WAVE1.quantity = (0.0 * u.s, 0.0 * u.s)
 modelin.WAVE2.quantity = (0.0 * u.s, 0.0 * u.s)
 modelin.WAVE3.quantity = (0.0 * u.s, 0.0 * u.s)
@@ -85,8 +92,10 @@ modelin.WAVE3.frozen = False
 modelin.WAVE4.frozen = False
 modelin.WAVE5.frozen = False
 
+# %%
 prefitresids = Residuals(realtoas, modelin)
 
+# %%
 try:
     f = fit.WLSFitter(realtoas, modelin)
     f.fit_toas()

--- a/docs/examples/example_pulse_numbers.py
+++ b/docs/examples/example_pulse_numbers.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
-import numpy as np
 from copy import deepcopy
 import pint.models
-from pint.models.parameter import strParameter
 import astropy.units as u
 import pint.toa
 from pint.residuals import Residuals

--- a/docs/examples/fit_NGC6440E.py
+++ b/docs/examples/fit_NGC6440E.py
@@ -33,6 +33,7 @@ import astropy.units as u
 # This will change which output method matplotlib uses and may behave better on some machines
 # import matplotlib
 # matplotlib.use('TKAgg')
+
 import matplotlib.pyplot as plt
 import pint.fitter
 import pint.residuals

--- a/docs/examples/fit_NGC6440E.py
+++ b/docs/examples/fit_NGC6440E.py
@@ -37,7 +37,7 @@ import matplotlib.pyplot as plt
 import pint.fitter
 import pint.residuals
 import pint.toa
-from pint.models import get_model, get_model_and_toas
+from pint.models import get_model_and_toas
 import pint.logging
 import os
 

--- a/docs/examples/fit_NGC6440E_MCMC.py
+++ b/docs/examples/fit_NGC6440E_MCMC.py
@@ -1,5 +1,5 @@
-#! /usr/bin/env python
-"""Demonstrate fitting from a script."""
+# %% [markdown]
+# # Demonstrate fitting from a script."""
 
 # %%
 import pint.toa
@@ -128,7 +128,3 @@ plt.xlabel("MJD")
 plt.ylabel("Residual (us)")
 plt.grid()
 plt.show()
-
-# %%
-print(ndim)
-# %%

--- a/docs/examples/fit_NGC6440E_MCMC.py
+++ b/docs/examples/fit_NGC6440E_MCMC.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 """Demonstrate fitting from a script."""
-from __future__ import print_function, division
-import os
+
+# %%
 import pint.toa
 import pint.models
 import pint.mcmc_fitter
@@ -9,13 +9,17 @@ import pint.sampler
 import pint.residuals
 import matplotlib.pyplot as plt
 import astropy.units as u
-from scipy.stats import norm, uniform
 import pint.logging
+import contextlib
+import pint.config
+import numpy as np
 
+# %%
 # setup logging
 pint.logging.setup(level="INFO")
 
 
+# %%
 def plot_chains(chain_dict, file=False):
     npts = len(chain_dict)
     fig, axes = plt.subplots(npts, 1, sharex=True, figsize=(8, 9))
@@ -32,22 +36,20 @@ def plot_chains(chain_dict, file=False):
     plt.close()
 
 
-import contextlib
-import pint.config
-
+# %%
 parfile = pint.config.examplefile("NGC6440E.par.good")
 timfile = pint.config.examplefile("NGC6440E.tim")
 print(parfile)
 print(timfile)
-nwalkers = 50
-nsteps = 2000
 
+# %%
 # Load the timing model and the TOAs
 m, t = pint.models.get_model_and_toas(parfile, timfile)
 
 # Print a summary of the TOAs that we have
 t.print_summary()
 
+# %%
 # These are pre-fit residuals
 rs = pint.residuals.Residuals(t, m).phase_resids
 xt = t.get_mjds()
@@ -58,8 +60,12 @@ plt.ylabel("Residual (phase)")
 plt.grid()
 plt.show()
 
-# Now do the fit
-print("Fitting...")
+# %%
+nwalkers = 50
+nsteps = 2000
+
+# %%
+# Now create the fitter.
 sampler = pint.sampler.EmceeSampler(nwalkers)
 f = pint.mcmc_fitter.MCMCFitter(
     t,
@@ -71,24 +77,28 @@ f = pint.mcmc_fitter.MCMCFitter(
     lnlike=pint.mcmc_fitter.lnlikelihood_chi2,
 )
 
+# %%
 # Now deal with priors
 pint.mcmc_fitter.set_priors_basic(f)
 print("Gaussian priors set")
 
 # Examples of custom position priors:
-
 # f.model.RAJ.prior = Prior(normal(0.001,1e5))
 
+# %%
 # Do the fit
+print("Fitting...")
 print(f.fit_toas(nsteps))
 
+# %%
 # plotting the chains
 chains = sampler.chains_to_dict(f.fitkeys)
 plot_chains(chains, file=f"{f.model.PSR.value}_chains.png")
 
+# %%
 # triangle plot
 # this doesn't include burn-in because we're not using it here, otherwise set get_chain(discard=burnin)
-# samples = sampler.sampler.chain[:, :, :].reshape((-1, f.n_fit_params))
+ndim = len(m.free_params)
 samples = np.transpose(sampler.get_chain(), (1, 0, 2)).reshape((-1, ndim))
 with contextlib.suppress(ImportError):
     import corner
@@ -97,8 +107,9 @@ with contextlib.suppress(ImportError):
         samples, labels=f.fitkeys, bins=50, truths=f.maxpost_fitvals, plot_contours=True
     )
     fig.savefig(f"{f.model.PSR.value}_triangle.png")
-    plt.close()
+    plt.show()
 
+# %%
 # Print some basic params
 print("Best fit has reduced chi^2 of", f.resids.reduced_chi2)
 print("RMS in phase is", f.resids.phase_resids.std())
@@ -117,3 +128,7 @@ plt.xlabel("MJD")
 plt.ylabel("Residual (us)")
 plt.grid()
 plt.show()
+
+# %%
+print(ndim)
+# %%

--- a/docs/examples/solar_wind.py
+++ b/docs/examples/solar_wind.py
@@ -31,13 +31,10 @@ from io import StringIO
 import numpy as np
 
 from astropy.time import Time
-from astropy import units as u
 import astropy.coordinates
-from pint.models import get_model, get_model_and_toas
+from pint.models import get_model
 from pint.fitter import Fitter
-from pint.toa import get_TOAs
 from pint.simulation import make_fake_toas_uniform
-from pint.models.solar_wind_dispersion import SolarWindDispersionX
 import pint.utils
 import pint.gridutils
 import pint.logging

--- a/docs/examples/time_a_pulsar.py
+++ b/docs/examples/time_a_pulsar.py
@@ -25,7 +25,6 @@ import matplotlib.pyplot as plt
 import pint.fitter
 from pint.models import get_model_and_toas
 from pint.residuals import Residuals
-from pint.toa import get_TOAs
 import pint.logging
 
 pint.logging.setup(level="INFO")

--- a/docs/examples/understanding_fitters.py
+++ b/docs/examples/understanding_fitters.py
@@ -20,8 +20,6 @@
 #
 
 # %%
-import numpy as np
-import astropy.units as u
 from IPython.display import display_markdown
 
 import pint.toa

--- a/docs/examples/understanding_parameters.py
+++ b/docs/examples/understanding_parameters.py
@@ -21,7 +21,6 @@
 import pint.models
 import pint.models.parameter as pp
 import astropy.units as u
-from astropy.coordinates.angles import Angle
 from astropy.time import Time
 import pint.config
 import pint.logging


### PR DESCRIPTION
Fixed fit_NGC6440E_MCMC.py

Cleanup of other example scripts, add notebook dividers into scripts.

Added comments on how to install `tempo2_utils` in comparison scripts.