### PR TITLE
Remove ERFA warnings

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -12,6 +12,7 @@ the released changes.
 - Moved `get_derived_params` to `timing_model`
 - `check_ephemeris_connection` CI test no longer requires access to static NANOGrav site
 - `TimingModel.compare()` now calls `change_binary_epoch()`.
+- Turned ErfaWarning into an exception during testing; cleaned up test suite.
 ### Added
 - Added numdifftools to setup.cfg to match requirements.txt
 - Documentation: Added `convert_parfile` to list of command-line tools in RTD

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    error::erfa.ErfaWarning

--- a/src/pint/data/runtime/observatories.json
+++ b/src/pint/data/runtime/observatories.json
@@ -627,6 +627,7 @@
             "leap2effix.clk",
             "effix2gps.clk"
         ],
+        "bogus_last_correction": true,
         "fullname": "The Large European Array for Pulsars",
         "origin": "This is the same as the position of the Effelsberg radio telescope.\nImported from TEMPO2 observatories.dat 2021 June 7."
     },

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -801,9 +801,11 @@ class AstrometryEcliptic(Astrometry):
             epoch if isinstance(epoch, Time) else Time(epoch, scale="tdb", format="mjd")
         )
         position_now = add_dummy_distance(self.get_psr_coords())
-        return remove_dummy_distance(
-            position_now.apply_space_motion(new_obstime=newepoch)
-        )
+        with warnings.catch_warnings():
+            # This is a fake position, no point ERFA warning the user it's bogus
+            warnings.filterwarnings("ignore", r".*distance overridden", ErfaWarning)
+            position_then = position_now.apply_space_motion(new_obstime=newepoch)
+        return remove_dummy_distance(position_then)
 
     def coords_as_ICRS(self, epoch=None):
         """Return the pulsar's ICRS coordinates as an astropy coordinate object."""

--- a/src/pint/observatory/__init__.py
+++ b/src/pint/observatory/__init__.py
@@ -103,9 +103,13 @@ def _load_bipm_clock(bipm_version):
         try:
             log.info(f"Loading BIPM clock version {bipm_version}")
             # FIXME: error handling?
+            # FIXME: BIPM2019 and earlier come fromm the TEMPO2 repository and have a bogus last correction
+            # later ones are generated and don't; how to manage this?
+            bogus_last_correction = bipm_version.lower() <= "bipm2019"
             _bipm_clock_versions[bipm_version] = find_clock_file(
                 f"tai2tt_{bipm_version}.clk",
                 format="tempo2",
+                bogus_last_correction=bogus_last_correction,
             )
         except Exception as e:
             raise ValueError(

--- a/src/pint/observatory/clock_file.py
+++ b/src/pint/observatory/clock_file.py
@@ -523,16 +523,22 @@ def read_tempo2_clock_file(
         mjd = mjd[1:]
         clk = clk[1:]
         comments = comments[1:]
-    return ClockFile(
-        mjd,
-        clk * u.s,
-        filename=filename,
-        comments=comments,
-        leading_comment=leading_comment,
-        header=header,
-        friendly_name=friendly_name,
-        valid_beyond_ends=valid_beyond_ends,
-    )
+    with warnings.catch_warnings():
+        # Some clock files have dubious years in them
+        # Most are removed by automatically ignoring MJD 0, or with "bogus_last_correction"
+        # But Parkes incudes a non-zero correction for MJD 0 so it isn't removed
+        # In any case, the user doesn't need a warning about strange years in clock files
+        warnings.filterwarnings("ignore", r".*dubious year", erfa.ErfaWarning)
+        return ClockFile(
+            mjd,
+            clk * u.s,
+            filename=filename,
+            comments=comments,
+            leading_comment=leading_comment,
+            header=header,
+            friendly_name=friendly_name,
+            valid_beyond_ends=valid_beyond_ends,
+        )
 
 
 ClockFile._formats["tempo2"] = read_tempo2_clock_file

--- a/src/pint/observatory/clock_file.py
+++ b/src/pint/observatory/clock_file.py
@@ -1,11 +1,13 @@
 """Routines for reading and writing various formats of clock file."""
 
 import re
+import warnings
 from pathlib import Path
 from textwrap import dedent
 from warnings import warn
 
 import astropy.units as u
+import erfa
 import numpy as np
 from loguru import logger as log
 
@@ -864,7 +866,11 @@ class GlobalClockFile(ClockFile):
         corrections : astropy.units.Quantity
             The corrections in units of microseconds.
         """
-        if np.any(t > self.clock_file.time[-1]):
+        with warnings.catch_warnings():
+            # FIXME: could these warnings be useful?
+            warnings.filterwarnings("ignore", r".*dubuious year", erfa.ErfaWarning)
+            needs_update = np.any(t > self.clock_file.time[-1])
+        if needs_update:
             self.update()
         return self.clock_file.evaluate(t, limits=limits)
 

--- a/src/pint/pulsar_mjd.py
+++ b/src/pint/pulsar_mjd.py
@@ -265,11 +265,7 @@ def time_from_longdouble(t, scale="utc", format="pulsar_mjd"):
     t = np.longdouble(t)
     i = float(np.floor(t))
     f = float(t - i)
-    # FIXME: double-check whether warnings from here could be useful
-    # if they only arise because of weird test inputs silence them in the tests
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", r".*dubious year", erfa.ErfaWarning)
-        return astropy.time.Time(val=i, val2=f, format=format, scale=scale)
+    return astropy.time.Time(val=i, val2=f, format=format, scale=scale)
 
 
 def time_to_mjd_string(t):
@@ -405,9 +401,7 @@ def jds_to_mjds_pulsar(jd1, jd2):
     # Note this will return an incorrect value during
     # leap seconds, so raise an exception in that
     # case.
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", r".*dubious year", erfa.ErfaWarning)
-        y, mo, d, hmsf = erfa.d2dtf("UTC", _digits, jd1, jd2)
+    y, mo, d, hmsf = erfa.d2dtf("UTC", _digits, jd1, jd2)
     # For ASTROPY_LT_3_1, convert to the new structured array dtype that
     # is returned by the new erfa gufuncs.
     if not hmsf.dtype.names:
@@ -450,9 +444,7 @@ def mjds_to_jds_pulsar(mjd1, mjd2):
     f -= m
     f *= 60
     s = f
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", r".*dubious year", erfa.ErfaWarning)
-        return erfa.dtf2d("UTC", y, mo, d, h, m, s)
+    return erfa.dtf2d("UTC", y, mo, d, h, m, s)
 
 
 # Please forgive the horrible hacks to make these work cleanly on both arrays

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    error::ErfaWarning

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-filterwarnings =
-    error::ErfaWarning


### PR DESCRIPTION
This PR sets `pytest` so that ERFA warnings become exceptions, then adjusts things so that the test suite passes. For the most part, this amounts to ignoring/suppressing ERFA warnings that are generated when the test suite (usually because of hypothesis) supplies very unusual dates to Time functions. There is at least one instance where loading the Parkes clock file requires handling MJD 0, which meant emitting an ERFA warning every time you worked with Parkes data. This has been fixed; "dubious year" warnings are no longer emitted when loading clock files.

