### PR TITLE
Making bad SINI raise exception to help fit

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -53,9 +53,11 @@ jobs:
 #          - os: ubuntu-latest
 #            python: '3.8'
 #            tox_env: 'codestyle'
-          - os: macos-12
-            python: '3.12'
-            tox_env: 'singletest'
+# uncomment this if needed to run a single test quickly
+# can specify OS and python versions
+          # - os: macos-12
+          #   python: '3.12'
+          #   tox_env: 'singletest'
 
     steps:
     - name: Check out repository

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -55,7 +55,7 @@ jobs:
 #            tox_env: 'codestyle'
           - os: macos-12
             python: '3.12'
-            tox_env: 'py312-singletest'
+            tox_env: 'singletest'
 
     steps:
     - name: Check out repository

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -53,6 +53,9 @@ jobs:
 #          - os: ubuntu-latest
 #            python: '3.8'
 #            tox_env: 'codestyle'
+          - os: macos-12
+            python: '3.12'
+            tox_env: 'py312-singletest'
 
     steps:
     - name: Check out repository

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -33,6 +33,7 @@ the released changes.
 - SWX model now has SWXP_0001 frozen by default, and new segments should also have SWXP frozen
 - Can now properly use local files for ephemeris
 - Typos in `explanation.rst` regarding local ephemeris.
+- DD/ELL1 models will check for valid SINI and raise exception if it strays, which will tell the fitter to try elsewhere
 ### Removed
 - Removed the argument `--usepickle` in `event_optimize` as the `load_events_weights` function checks the events file type to see if the 
 file is a pickle file.

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -76,6 +76,7 @@ from pint.models.parameter import (
     AngleParameter,
     boolParameter,
     strParameter,
+    InvalidModelParameters,
 )
 from pint.pint_matrix import (
     CorrelationMatrix,
@@ -885,10 +886,6 @@ class Fitter:
             category=DeprecationWarning,
         )
         return self.parameter_covariance_matrix
-
-
-class InvalidModelParameters(ValueError):
-    pass
 
 
 class CorrelatedErrors(ValueError):

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -54,8 +54,10 @@ from pint.utils import split_prefixed_name
 # in one place for consistency
 _parfile_formats = ["pint", "tempo", "tempo2"]
 
+
 class InvalidModelParameters(ValueError):
     pass
+
 
 def _identity_function(x):
     """A function to just return the input argument

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -54,6 +54,8 @@ from pint.utils import split_prefixed_name
 # in one place for consistency
 _parfile_formats = ["pint", "tempo", "tempo2"]
 
+class InvalidModelParameters(ValueError):
+    pass
 
 def _identity_function(x):
     """A function to just return the input argument

--- a/src/pint/models/stand_alone_psr_binaries/DD_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/DD_model.py
@@ -1,11 +1,13 @@
 """Damour and Deruelle binary model."""
 
+from multiprocessing import Value
 import astropy.constants as c
 import astropy.units as u
 import numpy as np
 from loguru import logger as log
 
 from pint import Tsun
+from pint.models.parameter import InvalidModelParameters
 
 from .binary_generic import PSR_BINARY
 
@@ -708,6 +710,9 @@ class DDmodel(PSR_BINARY):
         sOmega = np.sin(self.omega())
         cOmega = np.cos(self.omega())
         TM2 = self.M2.value * Tsun
