### PR TITLE
Improve clock error reporting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: check-yaml
     -   id: check-merge-conflict
     -   id: check-symlinks
 -   repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 24.2.0
     hooks:
     -   id: black

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -12,6 +12,7 @@ the released changes.
 - Moved `get_derived_params` to `timing_model`
 - `check_ephemeris_connection` CI test no longer requires access to static NANOGrav site
 - `TimingModel.compare()` now calls `change_binary_epoch()`.
+- When clock files contain out-of-order entries, the exception now records the first MJDs that are out of order
 ### Added
 - Added numdifftools to setup.cfg to match requirements.txt
 - Documentation: Added `convert_parfile` to list of command-line tools in RTD

--- a/src/pint/observatory/clock_file.py
+++ b/src/pint/observatory/clock_file.py
@@ -103,8 +103,9 @@ class ClockFile:
             raise ValueError(f"MJDs have {len(mjd)} entries but clock has {len(clock)}")
         self._time = Time(mjd, format="pulsar_mjd", scale="utc")
         if not np.all(np.diff(self._time.mjd) >= 0):
+            i = np.where(np.diff(self._time.mjd) < 0)[0][0]
             raise ValueError(
-                f"Clock file {self.friendly_name} appears to be out of order"
+                f"Clock file {self.friendly_name} appears to be out of order: {self._time[i]} > {self._time[i+1]}"
             )
         self._clock = clock.to(u.us)
         if comments is None:

--- a/tests/test_clock_file.py
+++ b/tests/test_clock_file.py
@@ -107,7 +107,8 @@ def test_merge_mjds_trims_range():
     ca = ClockFile(mjd=a, clock=np.zeros_like(a) * u.s)
     cb = ClockFile(mjd=b, clock=np.zeros_like(b) * u.s)
 
-    m = ClockFile.merge([ca, cb])
+    with pytest.warns(UserWarning, match="out of range"):
+        m = ClockFile.merge([ca, cb])
     assert_array_equal(m.time.mjd, np.array([50000, 55000, 60000]))
 
 
@@ -118,7 +119,8 @@ def test_merge_mjds_trims_range_repeat_beginning():
     ca = ClockFile(mjd=a, clock=np.zeros_like(a) * u.s)
     cb = ClockFile(mjd=b, clock=np.zeros_like(b) * u.s)
 
-    m = ClockFile.merge([ca, cb])
+    with pytest.warns(UserWarning, match="out of range"):
+        m = ClockFile.merge([ca, cb])
     assert_array_equal(m.time.mjd, np.array([50000, 50000, 55000, 60000]))
 
 
@@ -129,7 +131,8 @@ def test_merge_mjds_trims_range_repeat_end():
     ca = ClockFile(mjd=a, clock=np.zeros_like(a) * u.s)
     cb = ClockFile(mjd=b, clock=np.zeros_like(b) * u.s)
 
-    m = ClockFile.merge([ca, cb])
+    with pytest.warns(UserWarning, match="out of range"):
+        m = ClockFile.merge([ca, cb])
     assert_array_equal(m.time.mjd, np.array([50000, 55000, 60000, 60000]))
 
 
@@ -139,7 +142,8 @@ def test_merge_mjds_trims_range_mixed():
 
     ca = ClockFile(mjd=a, clock=np.zeros_like(a) * u.s)
     cb = ClockFile(mjd=b, clock=np.zeros_like(b) * u.s)
-    m = ClockFile.merge([ca, cb])
+    with pytest.warns(UserWarning, match="out of range"):
+        m = ClockFile.merge([ca, cb])
     assert_array_equal(m.time.mjd, np.array([50000, 55000, 60000]))
 
 
@@ -469,3 +473,13 @@ def test_out_of_range_allowed():
         valid_beyond_ends=True,
     )
     basic_clock.evaluate(Time(60001, format="mjd"), limits="error")
+
+
+def test_out_of_order_raises_exception():
+    with pytest.raises(ValueError) as excinfo:
+        ClockFile(
+            mjd=np.array([50000, 55000, 54000, 60000]),
+            clock=np.array([1.0, 2.0, -1.0, 1.0]) * u.us,
+            friendly_name="basic_clock",
+        )
+    assert "55000" in str(excinfo.value)


### PR DESCRIPTION
When PINT tries to read a clock file with out-of-order entries, it will raise an exception. (Such files have never worked correctly on any of TEMPO, TEMPO2, or PINT.) This PR makes sure that includes the first two out-of-order MJDs to aid in diagnosing the problem.

Helped with both https://github.com/ipta/pulsar-clock-corrections/issues/18 and https://github.com/ipta/pulsar-clock-corrections/issues/19

