### PR TITLE
Fix #1759 (coordinate comparison identity)

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -20,4 +20,5 @@ the released changes.
 - test for `pint.utils.split_swx()` 
 ### Fixed
 - `pint.utils.split_swx()` to use updated `SolarWindDispersionX()` parameter naming convention 
+- Fix #1759 by changing order of comparison
 ### Removed

--- a/tests/test_Galactic.py
+++ b/tests/test_Galactic.py
@@ -79,7 +79,7 @@ class TestGalactic:
         J0613_icrs_alt = self.modelJ0613.coords_as_ICRS(
             epoch=self.modelJ0613.POSEPOCH.quantity.mjd
         )
-        sep = J0613_icrs_alt.separation(J0613_icrs)
+        sep = J0613_icrs.separation(J0613_icrs_alt)
         assert sep < 1e-11 * u.arcsec
 
     def test_equatorial_to_galactic(self):


### PR DESCRIPTION
After astropy update to 6.1.0, the comparison between coordinates at the same epoch `tests/test_Galactic.py::TestGalactic::test_proper_motion_identity` fails. This is because:

`A.separation(B) = 1.3320388147503583e-14`
but
`B.separation(A) = 3.975693351829395e-16`
I think this happens because the RA comparison is done in different units in those cases.  In one it's done in degrees, so the error is ~1e-16 deg (machine precision).  The other is done in hourangle (~1e-16 h).  The latter is then converted to degrees which makes the comparison fail.

Not sure why this is different now but it's not a situation that comes up a lot.  This should just get around it.