### PR TITLE
Event_optimize results.txt bug fix

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -19,6 +19,7 @@ the released changes.
 - Explicit type conversion in `woodbury_dot()` function
 - Documentation: Fixed empty descriptions in the timing model components table
 - BIC implementation
+- `event_optimize`: Fixed a bug that was causing the results.txt file to be written without the median values. 
 ### Removed
 - Removed the argument `--usepickle` in `event_optimize` as the `load_events_weights` function checks the events file type to see if the 
 file is a pickle file.

--- a/src/pint/scripts/event_optimize.py
+++ b/src/pint/scripts/event_optimize.py
@@ -1005,20 +1005,24 @@ def main(argv=None):
     f.close()
 
     # Print the best MCMC values and ranges
-    ranges = map(
-        lambda v: (v[1], v[2] - v[1], v[1] - v[0]),
-        zip(*np.percentile(samples, [16, 50, 84], axis=0)),
+    ranges = list(
+        map(
+            lambda v: (v[1], v[2] - v[1], v[1] - v[0]),
+            zip(*np.percentile(samples, [16, 50, 84], axis=0)),
+        )
     )
     log.info(f"Post-MCMC values (50th percentile +/- (16th/84th percentile):")
     for name, vals in zip(ftr.fitkeys, ranges):
-        log.info("%8s:" % name + "%25.15g (+ %12.5g  / - %12.5g)" % vals)
+        log.info(f"{name:8s}: {vals[0]:25.15g} (+ {vals[1]:12.5g} / - {vals[2]:12.5g})")
 
     # Put the same stuff in a file
     f = open(filename + "_results.txt", "w")
 
     f.write(f"Post-MCMC values (50th percentile +/- (16th/84th percentile):\n")
     for name, vals in zip(ftr.fitkeys, ranges):
-        f.write("%8s:" % name + " %25.15g (+ %12.5g  / - %12.5g)\n" % vals)
+        f.write(
+            f"{name:8s}: {vals[0]:25.15g} (+ {vals[1]:12.5g} / - {vals[2]:12.5g})\n"
+        )
 
     f.write(f"\nMaximum likelihood par file:\n")
     f.write(ftr.model.as_parfile())

--- a/tests/test_event_optimize.py
+++ b/tests/test_event_optimize.py
@@ -35,6 +35,10 @@ def test_result(tmp_path):
         event_optimize.main(cmd.split())
         lines = sys.stdout.getvalue()
         # Need to add some check here.
+        with open("J0030+0451_results.txt") as f:
+            lines = f.readlines()
+        assert lines[1].split()[0] == "F0"
+        assert len(lines[1].split()[2]) == 16
     finally:
         os.chdir(p)
         sys.stdout = saved_stdout


### PR DESCRIPTION
A fix for issue #1811.

This saves the median ranges calculated post MCMC run as a variable to be called again in order to write them into the results.txt file