### PR TITLE
Set `UNITS` to TDB if it is not given in the par file.

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -61,4 +61,5 @@ the released changes.
 - `pintk` correctly displays initial log level
 - Fixed sign of y coordinate for Pico Veleta observatory (also being fixed in tempo2)
 - Minor bug fixes in example notebooks
+- Set `UNITS` to TDB if it's not given in the par file.
 ### Removed

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -199,7 +199,7 @@ class ModelBuilder:
             # log.warning(f"Unrecognized parfile line '{p_line}'")
 
         if tm.UNITS.value is None or tm.UNITS.value == "":
-            warnings.warn("UNITS is not specified. Assuming TDB...")
+            log.warning("UNITS is not specified. Assuming TDB...")
             tm.UNITS.value = "TDB"
 
         if tm.UNITS.value == "TCB" and convert_tcb:

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -198,6 +198,10 @@ class ModelBuilder:
             warnings.warn(f"Unrecognized parfile line '{p_line}'", UserWarning)
             # log.warning(f"Unrecognized parfile line '{p_line}'")
 
+        if tm.UNITS.value is None or tm.UNITS.value == "":
+            warnings.warn("UNITS is not specified. Assuming TDB...")
+            tm.UNITS.value = "TDB"
+
         if tm.UNITS.value == "TCB" and convert_tcb:
             convert_tcb_tdb(tm)
 

--- a/tests/test_timing_model.py
+++ b/tests/test_timing_model.py
@@ -51,6 +51,7 @@ class TestModelBuilding:
 
     def test_from_par(self):
         tm = get_model(self.parfile)
+        assert tm.UNITS.value == "TDB"
         assert len(tm.components) == 6
         assert len(tm.DelayComponent_list) == 4
         assert len(tm.PhaseComponent_list) == 2


### PR DESCRIPTION
TDB is assumed implicitly if no UNITS is given. This PR makes it explicit.