### PR TITLE
Added metadata to model, and included it in printout

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -22,6 +22,7 @@ the released changes.
 - `add_param` returns the name of the parameter (useful for numbered parameters)
 - Rerun intermittent failures in CI
 - micromamba CI environment for testing macOS-latest, without tox
+- models now have metadata dictionary
 ### Fixed
 - Changed WAVE_OM units from 1/d to rad/d.
 - When EQUAD is created from TNEQ, has proper TCB->TDB conversion info

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -251,6 +251,10 @@ class ModelBuilder:
         if not hasattr(tm, "NoiseComponent_list"):
             setattr(tm, "NoiseComponent_list", [])
 
+        tm.meta["allow_tcb"] = allow_tcb_
+        tm.meta["convert_tcb"] = convert_tcb
+        tm.meta["allow_T2"] = allow_T2
+
         return tm
 
     def _validate_components(self):
@@ -851,6 +855,7 @@ def get_model(
         **kwargs,
     )
     model.name = parfile
+    model.meta["original_name"] = parfile
 
     return model
 

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -29,6 +29,7 @@ See :ref:`Timing Models` for more details on how PINT's timing models work.
 
 import abc
 import copy
+import datetime
 import inspect
 import contextlib
 from collections import OrderedDict, defaultdict
@@ -228,6 +229,8 @@ class TimingModel:
     ----------
     name : str
         The name of the timing model
+    meta : dict
+        A dictionary of metadata
     component_types : list
         A list of the distinct categories of component. For example,
         delay components will be register as 'DelayComponent'.
@@ -242,6 +245,9 @@ class TimingModel:
                 "First parameter should be the model name, was {!r}".format(name)
             )
         self.name = name
+        self.meta = {
+            "read_time": f"{datetime.datetime.now().isoformat()}",
+        }
         self.component_types = []
         self.top_level_params = []
         self.add_param_from_top(
@@ -2766,6 +2772,7 @@ class TimingModel:
         if include_info:
             info_string = pint.utils.info_string(prefix_string="# ", comment=comment)
             info_string += f"\n# Format: {format.lower()}"
+            info_string += "".join([f"\n# {x}: {self.meta[x]}" for x in self.meta])
             result_begin = info_string + "\n"
         else:
             result_begin = ""


### PR DESCRIPTION
```
from pint.models import get_model
m=get_model("tests/datafile/NGC6440E.par")
print(m.as_parfile())
```
now returns:
```
# Created: 2024-12-12T13:41:07.865053
# PINT_version: 0.7+6065.g92675b80
# User: David Kaplan (kaplan)
# Host: plock
# OS: macOS-10.16-x86_64-i386-64bit
# Python: 3.9.7 (default, Sep 16 2021, 08:50:36) 
# [Clang 10.0.0 ]
# Format: pint
# read_time: 2024-12-12T13:41:04.663636
# allow_tcb: False
# convert_tcb: False
# allow_T2: False
# original_name: tests/datafile/NGC6440E.par
PSR                            1748-2021E
...
```
So there is now a metadata dictionary, which is initially populated with arguments that were used when reading in the par file along with the name of the file and the time it was read.  Other parameters can be added, and will be included in the info string on printout.

Addresses #1873