### PR TITLE
Make Astrometry faster & avoid long double operations where possible

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -15,6 +15,8 @@ the released changes.
 - When clock files contain out-of-order entries, the exception now records the first MJDs that are out of order
 - `np.compat.long` -> `int` (former is deprecated)
 - Turned ErfaWarning into an exception during testing; cleaned up test suite.
+- Avoided unnecessary creation of `SkyCoord` objects in `AstrometryEquatorial`.
+- Avoided unnecessary array slices in `SolarSystemShapiro`
 ### Added
 - Added numdifftools to setup.cfg to match requirements.txt
 - Documentation: Added `convert_parfile` to list of command-line tools in RTD
@@ -39,6 +41,7 @@ the released changes.
 - Better explanation of ELL1H behavior when H3/H4/STIGMA supplied and when NHARMS is used
 - FDJumpDM component for System-dependent DM offsets
 - Documentation: Explanation for FDJUMP and FDJUMPDM
+- `tdbfloat` column in the TOAs table (avoid long double operations as much as possible)
 ### Fixed
 - `MCMC_walkthrough` notebook now runs
 - Fixed runtime data README 

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -485,7 +485,9 @@ class AstrometryEquatorial(Astrometry):
         # does, which is to use https://github.com/liberfa/erfa/blob/master/src/starpm.c
         # and then just use the relevant pieces of that
         if epoch is None or (self.PMRA.quantity == 0 and self.PMDEC.quantity == 0):
-            return self.coords_as_ICRS(epoch=epoch).cartesian.xyz.transpose()
+            ra, dec = self.RAJ.quantity, self.DECJ.quantity
+            return self.xyz_from_radec(ra, dec)
+            # return self.coords_as_ICRS(epoch=epoch).cartesian.xyz.transpose()
 
         if isinstance(epoch, Time):
             jd1 = epoch.jd1
@@ -518,6 +520,9 @@ class AstrometryEquatorial(Astrometry):
             )
         # ra,dec now in radians
         ra, dec = starpmout[0], starpmout[1]
+        return self.xyz_from_radec(ra, dec)
+
+    def xyz_from_radec(self, ra, dec):
         x = np.cos(ra) * np.cos(dec)
         y = np.sin(ra) * np.cos(dec)
         z = np.sin(dec)

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -221,7 +221,7 @@ class DispersionDM(Dispersion):
                     f"DMEPOCH not set but some derivatives are not zero: {dm_terms}"
                 )
             else:
-                dt = (toas["tdbld"] - DMEPOCH) * u.day
+                dt = (toas["tdbfloat"] - DMEPOCH) * u.day
             dt_value = dt.to_value(u.yr)
         else:
             dt_value = np.zeros(len(toas), dtype=np.longdouble)
@@ -266,7 +266,7 @@ class DispersionDM(Dispersion):
             DMEPOCH = 0
         else:
             DMEPOCH = self.DMEPOCH.value
-        dt = (toas["tdbld"] - DMEPOCH) * u.day
+        dt = (toas["tdbfloat"] - DMEPOCH) * u.day
         dt_value = (dt.to(u.yr)).value
         return taylor_horner(dt_value, dm_terms) * (self.DM.units / par.units)
 

--- a/src/pint/models/dmwavex.py
+++ b/src/pint/models/dmwavex.py
@@ -1,4 +1,5 @@
 """DM variations expressed as a sum of sinusoids."""
+
 import astropy.units as u
 import numpy as np
 from loguru import logger as log
@@ -350,7 +351,7 @@ class DMWaveX(Dispersion):
         dmwave_sins = self.get_prefix_mapping_component("DMWXSIN_")
         dmwave_cos = self.get_prefix_mapping_component("DMWXCOS_")
 
-        base_phase = toas.table["tdbld"].data * u.d - self.DMWXEPOCH.value * u.d
+        base_phase = toas.table["tdbfloat"].data * u.d - self.DMWXEPOCH.value * u.d
         for idx, param in dmwave_freqs.items():
             freq = getattr(self, param).quantity
             dmwxsin = getattr(self, dmwave_sins[idx]).quantity
@@ -365,7 +366,7 @@ class DMWaveX(Dispersion):
     def d_dm_d_DMWXSIN(self, toas, param, acc_delay=None):
         par = getattr(self, param)
         freq = getattr(self, f"DMWXFREQ_{int(par.index):04d}").quantity
