### PR TITLE
Allow simulated TOAs to maintain a non-zero mean

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -32,6 +32,7 @@ the released changes.
     - Documentation: Noise fitting example notebook.
 - `freeze_params` option in `wavex_setup` and `dmwavex_setup`
 - `plrednoise_from_wavex`, `pldmnoise_from_dmwavex`, and `find_optimal_nharms` functions
+- fake TOAs can be created with `subtract_mean=False`, to maintain phase coherence between different data sets
 ### Fixed
 - `MCMC_walkthrough` notebook now runs
 - Fixed runtime data README 

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -1,8 +1,9 @@
 """Functions related to simulating TOAs and models
 """
+from __future__ import annotations
 from collections import OrderedDict
 from copy import deepcopy
-from typing import Optional, Union, List, Dict
+from typing import Optional, List
 import pathlib
 
 import astropy.units as u

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -22,7 +22,7 @@ __all__ = [
 ]
 
 
-def zero_residuals(ts, model, maxiter=10, tolerance=None):
+def zero_residuals(ts, model, subtract_mean=True, maxiter=10, tolerance=None):
     """Use a model to adjust a TOAs object, setting residuals to 0 iteratively.
 
     Parameters
@@ -42,7 +42,9 @@ def zero_residuals(ts, model, maxiter=10, tolerance=None):
     if tolerance is None:
         tolerance = 1 * u.ns if pint.utils.check_longdouble_precision() else 5 * u.us
     for i in range(maxiter):
-        r = pint.residuals.Residuals(ts, model, track_mode="use_pulse_numbers")
+        r = pint.residuals.Residuals(
+            ts, model, subtract_mean=subtract_mean, track_mode="use_pulse_numbers"
+        )
         resids = r.calc_time_resids(calctype="taylor")
         if maxresid is not None and (np.abs(resids).max() > maxresid):
             log.warning(
@@ -104,7 +106,14 @@ def get_fake_toa_clock_versions(model, include_bipm=False, include_gps=True):
     }
 
 
-def make_fake_toas(ts, model, add_noise=False, add_correlated_noise=False, name="fake"):
+def make_fake_toas(
+    ts,
+    model,
+    add_noise=False,
+    add_correlated_noise=False,
+    name="fake",
+    subtract_mean=True,
+):
     """Make toas from an array of times
 
     Can include alternating frequencies if fed an array of frequencies,
