### PR TITLE
Event optimize cleanup

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -9,20 +9,6 @@ the released changes.
 
 ## Unreleased
 ### Changed
-- Avoided unnecessary creation of `SkyCoord` objects in `AstrometryEquatorial` and `AstrometryEcliptic`.
-- Avoided unnecessary `TOAs` table slices in `SolarSystemShapiro`
-- Allow "CLK UNCORR" in par files (indicates no GPS or BIPM corrections). 
-- Better documentation for `akaike_information_criterion()`
-- Type hinting for most of the `pint.utils` module
-- `funcParameter`s are no longer listed in the `pintk` interface.
-- Updated location of CCERA
-- Removed `include_bipm`, and `bipm_version` from the Observatory class. Now they are passed as arguments to `site.clock_correction()`
-- Renamed `include_gps` to `apply_gps2utc` in the Observatory class
-- Removed `apply_gps2utc` from `TOAs.clock_corr_info` since it can be different for different observatories. It is not a global setting.
-- The following observatories no longer have a default of `include_bipm=False`: magic, lst, virgo, lho, llo, geo600, kagra, hess, hawc
-- New algorithm for TCB <-> TDB conversion
-- Reordered plotting axes in `pintk`
-- Changed `scipy.integrate.simps` to `scipy.integrate.simpson` to work with scipy 1.14
 - Moved the events -> TOAs and photon weights code into the function `load_events_weights` within `event_optimize`.
 - Updated the `maxMJD` argument in `event_optimize` to default to the current mjd
 ### Added

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -24,6 +24,7 @@ the released changes.
 - Reordered plotting axes in `pintk`
 - Changed `scipy.integrate.simps` to `scipy.integrate.simpson` to work with scipy 1.14
 - Moved the events -> TOAs and photon weights code into the function `load_events_weights` within `event_optimize`.
+- Updated the `maxMJD` argument in `event_optimize` to default to the current mjd
 ### Added
 ### Fixed
 ### Removed

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -22,6 +22,7 @@ the released changes.
 - The following observatories no longer have a default of `include_bipm=False`: magic, lst, virgo, lho, llo, geo600, kagra, hess, hawc
 - New algorithm for TCB <-> TDB conversion
 - Reordered plotting axes in `pintk`
+- Moved the events -> TOAs and photon weights code into the function `load_events_weights` within `event_optimize`.
 ### Added
 - `bayesian_information_criterion()` function 
 - `dmx_setup` function
@@ -44,3 +45,6 @@ the released changes.
 - Fixed bug in residual calculation when adding or removing phase wraps
 - Fix #1766 by correcting logic and more clearly naming argument (clkcorr->undo_clkcorr)
 ### Removed
