### PR TITLE
Minimal fixes for numpy 2.0

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -43,4 +43,5 @@ the released changes.
 - Moved the test in `test_pmtransform_units.py` into a function.
 - Fixed bug in residual calculation when adding or removing phase wraps
 - Fix #1766 by correcting logic and more clearly naming argument (clkcorr->undo_clkcorr)
+- Minimal fixes to allow usage of numpy 2.0
 ### Removed

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -490,9 +490,11 @@ class Fitter:
         """
 
         return self.model.get_derived_params(
-            rms=self.resids.toa.rms_weighted()
-            if self.is_wideband
-            else self.resids.rms_weighted(),
+            rms=(
+                self.resids.toa.rms_weighted()
+                if self.is_wideband
+                else self.resids.rms_weighted()
+            ),
             ntoas=self.toas.ntoas,
             returndict=returndict,
         )
@@ -1242,7 +1244,7 @@ class DownhillFitter(Fitter):
             for fp, x in zip(free_noise_params, xs):
                 getattr(res.model, fp).value = x
 
-            return -res.lnlikelihood()
+            return -res.lnlikelihood().astype(np.float64)
 
         if not res.model.has_correlated_errors:
 

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -1081,14 +1081,14 @@ def convert_binary_params_dict(
             log.debug("Converting KIN to/from IAU <--> DT96")
             entries = parfile_dict["KIN"][0].split()
             new_value = _convert_kin(float(entries[0]) * u.deg).value
-            parfile_dict["KIN"] = [" ".join([repr(new_value)] + entries[1:])]
+            parfile_dict["KIN"] = [" ".join([str(new_value)] + entries[1:])]
 
         # Convert KOM if requested
         if convert_komkin and "KOM" in parfile_dict:
             log.debug("Converting KOM to/from IAU <--> DT96")
             entries = parfile_dict["KOM"][0].split()
             new_value = _convert_kom(float(entries[0]) * u.deg).value
-            parfile_dict["KOM"] = [" ".join([repr(new_value)] + entries[1:])]
+            parfile_dict["KOM"] = [" ".join([str(new_value)] + entries[1:])]
 
         # Drop SINI if requested
         if drop_ddk_sini and binary_model_guesses[0] == "DDK":

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -103,7 +103,7 @@ def _return_frequency_asquantity(f):
     astropy.units.Quantity
     """
 
-    return u.Quantity(f, u.MHz, copy=False)
+    return f << u.MHz
 
 
 class Parameter:

