### PR TITLE
Allow setting of parameter quantity/value implicitly

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -39,6 +39,7 @@ the released changes.
 - `pint.models.chromatic_model.ChromaticCM` for a Taylor series representation of the variable-index chromatic delay.
 - Whitened residuals (`white-res`) as a plotting axis in `pintk`
 - `TOAs.get_Tspan()` method
+- Doing `model.par = something` will try to assign to `par.quantity` or `par.value` but will give warning
 ### Fixed
 - `pint.utils.split_swx()` to use updated `SolarWindDispersionX()` parameter naming convention 
 - Fix #1759 by changing order of comparison

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -545,17 +545,6 @@ class TimingModel:
         """Mostly this just sets ``self.name = value``.  But in the case where they are both :class:`Parameter` instances
         with different names, this copies the ``quantity``, ``uncertainty``, ``frozen`` attributes only.
         """
-        # print(name, value)
-        # try:
-        #     print(getattr(self, name).__class__)
-        # except:
-        #     pass
-        # try:
-        #     print(f"{name} in params: {name in self.params}")
-        # except:
-        #     print(f"Cannot tell if {name} is in params")
-        # if hasattr(self, "top_level_params"):
-        #     print(f"{self.top_level_params}")
         if isinstance(value, (Parameter, prefixParameter)) and name != value.name:
             for p in ["quantity", "uncertainty", "frozen"]:
                 setattr(getattr(self, name), p, getattr(value, p))

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -555,7 +555,7 @@ class TimingModel:
             getattr(self, name).quantity = value
         elif isinstance(value, (float, str, bool, int)) and name != "name":
             log.warning(
-                f"Setting '{name}.value' to '{value}' although 'value' not specified"
+                f"Setting '{name}.value' to '{value}' (assumed units '{getattr(self,name).units}') although 'value' not specified"
             )
             getattr(self, name).value = value
         else:

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -545,9 +545,30 @@ class TimingModel:
         """Mostly this just sets ``self.name = value``.  But in the case where they are both :class:`Parameter` instances
         with different names, this copies the ``quantity``, ``uncertainty``, ``frozen`` attributes only.
         """
+        # print(name, value)
+        # try:
+        #     print(getattr(self, name).__class__)
+        # except:
+        #     pass
+        # try:
+        #     print(f"{name} in params: {name in self.params}")
+        # except:
+        #     print(f"Cannot tell if {name} is in params")
+        # if hasattr(self, "top_level_params"):
+        #     print(f"{self.top_level_params}")
         if isinstance(value, (Parameter, prefixParameter)) and name != value.name:
             for p in ["quantity", "uncertainty", "frozen"]:
                 setattr(getattr(self, name), p, getattr(value, p))
+        elif isinstance(value, u.Quantity):
+            log.warning(
+                f"Setting '{name}.quantity' to '{value}' although 'quantity' not specified"
+            )
+            getattr(self, name).quantity = value
+        elif isinstance(value, (float, str, bool,int)) and name != "name":
+            log.warning(
+                f"Setting '{name}.value' to '{value}' although 'value' not specified"
+            )
+            getattr(self, name).value = value
         else:
             super().__setattr__(name, value)
 

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -559,7 +559,7 @@ class TimingModel:
         if isinstance(value, (Parameter, prefixParameter)) and name != value.name:
             for p in ["quantity", "uncertainty", "frozen"]:
                 setattr(getattr(self, name), p, getattr(value, p))
-        elif isinstance(value, u.Quantity):
+        elif isinstance(value, (u.Quantity, time.Time)):
             log.warning(
                 f"Setting '{name}.quantity' to '{value}' although 'quantity' not specified"
             )

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -564,7 +564,7 @@ class TimingModel:
                 f"Setting '{name}.quantity' to '{value}' although 'quantity' not specified"
             )
             getattr(self, name).quantity = value
-        elif isinstance(value, (float, str, bool,int)) and name != "name":
+        elif isinstance(value, (float, str, bool, int)) and name != "name":
             log.warning(
                 f"Setting '{name}.value' to '{value}' although 'value' not specified"
             )

--- a/tests/test_parchange.py
+++ b/tests/test_parchange.py
@@ -6,6 +6,7 @@ import pytest
 import os
 from pinttestdata import datadir
 
