### PR TITLE
DRAFT: NoiseComponent Free Specs

### DIFF
--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -805,6 +805,111 @@ class PLRedNoise(NoiseComponent):
         return np.dot(Fmat * phi[None, :], Fmat.T)
 
 
+class FreeSpecRedNoise(NoiseComponent):
+    """Timing noise with a free spectral model.
+
+    Over the long term, pulsars are observed to experience timing noise
+    dominated by low frequencies. This can occur, for example, if the
+    torque on the pulsar varies randomly. If the torque experiences
+    white noise, the phase we observe will experience "red" noise, that
+    is noise dominated by the lowest frequency. This results in errors
+    that are correlated between TOAs over fairly long time spans.
+    
+    Free spectral model. PSD amplitude at each frequency
+    is a free parameter. Model is parameterized by
+    S(f_i) = \rho_i^2 * T,
+    where \rho_i is the free parameter and T is the observation length.
+
+    Parameters supported:
+
+    .. paramtable::
+        :class: pint.models.noise_model.FreeSpecRedNoise
+
+    Note
+    ----
+    
+
+    """
+
+    register = True
+    category = "free_spec_red_noise"
+
+    introduces_correlated_errors = True
+    is_time_correlated = True
+
+    def __init__(
+        self,
+        free_spec_components=30
+    ):
+        super().__init__()
+
+        self.add_param(
+            floatParameter(
+                name="TNREDC",
+                units="",
+                aliases=[],
+                description="Number of red noise frequencies.",
+                convert_tcb2tdb=False,
+            )
+        )
+        for i in range(free_spec_components):
+            self.add_param(
+                floatParameter(
+                    name=f"TNRED_log10_rho_{i}",
+                    units="",
+                    aliases=[],
+                    description="Log10 PSD Amplitude at each Fourier mode.",
+                    convert_tcb2tdb=False,
+                )
+            )
+
+        self.covariance_matrix_funcs += [self.free_spec_rn_cov_matrix]
+        self.basis_funcs += [self.free_spec_rn_basis_weight_pair]
+
+    def get_free_spec_vals(self):
+        nf = int(self.TNREDC.value) if self.TNREDC.value is not None else 30
+        log10_rhos = [getattr(self, f"TNRED_log10_rho_{i}").value for i in range(nf)]
+        return (nf, log10_rhos)
+
+    def get_noise_basis(self, toas):
+        """Return a Fourier design matrix for red noise.
+
+        See the documentation for free_spec_rn_basis_weight_pair function for details."""
+
+        tbl = toas.table
+        t = (tbl["tdbld"].quantity * u.day).to(u.s).value
+        nf = self.get_free_spec_vals()[0]
+        return create_fourier_design_matrix(t, nf)
+
+    def get_noise_weights(self, toas):
+        """Return free spec red noise weights.
+
+        See the documentation for free_spec_rn_basis_weight_pair for details."""
+
+        tbl = toas.table
+        t = (tbl["tdbld"].quantity * u.day).to(u.s).value
+        nf, log10_rhos = self.get_free_spec_vals()
+        #Ffreqs = get_rednoise_freqs(t, nf)
+        return freespec(log10_rhos)# * Ffreqs[0]
+        #FIXME: what the heck is the Ffreqs doing in the above ??
+
+    def free_spec_rn_basis_weight_pair(self, toas):
+        """Return a Fourier design matrix and free spec red noise weights.
+
+        A Fourier design matrix contains the sine and cosine basis_functions
+        in a Fourier series expansion.
+        The weights used are the free-spec PSD values at frequencies n/T,
+        where n is in [1, TNREDC] and T is the total observing duration of
+        the dataset.
+
+        """
+        return (self.get_noise_basis(toas), self.get_noise_weights(toas))
+
+    def free_spec_rn_cov_matrix(self, toas):
+        Fmat, phi = self.free_spec_rn_basis_weight_pair(toas)
+        return np.dot(Fmat * phi[None, :], Fmat.T)
+
+
 def get_ecorr_epochs(toas_table, dt=1, nmin=2):
     """Find only epochs with more than 1 TOA for applying ECORR."""
     if len(toas_table) == 0:
@@ -890,3 +995,11 @@ def powerlaw(f, A=1e-16, gamma=5):
 
     fyr = 1 / 3.16e7
     return A**2 / 12.0 / np.pi**2 * fyr ** (gamma - 3) * f ** (-gamma)
+
+def freespec(log10_rhos):
+    """Free-spectral PSD.
+    
+    :param log10_rhos: array - rho values in free spec model [GW units]
+    """
+    return np.repeat(10 ** (2 * np.array(log10_rhos)), 2)
+


### PR DESCRIPTION
This MR adds the ability to input free spectral model for red noise, dm noise, and chromatic noise.
It is essentially a copy of PLRedNoise, PLDMNoise, and PLChromNoise, replacing the PL with FreeSpec.