### PR TITLE
Removed np.compat.long (deprecated)

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -13,6 +13,7 @@ the released changes.
 - `check_ephemeris_connection` CI test no longer requires access to static NANOGrav site
 - `TimingModel.compare()` now calls `change_binary_epoch()`.
 - When clock files contain out-of-order entries, the exception now records the first MJDs that are out of order
+- `np.compat.long` -> `int` (former is deprecated)
 ### Added
 - Added numdifftools to setup.cfg to match requirements.txt
 - Documentation: Added `convert_parfile` to list of command-line tools in RTD

--- a/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
+++ b/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
@@ -25,7 +25,7 @@ class Orbit:
     def orbit_phase(self):
         """Orbital phase (between zero and two pi)."""
         orbits = self.orbits()
-        norbits = np.array(np.floor(orbits), dtype=np.compat.long)
+        norbits = np.array(np.floor(orbits), dtype=int)
         return (orbits - norbits) * 2 * np.pi * u.rad
 
     def pbprime(self):


### PR DESCRIPTION
Addresses #1727.  I think that in this case `np.compat.long` is just an alias for `int` (that's what I see when I look at it on my local system).