-        base_phase = toas.table["tdbld"].data * u.d - self.DMWXEPOCH.value * u.d
+        base_phase = toas.table["tdbfloat"].data * u.d - self.DMWXEPOCH.value * u.d
         arg = 2.0 * np.pi * freq * base_phase
         deriv = np.sin(arg.value)
         return deriv * dmu / par.units
@@ -373,7 +374,7 @@ class DMWaveX(Dispersion):
     def d_dm_d_DMWXCOS(self, toas, param, acc_delay=None):
         par = getattr(self, param)
         freq = getattr(self, f"DMWXFREQ_{int(par.index):04d}").quantity
-        base_phase = toas.table["tdbld"].data * u.d - self.DMWXEPOCH.value * u.d
+        base_phase = toas.table["tdbfloat"].data * u.d - self.DMWXEPOCH.value * u.d
         arg = 2.0 * np.pi * freq * base_phase
         deriv = np.cos(arg.value)
         return deriv * dmu / par.units

--- a/src/pint/models/glitch.py
+++ b/src/pint/models/glitch.py
@@ -1,4 +1,5 @@
 """Pulsar timing glitches."""
+
 import astropy.units as u
 import numpy as np
 
@@ -199,7 +200,7 @@ class Glitch(PhaseComponent):
             dF0 = getattr(self, "GLF0_%d" % idx).quantity
             dF1 = getattr(self, "GLF1_%d" % idx).quantity
             dF2 = getattr(self, "GLF2_%d" % idx).quantity
-            dt = (tbl["tdbld"] - eph) * u.day - delay
+            dt = (tbl["tdbfloat"] - eph) * u.day - delay
             dt = dt.to(u.second)
             affected = dt > 0.0  # TOAs affected by glitch
             # decay term
@@ -228,7 +229,7 @@ class Glitch(PhaseComponent):
         tbl = toas.table
         p, ids, idv = split_prefixed_name(param)
         eph = getattr(self, f"GLEP_{ids}").value
-        dt = (tbl["tdbld"] - eph) * u.day - delay
+        dt = (tbl["tdbfloat"] - eph) * u.day - delay
         dt = dt.to(u.second)
         affected = np.where(dt > 0.0)[0]
         return tbl, p, ids, idv, dt, affected

--- a/src/pint/models/ifunc.py
+++ b/src/pint/models/ifunc.py
@@ -1,4 +1,5 @@
 """Tabulated extra delays."""
+
 import astropy.units as u
 import numpy as np
 
@@ -110,7 +111,7 @@ class IFunc(PhaseComponent):
         # the MJDs(x) and offsets (y) of the interpolation points
         x, y = np.asarray([t.quantity for t in terms]).T
         # form barycentered times
-        ts = toas.table["tdbld"] - delays.to(u.day).value
+        ts = toas.table["tdbfloat"] - delays.to(u.day).value
         times = np.zeros(len(ts))
 
         # Determine what type of interpolation we are doing.

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -382,7 +382,7 @@ class EcorrNoise(NoiseComponent):
         A quantization matrix maps TOAs to observing epochs.
         """
         tbl = toas.table
-        t = (tbl["tdbld"].quantity * u.day).to(u.s).value
+        t = (tbl["tdbfloat"].quantity * u.day).to(u.s).value
         ecorrs = self.get_ecorrs()
         umats = []
         for ec in ecorrs:
@@ -408,7 +408,7 @@ class EcorrNoise(NoiseComponent):
         """
         ecorrs = self.get_ecorrs()
         if nweights is None:
-            ts = (toas.table["tdbld"].quantity * u.day).to(u.s).value
+            ts = (toas.table["tdbfloat"].quantity * u.day).to(u.s).value
             nweights = [
                 get_ecorr_nweights(ts[ec.select_toa_mask(toas)]) for ec in ecorrs
             ]
@@ -508,7 +508,7 @@ class PLDMNoise(NoiseComponent):
         See the documentation for pl_dm_basis_weight_pair function for details."""
 
         tbl = toas.table
-        t = (tbl["tdbld"].quantity * u.day).to(u.s).value
+        t = (tbl["tdbfloat"].quantity * u.day).to(u.s).value
         freqs = self._parent.barycentric_radio_freq(toas).to(u.MHz)
         fref = 1400 * u.MHz
         D = (fref.value / freqs.value) ** 2
@@ -522,7 +522,7 @@ class PLDMNoise(NoiseComponent):
         See the documentation for pl_dm_basis_weight_pair for details."""
 
         tbl = toas.table
