### PR TITLE
WIP: mypy checking as part of CI

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -35,6 +35,9 @@ jobs:
           - os: ubuntu-latest
             python: '3.12'
             tox_env: 'notebooks'
+          - os: ubuntu-latest
+            python: '3.12'
+            tox_env: 'mypy'
 #          - os: ubuntu-latest
 #            python: '3.8'
 #            tox_env: 'docs'

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ tests/datafile/par_*.par
 tests/datafile/fake_toas.tim
 tests/datafile/*.converted.par
 tests/datafile/_test_pintempo.out
+
+# mypy
+.mypy_cache

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -41,3 +41,7 @@ loguru
 gprof2dot
 py-cpuinfo
 pytest-xdist
+mypy==1.8.0
+GitPython
+types-setuptools
+types-tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -129,3 +129,67 @@ skip_glob =
     src/pint/extern/*
 include_trailing_comma = True
 combine_as_imports = True
+
+[mypy]
+warn_unused_configs = True
+files = src/pint
+
+[mypy-pint.templates.*]
+ignore_errors = True
+
+[mypy-pint.derived_quantities]
+ignore_errors = True
+
+[mypy-pint.observatory.*]
+ignore_errors = True
+
+[mypy-pint.models.stand_alone_psr_binaries.*]
+ignore_errors = True
+
+[mypy-pint.models.timing_model]
+ignore_errors = True
+
+[mypy-pint.models.pulsar_binary]
+ignore_errors = True
+
+[mypy-pint.fitter]
+ignore_errors = True
+
+[mypy-pint.polycos]
+ignore_errors = True
+
+[mypy-pint.output.publish]
+ignore_errors = True
+
+[mypy-pint.gridutils]
+ignore_errors = True
+
+[mypy-pint.scripts.*]
+ignore_errors = True
+
+[mypy-pint.pintk.plk]
+ignore_errors = True
+
+[mypy-astropy.*]
+ignore_missing_imports = True
+
+[mypy-erfa]
+ignore_missing_imports = True
+
+[mypy-emcee]
+ignore_missing_imports = True
+
+[mypy-jplephem]
+ignore_missing_imports = True
+
+[mypy-numdifftools]
+ignore_missing_imports = True
+
+[mypy-pylab]
+ignore_missing_imports = True
+
+[mypy-scipy.*]
+ignore_missing_imports = True
+
+[mypy-uncertainties]
+ignore_missing_imports = True

--- a/src/pint/logging.py
+++ b/src/pint/logging.py
@@ -72,7 +72,7 @@ script_level = "WARNING"
 # https://loguru.readthedocs.io/en/stable/api/logger.html#color
 
 showwarning_ = warnings.showwarning
-warning_onceregistry = {}
+warning_onceregistry: dict[tuple[str, str], int] = {}
 
 # basic loguru level definitions from:
 # https://loguru.readthedocs.io/en/stable/api/logger.html

--- a/src/pint/observatory/__init__.py
+++ b/src/pint/observatory/__init__.py
@@ -787,7 +787,7 @@ def list_last_correction_mjds() -> None:
                 print(f"    {c.friendly_name:<20} MISSING")
 
 
-def update_clock_files(bipm_versions: Optional[list[str]] = None) -> None:
+def update_clock_files(bipm_versions: Optional[List[str]] = None) -> None:
     """Obtain an up-to-date version of all clock files.
 
     This up-to-date version will be stored in the Astropy cache;

--- a/src/pint/observatory/__init__.py
+++ b/src/pint/observatory/__init__.py
@@ -28,7 +28,7 @@ from collections.abc import Callable
 from copy import deepcopy
 from io import StringIO
 from pathlib import Path
-from typing import Optional, Union, List, Dict
+from typing import Optional, Union, List, Dict, Literal
 
 import astropy.coordinates
 import astropy.time
@@ -348,7 +348,7 @@ class Observatory:
         """
         return None
 
-    def get_gcrs(self, t: astropy.time.Time, ephem=None):
+    def get_gcrs(self, t: astropy.time.Time, ephem: Optional[str] = None):
         """Return position vector of observatory in GCRS.
 
         t is an astropy.Time or array of astropy.Time objects
@@ -468,17 +468,17 @@ class Observatory:
         else:
             raise ValueError(f"Unknown method '{method}'.")
 
-    def _get_TDB_default(self, t: astropy.time.Time, ephem):
+    def _get_TDB_default(self, t: astropy.time.Time, ephem: Optional[str]):
         return t.tdb
 
-    def _get_TDB_ephem(self, t: astropy.time.Time, ephem):
+    def _get_TDB_ephem(self, t: astropy.time.Time, ephem: Optional[str]):
         """Read the ephem TDB-TT column.
 
         This column is provided by DE4XXt version of ephemeris.
         """
         raise NotImplementedError
 
-    def posvel(self, t: astropy.time.Time, ephem, group=None) -> PosVel:
+    def posvel(self, t: astropy.time.Time, ephem: Optional[str], group=None) -> PosVel:
         """Return observatory position and velocity for the given times.
 
         Position is relative to solar system barycenter; times are
@@ -491,7 +491,10 @@ class Observatory:
 
 
 def get_observatory(
-    name: str, include_gps=None, include_bipm=None, bipm_version: str = bipm_default
+    name: str,
+    include_gps: Optional[bool] = None,
+    include_bipm: Optional[bool] = None,
+    bipm_version: str = bipm_default,
 ):
     """Convenience function to get observatory object with options.
 
@@ -753,7 +756,7 @@ def compare_tempo_obsys_dat(tempodir: Optional[str] = None) -> Dict[str, List[Di
     return report
 
 
-def list_last_correction_mjds():
+def list_last_correction_mjds() -> None:
     """Print out a list of the last MJD each clock correction is good for.
 
     Each observatory lists the clock files it uses and their last dates,
@@ -784,7 +787,7 @@ def list_last_correction_mjds():
                 print(f"    {c.friendly_name:<20} MISSING")
 
 
-def update_clock_files(bipm_versions=None):
+def update_clock_files(bipm_versions: Optional[list[str]] = None) -> None:
     """Obtain an up-to-date version of all clock files.
 
     This up-to-date version will be stored in the Astropy cache;
@@ -826,13 +829,13 @@ def update_clock_files(bipm_versions=None):
 
 # Both topo_obs and special_locations need this
 def find_clock_file(
-    name,
-    format,
-    bogus_last_correction=False,
-    url_base=None,
-    clock_dir=None,
-    valid_beyond_ends=False,
-):
+    name: str,
+    format: Literal["tempo", "tempo2"],
+    bogus_last_correction: bool = False,
+    url_base: Optional[str] = None,
+    clock_dir: Union[str, Path, None] = None,
+    valid_beyond_ends: bool = False,
+) -> "ClockFile":
     """Locate and return a ClockFile in one of several places.
 
     PINT looks for clock files in three places, in order:

--- a/src/pint/observatory/__init__.py
+++ b/src/pint/observatory/__init__.py
@@ -140,9 +140,13 @@ class Observatory:
     """
 
     fullname: str
+    """Full human-readable name of the observatory."""
     include_gps: bool
+    """Whether to include GPS clock corrections."""
     include_bipm: bool
+    """Whether to include BIPM clock corrections."""
     bipm_version: str
+    """Version of the BIPM clock file to use."""
 
     # This is a dict containing all defined Observatory instances,
     # keyed on standard observatory name.
@@ -255,10 +259,19 @@ class Observatory:
 
     @property
     def name(self) -> str:
+        """Short name of the observatory.
+
+        This is the name used in TOA files and in the observatory registry.
+        """
         return self._name
 
     @property
     def aliases(self) -> List[str]:
+        """List of aliases for the observatory.
+
+        These are short names also used to specify this observatory.
+        Includes ITOA and TEMPO codes, and any other common names.
+        """
         return self._aliases
 
     @classmethod

--- a/src/pint/observatory/__init__.py
+++ b/src/pint/observatory/__init__.py
@@ -28,7 +28,7 @@ from collections.abc import Callable
 from copy import deepcopy
 from io import StringIO
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, List, Dict
 
 import astropy.coordinates
 import astropy.time
@@ -140,31 +140,31 @@ class Observatory:
     """
 
     fullname: str
-    aliases: list[str]
+    aliases: List[str]
     include_gps: bool
     include_bipm: bool
     bipm_version: str
 
     # This is a dict containing all defined Observatory instances,
     # keyed on standard observatory name.
-    _registry: dict[str, "Observatory"] = {}
+    _registry: Dict[str, "Observatory"] = {}
 
     # This is a dict mapping any defined aliases to the corresponding
     # standard name.
-    _alias_map: dict[str, str] = {}
+    _alias_map: Dict[str, str] = {}
 
     def __init__(
         self,
         name: str,
         fullname: Optional[str] = None,
-        aliases: Optional[list[str]] = None,
+        aliases: Optional[List[str]] = None,
         include_gps: bool = True,
         include_bipm: bool = True,
         bipm_version: str = bipm_default,
         overwrite: bool = False,
     ):
         self._name: str = name.lower()
-        self._aliases: list[str] = (
+        self._aliases: List[str] = (
             list(set(map(str.lower, aliases))) if aliases is not None else []
         )
         if aliases is not None:
@@ -195,7 +195,7 @@ class Observatory:
         cls._registry[name.lower()] = obs
 
     @classmethod
-    def _add_aliases(cls, obs: "Observatory", aliases: list[str]):
+    def _add_aliases(cls, obs: "Observatory", aliases: List[str]):
         """Add aliases for the specified Observatory.  Aliases
         should be given as a list.  If any of the new aliases are already in
         use, they will be replaced.  Aliases are not checked against the
@@ -243,7 +243,7 @@ class Observatory:
         return cls._registry.keys()
 
     @classmethod
-    def names_and_aliases(cls) -> dict[str, list[str]]:
+    def names_and_aliases(cls) -> Dict[str, List[str]]:
         """List all observatories and their aliases"""
         import pint.observatory.topo_obs  # noqa
         import pint.observatory.special_locations  # noqa
@@ -259,7 +259,7 @@ class Observatory:
         return self._name
 
     @property
-    def aliases(self) -> list[str]:
+    def aliases(self) -> List[str]:
         return self._aliases
 
     @classmethod

--- a/src/pint/observatory/topo_obs.py
+++ b/src/pint/observatory/topo_obs.py
@@ -404,7 +404,7 @@ class TopoObs(Observatory):
             t = min(t, clock.last_correction_mjd())
         return t
 
-    def _get_TDB_ephem(self, t: Time, ephem) -> Time:
+    def _get_TDB_ephem(self, t: Time, ephem: Optional[str]) -> Time:
         """Read the ephem TDB-TT column.
 
         This column is provided by DE4XXt version of ephemeris. This function is only

--- a/src/pint/observatory/topo_obs.py
+++ b/src/pint/observatory/topo_obs.py
@@ -306,11 +306,11 @@ class TopoObs(Observatory):
         return {self.name: output}
 
     def get_json(self):
-        """Return as a JSON string"""
+        """Return as a JSON string."""
         return json.dumps(self.get_dict())
 
     def separation(self, other: "TopoObs", method: str = "cartesian"):
-        """Return separation between two TopoObs objects
+        """Return separation between two TopoObs objects.
 
         Parameters
         ----------

--- a/src/pint/observatory/topo_obs.py
+++ b/src/pint/observatory/topo_obs.py
@@ -22,7 +22,7 @@ import json
 import os
 from functools import cached_property
 from pathlib import Path
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Any
 
 import astropy.constants as c
 import astropy.time
@@ -183,14 +183,14 @@ class TopoObs(Observatory):
         tempo_code: Optional[str] = None,
         itoa_code: Optional[str] = None,
         aliases: Optional[List[str]] = None,
-        location=None,
+        location: Optional[EarthLocation] = None,
         itrf_xyz=None,
         lat: Optional[float] = None,
         lon: Optional[float] = None,
         height=None,
         clock_file: str = "",
         clock_fmt: str = "tempo",
-        clock_dir=None,
+        clock_dir: Union[str, Path, None] = None,
         include_gps: bool = True,
         include_bipm: bool = True,
         bipm_version: str = bipm_default,
@@ -287,10 +287,10 @@ class TopoObs(Observatory):
         return f"TopoObs('{self.name}' ({','.join(aliases)}) at [{self.location.x}, {self.location.y} {self.location.z}]:\n{origin})"
 
     @property
-    def timescale(self):
+    def timescale(self) -> str:
         return "utc"
 
-    def get_dict(self):
+    def get_dict(self) -> dict[str, dict[str, Any]]:
         """Return as a dict with limited/changed info"""
         # start with the default __dict__
         # copy some attributes to rename them and remove those that aren't needed for initialization
@@ -305,11 +305,11 @@ class TopoObs(Observatory):
         output["itrf_xyz"] = [x.to_value(u.m) for x in self.location.geocentric]
         return {self.name: output}
 
-    def get_json(self):
+    def get_json(self) -> str:
         """Return as a JSON string."""
         return json.dumps(self.get_dict())
 
-    def separation(self, other: "TopoObs", method: str = "cartesian"):
+    def separation(self, other: "TopoObs", method: str = "cartesian") -> u.Quantity:
         """Return separation between two TopoObs objects.
 
         Parameters
@@ -433,7 +433,7 @@ class TopoObs(Observatory):
             location=self.earth_location_itrf(),
         )
 
-    def get_gcrs(self, t: astropy.time.Time, ephem=None):
+    def get_gcrs(self, t: astropy.time.Time, ephem: Optional[str] = None):
         """Return position vector of TopoObs in GCRS
 
         Parameters
@@ -450,7 +450,7 @@ class TopoObs(Observatory):
         )
         return obs_geocenter_pv.pos
 
-    def posvel(self, t: astropy.time.Time, ephem, group=None) -> PosVel:
+    def posvel(self, t: astropy.time.Time, ephem: Optional[str], group=None) -> PosVel:
         if t.isscalar:
             t = Time([t])
         earth_pv: PosVel = objPosVel_wrt_SSB("earth", t, ephem)

--- a/src/pint/observatory/topo_obs.py
+++ b/src/pint/observatory/topo_obs.py
@@ -22,7 +22,7 @@ import json
 import os
 from functools import cached_property
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union, List
 
 import astropy.constants as c
 import astropy.time
@@ -150,6 +150,31 @@ class TopoObs(Observatory):
 
     """
 
+    tempo_code: Optional[str]
+    """One-character TEMPO code."""
+    itoa_code: Optional[str]
+    """Two-character ITOA code."""
+    location: EarthLocation
+    """Location of the observatory."""
+    clock_files: List[str]
+    """List of files to read for clock corrections.  If empty, no clock corrections are applied."""
+    clock_fmt: str
+    """Format of the clock files.
+    
+    See :class:`pint.observatory.clock_file.ClockFile` for allowed values.
+    """
+    bogus_last_correction: bool
+    """Clock correction files include a bogus last correction.
+    
+    This is common with TEMPO/TEMPO2 clock files since neither program does
+    a good job with times past the end ot the table. It makes detecting values
+    past the end of real calibration difficult if it's not marked as bogus.
+    """
+    clock_dir: Optional[Union[str, Path]]
+    """Where to look for the clock files."""
+    origin: Optional[str]
+    """Documentation of the origin/author/date for the information."""
+
     def __init__(
         self,
         name: str,
@@ -157,7 +182,7 @@ class TopoObs(Observatory):
         fullname: Optional[str] = None,
         tempo_code: Optional[str] = None,
         itoa_code: Optional[str] = None,
-        aliases: Optional[list[str]] = None,
+        aliases: Optional[List[str]] = None,
         location=None,
         itrf_xyz=None,
         lat: Optional[float] = None,
@@ -169,7 +194,7 @@ class TopoObs(Observatory):
         include_gps: bool = True,
         include_bipm: bool = True,
         bipm_version: str = bipm_default,
-        origin=None,
+        origin: Optional[str] = None,
         overwrite: bool = False,
         bogus_last_correction: bool = False,
     ):
@@ -212,10 +237,10 @@ class TopoObs(Observatory):
 
         # Save clock file info, the data will be read only if clock
         # corrections for this site are requested.
-        clock_files: list[str] = (
+        clock_files: List[str] = (
             [clock_file] if isinstance(clock_file, str) else clock_file
         )
-        self.clock_files: list[str] = [c for c in clock_files if c != ""]
+        self.clock_files: List[str] = [c for c in clock_files if c != ""]
         self.clock_fmt: str = clock_fmt
         self.clock_dir = clock_dir
 

--- a/src/pint/observatory/topo_obs.py
+++ b/src/pint/observatory/topo_obs.py
@@ -22,7 +22,7 @@ import json
 import os
 from functools import cached_property
 from pathlib import Path
-from typing import Optional, Union, List, Any
+from typing import Optional, Union, List, Any, Dict
 
 import astropy.constants as c
 import astropy.time
@@ -290,7 +290,7 @@ class TopoObs(Observatory):
     def timescale(self) -> str:
         return "utc"
 
-    def get_dict(self) -> dict[str, dict[str, Any]]:
+    def get_dict(self) -> Dict[str, Dict[str, Any]]:
         """Return as a dict with limited/changed info"""
         # start with the default __dict__
         # copy some attributes to rename them and remove those that aren't needed for initialization

--- a/src/pint/pulsar_mjd.py
+++ b/src/pint/pulsar_mjd.py
@@ -34,13 +34,6 @@ import numpy as np
 from astropy.time import Time
 from astropy.time.formats import TimeFormat
 
-try:
-    maketrans = str.maketrans
-except AttributeError:
-    # fallback for Python 2
-    from string import maketrans
-
-
 # This check is implemented in pint.utils, but we want to avoid circular imports
 if np.finfo(np.longdouble).eps > 2e-19:
     import warnings
@@ -303,7 +296,7 @@ def fortran_float(x):
     """
     try:
         # First treat it as a string, wih d->e
-        return float(x.translate(maketrans("Dd", "ee")))
+        return float(x.translate(str.maketrans("Dd", "ee")))
     except AttributeError:
         # If that didn't work it may already be a numeric type
         return float(x)
@@ -361,7 +354,7 @@ def str2longdouble(str_data):
     """
     if not isinstance(str_data, (str, bytes)):
         raise TypeError("Need a string: {!r}".format(str_data))
-    return np.longdouble(str_data.translate(maketrans("Dd", "ee")))
+    return np.longdouble(str_data.translate(str.maketrans("Dd", "ee")))
 
 
 # Simplified functions: These core functions, if they can be made to work
@@ -453,7 +446,7 @@ def mjds_to_jds_pulsar(mjd1, mjd2):
 def _str_to_mjds(s):
     ss = s.lower().strip()
     if "e" in ss or "d" in ss:
-        ss = ss.translate(maketrans("d", "e"))
+        ss = ss.translate(str.maketrans("d", "e"))
         num, expon = ss.split("e")
         expon = int(expon)
         if expon < 0:

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ envlist =
     report
     codestyle
     black
+    mypy
     py{38,39,310,311,312}-test{,-alldeps,-devdeps}{,-cov}
 
 skip_missing_interpreters = True
@@ -136,3 +137,12 @@ deps =
 commands = black --check src tests examples
 
 
+[testenv:mypy]
+changedir = .
+description = use mypy
+deps =
+    mypy==1.8.0
+    GitPython
+    types-setuptools
+    types-tqdm
+commands = mypy


### PR DESCRIPTION
If we do want to apply static typing to PINT (#1709 ), a possible goal is for the static type checker `mypy` to successfully check the entire code base. 

`mypy` is designed for gradual typing, and in fact there is a [guide to applying mypy to an existing codebase](https://mypy.readthedocs.io/en/stable/existing_code.html). A key first step is to [enable mypy as part of CI](https://mypy.readthedocs.io/en/stable/existing_code.html#run-mypy-consistently-and-prevent-regressions). Of course, this requires an appropriate `mypy` setup; in particular it requires ignoring a lot of errors. As long as these are ignored, `mypy` isn't doing a particularly strict job, but this is a starting point for gradual typing.

Next steps:

1. Get `mypy` working on the whole codebase and running in CI, but with sufficiently permissive settings that it passes. *This PR does this.*
2. Select a small subset of the codebase (ideally something that is widely used) and enable stricter `mypy` checking, fixing that part of the codebase so it passes. *This PR does this for `pint.utils` and a few other tiny parts.*
3. Add type annotations to the subset where `mypy` is checking, making sure `mypy` continues to pass.
4. Add a new piece of code to the subset `mypy` checks and apply the above.

