### PR TITLE
FDJUMPDM : System-dependent DM offset

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -36,6 +36,7 @@ the released changes.
 - `plrednoise_from_wavex`, `pldmnoise_from_dmwavex`, and `find_optimal_nharms` functions
 - fake TOAs can be created with `subtract_mean=False`, to maintain phase coherence between different data sets
 - FDJumpDM component for System-dependent DM offsets / Index-0 FD jumps 
+- Documentation: Explanation for FDJUMP and FDJUMPDM
 ### Fixed
 - `MCMC_walkthrough` notebook now runs
 - Fixed runtime data README 

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -35,6 +35,7 @@ the released changes.
 - `freeze_params` option in `wavex_setup` and `dmwavex_setup`
 - `plrednoise_from_wavex`, `pldmnoise_from_dmwavex`, and `find_optimal_nharms` functions
 - fake TOAs can be created with `subtract_mean=False`, to maintain phase coherence between different data sets
+- FDJumpDM component for System-dependent DM offsets / Index-0 FD jumps 
 ### Fixed
 - `MCMC_walkthrough` notebook now runs
 - Fixed runtime data README 

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -36,7 +36,7 @@ the released changes.
 - `freeze_params` option in `wavex_setup` and `dmwavex_setup`
 - `plrednoise_from_wavex`, `pldmnoise_from_dmwavex`, and `find_optimal_nharms` functions
 - fake TOAs can be created with `subtract_mean=False`, to maintain phase coherence between different data sets
-- FDJumpDM component for System-dependent DM offsets / Index-0 FD jumps 
+- FDJumpDM component for System-dependent DM offsets
 - Documentation: Explanation for FDJUMP and FDJUMPDM
 ### Fixed
 - `MCMC_walkthrough` notebook now runs

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -49,4 +49,5 @@ the released changes.
 - Emit warnings when `WaveX`/`DMWaveX` is used together with other representations of red/DM noise
 - `get_observatory()` no longer overwrites `include_gps` and `include_bipm` of `Observatory` objects unless explicitly stated (BIPM and GPS clock corrections no longer incorrectly applied to BAT TOAs).
 - Added back `spacecraft` as an alias for `stl_geo`
+- Docstring of `DispersionJump`
 ### Removed

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -254,7 +254,7 @@ This type of offset only applies to the wideband DM values and not to the wideba
 
 Similar offsets also arise in the case of narrowband TOAs. Unlike the wideband case, these offsets 
 manifest as system-dependent corrections to the DM delay. They are modeled using the FDJUMPDM parameters