-        t = (tbl["tdbld"].quantity * u.day).to(u.s).value
+        t = (tbl["tdbfloat"].quantity * u.day).to(u.s).value
         amp, gam, nf = self.get_pl_vals()
         Ffreqs = get_rednoise_freqs(t, nf)
         return powerlaw(Ffreqs, amp, gam) * Ffreqs[0]
@@ -639,7 +639,7 @@ class PLRedNoise(NoiseComponent):
         See the documentation for pl_rn_basis_weight_pair function for details."""
 
         tbl = toas.table
-        t = (tbl["tdbld"].quantity * u.day).to(u.s).value
+        t = (tbl["tdbfloat"].quantity * u.day).to(u.s).value
         nf = self.get_pl_vals()[2]
         return create_fourier_design_matrix(t, nf)
 
@@ -649,7 +649,7 @@ class PLRedNoise(NoiseComponent):
         See the documentation for pl_rn_basis_weight_pair for details."""
 
         tbl = toas.table
-        t = (tbl["tdbld"].quantity * u.day).to(u.s).value
+        t = (tbl["tdbfloat"].quantity * u.day).to(u.s).value
         amp, gam, nf = self.get_pl_vals()
         Ffreqs = get_rednoise_freqs(t, nf)
         return powerlaw(Ffreqs, amp, gam) * Ffreqs[0]

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -21,6 +21,7 @@ See :ref:`Supported Parameters` for an overview, including a table of all the
 parameters PINT understands.
 
 """
+
 import numbers
 from warnings import warn
 
@@ -577,7 +578,7 @@ class Parameter:
         return True
 
     def value_as_latex(self):
-        return f"${self.as_ufloat():.1uSL}$" if not self.frozen else f"{self.value:f}"
+        return f"{self.value:f}" if self.frozen else f"${self.as_ufloat():.1uSL}$"
 
     def as_latex(self):
         try:

--- a/src/pint/models/piecewise.py
+++ b/src/pint/models/piecewise.py
@@ -1,4 +1,5 @@
 """Pulsar timing piecewise spin-down solution."""
+
 import astropy.units as u
 import numpy as np
 
@@ -176,9 +177,9 @@ class PiecewiseSpindown(PhaseComponent):
         idx = glep.index
         start = getattr(self, "PWSTART_%d" % idx).value
         stop = getattr(self, "PWSTOP_%d" % idx).value
-        affected = (tbl["tdbld"] >= start) & (tbl["tdbld"] < stop)
+        affected = (tbl["tdbfloat"] >= start) & (tbl["tdbfloat"] < stop)
         phsepoch_ld = glep.quantity.tdb.mjd_long
-        dt = (tbl["tdbld"][affected] - phsepoch_ld) * u.day - delay[affected]
+        dt = (tbl["tdbfloat"][affected] - phsepoch_ld) * u.day - delay[affected]
         return dt, affected
 
     def piecewise_phase(self, toas, delay):

--- a/src/pint/models/pulsar_binary.py
+++ b/src/pint/models/pulsar_binary.py
@@ -309,11 +309,11 @@ class PulsarBinary(DelayComponent):
                 method_name = f"{p.lower()}_func"
                 try:
                     par_method = getattr(self.binary_instance, method_name)
-                except AttributeError:
+                except AttributeError as e:
                     raise MissingParameter(
                         self.binary_model_name,
                         f"{p} is required for '{self.binary_model_name}'.",
-                    )
+                    ) from e
                 par_method()
 
     # With new parameter class set up, do we need this?
@@ -401,13 +401,13 @@ class PulsarBinary(DelayComponent):
             if hasattr(self._parent, par) or set(alias).intersection(self.params):
                 try:
                     pint_bin_name = self._parent.match_param_aliases(par)
-                except UnknownParameter:
+                except UnknownParameter as e:
                     if par in self.internal_params:
                         pint_bin_name = par
                     else:
                         raise UnknownParameter(
                             f"Unable to find {par} in the parent model"
-                        )
+                        ) from e
                 binObjpar = getattr(self._parent, pint_bin_name)
 
                 # make sure we aren't passing along derived parameters to the binary instance

--- a/src/pint/models/pulsar_binary.py
+++ b/src/pint/models/pulsar_binary.py
@@ -4,7 +4,6 @@ This module if for wrapping standalone binary models so that they work
 as PINT timing models.
 """
 
-
 import astropy.units as u
 import contextlib
 import numpy as np
@@ -371,13 +370,13 @@ class PulsarBinary(DelayComponent):
                 # use the barycentered TOAS
                 self.barycentric_time = self._parent.get_barycentric_toas(toas)
             else:
