### PR TITLE
Simulate TOA flags

### DIFF
--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -190,6 +190,7 @@ def make_fake_toas_uniform(
     include_bipm=False,
     include_gps=True,
     multi_freqs_in_epoch=False,
+    flags=None,
 ):
     """Simulate uniformly spaced TOAs.
 
@@ -233,6 +234,8 @@ def make_fake_toas_uniform(
         (see :class:`pint.observatory.topo_obs.TopoObs`)
     multi_freqs_in_epoch : bool, optional
         Whether to generate multiple frequency TOAs for the same epoch.
+    flags: None or dict
+        Dictionary of flags to be added to all simulated TOAs.
 
     Returns
     -------
@@ -293,6 +296,7 @@ def make_fake_toas_uniform(
         bipm_version=clk_version["bipm_version"],
         include_gps=clk_version["include_gps"],
         planets=model["PLANET_SHAPIRO"].value if "PLANET_SHAPIRO" in model else False,
+        flags=flags,
     )
 
     if wideband:
@@ -321,6 +325,7 @@ def make_fake_toas_fromMJDs(
     include_bipm=False,
     include_gps=True,
     multi_freqs_in_epoch=False,
+    flags=None,
 ):
     """Simulate TOAs from a list of MJDs
 
@@ -356,6 +361,8 @@ def make_fake_toas_fromMJDs(
         (see :class:`pint.observatory.topo_obs.TopoObs`)
     multi_freqs_in_epoch : bool, optional
         Whether to generate multiple frequency TOAs for the same epoch.
+    flags: None or dict
+        Dictionary of flags to be added to all simulated TOAs.
 
     Returns
     -------
@@ -420,6 +427,7 @@ def make_fake_toas_fromMJDs(
         bipm_version=clk_version["bipm_version"],
         include_gps=clk_version["include_gps"],
         planets=model["PLANET_SHAPIRO"].value,
+        flags=flags,
     )
 
     if wideband:

--- a/tests/test_fake_toas.py
+++ b/tests/test_fake_toas.py
@@ -68,11 +68,22 @@ def test_roundtrip(clock, planet):
         obs="gbt",
         error=1 * u.microsecond,
         freq=1400 * u.MHz,
+        flags={"be": "GUPPI"},
     )
     res = pint.residuals.Residuals(toas, model)
     toas2 = roundtrip(toas, model)
     res2 = pint.residuals.Residuals(toas2, model)
     assert np.allclose(res.time_resids, res2.time_resids)
+    assert (
+        "be" in toas.get_all_flags()
+        and all(np.array(toas.get_flag_value("be")[0]) == "GUPPI")
+        and len(toas.get_flag_value("be")[0]) == len(toas)
+    )
+    assert (
+        "be" in toas2.get_all_flags()
+        and all(np.array(toas2.get_flag_value("be")[0]) == "GUPPI")
+        and len(toas2.get_flag_value("be")[0]) == len(toas2)
+    )
 
 
 def test_noise_addition():


### PR DESCRIPTION
The infrastructure for doing this is already there in `pint.toa` and is straightforward to use. This PR just uses that in `pint.simulation`.