+
+        if (self.SINI < 0) or (self.SINI > 1):
+            raise InvalidModelParameters("SINI parameter must be between 0 and 1")
 
         return (
             -2

--- a/src/pint/models/stand_alone_psr_binaries/DD_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/DD_model.py
@@ -711,7 +711,7 @@ class DDmodel(PSR_BINARY):
         cOmega = np.cos(self.omega())
         TM2 = self.M2.value * Tsun
 
-        if (self.SINI < 0) or (self.SINI > 1):
+        if np.any(self.SINI < 0) or np.any(self.SINI > 1):
             raise InvalidModelParameters("SINI parameter must be between 0 and 1")
 
         return (

--- a/src/pint/models/stand_alone_psr_binaries/DD_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/DD_model.py
@@ -1,6 +1,5 @@
 """Damour and Deruelle binary model."""
 
-from multiprocessing import Value
 import astropy.constants as c
 import astropy.units as u
 import numpy as np

--- a/src/pint/models/stand_alone_psr_binaries/ELL1_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/ELL1_model.py
@@ -601,7 +601,7 @@ class ELL1model(ELL1BaseModel):
         """ELL1 Shapiro delay. Lange et al 2001 eq. A16"""
         TM2 = self.TM2()
         Phi = self.Phi()
-        if (self.SINI < 0) or (self.SINI > 1):
+        if np.any(self.SINI < 0) or np.any(self.SINI > 1):
             raise InvalidModelParameters("SINI must be between 0 and 1")
         return -2 * TM2 * np.log(1 - self.SINI * np.sin(Phi))
 

--- a/src/pint/models/stand_alone_psr_binaries/ELL1_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/ELL1_model.py
@@ -4,6 +4,7 @@ import astropy.constants as c
 import astropy.units as u
 import numpy as np
 
+from pint.models.parameter import InvalidModelParameters
 from .binary_generic import PSR_BINARY
 
 
@@ -600,6 +601,8 @@ class ELL1model(ELL1BaseModel):
         """ELL1 Shapiro delay. Lange et al 2001 eq. A16"""
         TM2 = self.TM2()
         Phi = self.Phi()
+        if (self.SINI < 0) or (self.SINI > 1):
+            raise InvalidModelParameters("SINI must be between 0 and 1")
         return -2 * TM2 * np.log(1 - self.SINI * np.sin(Phi))
 
     def d_delayS_d_par(self, par):

--- a/tests/test_model_derivatives.py
+++ b/tests/test_model_derivatives.py
@@ -179,7 +179,7 @@ def test_derivative_equals_numerical(parfile, param):
             np.abs(model.FB3.value.astype(np.float64)) * 1e7
         )
     elif param == "SINI":
-        sini = model.SINI.value
+        sini = model.SINI.value.astype(np.float64)
         stepgen = numdifftools.MaxStepGenerator(abs(sini) / 2)
     else:
         stepgen = None

--- a/tests/test_model_derivatives.py
+++ b/tests/test_model_derivatives.py
@@ -180,10 +180,16 @@ def test_derivative_equals_numerical(parfile, param):
         )
     elif param == "SINI":
         sini = model.SINI.value.astype(np.float64)
-        stepgen = numdifftools.MaxStepGenerator(abs(sini) / 2)
+        print(sini.dtype)
+        stepgen = numdifftools.MaxStepGenerator(abs(sini) / 10)
+        print(stepgen)
     else:
         stepgen = None
     df = numdifftools.Derivative(f, step=stepgen)
+
+    if param == "SINI":
+        print(getattr(model, param).value.astype(np.float64).dtype)
+        print(f(getattr(model, param).value.astype(np.float64)).dtype)
 
     a = model.d_phase_d_param(toas, delay=None, param=param).to_value(1 / units)
     b = df(getattr(model, param).value.astype(np.float64))

--- a/tests/test_model_derivatives.py
+++ b/tests/test_model_derivatives.py
@@ -178,6 +178,9 @@ def test_derivative_equals_numerical(parfile, param):
         stepgen = numdifftools.MaxStepGenerator(
             np.abs(model.FB3.value.astype(np.float64)) * 1e7
         )
+    elif param == "SINI":
+        sini = model.SINI.value
+        stepgen = numdifftools.MaxStepGenerator(abs(sini) / 2)
     else:
         stepgen = None
     df = numdifftools.Derivative(f, step=stepgen)