-                self.barycentric_time = tbl["tdbld"] * u.day - acc_delay
+                self.barycentric_time = tbl["tdbfloat"] * u.day - acc_delay
             updates["barycentric_toa"] = self.barycentric_time
             if "AstrometryEquatorial" in self._parent.components:
                 # it's already in ICRS
                 updates["obs_pos"] = tbl["ssb_obs_pos"].quantity
                 updates["psr_pos"] = self._parent.ssb_to_psb_xyz_ICRS(
-                    epoch=tbl["tdbld"].astype(np.float64)
+                    epoch=tbl["tdbfloat"]
                 )
             elif "AstrometryEcliptic" in self._parent.components:
                 # convert from ICRS to ECL
@@ -390,7 +389,7 @@ class PulsarBinary(DelayComponent):
                     PulsarEcliptic(ecl=self._parent.ECL.value)
                 ).cartesian.xyz.transpose()
                 updates["psr_pos"] = self._parent.ssb_to_psb_xyz_ECL(
-                    epoch=tbl["tdbld"].astype(np.float64), ecl=self._parent.ECL.value
+                    epoch=tbl["tdbfloat"], ecl=self._parent.ECL.value
                 )
         for par in self.binary_instance.binary_params:
             if par in self.binary_instance.param_aliases.keys():

--- a/src/pint/models/pulsar_binary.py
+++ b/src/pint/models/pulsar_binary.py
@@ -370,13 +370,13 @@ class PulsarBinary(DelayComponent):
                 # use the barycentered TOAS
                 self.barycentric_time = self._parent.get_barycentric_toas(toas)
             else:
-                self.barycentric_time = tbl["tdbfloat"] * u.day - acc_delay
+                self.barycentric_time = tbl["tdbld"] * u.day - acc_delay
             updates["barycentric_toa"] = self.barycentric_time
             if "AstrometryEquatorial" in self._parent.components:
                 # it's already in ICRS
                 updates["obs_pos"] = tbl["ssb_obs_pos"].quantity
                 updates["psr_pos"] = self._parent.ssb_to_psb_xyz_ICRS(
-                    epoch=tbl["tdbfloat"]
+                    epoch=tbl["tdbld"]
                 )
             elif "AstrometryEcliptic" in self._parent.components:
                 # convert from ICRS to ECL
@@ -389,7 +389,7 @@ class PulsarBinary(DelayComponent):
                     PulsarEcliptic(ecl=self._parent.ECL.value)
                 ).cartesian.xyz.transpose()
                 updates["psr_pos"] = self._parent.ssb_to_psb_xyz_ECL(
-                    epoch=tbl["tdbfloat"], ecl=self._parent.ECL.value
+                    epoch=tbl["tdbld"], ecl=self._parent.ECL.value
                 )
         for par in self.binary_instance.binary_params:
             if par in self.binary_instance.param_aliases.keys():

--- a/src/pint/models/pulsar_binary.py
+++ b/src/pint/models/pulsar_binary.py
@@ -376,7 +376,7 @@ class PulsarBinary(DelayComponent):
                 # it's already in ICRS
                 updates["obs_pos"] = tbl["ssb_obs_pos"].quantity
                 updates["psr_pos"] = self._parent.ssb_to_psb_xyz_ICRS(
-                    epoch=tbl["tdbld"]
+                    epoch=tbl["tdbfloat"]
                 )
             elif "AstrometryEcliptic" in self._parent.components:
                 # convert from ICRS to ECL
@@ -389,7 +389,7 @@ class PulsarBinary(DelayComponent):
                     PulsarEcliptic(ecl=self._parent.ECL.value)
                 ).cartesian.xyz.transpose()
                 updates["psr_pos"] = self._parent.ssb_to_psb_xyz_ECL(
-                    epoch=tbl["tdbld"], ecl=self._parent.ECL.value
+                    epoch=tbl["tdbfloat"], ecl=self._parent.ECL.value
                 )
         for par in self.binary_instance.binary_params:
             if par in self.binary_instance.param_aliases.keys():

--- a/src/pint/models/solar_system_shapiro.py
+++ b/src/pint/models/solar_system_shapiro.py
@@ -98,20 +98,19 @@ class SolarSystemShapiro(DelayComponent):
         tbl = toas.table
         delay = numpy.zeros(len(tbl))
         for key, grp in toas.get_obs_groups():