--- a/src/pint/plot_utils.py
+++ b/src/pint/plot_utils.py
@@ -168,10 +168,10 @@ def phaseogram_binned(
             ax2.scatter(phss, mjds, s=size, color=colarray)
             ax2.scatter(phss + 1.0, mjds, s=size, color=colarray)
     else:
-        profile = np.zeros(bins, dtype=np.float_)
+        profile = np.zeros(bins, dtype=np.float64)
         ntoa = 64
         toadur = (mjds.max() - mjds.min()) / ntoa
-        mjdstarts = mjds.min() + toadur * np.arange(ntoa, dtype=np.float_)
+        mjdstarts = mjds.min() + toadur * np.arange(ntoa, dtype=np.float64)
         mjdstops = mjdstarts + toadur
         # Loop over blocks to process
         a = []

--- a/src/pint/pulsar_mjd.py
+++ b/src/pint/pulsar_mjd.py
@@ -26,6 +26,7 @@ was observing the sky at the moment a leap second was introduced.
 
 .. _leap_smear: https://developers.google.com/time/smear
 """
+
 import warnings
 
 import erfa
@@ -352,7 +353,7 @@ def quantity2longdouble_withunit(data):
 
 def longdouble2str(x):
     """Convert numpy longdouble to string."""
-    return repr(x)
+    return str(x)
 
 
 def str2longdouble(str_data):

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -151,7 +151,7 @@ def profile_likelihood(phs, *otherargs):
     Likelihood is calculated as per eqn 2 in Pletsch & Clark 2015.
     """
     xvals, phases, template, weights = otherargs
-    phss = phases.astype(np.float64) + phs
+    phss = phases.astype(np.float64) + phs.astype(np.float64)
     phss %= 1
     probs = np.interp(phss, xvals, template, right=template[0])
     if weights is None:

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -955,7 +955,7 @@ class FlagDict(MutableMapping):
     def check_allowed_value(k: str, v: Any) -> None:
         if not isinstance(v, str):
             raise ValueError(f"value {v} for key {k} must be a string")
-        if not v and len(v.split()) != 1:
+        if len(v.split()) != 1:
             raise ValueError(f"value {repr(v)} for key {k} cannot contain whitespace")
 
     def __setitem__(self, key: str, val: str):

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -1601,7 +1601,7 @@ class TOAs:
     @property
     def observatories(self) -> Set[str]:
         """The set of observatories in use by these TOAs."""
-        return set(self.get_obss())
+        return set([str(x) for x in self.get_obss()])
 
     @property
     def first_MJD(self) -> time.Time:

--- a/tests/test_model_derivatives.py
+++ b/tests/test_model_derivatives.py
@@ -163,19 +163,27 @@ def test_derivative_equals_numerical(parfile, param):
         h3 = model.H3.value
         stepgen = numdifftools.MaxStepGenerator(abs(h3) / 2)
     elif param == "FB0":
-        stepgen = numdifftools.MaxStepGenerator(np.abs(model.FB0.value) * 1e-2)
+        stepgen = numdifftools.MaxStepGenerator(
+            np.abs(model.FB0.value.astype(np.float64)) * 1e-2
+        )
     elif param == "FB1":
-        stepgen = numdifftools.MaxStepGenerator(np.abs(model.FB1.value) * 1e3)
+        stepgen = numdifftools.MaxStepGenerator(
+            np.abs(model.FB1.value.astype(np.float64)) * 1e3
+        )
     elif param == "FB2":
-        stepgen = numdifftools.MaxStepGenerator(np.abs(model.FB2.value) * 1e5)
+        stepgen = numdifftools.MaxStepGenerator(
+            np.abs(model.FB2.value.astype(np.float64)) * 1e5
+        )
     elif param == "FB3":
-        stepgen = numdifftools.MaxStepGenerator(np.abs(model.FB3.value) * 1e7)
+        stepgen = numdifftools.MaxStepGenerator(
+            np.abs(model.FB3.value.astype(np.float64)) * 1e7
+        )
     else:
         stepgen = None
     df = numdifftools.Derivative(f, step=stepgen)
 
     a = model.d_phase_d_param(toas, delay=None, param=param).to_value(1 / units)
-    b = df(getattr(model, param).value)
+    b = df(getattr(model, param).value.astype(np.float64))
     if param.startswith("FB"):
         assert np.amax(np.abs(a - b)) / np.amax(np.abs(a) + np.abs(b)) < 1.5e-6
     else:

--- a/tests/test_model_derivatives.py
+++ b/tests/test_model_derivatives.py
@@ -154,7 +154,7 @@ def test_derivative_equals_numerical(parfile, param):
                 dphase = m.phase(toas, abs_phase=False) - phase
             except ValueError:
                 return np.nan * np.zeros_like(phase.frac)
-        return dphase.int + dphase.frac
+        return np.float64(dphase.int + dphase.frac)
 
     if param == "ECC":
         e = model.ECC.value

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -146,11 +146,10 @@ def test_longdouble_str_roundtrip_is_exact(i_f):
 
 
 @given(any_mjd())
-def test_longdouble2str_same_as_str_and_repr(i_f):
+def test_longdouble2str_same_as_str(i_f):
     i, f = i_f
     ld = np.longdouble(i) + np.longdouble(f)
     assert longdouble2str(ld) == str(ld)
-    assert longdouble2str(ld) == repr(ld)
 
 
 @pytest.mark.parametrize("s", ["1.0.2", "1.0.", "1.0e1e0", "twelve"])


### PR DESCRIPTION
Trying minimal fixes to assure numpy 2.0 compatibility.  A lot of these are related to how float128 objects are treated, and which functions accept them.