### PR TITLE
Finds the correct component when assigning parameters

### DIFF
--- a/tests/test_parchange.py
+++ b/tests/test_parchange.py
@@ -79,6 +79,7 @@ def test_parcopy():
     m1.F0 = m2.F0
     assert m1.F0 == m2.F0
     assert m1.components["Spindown"].F0 == m2.components["Spindown"].F0
+    assert m1.as_parfile(include_info=False) == m2.as_parfile(include_info=False)
 
 
 def test_parcopy_andchange():
@@ -88,6 +89,7 @@ def test_parcopy_andchange():
     m2.F0.value = 20
     assert m1.F0 == m2.F0
     assert m1.components["Spindown"].F0 == m2.components["Spindown"].F0
+    assert m1.as_parfile(include_info=False) == m2.as_parfile(include_info=False)
 
 
 def test_parcopy_toplevel():
@@ -97,6 +99,8 @@ def test_parcopy_toplevel():
     m2.PSR.value = "DEF"
     m1.PSR = m2.PSR
     assert m1.PSR == m2.PSR
+    m1.F0 = m2.F0
+    assert m1.as_parfile(include_info=False) == m2.as_parfile(include_info=False)
 
 
 def test_parcopy_toplevel_andchange():
@@ -108,3 +112,5 @@ def test_parcopy_toplevel_andchange():
     assert m1.PSR == m2.PSR
     m2.PSR.value = "HGI"
     assert m1.PSR == m2.PSR
+    m1.F0 = m2.F0
+    assert m1.as_parfile(include_info=False) == m2.as_parfile(include_info=False)

--- a/tests/test_parchange.py
+++ b/tests/test_parchange.py
@@ -1,10 +1,38 @@
 from astropy import units as u, constants as c
 from astropy.time import Time
 import numpy as np
-from pint.models import get_model_and_toas
+from pint.models import get_model, get_model_and_toas
 import pytest
 import os
+from io import StringIO
 from pinttestdata import datadir
+
+
+par1 = """
+RAJ      17:48:04.53480592  0          0.00005548
+DECJ     -24:46:34.6586741  0           0.0279874
+F0              118.538254  1  0.0000000000054826
+F1            8.485977D-15  0  9.543894501911D-20
+PEPOCH        53000.000000
+DM              237.062679  0            0.005850
+SOLARN0              10.00
+EPHEM               DE421
+CLK                 UNCORR                          
+UNITS               TDB
+"""
+
+par2 = """
+RAJ      17:48:04.53480592  0          0.00005548
+DECJ     -24:46:34.6586741  0           0.0279874
+F0              666.666666  1  0.0000000000054826
+F1            8.485977D-15  0  9.543894501911D-20
+PEPOCH        53000.000000
+DM              237.062679  0            0.005850
+SOLARN0              10.00
+EPHEM               DE421
+CLK                 UNCORR                          
+UNITS               TDB
+"""
 
 
 @pytest.mark.parametrize(
@@ -43,3 +71,40 @@ def test_parchange_fails(par, newvalue):
 
     with pytest.raises((ValueError, u.UnitConversionError)):
         setattr(m, par, newvalue)
+
+
+def test_parcopy():
+    m1 = get_model(StringIO(par1))
+    m2 = get_model(StringIO(par2))
+    m1.F0 = m2.F0
+    assert m1.F0 == m2.F0
+    assert m1.components["Spindown"].F0 == m2.components["Spindown"].F0
+
+
+def test_parcopy_andchange():
+    m1 = get_model(StringIO(par1))
+    m2 = get_model(StringIO(par2))
+    m1.F0 = m2.F0
+    m2.F0.value = 20
+    assert m1.F0 == m2.F0
+    assert m1.components["Spindown"].F0 == m2.components["Spindown"].F0
+
+
+def test_parcopy_toplevel():
+    m1 = get_model(StringIO(par1))
+    m2 = get_model(StringIO(par2))
+    m1.PSR.value = "ABC"
+    m2.PSR.value = "DEF"
+    m1.PSR = m2.PSR
+    assert m1.PSR == m2.PSR
+
+
+def test_parcopy_toplevel_andchange():
+    m1 = get_model(StringIO(par1))
+    m2 = get_model(StringIO(par2))
+    m1.PSR.value = "ABC"
+    m2.PSR.value = "DEF"
+    m1.PSR = m2.PSR
+    assert m1.PSR == m2.PSR
+    m2.PSR.value = "HGI"
+    assert m1.PSR == m2.PSR


### PR DESCRIPTION
Addresses #1809 

When doing:
```
m1.F0 = m2.F0
```
it will correctly find `F0` in the `Spindown` component and do the assignment there.  The assignment will be via reference, so future changes to `m2.F0` will change `m1.F0`.

The tests also check that this works OK for top-level parameters.