### PR TITLE
Fixed `find_empty_masks` for `CMX`

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -26,6 +26,7 @@ the released changes.
 - When EQUAD is created from TNEQ, has proper TCB->TDB conversion info
 - TOA selection masks will work when only TOA is the first one
 - Condense code in Glitch model and add test coverage.
+- `find_empty_masks` will now search through `CMX` parameters
 ### Removed
 - macOS 12 CI 
 

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -627,6 +627,10 @@ class DispersionDMX(Dispersion):
                 r2[j] = getattr(self, f"DMXR2_{index:04d}").quantity.mjd
                 indices[j] = index
         for j, index in enumerate(DMXR1_mapping):
+            if (r1[j] == r2[j]) and (r1[j] > 0):
+                log.warning(
+                    f"Start of DMX_{index:04d} ({r1[j]}) equal to end of DMX_{index:04d} ({r2[j]})"
+                )
             if np.any((r1[j] > r1) & (r1[j] < r2)):
                 k = np.where((r1[j] > r1) & (r1[j] < r2))[0]
                 for kk in k.flatten():
@@ -651,7 +655,7 @@ class DispersionDMX(Dispersion):
             b = self._parent[DMXR1_mapping[k]].quantity.mjd * u.d
             e = self._parent[DMXR2_mapping[k]].quantity.mjd * u.d
             mjds = toas.get_mjds()
-            n = np.sum((b <= mjds) & (mjds < e))
+            n = np.sum((b <= mjds) & (mjds <= e))
             if n == 0:
                 bad_parameters.append(DMX_mapping[k])
         if bad_parameters:

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -643,6 +643,8 @@ class DispersionDMX(Dispersion):
                     log.warning(
                         f"End of DMX_{index:04d} ({r1[j]}-{r2[j]}) overlaps with DMX_{indices[kk]:04d} ({r1[kk]}-{r2[kk]})"
                     )
+        if not hasattr(self, "dmx_toas_selector"):
+            self.dmx_toas_selector = TOASelect(is_range=True)
 
     def validate_toas(self, toas):
         DMX_mapping = self.get_prefix_mapping_component("DMX_")

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -109,6 +109,9 @@ ignore_params = {
 
 ignore_prefix = {"DMXF1_", "DMXF2_", "DMXEP_"}
 
+# prefixes of parameters that may need to be checked for empty ranges
+prefixes = ["DM", "SW", "CM"]
+
 DEFAULT_ORDER = [
     "astrometry",
     "jump_delay",
@@ -2901,7 +2904,7 @@ class TimingModel:
                 if freeze:
                     log.info(f"'{maskpar}' has no TOAs so freezing")
                     getattr(self, maskpar).frozen = True
-        for prefix in ["DM", "SW"]:
+        for prefix in prefixes:
             mapping = pint.utils.xxxselections(self, toas, prefix=prefix)
             for k in mapping:
                 if len(mapping[k]) == 0:


### PR DESCRIPTION
`model.find_empty_masks` did not search through `CMX` parameters.  Now it does.