-(see see :class:`pint.models.fdjump.FDJumpDM`)
+(see see :class:`pint.models.dispersion_model.FDJumpDM`)
 
 System- and frequency-dependent offsets (FDJUMPs)
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -235,8 +235,12 @@ corrections. The explicit phase offset (option 3) can be invoked by adding the `
 (implemented in :class:`pint.models.phase_offset.PhaseOffset`). If the explicit offset `PHOFF`
 is given, the implicit residual mean subtraction behavior will be disabled.
 
-System-dependent delays (JUMPs)
-'''''''''''''''''''''''''''''''
+In the pulsar ephemeris (par) file, an example `PHOFF` parameter looks like this:
+
+    `PHOFF   0.1   1   0.001`
+
+System-dependent delays (`JUMP`s)
+'''''''''''''''''''''''''''''''''
 It is very common to have TOAs for the same pulsar obtained using different observatories, 
 telescope receivers, backend systems, and data processing pipelines, especially in long-running 
 campaigns. Delays can arise between the TOAs measured using such different systems due to, among
@@ -245,18 +249,35 @@ measurement etc., and the choice of different template profiles used for TOA mea
 offsets are usually modeled using phase jumps (the `JUMP` parameter, see :class:`pint.models.jump.PhaseJump`) 
 between TOAs generated from different systems.
 
-System-dependent DM offsets (DMJUMPs and FDJUMPDMs)
+Here are some examples for `JUMP` parameters in a par file:
+
+    `JUMP   -f 430_PUPPI    0.01  1   1e-5`
+    `JUMP   tel ao          0.01  1   1e-5`
+    `JUMP   mjd 55000 55100 0.01  1   1e-5`
+    `JUMP   freq 1000 1400  0.01  1   1e-5`
+
+System-dependent DM offsets (`DMJUMP`s and `FDJUMPDM`s)
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''
 Similar to system-dependent delays, offsets can arise between wideband DM values measured using 
 different systems due to the choice of template portraits with different fiducial DMs. This is 
 usually modeled using DM jumps (the `DMJUMP` parameter, see :class:`pint.models.dispersion_model.DispersionJump`).
 This type of offset only applies to the wideband DM values and not to the wideband TOAs. 
 
+Here are some examples for `DMJUMP` parameters in a par file:
+    `DMJUMP   -f 430_PUPPI    1e-4  1   1e-5`
+    `DMJUMP   tel ao          1e-4  1   1e-5`
+    `DMJUMP   mjd 55000 55100 1e-4  1   1e-5`
+    `DMJUMP   freq 1000 1400  1e-4  1   1e-5`
+
 Similar offsets also arise in the case of narrowband TOAs. Unlike the wideband case, these offsets 
-manifest as system-dependent corrections to the DM delay. They are modeled using the FDJUMPDM parameters
+manifest as system-dependent corrections to the DM delay. They are modeled using the `FDJUMPDM` parameters
 (see see :class:`pint.models.dispersion_model.FDJumpDM`)
 
-System- and frequency-dependent offsets (FDJUMPs)
+Here are some examples for `FDJUMPDM` parameters in a par file:
+    `FDJUMPDM   -f 430_PUPPI       1e-4  1   1e-5`
+    `FDJUMPDM   -f L-wide_PUPPI    1e-4  1   1e-5`
+
+System- and frequency-dependent offsets (`FDJUMP`s)
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 In narrowband datasets, the template profiles often do not adequately model the frequency-dependent 
 evolution of pulse profiles, resulting in a frequency-dependent artefact in the timing residuals.
@@ -265,6 +286,12 @@ whose coefficients are the so-called FD parameters (see :class:`pint.models.freq
 Sometimes, this effect needs to be modeled separately for different systems since different template 
 profiles will be used for each system. This is achieved through system-dependent FD parameters or FDJUMPs 
 (see :class:`pint.models.fdjump.FDJump`). 
+
+Here are some examples for `FDJUMP` parameters in a par file:
+    `FD1JUMP   -f L-wide_PUPPI    1e-4  1   1e-5`
+    `FD2JUMP   -f L-wide_PUPPI    1e-4  1   1e-5`
+    `FD1JUMP   -f 430_PUPPI       1e-4  1   1e-5`
+    `FD2JUMP   -f 430_PUPPI       1e-4  1   1e-5`
 
 Observatories
 -------------

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -220,8 +220,8 @@ Offsets in pulsar timing
 Offsets arise in pulsar timing models for a variety of reasons. The different types of
 offsets are listed below:
 
-Overall phase offset
-''''''''''''''''''''
+Overall phase offset (PHOFF)
+''''''''''''''''''''''''''''
 The pulse phase corresponding to the TOAs are usually computed in reference to an arbitrary 
 fiducial TOA known as the TZR TOA (see :class:`pint.models.absolute_phase.AbsPhase`). Since the 
 choice of the TZR TOA is arbitrary, there can be an overall phase offset between the TZR TOA and 
@@ -235,8 +235,8 @@ corrections. The explicit phase offset (option 3) can be invoked by adding the `
 (implemented in :class:`pint.models.phase_offset.PhaseOffset`). If the explicit offset `PHOFF`
 is given, the implicit residual mean subtraction behavior will be disabled.
 
-System-dependent delays
-'''''''''''''''''''''''
+System-dependent delays (JUMPs)
+'''''''''''''''''''''''''''''''
 It is very common to have TOAs for the same pulsar obtained using different observatories, 
 telescope receivers, backend systems, and data processing pipelines, especially in long-running 
 campaigns. Delays can arise between the TOAs measured using such different systems due to, among
