### PR TITLE
CI ephemeris test no longer requires access to static NANOGrav site

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -10,6 +10,7 @@ the released changes.
 ## Unreleased
 ### Changed
 - Moved `get_derived_params` to `timing_model`
+- `check_ephemeris_connection` CI test no longer requires access to static NANOGrav site
 ### Added
 - Added numdifftools to setup.cfg to match requirements.txt
 - Documentation: Added `convert_parfile` to list of command-line tools in RTD

--- a/check_ephemeris_connection.py
+++ b/check_ephemeris_connection.py
@@ -1,8 +1,5 @@
-import urllib.request
 import pint.solar_system_ephemerides
 
-
-urllib.request.urlopen("https://data.nanograv.org/static/data/ephem/de405.bsp").read()
 
 for e in [
     "de440",


### PR DESCRIPTION
In general the ephemeris downloader is smart enough to look at astropy first and then a list of mirror sites.  But in `check_ephemeris_connection.py` it also had a command to look explicitly at `data.nanograv.org`.  This meant that any disruption to that site would break CI.

This removes that one command.  The remainder of the ephemeris files are still searched using the standard method.