### PR TITLE
Updated docs for ELL1H

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -36,6 +36,7 @@ the released changes.
 - `freeze_params` option in `wavex_setup` and `dmwavex_setup`
 - `plrednoise_from_wavex`, `pldmnoise_from_dmwavex`, and `find_optimal_nharms` functions
 - fake TOAs can be created with `subtract_mean=False`, to maintain phase coherence between different data sets
+- Better explanation of ELL1H behavior when H3/H4/STIGMA supplied and when NHARMS is used
 ### Fixed
 - `MCMC_walkthrough` notebook now runs
 - Fixed runtime data README 

--- a/src/pint/models/binary_ell1.py
+++ b/src/pint/models/binary_ell1.py
@@ -367,7 +367,7 @@ class BinaryELL1H(BinaryELL1):
             intParameter(
                 name="NHARMS",
                 units="",
-                value=7,
+                # value=7,
                 description="Number of harmonics for ELL1H shapiro delay.",
             )
         )
@@ -384,21 +384,22 @@ class BinaryELL1H(BinaryELL1):
         if self.H4.quantity is not None:
             self.binary_instance.fit_params = ["H3", "H4"]
             # If have H4 or STIGMA, choose 7th order harmonics
-            if self.NHARMS.value < 7:
+            if (self.NHARMS.value is not None) and (self.NHARMS.value < 7):
                 log.warning(
                     f"Requested NHARMS={self.NHARMS.value}, but setting it to 7 since H4 is also specified"
                 )
-            self.NHARMS.value = max(self.NHARMS.value, 7)
+            self.NHARMS.value = (
+                max(self.NHARMS.value, 7) if self.NHARMS.value is not None else 7
+            )
             if self.STIGMA.quantity is not None:
                 raise ValueError("ELL1H can use H4 or STIGMA but not both")
 
         if self.STIGMA.quantity is not None:
             self.binary_instance.fit_params = ["H3", "STIGMA"]
-            if self.NHARMS.value != 7:
+            if self.NHARMS.value is not None:
                 log.warning(
                     f"Requested NHARMS={self.NHARMS.value} will be ignored, since will use exact parameterization with STIGMA specified"
                 )
-            self.remove_param("NHARMS")
             self.binary_instance.ds_func = self.binary_instance.delayS_H3_STIGMA_exact
             if self.STIGMA.quantity <= 0:
                 raise ValueError("STIGMA must be greater than zero.")

--- a/src/pint/models/binary_ell1.py
+++ b/src/pint/models/binary_ell1.py
@@ -398,6 +398,7 @@ class BinaryELL1H(BinaryELL1):
                 log.warning(
                     f"Requested NHARMS={self.NHARMS.value} will be ignored, since will use exact parameterization with STIGMA specified"
                 )
+            self.remove_param("NHARMS")
             self.binary_instance.ds_func = self.binary_instance.delayS_H3_STIGMA_exact
             if self.STIGMA.quantity <= 0:
                 raise ValueError("STIGMA must be greater than zero.")

--- a/src/pint/models/binary_ell1.py
+++ b/src/pint/models/binary_ell1.py
@@ -1,4 +1,5 @@
 """Approximate binary model for small eccentricity."""
+
 import astropy.units as u
 import numpy as np
 from astropy.time import Time
@@ -314,9 +315,12 @@ class BinaryELL1H(BinaryELL1):
 
     Notes
     -----
-    Only the Medium-inclination case model is implemented.
+    When `H3` only is supplied, `NHARMS` is ignored, and the approximate version is used (Eqn. 19) appropriate for medium inclinations.
 
-    Default value in `pint` for `NHARMS` is 7, while in `tempo2` it is 4.
+    When `H3` and `H4` are supplied, `NHARMS` is taken to be `max(7,NHARMS)`, and the approximate version is used (Eqn. 19) appropriate for medium inclinations.
+    Note that the default value in `pint` for `NHARMS` is 7, while in `tempo2` it is 4.
+
+    When `H3` and `STIGMA` are supplied, `NHARMS` is ignored since the exact version is used (Eqn. 29) appropriate for very high inclinations.
 
     References
     ----------
@@ -363,7 +367,7 @@ class BinaryELL1H(BinaryELL1):
             intParameter(
                 name="NHARMS",
                 units="",
-                value=3,
+                value=7,
                 description="Number of harmonics for ELL1H shapiro delay.",
             )
         )
@@ -380,12 +384,20 @@ class BinaryELL1H(BinaryELL1):
         if self.H4.quantity is not None:
             self.binary_instance.fit_params = ["H3", "H4"]
             # If have H4 or STIGMA, choose 7th order harmonics
+            if self.NHARMS.value < 7:
+                log.warning(
+                    f"Requested NHARMS={self.NHARMS.value}, but setting it to 7 since H4 is also specified"
+                )
             self.NHARMS.value = max(self.NHARMS.value, 7)
             if self.STIGMA.quantity is not None:
                 raise ValueError("ELL1H can use H4 or STIGMA but not both")
 
         if self.STIGMA.quantity is not None:
             self.binary_instance.fit_params = ["H3", "STIGMA"]
+            if self.NHARMS.value != 7:
+                log.warning(
+                    f"Requested NHARMS={self.NHARMS.value} will be ignored, since will use exact parameterization with STIGMA specified"
+                )
             self.binary_instance.ds_func = self.binary_instance.delayS_H3_STIGMA_exact
             if self.STIGMA.quantity <= 0:
                 raise ValueError("STIGMA must be greater than zero.")

--- a/tests/test_ell1h.py
+++ b/tests/test_ell1h.py
@@ -1,4 +1,5 @@
 """Tests of ELL1H model """
+
 import logging
 import os
 import pytest
@@ -95,17 +96,18 @@ def test_J1853_binary_delay(toasJ1853, modelJ1853, tempo2_res):
 # TODO need a better derivative test
 def test_derivative(toasJ1853, modelJ1853):
     log = logging.getLogger("TestJ1853.derivative_test")
-    test_params = ["H3", "H4", "STIGMA"]
+    # only H3 is set in this model, so the other derivatives don't make sense
+    test_params = ["H3"]  # , "H4", "STIGMA"]
     modelJ1853.H4.value = 0.0  # For test PBDOT
     modelJ1853.STIGMA.value = 0.0
     testp = tdu.get_derivative_params(modelJ1853)
     delay = modelJ1853.delay(toasJ1853)
     # Change parameter test step
     testp["H3"] = 6e-1
-    testp["H4"] = 1e-2
-    testp["STIGMA"] = 1e-2
+    #    testp["H4"] = 1e-2
+    #    testp["STIGMA"] = 1e-2
     for p in test_params:
-        log.debug("Runing derivative for %s", f"d_delay_d_{p}")
+        log.debug(f"Runing derivative for {p}: d_delay_d_{p}")
         ndf = modelJ1853.d_phase_d_param_num(toasJ1853, p, testp[p])
         adf = modelJ1853.d_phase_d_param(toasJ1853, delay, p)
         diff = adf - ndf


### PR DESCRIPTION
Made it clear that when STIGMA is used, NHARMS is ignored.  In those cases NHARMS will remain unset unless it is explicitly used.

Made it clear that when NHARMS < 7 is specified, it will pick 7.

Both in the docstring and added warnings.