--- a/tests/test_model_derivatives.py
+++ b/tests/test_model_derivatives.py
@@ -180,16 +180,10 @@ def test_derivative_equals_numerical(parfile, param):
         )
     elif param == "SINI":
         sini = model.SINI.value.astype(np.float64)
-        print(sini.dtype)
         stepgen = numdifftools.MaxStepGenerator(abs(sini) / 10)
-        print(stepgen)
     else:
         stepgen = None
     df = numdifftools.Derivative(f, step=stepgen)
-
-    if param == "SINI":
-        print(getattr(model, param).value.astype(np.float64).dtype)
-        print(f(getattr(model, param).value.astype(np.float64)).dtype)
 
     a = model.d_phase_d_param(toas, delay=None, param=param).to_value(1 / units)
     b = df(getattr(model, param).value.astype(np.float64))

--- a/tests/test_model_derivatives.py
+++ b/tests/test_model_derivatives.py
@@ -153,7 +153,7 @@ def test_derivative_equals_numerical(parfile, param):
             try:
                 dphase = m.phase(toas, abs_phase=False) - phase
             except ValueError:
-                return np.nan * np.zeros_like(phase.frac)
+                return np.nan * np.zeros_like(phase.frac).astype(np.float64)
         return np.float64(dphase.int + dphase.frac)
 
     if param == "ECC":

--- a/tests/test_sini.py
+++ b/tests/test_sini.py
@@ -1,0 +1,69 @@
+import pytest
+import io
+from astropy import units as u
+import pint.logging
+from pint.models import get_model
+import pint.fitter
+import pint.simulation
+
+pint.logging.setup("ERROR")
+
+
+def test_sini_fit():
+    s = """PSRJ                           J1853+1303
+    EPHEM                               DE440
+    CLK                               TT(TAI)
+    UNITS                                 TDB
+    START              55731.1937186050359860
+    FINISH             59051.1334073910116910
+    TIMEEPH                              FB90
+    T2CMETHOD                        IAU2000B
+    DILATEFREQ                              N
+    DMDATA                                  N
+    NTOA                                 4570
+    CHI2R                              0.9873 0 4455.0
+    TRES                                1.297
+    ELONG                 286.257303932061347 1 0.00000000931838521883
+    ELAT                   35.743349195626379 1 0.00000001342269042838
+    PMELONG               -1.9106838589844408 1 0.011774688289719207
+    PMELAT                -2.7055634767966588 1 0.02499026250312041
+    PX                     0.6166118941596491 1 0.13495439191146907
+    ECL                              IERS2010
+    POSEPOCH           57391.0000000000000000
+    F0                  244.39137771284777388 1 4.741681125242900587e-13
+    F1              -5.2068158193285555695e-16 1 1.657252200776189767e-20
+    PEPOCH             57391.0000000000000000
+    CORRECT_TROPOSPHERE                         Y
+    PLANET_SHAPIRO                          Y
+    NE_SW                                 0.0
+    SWM                                   0.0
+    DM                  30.570200097819536894
+    DM1                                   0.0
+    DMEPOCH            57391.0000000000000000
+    BINARY                                 DD
+    PB                  115.65378643873621578 1 3.2368969907e-09
+    PBDOT                                 0.0
+    A1                     40.769522249658145 1 1.53854961349644e-06
+    XDOT                1.564794972862985e-14 1 8.617009015429654e-16
+    ECC                2.3701427108198803e-05 1 3.467883031e-09
+    EDOT                                  0.0
+    T0                 57400.7367807004642730 1 0.00999271094974152688
+    OM                  346.60040313716600618 1 0.03110468777178034688
+    OMDOT                                 0.0
+    M2                    0.18373369620702712 1 0.19097347492091507
+    SINI                   0.8630519453652643 1 0.14457246899831822
+    A0                                    0.0
+    B0                                    0.0
+    GAMMA                                 0.0
+    DR                                    0.0
+    DTH                                   0.0
+    TZRMJD             57390.6587742196275694
+    TZRSITE                           arecibo
+    TZRFRQ                            426.875
+    """
+    m = get_model(io.StringIO(s))
+    t = pint.simulation.make_fake_toas_uniform(
+        55731, 59051, 100, m, obs="axis", error=1 * u.us, add_noise=True
+    )
+    f = pint.fitter.Fitter.auto(t, m)
+    f.fit_toas()

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ envlist =
     report
     codestyle
     black
