### PR TITLE
Fixed bug in derived params when OMDOT uncertainty is 0

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -14,4 +14,5 @@ the released changes.
 - Documentation: Added `convert_parfile` to list of command-line tools in RTD
 ### Fixed
 - Fixed runtime data README 
+- Fixed `derived_params` when OMDOT has 0 uncertainty
 ### Removed

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -72,7 +72,12 @@ from numdifftools import Hessdiag
 import pint
 import pint.utils
 import pint.derived_quantities
-from pint.models.parameter import AngleParameter, boolParameter, strParameter
+from pint.models.parameter import (
+    AngleParameter,
+    boolParameter,
+    strParameter,
+    funcParameter,
+)
 from pint.pint_matrix import (
     CorrelationMatrix,
     CovarianceMatrix,
@@ -624,7 +629,11 @@ class Fitter:
                 and self.model.OMDOT.value != 0.0
             ):
                 omdot = self.model.OMDOT.quantity
-                omdot_err = self.model.OMDOT.uncertainty
+                omdot_err = (
+                    self.model.OMDOT.uncertainty
+                    if self.model.OMDOT.uncertainty is not None
+                    else 0 * self.model.OMDOT.quantity.unit
+                )
                 ecc = (
                     ecc.n * u.dimensionless_unscaled
                     if ell1


### PR DESCRIPTION
Closes #1688 

Tried to compute Mtot from OMDOT including uncertainty in `fitter.derived_params()`.  But in this case OMDOT had no uncertainty since it was a `funcParameter`.  Now has explicit protection against 0 uncertainties (whether from this or a frozen model).

Related question: should the Mtot computation there happen at all if OMDOT < 0?