+- Removed the argument `--usepickle` in `event_optimize` as the `load_events_weights` function checks the events file type to see if the 
+file is a pickle file.
+- Removed obsolete code, such as manually tracking the progress of the MCMC run within `event_optimize`

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -586,7 +586,7 @@ def main(argv=None):
         default=1000,
     )
     parser.add_argument(
-        "--minMJD", help="Earliest MJD to use", type=float, default=54680.0
+        "--minMJD", help="Earliest MJD to use", type=float, default=39822.0
     )
     parser.add_argument("--maxMJD", help="Latest MJD to use", type=float, default=tnow)
     parser.add_argument(
@@ -706,7 +706,7 @@ def main(argv=None):
     burnin = args.burnin
     nsteps = args.nsteps
     if burnin >= nsteps:
-        log.error("burnin must be < nsteps")
+        log.error(f"burnin must be < nsteps")
         sys.exit(1)
     nbins = 256  # For likelihood calculation based on gaussians file
     outprof_nbins = 256  # in the text file, for pygaussfit.py, for instance
@@ -774,7 +774,7 @@ def main(argv=None):
 
     # Use this if you want to see the effect of setting minWeight
     if args.testWeights:
-        log.info("Checking H-test vs weights")
+        log.info(f"Checking H-test vs weights")
         ftr.prof_vs_weights(use_weights=True)
         ftr.prof_vs_weights(use_weights=False)
         sys.exit()
@@ -784,18 +784,17 @@ def main(argv=None):
     maxbin, like_start = marginalize_over_phase(
         phss, gtemplate, weights=ftr.weights, minimize=True, showplot=False
     )
-    log.info("Starting pulse likelihood: %f" % like_start)
+    log.info(f"Starting pulse likelihood: {like_start}")
     if args.phs is None:
         fitvals[-1] = 1.0 - maxbin[0] / float(len(gtemplate))
         if fitvals[-1] > 1.0:
             fitvals[-1] -= 1.0
         if fitvals[-1] < 0.0:
             fitvals[-1] += 1.0
-        log.info("Starting pulse phase: %f" % fitvals[-1])
+        log.info(f"Starting pulse phase: {fitvals[-1]}")
     else:
         log.warning(
-            "Measured starting pulse phase is %f, but using %f"
-            % (1.0 - maxbin / float(len(gtemplate)), args.phs)
+            f"Measured starting pulse phase is {1.0 - maxbin / float(len(gtemplate))}, but using {args.phs}"
         )
         fitvals[-1] = args.phs
     ftr.fitvals[-1] = fitvals[-1]
@@ -817,7 +816,7 @@ def main(argv=None):
         result = op.minimize(ftr.minimize_func, np.zeros_like(ftr.fitvals))
         newfitvals = np.asarray(result["x"]) * ftr.fiterrs + ftr.fitvals
         like_optmin = -result["fun"]
-        log.info("Optimization likelihood: %f" % like_optmin)
+        log.info(f"Optimization likelihood: {like_optmin}")
         ftr.set_params(dict(zip(ftr.fitkeys, newfitvals)))
         ftr.phaseogram()
     else:
@@ -871,7 +870,7 @@ def main(argv=None):
             backend = emcee.backends.HDFBackend(filename + "_chains.h5")
             backend.reset(nwalkers, ndim)
         except ImportError:
-            log.warning("h5py package not installed. Backend set to None")
+            log.warning(f"h5py package not installed. Backend set to None")
             backend = None
     else:
         backend = None
@@ -902,7 +901,7 @@ def main(argv=None):
             pool.close()
             pool.join()
         except ImportError:
-            log.info("Pathos module not available, using single core")
+            log.info(f"Pathos module not available, using single core")
             sampler = emcee.EnsembleSampler(
                 nwalkers, ndim, ftr.lnposterior, blobs_dtype=dtype, backend=backend
             )
@@ -1010,18 +1009,18 @@ def main(argv=None):
         lambda v: (v[1], v[2] - v[1], v[1] - v[0]),
         zip(*np.percentile(samples, [16, 50, 84], axis=0)),
     )
-    log.info("Post-MCMC values (50th percentile +/- (16th/84th percentile):")
+    log.info(f"Post-MCMC values (50th percentile +/- (16th/84th percentile):")
     for name, vals in zip(ftr.fitkeys, ranges):
         log.info("%8s:" % name + "%25.15g (+ %12.5g  / - %12.5g)" % vals)
 
     # Put the same stuff in a file
     f = open(filename + "_results.txt", "w")
 
-    f.write("Post-MCMC values (50th percentile +/- (16th/84th percentile):\n")
+    f.write(f"Post-MCMC values (50th percentile +/- (16th/84th percentile):\n")
     for name, vals in zip(ftr.fitkeys, ranges):
         f.write("%8s:" % name + " %25.15g (+ %12.5g  / - %12.5g)\n" % vals)
 
-    f.write("\nMaximum likelihood par file:\n")
+    f.write(f"\nMaximum likelihood par file:\n")
     f.write(ftr.model.as_parfile())
     f.close()
 

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -310,8 +310,9 @@ def run_sampler_autocorr(sampler, pos, nsteps, burnin, csteps=100, crit1=10):
 
 def load_events_weights(eventfile, model, weightcol, wgtexp, minMJD, maxMJD, minWeight):
     """Loads in Fermi photon events and generates a TOA object and a corresponding weights array
-    ----------
+
     Parameters
+    ----------
         eventfile: Photon events file, format: fits, pickle, pickle.gz
         model: Timing Model
         weightcol (str): Name of weight column (or 'CALC' to have them computed)
@@ -319,8 +320,8 @@ def load_events_weights(eventfile, model, weightcol, wgtexp, minMJD, maxMJD, min
         minMJD (float): Earliest MJD to use
         maxMJD (float): Latest MJD to use
         minWeight (float)): Minimum weight to include
-    -------
     Returns
+    -------
         ts: TOA object containing all of the photon data
         weights: numpy array containing the corresponding weights
     """

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -25,6 +25,7 @@ from pint.observatory.satellite_obs import get_satellite_observatory
 
 __all__ = ["read_gaussfitfile", "marginalize_over_phase", "main"]
 
