### PR TITLE
Fix documentation of local ephemerides

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -31,6 +31,7 @@ the released changes.
 - `event_optimize`: Fixed a bug that was causing the results.txt file to be written without the median values. 
 - SWX model now has SWXP_0001 frozen by default, and new segments should also have SWXP frozen
 - Can now properly use local files for ephemeris
+- Typos in `explanation.rst` regarding local ephemeris.
 ### Removed
 - Removed the argument `--usepickle` in `event_optimize` as the `load_events_weights` function checks the events file type to see if the 
 file is a pickle file.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -529,8 +529,8 @@ Ephemerides
 '''''''''''
 
 JPL Solar System ephemerides (of the form ``DE*.bsp``) are typically downloaded automatically 
-and stored using ```astropy``'s data downloading and caching mechanism.  The list of URLs used for this 
-are given in :module:`pint.solar_system_ephemerides`.  However, you can also specify a local file instead.  
+and stored using ``astropy``'s data downloading and caching mechanism.  The list of URLs used for this 
+are given in :mod:`pint.solar_system_ephemerides`.  However, you can also specify a local file instead.  
 To do this, load the file explicitly with:
 ::
 


### PR DESCRIPTION
There were a couple of typos in the RST file that messed up the formatting.