+    singletest
     py{38,39,310,311,312}-test{,-alldeps,-devdeps}{,-cov}
 
 skip_missing_interpreters = True

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,27 @@ depends =
     report: py38,py39,py310,py312
     docs: notebooks
 
+[testenv:singletest]
+# Make sure the astropy cache is shared with the user's usual.
+# Also allow tests that pop up a window to work if possible
+passenv =
+    HOME
+    DISPLAY
+    HYPOTHESIS_PROFILE
+
+deps =
+    pytest
+    cov: coverage
+    cov: pytest-cov
+    cov: pytest-remotedata
+    hypothesis
+    numdifftools
+    pathos
+    setuptools
+commands =
+    pip freeze
+    pytest -v --pyargs tests test_model_derivatives.py {posargs}
+
 [testenv:ephemeris_connection]
 description =
     Check whether PINT can obtain the DE440 ephemeris (usually from a server)

--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,7 @@ deps =
     coverage
     hypothesis<=6.72.0
     setuptools
+# can change this as needed for a single test run
 commands = pytest tests/test_model_derivatives.py
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -53,13 +53,8 @@ depends =
     docs: notebooks
 
 [testenv:singletest]
-# Make sure the astropy cache is shared with the user's usual.
-# Also allow tests that pop up a window to work if possible
-passenv =
-    HOME
-    DISPLAY
-    HYPOTHESIS_PROFILE
-    
+description =
+    Try a simple run with a single test
 deps =
     numpy
     numdifftools
@@ -70,7 +65,7 @@ deps =
     coverage
     hypothesis<=6.72.0
     setuptools
-commands = pytest -v tests/test_model_derivatives.py
+commands = pytest tests/test_model_derivatives.py
 
 
 [testenv:ephemeris_connection]

--- a/tox.ini
+++ b/tox.ini
@@ -58,16 +58,19 @@ passenv =
     HOME
     DISPLAY
     HYPOTHESIS_PROFILE
-
+    
 deps =
-    pytest
-    hypothesis
+    numpy
     numdifftools
-    pathos
+    astropy
+    matplotlib
+    scipy
+    pytest
+    coverage
+    hypothesis<=6.72.0
     setuptools
-commands =
-    pip freeze
-    pytest -v --pyargs tests/test_model_derivatives.py {posargs}
+commands = pytest -v tests/test_model_derivatives.py
+
 
 [testenv:ephemeris_connection]
 description =

--- a/tox.ini
+++ b/tox.ini
@@ -61,16 +61,13 @@ passenv =
 
 deps =
     pytest
-    cov: coverage
-    cov: pytest-cov
-    cov: pytest-remotedata
     hypothesis
     numdifftools
     pathos
     setuptools
 commands =
     pip freeze
-    pytest -v --pyargs tests test_model_derivatives.py {posargs}
+    pytest -v --pyargs tests/test_model_derivatives.py {posargs}
 
 [testenv:ephemeris_connection]
 description =


### PR DESCRIPTION
If the fitter encounters a SINI value outside of 0->1, rather than having some cryptic warning messages about bad values in the log and then fail with an error about NaN's in the array, it should be able to avoid taking steps to those places.

Overall the fitters know how to try a step and change that step if it ends in a bad place.  I think all that was missing was to raise an exception for a bad SINI value.  

Also moved `InvalidModelParameters` to `pint.models.parameter` to make it easier to import from within a model (it's a subclass of `ValueError`, so I think either will work).