+
 def read_gaussfitfile(gaussfitfile, proflen):
     """Read a Gaussian-fit file as created by the output of pygaussfit.py.
 
@@ -388,6 +389,7 @@ def load_events_weights(eventfile, model, weightcol, wgtexp, minMJD, maxMJD, min
         log.info("There are %d events, no weights are being used." % ts.ntoas)
 
     return ts, weights
+
 
 class emcee_fitter(Fitter):
     def __init__(

--- a/tests/test_event_optimize.py
+++ b/tests/test_event_optimize.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 from io import StringIO
 from pathlib import Path
+from contextlib import suppress
 
 import emcee.backends
 import pytest
@@ -55,34 +56,30 @@ def test_parallel(tmp_path):
     saved_stdout, sys.stdout = (sys.stdout, StringIO("_"))
 
     np.random.seed(1)
-    event_optimize.maxpost = -9e99
-    event_optimize.numcalls = 0
     try:
         import pathos
-
-        os.chdir(tmp_path)
-        cmd = f"{eventfile} {parfile} {temfile} --weightcol=PSRJ0030+0451 --minWeight=0.9 --nwalkers=10 --nsteps=50 --burnin 10 --clobber"
-        event_optimize.main(cmd.split())
-        with open("J0030+0451_samples.pickle", "rb") as f:
-            samples1 = pickle.load(f)
-        f.close
-        np.random.seed(1)
-        event_optimize.maxpost = -9e99
-        event_optimize.numcalls = 0
-
-        cmd = f"{eventfile} {parfile} {temfile} --weightcol=PSRJ0030+0451 --minWeight=0.9 --nwalkers=10 --nsteps=50 --burnin 10 --multicore --clobber"
-        event_optimize.main(cmd.split())
-        with open("J0030+0451_samples.pickle", "rb") as f:
-            samples2 = pickle.load(f)
-        f.close()
-
-        for i in range(samples1.shape[1]):
-            assert stats.ks_2samp(samples1[:, i], samples2[:, i])[1] == 1.0
     except ImportError:
         pytest.skip(f"Pathos multiprocessing package not found")
-    finally:
-        os.chdir(p)
-        sys.stdout = saved_stdout
+
+    os.chdir(tmp_path)
+    cmd = f"{eventfile} {parfile} {temfile} --weightcol=PSRJ0030+0451 --minWeight=0.9 --nwalkers=10 --nsteps=50 --burnin 10 --clobber"
+    event_optimize.main(cmd.split())
+    with open("J0030+0451_samples.pickle", "rb") as f:
+        samples1 = pickle.load(f)
+    f.close
+    np.random.seed(1)
+
+    cmd = f"{eventfile} {parfile} {temfile} --weightcol=PSRJ0030+0451 --minWeight=0.9 --nwalkers=10 --nsteps=50 --burnin 10 --multicore --clobber"
+    event_optimize.main(cmd.split())
+    with open("J0030+0451_samples.pickle", "rb") as f:
+        samples2 = pickle.load(f)
+    f.close()
+
+    for i in range(samples1.shape[1]):
+        assert stats.ks_2samp(samples1[:, i], samples2[:, i])[1] == 1.0
+
+    os.chdir(p)
+    sys.stdout = saved_stdout
 
 
 def test_backend(tmp_path):
@@ -100,31 +97,27 @@ def test_backend(tmp_path):
     saved_stdout, sys.stdout = (sys.stdout, StringIO("_"))
     try:
         import h5py
-
-        samples = None
-
-        # Running with backend
-        os.chdir(tmp_path)
-        cmd = f"{eventfile} {parfile} {temfile} --weightcol=PSRJ0030+0451 --minWeight=0.9 --nwalkers=10 --nsteps=50 --burnin=10 --backend --clobber"
-        event_optimize.maxpost = -9e99
-        event_optimize.numcalls = 0
-        event_optimize.main(cmd.split())
-        reader = emcee.backends.HDFBackend("J0030+0451_chains.h5")
-        samples = reader.get_chain(discard=10)
-        assert samples is not None
-
-        try:
-            # Clobber flag test
-            timestamp = os.path.getmtime("J0030+0451_chains.h5")
-            cmd = f"{eventfile} {parfile} {temfile} --weightcol=PSRJ0030+0451 --minWeight=0.9 --nwalkers=10 --nsteps=50 --burnin=10 --backend"
-            event_optimize.maxpost = -9e99
-            event_optimize.numcalls = 0
-            event_optimize.main(cmd.split())
-        except Exception:
-            assert timestamp == os.path.getmtime("J0030+0451_chains.h5")
-
     except ImportError:
         pytest.skip(f"h5py package not found")
+
+    samples = None
+
+    # Running with backend
+    os.chdir(tmp_path)
+    cmd = f"{eventfile} {parfile} {temfile} --weightcol=PSRJ0030+0451 --minWeight=0.9 --nwalkers=10 --nsteps=50 --burnin=10 --backend --clobber"
+    event_optimize.main(cmd.split())
+    reader = emcee.backends.HDFBackend("J0030+0451_chains.h5")
+    samples = reader.get_chain(discard=10)
+    assert samples is not None
+
+    try:
+        # Clobber flag test
+        timestamp = os.path.getmtime("J0030+0451_chains.h5")
+        cmd = f"{eventfile} {parfile} {temfile} --weightcol=PSRJ0030+0451 --minWeight=0.9 --nwalkers=10 --nsteps=50 --burnin=10 --backend"
+        event_optimize.main(cmd.split())
+    except Exception:
+        assert timestamp == os.path.getmtime("J0030+0451_chains.h5")
+
     finally:
         os.chdir(p)
         sys.stdout = saved_stdout
@@ -153,3 +146,37 @@ def test_autocorr(tmp_path):
     samples = np.transpose(sampler.get_chain(discard=10), (1, 0, 2)).reshape((-1, ndim))
 
     assert len(samples) < nsteps
+
+
+def test_load_events_weights(tmp_path):
+    import pint.models as models
+    from astropy.time import Time
+
+    parfile = datadir / "PSRJ0030+0451_psrcat.par"
+    eventfile_orig = (
+        datadir
+        / "J0030+0451_P8_15.0deg_239557517_458611204_ft1weights_GEO_wt.gt.0.4.fits"
+    )
+    temfile = datadir / "templateJ0030.3gauss"
+    eventfile = tmp_path / "event.fits"
+    # We will write a pickle next to this file, let's make sure it's not under tests/
+    shutil.copy(eventfile_orig, eventfile)
+    minMJD = 54680.0
+    maxMJD = Time.now().mjd
+    minWeight = 0.9
+    wgtexp = 0.0
+    weightcol = "PSRJ0030+0451"
+
+    p = Path.cwd()
+    saved_stdout, sys.stdout = (sys.stdout, StringIO("_"))
+    try:
+        os.chdir(tmp_path)
+        m = models.get_model(parfile)
+        eventfile = "event.fits"
+        t, weights = event_optimize.load_events_weights(
+            eventfile, m, weightcol, wgtexp, minMJD, maxMJD, minWeight
+        )
+        assert t is not None
+    finally:
+        os.chdir(p)
+        sys.stdout = saved_stdout


### PR DESCRIPTION
Removed obsolete code that is no longer being used within event_optimize
- Manually tracking the progress of the MCMC run has been removed since the emcee sampler has a built in progress bar
- Global tracking of the maximum posterior has been removed as it was not working properly with parallel processing and the maximum posterior values were switched to being calculated using the metadata within the emcee sampler in the original parallel processing implementation. 
- Removed the custom timing class as it is not being used

Moved the portion of the code that generates a TOA object and weights from the photon data into a dedicated function.
- The function loads in the photon data, creates a TOAs object using the photon data between the passed min and max MJD arguments, and the corresponding photon weights. 
- Removed the usepickle argument as the function checks the events file name to determine it is a pickle file or not. 