### PR TITLE
Fix removal of top-level parameter

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -43,4 +43,5 @@ the released changes.
 - Moved the test in `test_pmtransform_units.py` into a function.
 - Fixed bug in residual calculation when adding or removing phase wraps
 - Fix #1766 by correcting logic and more clearly naming argument (clkcorr->undo_clkcorr)
+- Fix removal of top-level parameter
 ### Removed

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -1372,7 +1372,7 @@ class TimingModel:
         param_map = self.get_params_mapping()
         if param not in param_map:
             raise AttributeError(f"Can not find '{param}' in timing model.")
-        if param_map[param] == "timing_model":
+        if param_map[param] == "TimingModel":
             delattr(self, param)
             self.top_level_params.remove(param)
         else:

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -639,6 +639,15 @@ def test_fitter_construction_success_after_remove_param():
     f = pint.fitter.GLSFitter(toas=t, model=m)
 
 
+def test_fitter_construction_success_after_remove_param_toplevel():
+    """Checks that remove_param succeeds when removing a paramter from the top-level model (not always meaningful)"""
+    m = get_model(os.path.join(datadir, "B1855+09_NANOGrav_9yv1.gls.par"))
+    t = get_TOAs(os.path.join(datadir, "B1855+09_NANOGrav_9yv1.tim"))
+    m.remove_component("BinaryDD")
+    m.remove_param("BINARY")
+    f = pint.fitter.GLSFitter(toas=t, model=m)
+
+
 def test_correct_number_of_params_and_FD_terms_after_add_or_remove_param():
     """Checks that the number of parameters in some component after add_param or remove_param is correct. Similarly checks that len(m.get_prefix_mapping('FD')) (i.e. num_FD_terms) is correct after seeing a bug where the length didn't change after FD param removal (see #1260)."""
     m = get_model(os.path.join(datadir, "B1855+09_NANOGrav_9yv1.gls.par"))


### PR DESCRIPTION
Previously there was a bug such that if you tried to remove a parameter that was part of the top-level `TimingModel` it would fail.  This is a small fix and a test.