+
 @pytest.mark.parametrize(
     "par,newvalue",
     (
@@ -37,7 +38,8 @@ def test_parchange(par, newvalue):
 )
 def test_parchange_fails(par, newvalue):
     m, t = get_model_and_toas(
-           os.path.join(datadir, "NGC6440E.par"), os.path.join(datadir, "NGC6440E.tim")
+        os.path.join(datadir, "NGC6440E.par"), os.path.join(datadir, "NGC6440E.tim")
+    )
 
     with pytest.raises((ValueError, u.UnitConversionError)):
         setattr(m, par, newvalue)

--- a/tests/test_parchange.py
+++ b/tests/test_parchange.py
@@ -1,0 +1,43 @@
+from astropy import units as u, constants as c
+from astropy.time import Time
+import numpy as np
+from pint.models import get_model_and_toas
+import pint.logging
+import pytest
+
+
+@pytest.mark.parametrize(
+    "par,newvalue",
+    (
+        ("PLANET_SHAPIRO", True),
+        ("F1", 10 * u.Hz / u.s),
+        ("F0", 20),
+        ("PSR", "ABC-XYZ"),
+        ("POSEPOCH", 53760.0),
+        ("PEPOCH", Time(53760, format="mjd")),
+    ),
+)
+def test_parchange(par, newvalue):
+    m, t = get_model_and_toas(
+        "tests/datafile/NGC6440E.par", "tests/datafile/NGC6440E.tim"
+    )
+    setattr(m, par, newvalue)
+    if isinstance(newvalue, (u.Quantity, Time)):
+        assert m[par].quantity == newvalue
+    else:
+        assert m[par].value == newvalue
+
+
+@pytest.mark.parametrize(
+    "par,newvalue",
+    (
+        ("F1", 10 * u.Hz / u.s**2),
+        ("F0", "abc"),
+    ),
+)
+def test_parchange_fails(par, newvalue):
+    m, t = get_model_and_toas(
+        "tests/datafile/NGC6440E.par", "tests/datafile/NGC6440E.tim"
+    )
+    with pytest.raises((ValueError, u.UnitConversionError)):
+        setattr(m, par, newvalue)

--- a/tests/test_parchange.py
+++ b/tests/test_parchange.py
@@ -2,9 +2,9 @@ from astropy import units as u, constants as c
 from astropy.time import Time
 import numpy as np
 from pint.models import get_model_and_toas
-import pint.logging
 import pytest
-
+import os
+from pinttestdata import datadir
 
 @pytest.mark.parametrize(
     "par,newvalue",
@@ -19,7 +19,7 @@ import pytest
 )
 def test_parchange(par, newvalue):
     m, t = get_model_and_toas(
-        "tests/datafile/NGC6440E.par", "tests/datafile/NGC6440E.tim"
+        os.path.join(datadir, "NGC6440E.par"), os.path.join(datadir, "NGC6440E.tim")
     )
     setattr(m, par, newvalue)
     if isinstance(newvalue, (u.Quantity, Time)):
@@ -37,7 +37,7 @@ def test_parchange(par, newvalue):
 )
 def test_parchange_fails(par, newvalue):
     m, t = get_model_and_toas(
-        "tests/datafile/NGC6440E.par", "tests/datafile/NGC6440E.tim"
-    )
+           os.path.join(datadir, "NGC6440E.par"), os.path.join(datadir, "NGC6440E.tim")
+
     with pytest.raises((ValueError, u.UnitConversionError)):
         setattr(m, par, newvalue)


### PR DESCRIPTION
Often I will accidentally do things like:
```
model.F0 = 10*u.Hz
```
or otherwise set the parameter to a value when I mean to set `parameter.quantity` or `parameter.value`.  This can be annoying.  However, nothing prevents you from doing this even if it makes no sense (I don't think it's caught by the validate step, but later attempts to fit the data end up with weird exceptions).

My thoughts to fix this were to either catch this and through an explicit exception or to try to interpret the intent.  This attempts to do the latter, although if that is too messy I can change it to the former.

So now with this PR if you do:
```
model.F0 = 10*u.Hz
```
you get:
```
WARNING  (pint.models.timing_model      ): Setting 'F0.quantity' to '10 Hz' although 'quantity' not specified
```
and similarly if you do:
```
model.PLANET_SHAPIRO = False
```
you get:
```
WARNING  (pint.models.timing_model      ): Setting 'PLANET_SHAPIRO.value' to 'True' although 'value' not specified
```
In both cases the quantity/value is correctly set.