+            tbl_grp = tbl[grp]
             if key.lower() == "barycenter":
                 log.debug("Skipping Shapiro delay for Barycentric TOAs")
                 continue
-            psr_dir = self._parent.ssb_to_psb_xyz_ICRS(
-                epoch=tbl[grp]["tdbfloat"].astype(numpy.float64)
-            )
+            psr_dir = self._parent.ssb_to_psb_xyz_ICRS(epoch=tbl_grp["tdbfloat"])
             delay[grp] += self.ss_obj_shapiro_delay(
-                tbl[grp]["obs_sun_pos"], psr_dir, self._ss_mass_sec["sun"]
+                tbl_grp["obs_sun_pos"], psr_dir, self._ss_mass_sec["sun"]
             )
             try:
                 if self.PLANET_SHAPIRO.value:
                     for pl in ("jupiter", "saturn", "venus", "uranus", "neptune"):
                         delay[grp] += self.ss_obj_shapiro_delay(
-                            tbl[grp][f"obs_{pl}_pos"],
+                            tbl_grp[f"obs_{pl}_pos"],
                             psr_dir,
                             self._ss_mass_sec[pl],
                         )

--- a/src/pint/models/solar_system_shapiro.py
+++ b/src/pint/models/solar_system_shapiro.py
@@ -102,7 +102,7 @@ class SolarSystemShapiro(DelayComponent):
                 log.debug("Skipping Shapiro delay for Barycentric TOAs")
                 continue
             psr_dir = self._parent.ssb_to_psb_xyz_ICRS(
-                epoch=tbl[grp]["tdbld"].astype(numpy.float64)
+                epoch=tbl[grp]["tdbfloat"].astype(numpy.float64)
             )
             delay[grp] += self.ss_obj_shapiro_delay(
                 tbl[grp]["obs_sun_pos"], psr_dir, self._ss_mass_sec["sun"]

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -3211,9 +3211,7 @@ class TimingModel:
                     )
                     s += f"Pulsar mass (Shapiro Delay) = {psrmass}"
                     outdict["Mp (Msun)"] = psrmass
-        if not returndict:
-            return s
-        return s, outdict
+        return (s, outdict) if returndict else s
 
 
 class ModelMeta(abc.ABCMeta):
@@ -3227,8 +3225,8 @@ class ModelMeta(abc.ABCMeta):
     """
 
     def __init__(cls, name, bases, dct):
-        regname = "component_types"
         if "register" in dct and cls.register:
+            regname = "component_types"
             getattr(cls, regname)[name] = cls
         super().__init__(name, bases, dct)
 
@@ -3308,10 +3306,10 @@ class Component(metaclass=ModelMeta):
         for p in self.params:
             par = getattr(self, p)
             if par.is_prefix:
-                if par.prefix not in prefixs.keys():
-                    prefixs[par.prefix] = [p]
-                else:
+                if par.prefix in prefixs:
                     prefixs[par.prefix].append(p)
+                else:
+                    prefixs[par.prefix] = [p]
         return prefixs
 
     @property_exists

--- a/src/pint/models/troposphere_delay.py
+++ b/src/pint/models/troposphere_delay.py
@@ -1,4 +1,5 @@
 """Delay due to Earth's troposphere"""
+
 import astropy.constants as const
 import astropy.units as u
 import numpy as np
@@ -175,7 +176,7 @@ class TroposphereDelay(DelayComponent):
                 # now actually calculate the atmospheric delay based on the models
 
                 delay[grp] = self.delay_model(
-                    alt, obs.lat, obs.height, tbl[grp]["tdbld"]
+                    alt, obs.lat, obs.height, tbl[grp]["tdbfloat"]
                 )
         return delay * u.s
 
@@ -358,11 +359,12 @@ class TroposphereDelay(DelayComponent):
             [(i.jyear + seasonOffset + self.DOY_OFFSET / 365.25) % 1.0 for i in mjd]
         )
 
-    def _get_year_fraction_fast(self, tdbld, lat):
+    def _get_year_fraction_fast(self, tdbfloat, lat):
         """
         use numpy array arithmetic to calculate the year fraction more quickly
         """
         seasonOffset = 0.5 if lat < 0 else 0.0
         return np.mod(
-            2000.0 + (tdbld - 51544.5 + self.DOY_OFFSET) / (365.25) + seasonOffset, 1.0
+            2000.0 + (tdbfloat - 51544.5 + self.DOY_OFFSET) / (365.25) + seasonOffset,
+            1.0,
         )