@@ -245,11 +245,26 @@ measurement etc., and the choice of different template profiles used for TOA mea
 offsets are usually modeled using phase jumps (the `JUMP` parameter, see :class:`pint.models.jump.PhaseJump`) 
 between TOAs generated from different systems.
 
-System-dependent DM offsets
-'''''''''''''''''''''''''''
+System-dependent DM offsets (DMJUMPs and FDJUMPDMs)
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''
 Similar to system-dependent delays, offsets can arise between wideband DM values measured using 
 different systems due to the choice of template portraits with different fiducial DMs. This is 
 usually modeled using DM jumps (the `DMJUMP` parameter, see :class:`pint.models.dispersion_model.DispersionJump`).
+This type of offset only applies to the wideband DM values and not to the wideband TOAs. 
+
+Similar offsets also arise in the case of narrowband TOAs. Unlike the wideband case, these offsets 
+manifest as system-dependent corrections to the DM delay. They are modeled using the FDJUMPDM parameters
+(see see :class:`pint.models.fdjump.FDJUMPDM`)
+
+System- and frequency-dependent offsets (FDJUMPs)
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+In narrowband datasets, the template profiles often do not adequately model the frequency-dependent 
+evolution of pulse profiles, resulting in a frequency-dependent artefact in the timing residuals.
+This systematic effect is usually modeled phenomenologically as a log-polynomial function of frequency 
+whose coefficients are the so-called FD parameters (see :class:`pint.models.frequency_dependent.FD`). 
+Sometimes, this effect needs to be modeled separately for different systems since different template 
+profiles will be used for each system. This is achieved through system-dependent FD parameters or FDJUMPs 
+(see :class:`pint.models.frequency_dependent.FDJump`). 
 
 Observatories
 -------------

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -250,7 +250,6 @@ offsets are usually modeled using phase jumps (the `JUMP` parameter, see :class:
 between TOAs generated from different systems.
 
 Here are some examples for `JUMP` parameters in a par file:
-
     `JUMP   -f 430_PUPPI    0.01  1   1e-5`
     `JUMP   tel ao          0.01  1   1e-5`
     `JUMP   mjd 55000 55100 0.01  1   1e-5`
@@ -284,7 +283,7 @@ evolution of pulse profiles, resulting in a frequency-dependent artefact in the 
 This systematic effect is usually modeled phenomenologically as a log-polynomial function of frequency 
 whose coefficients are the so-called FD parameters (see :class:`pint.models.frequency_dependent.FD`). 
 Sometimes, this effect needs to be modeled separately for different systems since different template 
-profiles will be used for each system. This is achieved through system-dependent FD parameters or FDJUMPs 
+profiles will be used for each system. This is achieved through system-dependent FD parameters or `FDJUMP`s 
 (see :class:`pint.models.fdjump.FDJump`). 
 
 Here are some examples for `FDJUMP` parameters in a par file:

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -254,7 +254,7 @@ This type of offset only applies to the wideband DM values and not to the wideba
 
 Similar offsets also arise in the case of narrowband TOAs. Unlike the wideband case, these offsets 
 manifest as system-dependent corrections to the DM delay. They are modeled using the FDJUMPDM parameters
-(see see :class:`pint.models.fdjump.FDJUMPDM`)
+(see see :class:`pint.models.fdjump.FDJumpDM`)
 
 System- and frequency-dependent offsets (FDJUMPs)
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -264,7 +264,7 @@ This systematic effect is usually modeled phenomenologically as a log-polynomial
 whose coefficients are the so-called FD parameters (see :class:`pint.models.frequency_dependent.FD`). 
 Sometimes, this effect needs to be modeled separately for different systems since different template 
 profiles will be used for each system. This is achieved through system-dependent FD parameters or FDJUMPs 
-(see :class:`pint.models.frequency_dependent.FDJump`). 
+(see :class:`pint.models.fdjump.FDJump`). 
 
 Observatories
 -------------

--- a/src/pint/models/__init__.py
+++ b/src/pint/models/__init__.py
@@ -16,6 +16,7 @@ handling; they are implemented by deriving from
 :class:`~pint.models.stand_alone_psr_binaries.binary_generic.PSR_BINARY`, which
 provides some of the infrastructure needed to implement them conveniently.
 """
+
 from pint.models.absolute_phase import AbsPhase
 
 # Import all standard model components here
@@ -24,7 +25,7 @@ from pint.models.binary_bt import BinaryBT, BinaryBTPiecewise
 from pint.models.binary_dd import BinaryDD, BinaryDDS, BinaryDDGR
 from pint.models.binary_ddk import BinaryDDK
 from pint.models.binary_ell1 import BinaryELL1, BinaryELL1H, BinaryELL1k
-from pint.models.dispersion_model import DispersionDM, DispersionDMX
+from pint.models.dispersion_model import DispersionDM, DispersionDMX, DispersionJump
 from pint.models.dmwavex import DMWaveX
 from pint.models.frequency_dependent import FD
 from pint.models.glitch import Glitch
@@ -37,7 +38,7 @@ from pint.models.noise_model import EcorrNoise, PLRedNoise, ScaleToaError
 from pint.models.solar_system_shapiro import SolarSystemShapiro
 from pint.models.solar_wind_dispersion import SolarWindDispersion, SolarWindDispersionX
 from pint.models.spindown import Spindown
-from pint.models.fdjump import FDJump
+from pint.models.fdjump import FDJump, FDJumpDM
 
 # Import the main timing model classes
 from pint.models.timing_model import DEFAULT_ORDER, TimingModel

--- a/src/pint/models/__init__.py
+++ b/src/pint/models/__init__.py
@@ -25,7 +25,12 @@ from pint.models.binary_bt import BinaryBT, BinaryBTPiecewise
 from pint.models.binary_dd import BinaryDD, BinaryDDS, BinaryDDGR
 from pint.models.binary_ddk import BinaryDDK
 from pint.models.binary_ell1 import BinaryELL1, BinaryELL1H, BinaryELL1k
-from pint.models.dispersion_model import DispersionDM, DispersionDMX, DispersionJump
+from pint.models.dispersion_model import (
+    DispersionDM,
+    DispersionDMX,
+    DispersionJump,
+    FDJumpDM,
+)
 from pint.models.dmwavex import DMWaveX
 from pint.models.frequency_dependent import FD
 from pint.models.glitch import Glitch
@@ -38,7 +43,7 @@ from pint.models.noise_model import EcorrNoise, PLRedNoise, ScaleToaError
 from pint.models.solar_system_shapiro import SolarSystemShapiro
 from pint.models.solar_wind_dispersion import SolarWindDispersion, SolarWindDispersionX
 from pint.models.spindown import Spindown
-from pint.models.fdjump import FDJump, FDJumpDM
+from pint.models.fdjump import FDJump
 
 # Import the main timing model classes
 from pint.models.timing_model import DEFAULT_ORDER, TimingModel

--- a/src/pint/models/__init__.py
+++ b/src/pint/models/__init__.py
@@ -22,7 +22,7 @@ from pint.models.absolute_phase import AbsPhase
 # Import all standard model components here
 from pint.models.astrometry import AstrometryEcliptic, AstrometryEquatorial
 from pint.models.binary_bt import BinaryBT, BinaryBTPiecewise
-from pint.models.binary_dd import BinaryDD, BinaryDDS, BinaryDDGR
+from pint.models.binary_dd import BinaryDD, BinaryDDS, BinaryDDGR, BinaryDDH
 from pint.models.binary_ddk import BinaryDDK
 from pint.models.binary_ell1 import BinaryELL1, BinaryELL1H, BinaryELL1k
 from pint.models.dispersion_model import (

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -1,4 +1,5 @@
 """A simple model of a base dispersion delay and DMX dispersion."""
+
 from warnings import warn
 
 import numpy as np
@@ -713,7 +714,7 @@ class DispersionJump(Dispersion):
     Parameters supported:
 
     .. paramtable::
-        :class: pint.models.dispersion_model.DispersionDMX
+        :class: pint.models.dispersion_model.DispersionJump
 
     Notes
     -----
@@ -749,14 +750,14 @@ class DispersionJump(Dispersion):
             # Note we can not use the derivative function 'd_delay_d_dmparam',
             # Since dmjump does not effect delay.
             # The function 'd_delay_d_dmparam' applies d_dm_d_dmparam first and
-            # than applys the time delay part.
+            # than applies the time delay part.
             self.register_deriv_funcs(self.d_delay_d_dmjump, j)
 
     def validate(self):
         super().validate()
 
     def jump_dm(self, toas):
-        """Return the DM jump for each dm section collected by dmjump parameters.
+        """Return the DM jump for each DM section collected by DMJUMP parameters.
 
         The delay value is determined by DMJUMP parameter
         value in the unit of pc / cm ** 3.
@@ -770,18 +771,18 @@ class DispersionJump(Dispersion):
         return jdm * dm_jump_par.units
 
     def d_dm_d_dmjump(self, toas, jump_param):
-        """Derivative of dm values wrt dm jumps."""
+        """Derivative of the DM values w.r.t DM jumps."""
         tbl = toas.table
         d_dm_d_j = np.zeros(len(tbl))
         jpar = getattr(self, jump_param)
         mask = jpar.select_toa_mask(toas)
         d_dm_d_j[mask] = -1.0
-        return d_dm_d_j * jpar.units / jpar.units
+        return d_dm_d_j * u.dimensionless_unscaled
 
     def d_delay_d_dmjump(self, toas, param_name, acc_delay=None):
-        """Derivative for delay wrt to dm jumps.
+        """Derivative of the delay w.r.t DM jumps.
 
-        Since DMJUMPS does not affect delay, this would be zero.
+        Since DMJUMPs do not affect the delay, this should be zero.
         """
         dmjump = getattr(self, param_name)
         return np.zeros(toas.ntoas) * (u.s / dmjump.units)

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -808,7 +808,7 @@ class FDJumpDM(Dispersion):
     Parameters supported:
 
     .. paramtable::
-        :class: pint.models.fdjump.FDJumpDM
+        :class: pint.models.dispersion_model.FDJumpDM
     """
 
     register = True

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -786,3 +786,84 @@ class DispersionJump(Dispersion):
         """
         dmjump = getattr(self, param_name)
         return np.zeros(toas.ntoas) * (u.s / dmjump.units)
+
+
+class FDJumpDM(Dispersion):
+    """This class provides system-dependent DM offsets for narrow-band
+    datasets. Such offsets can arise if different fiducial DMs are used
+    to dedisperse the template profiles used to derive the TOAs for different
+    systems. They can also arise while combining TOAs obtained using frequency-
+    collapsed templates with those obtained using frequency-resolved templates.
+
+    FDJumpDM is not to be confused with DMJump, which provides a DM offset
+    without providing the corresponding DM delay. DMJump is specific to
+    wideband datasets whereas FDJumpDM is intended to be used with narrowband
+    datasets.
+
+    This component is called FDJumpDM because the name DMJump was already taken,
+    and because this is often used in conjunction with FDJumps which account for
+    the fact that the templates may not adequately model the frequency-dependent
+    profile evolution.
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.fdjump.FDJumpDM
+    """
+
+    register = True
+    category = "fdjumpdm"
+
+    def __init__(self):
+        super().__init__()
+        self.dm_value_funcs += [self.fdjump_dm]
+        self.delay_funcs_component += [self.fdjump_dm_delay]
+
+        self.add_param(
+            maskParameter(
+                name="FDJUMPDM",
+                units="pc cm^-3",
+                value=None,
+                description="System-dependent DM offset.",
+            )
+        )
+
+    def setup(self):
+        super().setup()
+        self.fdjump_dms = []
+        for mask_par in self.get_params_of_type("maskParameter"):
+            if mask_par.startswith("FDJUMPDM"):
+                self.fdjump_dms.append(mask_par)
+        for j in self.fdjump_dms:
+            self.register_dm_deriv_funcs(self.d_dm_d_fdjumpdm, j)
+            self.register_deriv_funcs(self.d_delay_d_dmparam, j)
+
+    def validate(self):
+        super().validate()
+
+    def fdjump_dm(self, toas):
+        """Return the system-dependent DM offset.
+
+        The delay value is determined by FDJUMPDM parameter
+        value in the unit of pc / cm ** 3.
+        """
+        tbl = toas.table
+        jdm = np.zeros(len(tbl))
+        for fdjumpdm in self.fdjump_dms:
+            fdjumpdm_par = getattr(self, fdjumpdm)
+            mask = fdjumpdm_par.select_toa_mask(toas)
+            jdm[mask] += -fdjumpdm_par.value
+        return jdm * fdjumpdm_par.units
+
+    def fdjump_dm_delay(self, toas, acc_delay=None):
+        """This is a wrapper function for interacting with the TimingModel class"""
+        return self.dispersion_type_delay(toas)
+
+    def d_dm_d_fdjumpdm(self, toas, jump_param):
+        """Derivative of DM values w.r.t FDJUMPDM parameters."""
+        tbl = toas.table
+        d_dm_d_j = np.zeros(len(tbl))
+        jpar = getattr(self, jump_param)
+        mask = jpar.select_toa_mask(toas)
+        d_dm_d_j[mask] = -1.0
+        return d_dm_d_j * u.dimensionless_unscaled

--- a/src/pint/models/fdjump.py
+++ b/src/pint/models/fdjump.py
@@ -277,7 +277,7 @@ class FDJumpDM(Dispersion):
         return self.dispersion_type_delay(toas)
 
     def d_dm_d_fdjumpdm(self, toas, jump_param):
-        """Derivative of dm values wrt dm jumps."""
+        """Derivative of DM values w.r.t FDJUMPDM parameters."""
         tbl = toas.table
         d_dm_d_j = np.zeros(len(tbl))
         jpar = getattr(self, jump_param)

--- a/src/pint/models/fdjump.py
+++ b/src/pint/models/fdjump.py
@@ -8,7 +8,6 @@ import numpy as np
 
 from pint.models.parameter import boolParameter, maskParameter
 from pint.models.timing_model import DelayComponent
-from pint.models.dispersion_model import Dispersion
 
 fdjump_max_index = 20
 
@@ -204,84 +203,3 @@ class FDJump(DelayComponent):
                 par = par.replace(f"FD{j}JUMP", f"FDJUMP{j}")
 
         return par
-
-
-class FDJumpDM(Dispersion):
-    """This class provides system-dependent DM offsets for narrow-band
-    datasets. Such offsets can arise if different fiducial DMs are used
-    to dedisperse the template profiles used to derive the TOAs for different
-    systems. They can also arise while combining TOAs obtained using frequency-
-    collapsed templates with those obtained using frequency-resolved templates.
-
-    FDJumpDM is not to be confused with DMJump, which provides a DM offset
-    without providing the corresponding DM delay. DMJump is specific to
-    wideband datasets whereas FDJumpDM is intended to be used with narrowband
-    datasets.
-
-    This component is called FDJumpDM because the name DMJump was already taken,
-    and because this is often used in conjunction with FDJumps which account for
-    the fact that the templates may not adequately model the frequency-dependent
-    profile evolution.
-
-    Parameters supported:
-
-    .. paramtable::
-        :class: pint.models.fdjump.FDJumpDM
-    """
-
-    register = True
-    category = "fdjumpdm"
-
-    def __init__(self):
-        super().__init__()
-        self.dm_value_funcs += [self.fdjump_dm]
-        self.delay_funcs_component += [self.fdjump_dm_delay]
-
-        self.add_param(
-            maskParameter(
-                name="FDJUMPDM",
-                units="pc cm^-3",
-                value=None,
-                description="System-dependent DM offset.",
-            )
-        )
-
-    def setup(self):
-        super().setup()
-        self.fdjump_dms = []
-        for mask_par in self.get_params_of_type("maskParameter"):
-            if mask_par.startswith("FDJUMPDM"):
-                self.fdjump_dms.append(mask_par)
-        for j in self.fdjump_dms:
-            self.register_dm_deriv_funcs(self.d_dm_d_fdjumpdm, j)
-            self.register_deriv_funcs(self.d_delay_d_dmparam, j)
-
-    def validate(self):
-        super().validate()
-
-    def fdjump_dm(self, toas):
-        """Return the system-dependent DM offset.
-
-        The delay value is determined by FDJUMPDM parameter
-        value in the unit of pc / cm ** 3.
-        """
-        tbl = toas.table
-        jdm = np.zeros(len(tbl))
-        for fdjumpdm in self.fdjump_dms:
-            fdjumpdm_par = getattr(self, fdjumpdm)
-            mask = fdjumpdm_par.select_toa_mask(toas)
-            jdm[mask] += -fdjumpdm_par.value
-        return jdm * fdjumpdm_par.units
-
-    def fdjump_dm_delay(self, toas, acc_delay=None):
-        """This is a wrapper function for interacting with the TimingModel class"""
-        return self.dispersion_type_delay(toas)
-
-    def d_dm_d_fdjumpdm(self, toas, jump_param):
-        """Derivative of DM values w.r.t FDJUMPDM parameters."""
-        tbl = toas.table
-        d_dm_d_j = np.zeros(len(tbl))
-        jpar = getattr(self, jump_param)
-        mask = jpar.select_toa_mask(toas)
-        d_dm_d_j[mask] = -1.0
-        return d_dm_d_j * u.dimensionless_unscaled

--- a/src/pint/models/fdjump.py
+++ b/src/pint/models/fdjump.py
@@ -210,7 +210,8 @@ class FDJumpDM(Dispersion):
     """This class provides system-dependent DM offsets for narrow-band
     datasets. Such offsets can arise if different fiducial DMs are used
     to dedisperse the template profiles used to derive the TOAs for different
-    systems.
+    systems. They can also arise while combining TOAs obtained using frequency-
+    collapsed templates with those obtained using frequency-resolved templates.
 
     FDJumpDM is not to be confused with DMJump, which provides a DM offset
     without providing the corresponding DM delay. DMJump is specific to

--- a/src/pint/models/fdjump.py
+++ b/src/pint/models/fdjump.py
@@ -241,7 +241,7 @@ class FDJumpDM(Dispersion):
                 name="FDJUMPDM",
                 units="pc cm^-3",
                 value=None,
-                description="System-dependent DM offset / FD parameter of polynomial index 0.",
+                description="System-dependent DM offset.",
             )
         )
 

--- a/src/pint/models/fdjump.py
+++ b/src/pint/models/fdjump.py
@@ -207,15 +207,20 @@ class FDJump(DelayComponent):
 
 
 class FDJumpDM(Dispersion):
-    """This class provides index-0 (frequency-independent) FD jumps.
-    These can also be interpreted as system-dependent DM offsets.
-    Hence, we have chosen the offset parameters to have dimensions
-    of DM. This convention is different from regular FD jumps.
+    """This class provides system-dependent DM offsets for narrow-band
+    datasets. Such offsets can arise if different fiducial DMs are used
+    to dedisperse the template profiles used to derive the TOAs for different
+    systems.
 
     FDJumpDM is not to be confused with DMJump, which provides a DM offset
     without providing the corresponding DM delay. DMJump is specific to
     wideband datasets whereas FDJumpDM is intended to be used with narrowband
-    datasets in conjunction with FDJump.
+    datasets.
+
+    This component is called FDJumpDM because the name DMJump was already taken,
+    and because this is often used in conjunction with FDJumps which account for
+    the fact that the templates may not adequately model the frequency-dependent
+    profile evolution.
 
     Parameters supported:
 

--- a/src/pint/models/fdjump.py
+++ b/src/pint/models/fdjump.py
@@ -267,7 +267,11 @@ class FDJumpDM(Dispersion):
             jdm[mask] += -fdjumpdm_par.value
         return jdm * fdjumpdm_par.units
 
-    def d_dm_d_dmjump(self, toas, jump_param):
+    def fdjump_dm_delay(self, toas, acc_delay=None):
+        """This is a wrapper function for interacting with the TimingModel class"""
+        return self.dispersion_type_delay(toas)
+
+    def d_dm_d_fdjumpdm(self, toas, jump_param):
         """Derivative of dm values wrt dm jumps."""
         tbl = toas.table
         d_dm_d_j = np.zeros(len(tbl))

--- a/tests/test_fdjump.py
+++ b/tests/test_fdjump.py
@@ -130,7 +130,7 @@ def test_fdjumpdm_offset(model_and_toas):
     model, toas = model_and_toas
 
     model2 = deepcopy(model)
-    model2.FDJUMPDM.value = 0
+    model2.FDJUMPDM1.value = 0
 
     mask = model.FDJUMPDM1.select_toa_mask(toas)
     not_mask = np.setdiff1d(np.arange(len(toas)), mask)

--- a/tests/test_fdjump.py
+++ b/tests/test_fdjump.py
@@ -17,6 +17,8 @@ def model_and_toas():
         "FD1JUMP -sys GM_GWB_1460_100_b1 0.02 1\n"
         "FD2JUMP -sys GM_GWB_500_100_b1 0.001 1\n"
         "FD2JUMP -sys GM_GWB_1460_100_b1 0.002 1\n"
+        "FDJUMPDM -sys GM_GWB_500_100_b1 0.00002 1\n"
+        "FDJUMPDM -sys GM_GWB_1460_100_b1 0.00001 1\n"
     )
     par = str(model_raw) + fdlines
 
@@ -34,6 +36,8 @@ def test_params(model_and_toas):
         and hasattr(model, "FD2JUMP1")
         and hasattr(model, "FD1JUMP2")
         and hasattr(model, "FD2JUMP2")
+        and hasattr(model, "FDJUMPDM1")
+        and hasattr(model, "FDJUMPDM2")
     )
 
 
@@ -56,6 +60,7 @@ def test_refitting(model_and_toas):
     model, toas = model_and_toas
     FD1JUMP1_value_original = model.FD1JUMP1.value
     model.FD1JUMP1.value = 0
+    model.FDJUMPDM1.value = 0
 
     ftr = DownhillWLSFitter(toas, model)
     ftr.fit_toas()


### PR DESCRIPTION
This PR implements the system-dependent DM offset for narrowband TOAs. Such offsets can arise in large datasets where the template profiles used for different observing systems may not have been dedispersed with the same fiducial DM. 

This is different from DMJump. DMJump applies to wideband TOAs and only provides a DM offset without a corresponding delay. 

FDJumpDM should only be used for narrowband TOAs, and its effect on wideband timing is yet unexplored.

The name FDJUMPDM was introduced by the IPTA DR3 data combination team partly because the name DMJUMP was already taken. This parameter has recently been added to tempo2.

Also adds an explanation for FDJUMPs and FDJUMPDMs in the documentation. 