@@ -122,6 +131,8 @@ def make_fake_toas(ts, model, add_noise=False, add_correlated_noise=False, name=
         Add correlated noise to the TOAs if it's present in the timing mode.
     name : str, optional
         Name for the TOAs (goes into the flags)
+    subtract_mean : bool, optional
+        Controls whether mean will be subtracted from the residuals when making fake TOAs
 
     Returns
     -------
@@ -133,7 +144,7 @@ def make_fake_toas(ts, model, add_noise=False, add_correlated_noise=False, name=
     `add_noise` respects any ``EFAC`` or ``EQUAD`` present in the `model`
     """
     tsim = deepcopy(ts)
-    zero_residuals(tsim, model)
+    zero_residuals(tsim, model, subtract_mean=subtract_mean)
 
     if add_correlated_noise:
         U = model.noise_model_designmatrix(tsim)
@@ -191,6 +202,7 @@ def make_fake_toas_uniform(
     include_gps=True,
     multi_freqs_in_epoch=False,
     flags=None,
+    subtract_mean=True,
 ):
     """Simulate uniformly spaced TOAs.
 
@@ -236,6 +248,8 @@ def make_fake_toas_uniform(
         Whether to generate multiple frequency TOAs for the same epoch.
     flags: None or dict
         Dictionary of flags to be added to all simulated TOAs.
+    subtract_mean : bool, optional
+        Controls whether mean will be subtracted from the residuals when making fake TOAs
 
     Returns
     -------
@@ -308,6 +322,7 @@ def make_fake_toas_uniform(
         add_noise=add_noise,
         add_correlated_noise=add_correlated_noise,
         name=name,
+        subtract_mean=subtract_mean,
     )
 
 
@@ -326,6 +341,7 @@ def make_fake_toas_fromMJDs(
     include_gps=True,
     multi_freqs_in_epoch=False,
     flags=None,
+    subtract_mean=True,
 ):
     """Simulate TOAs from a list of MJDs
 
@@ -363,6 +379,8 @@ def make_fake_toas_fromMJDs(
         Whether to generate multiple frequency TOAs for the same epoch.
     flags: None or dict
         Dictionary of flags to be added to all simulated TOAs.
+    subtract_mean : bool, optional
+        Controls whether mean will be subtracted from the residuals when making fake TOAs
 
     Returns
     -------
@@ -439,11 +457,17 @@ def make_fake_toas_fromMJDs(
         add_noise=add_noise,
         add_correlated_noise=add_correlated_noise,
         name=name,
+        subtract_mean=subtract_mean,
     )
 
 
 def make_fake_toas_fromtim(
-    timfile, model, add_noise=False, add_correlated_noise=False, name="fake"
+    timfile,
+    model,
+    add_noise=False,
+    add_correlated_noise=False,
+    name="fake",
+    subtract_mean=True,
 ):
     """Simulate fake TOAs with the same times as an input tim file
 
@@ -459,6 +483,8 @@ def make_fake_toas_fromtim(
         Add correlated noise to the TOAs if it's present in the timing mode.
     name : str, optional
         Name for the TOAs (goes into the flags)
+    subtract_mean : bool, optional
+        Controls whether mean will be subtracted from the residuals when making fake TOAs
 
     Returns
     -------
@@ -493,6 +519,7 @@ def make_fake_toas_fromtim(
         add_noise=add_noise,
         add_correlated_noise=add_correlated_noise,
         name=name,
+        subtract_mean=subtract_mean,
     )
 
 

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -22,7 +22,7 @@ __all__ = [
 ]
 
 
-def zero_residuals(ts, model, subtract_mean=True, maxiter=10, tolerance=None):
+def zero_residuals(ts, model, *, subtract_mean=True, maxiter=10, tolerance=None):
     """Use a model to adjust a TOAs object, setting residuals to 0 iteratively.
 
     Parameters
@@ -31,6 +31,8 @@ def zero_residuals(ts, model, subtract_mean=True, maxiter=10, tolerance=None):
         Input TOAs (modified in-place)
     model : pint.models.timing_model.TimingModel
         current model
+    subtract_mean : bool, optional
+        Controls whether mean will be subtracted from the residuals when making fake TOAs
     maxiter : int, optional
         maximum number of iterations allowed
     tolerance : astropy.units.Quantity

--- a/src/pint/simulation.py
+++ b/src/pint/simulation.py
@@ -1,5 +1,6 @@
 """Functions related to simulating TOAs and models
 """
+
 from __future__ import annotations
 from collections import OrderedDict
 from copy import deepcopy
@@ -13,6 +14,7 @@ from astropy import time
 
 import pint.residuals
 import pint.toa
+import pint.fitter
 from pint.observatory import bipm_default, get_observatory
 
 __all__ = [

--- a/tests/test_fake_toas.py
+++ b/tests/test_fake_toas.py
@@ -236,6 +236,60 @@ def test_fake_fromMJDs(MJDs):
     assert np.isclose(r.calc_time_resids().std(), 1 * u.us, rtol=0.2)
 
 
+def test_fake_fromMJDs_keepmean():
+    # basic model, no EFAC or EQUAD
+    model = get_model(
+        io.StringIO(
+            """
+        PSRJ J1234+5678
+        ELAT 0
+        ELONG 0
+        DM 10
+        F0 1
+        F1 -1E-15
+        PEPOCH 58000
+        """
+        )
+    )
+    t1 = np.linspace(57001, 57500, 100, dtype=np.longdouble) * u.d
+    t2 = np.linspace(57501, 58000, 100, dtype=np.longdouble) * u.d
+    toas1 = pint.simulation.make_fake_toas_fromMJDs(
+        t1,
+        model=model,
+        error=1 * u.us,
+        add_noise=True,
+    )
+    toas2 = pint.simulation.make_fake_toas_fromMJDs(
+        t2,
+        model=model,
+        error=1 * u.us,
+        add_noise=True,
+    )
+    r = pint.residuals.Residuals(toas1 + toas2, model)
+    toas1m = pint.simulation.make_fake_toas_fromMJDs(
+        t1,
+        model=model,
+        error=1 * u.us,
+        add_noise=True,
+        subtract_mean=False,
+    )
+    toas2m = pint.simulation.make_fake_toas_fromMJDs(
+        t2,
+        model=model,
+        error=1 * u.us,
+        add_noise=True,
+        subtract_mean=False,
+    )
+    r = pint.residuals.Residuals(toas1 + toas2, model)
+    rm = pint.residuals.Residuals(toas1m + toas2m, model)
+
+    # need a generous rtol because of the small statistics
+    # this first test should fail because the two segments won't have the same mean
+    assert not np.isclose(r.calc_time_resids().std(), 1 * u.us, rtol=0.2)
+    # but this should pass because we no longer subtract the mean.  they should be coherent
+    assert np.isclose(rm.calc_time_resids().std(), 1 * u.us, rtol=0.2)
+
+
 @pytest.mark.parametrize(
     "t1,t2",
     [


### PR DESCRIPTION
Normally when creating fake TOAs, the residuals are set to zero with `subtract_mean=True`.  This means that when comparing a set of TOAs (real or fake) against another set of fake TOAs, they will not connect coherently.  

This PR allows the option of setting `subtract_mean=False` to the various fake TOA creation routines to preserve coherence.