### PR TITLE
Try macos 12 to see if it is still intel

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -41,7 +41,7 @@ jobs:
 #          - os: ubuntu-latest
 #            python: '3.10'
 #            tox_env: 'py310-test-alldeps-cov'
-          - os: macos-latest
+          - os: macos-12
             python: '3.12'
             tox_env: 'py312-test'
 #          - os: windows-latest

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -15,6 +15,7 @@ the released changes.
 - When clock files contain out-of-order entries, the exception now records the first MJDs that are out of order
 - `np.compat.long` -> `int` (former is deprecated)
 - Turned ErfaWarning into an exception during testing; cleaned up test suite.
+- macos-latest runner changed to macos-12 runner for CI tests to avoid M1 architecture issues
 ### Added
 - Added numdifftools to setup.cfg to match requirements.txt
 - Documentation: Added `convert_parfile` to list of command-line tools in RTD


### PR DESCRIPTION
Change `macOS-latest` to `macOS-12` to see if that will force use of an intel processor (and hence have the precision needed).

Deals with #1742, although not optimally.