--- a/src/pint/models/wave.py
+++ b/src/pint/models/wave.py
@@ -1,4 +1,5 @@
 """Delays expressed as a sum of sinusoids."""
+
 import astropy.units as u
 import numpy as np
 
@@ -148,7 +149,7 @@ class Wave(PhaseComponent):
         base_phase = (
             wave_om
             * (
-                toas.table["tdbld"] * u.day
+                toas.table["tdbfloat"] * u.day
                 - self.WAVEEPOCH.value * u.day
                 - delays.to(u.day)
             )

--- a/src/pint/models/wavex.py
+++ b/src/pint/models/wavex.py
@@ -1,4 +1,5 @@
 """Delays expressed as a sum of sinusoids."""
+
 import astropy.units as u
 import numpy as np
 from loguru import logger as log
@@ -361,7 +362,9 @@ class WaveX(DelayComponent):
         wave_cos = self.get_prefix_mapping_component("WXCOS_")
 
         base_phase = (
-            toas.table["tdbld"].data * u.d - self.WXEPOCH.value * u.d - delays.to(u.d)
+            toas.table["tdbfloat"].data * u.d
+            - self.WXEPOCH.value * u.d
+            - delays.to(u.d)
         )
         for idx, param in wave_freqs.items():
             freq = getattr(self, param).quantity
@@ -374,7 +377,7 @@ class WaveX(DelayComponent):
     def d_wavex_delay_d_WXSIN(self, toas, param, delays, acc_delay=None):
         par = getattr(self, param)
         freq = getattr(self, f"WXFREQ_{int(par.index):04d}").quantity
-        base_phase = toas.table["tdbld"].data * u.d - self.WXEPOCH.value * u.d
+        base_phase = toas.table["tdbfloat"].data * u.d - self.WXEPOCH.value * u.d
         arg = 2.0 * np.pi * freq * base_phase
         deriv = np.sin(arg.value)
         return deriv * u.s / par.units
@@ -382,7 +385,7 @@ class WaveX(DelayComponent):
     def d_wavex_delay_d_WXCOS(self, toas, param, delays, acc_delay=None):
         par = getattr(self, param)
         freq = getattr(self, f"WXFREQ_{int(par.index):04d}").quantity
-        base_phase = toas.table["tdbld"].data * u.d - self.WXEPOCH.value * u.d
+        base_phase = toas.table["tdbfloat"].data * u.d - self.WXEPOCH.value * u.d
         arg = 2.0 * np.pi * freq * base_phase
         deriv = np.cos(arg.value)
         return deriv * u.s / par.units

--- a/tests/test_toa.py
+++ b/tests/test_toa.py
@@ -12,7 +12,7 @@ from pinttestdata import datadir
 
 from pint.models import get_model
 from pint.observatory import get_observatory
-from pint.toa import TOA, TOAs
+from pint.toa import TOA, TOAs, get_TOAs
 import pint.toa
 from pint.simulation import make_fake_toas_uniform
 
@@ -113,7 +113,6 @@ class TestTOAs:
         assert toas.table["error"].unit == u.us
         assert toas.table["mjd"][0].precision == 9
         assert toas.table["mjd"][0].location is not None
-        assert all(toas.table["tdbfloat"] == toas.table["tdbld"].astype(float))
 
     def test_multiple_observatories_stay_attached(self):
         obs1 = "gbt"
@@ -195,3 +194,8 @@ def test_mix_nb_wb():
                 """
             )
         )
+
+
+def test_tdbfloat():
+    toas = get_TOAs(datadir / "NGC6440E.tim")
+    assert all(toas.table["tdbfloat"] == toas.table["tdbld"].astype(float))

--- a/tests/test_toa.py
+++ b/tests/test_toa.py
@@ -113,6 +113,7 @@ class TestTOAs:
         assert toas.table["error"].unit == u.us
         assert toas.table["mjd"][0].precision == 9
         assert toas.table["mjd"][0].location is not None
+        assert all(toas.table["tdbfloat"] == toas.table["tdbld"].astype(float))
 
     def test_multiple_observatories_stay_attached(self):
         obs1 = "gbt"


### PR DESCRIPTION
Avoid creating `SkyCoord` objects during Astrometry computations. This was partly implemented in #1646 for models with proper motion. This PR does the same thing for cases without proper motion. This has a significant performance advantage.

Also, avoid long double operations where possible. This is done by including a new column `tdbfloat` in the TOAs table. This is the same thing as `tdbld`, but reduced to float64 precision.

Includes some refactorings suggested by sourcery.