### PR TITLE
Fixed common CI failure in `tests/test_observatory.py::test_json_observatory_input_latlon`

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -49,4 +49,5 @@ the released changes.
 - `get_observatory()` no longer overwrites `include_gps` and `include_bipm` of `Observatory` objects unless explicitly stated (BIPM and GPS clock corrections no longer incorrectly applied to BAT TOAs).
 - Added back `spacecraft` as an alias for `stl_geo`
 - Fix bug 1729 (missing f-string)
+- Fixed common failure of test_observatory
 ### Removed

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -297,7 +297,10 @@ def test_json_observatory_input_latlon(sandbox):
     for p in gbt_orig.__dict__:
         if p not in ["location", "_clock"]:
             # everything else should be identical
-            assert getattr(gbt_orig, p) == getattr(gbt_reload, p)
+            # but check for either order
+            assert (getattr(gbt_orig, p) == getattr(gbt_reload, p)) or (
+                getattr(gbt_orig, p) == getattr(gbt_reload, p)[::-1]
+            )
     # check distance separately to allow for precision
     distance = gbt_orig.separation(gbt_reload)
     assert distance < 1 * u.m

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -298,9 +298,7 @@ def test_json_observatory_input_latlon(sandbox):
         if p not in ["location", "_clock"]:
             # everything else should be identical
             # but check for either order
-            assert (getattr(gbt_orig, p) == getattr(gbt_reload, p)) or (
-                getattr(gbt_orig, p) == getattr(gbt_reload, p)[::-1]
-            )
+            assert set(getattr(gbt_orig, p)) == set(getattr(gbt_reload, p))
     # check distance separately to allow for precision
     distance = gbt_orig.separation(gbt_reload)
     assert distance < 1 * u.m

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -297,8 +297,11 @@ def test_json_observatory_input_latlon(sandbox):
     for p in gbt_orig.__dict__:
         if p not in ["location", "_clock"]:
             # everything else should be identical
-            # but check for either order
-            assert set(getattr(gbt_orig, p)) == set(getattr(gbt_reload, p))
+            # but fix the order if it is a list
+            if isinstance(getattr(gbt_orig, p), list):
+                assert set(getattr(gbt_orig, p)) == set(getattr(gbt_reload, p))
+            else:
+                assert getattr(gbt_orig, p) == getattr(gbt_reload, p)
     # check distance separately to allow for precision
     distance = gbt_orig.separation(gbt_reload)
     assert distance < 1 * u.m


### PR DESCRIPTION
I think this failure was just that sometimes it was adding to a database in a different order.  This should fix that.