### PR TITLE
More correct low-rank expansion of powerlaw noise

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -9,27 +9,7 @@ the released changes.
 
 ## Unreleased
 ### Changed
-- Command line scripts now automatically do `allow_tcb` and `allow_T2` while reading par files.
-- Updated the `plot_chains` function in `event_optimize` so that the subplots are a fixed size to prevent the subplots from being condensed in the case of many fit parameters.
 ### Added
-- Time derivatives of NE_SW in `SolarWindDispersion`
-- New prefix pattern for `split_prefixed_name` to handle derivatives of NE_SW
-- Added an option `nbin` to `photonphase` to decide how many phase bins to use for the phaseogram
-- Added an option `linearize_model` to speed up the photon phases calculation within `event_optimize` through the designmatrix.
-- Added AIC and BIC calculation to be written in the post fit parfile from `event_optimize`
-- When TCB->TDB conversion info is missing, will print parameter name
-- Piecewise-constant model for chromatic variations (CMX)
-- `add_param` returns the name of the parameter (useful for numbered parameters)
-- Rerun intermittent failures in CI
-- micromamba CI environment for testing macOS-latest, without tox
-- models now have metadata dictionary
 ### Fixed
-- Changed WAVE_OM units from 1/d to rad/d.
-- When EQUAD is created from TNEQ, has proper TCB->TDB conversion info
-- TOA selection masks will work when only TOA is the first one
-- Condense code in Glitch model and add test coverage.
-- `find_empty_masks` will now search through `CMX` parameters
-- Fixed some docstrings for binary models.
 ### Removed
-- macOS 12 CI 
 

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -16,6 +16,7 @@ the released changes.
 - Type hints in `pint.models.timing_model`
 - `full_designmatrix()` and `full_basis_weights()` methods in `TimingModel`
 - Added checkbox for optional subtraction of mean in `pintk`
+- Added Log-Linear Powerlaw noise parameters to PLRedNoise, PLDMNoise, PLChromNoise
 ### Fixed
 - Shape of `Fitter.resids.noise_ampls` (it was wrong before due to bad indexing)
 - Made `TimingModel.is_binary()` more robust.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project, at least loosely, adheres to [Semantic Versioning](https://sem
 This file contains the released changes to the codebase. See CHANGELOG-unreleased.md for
 the unreleased changes. This file should only be changed while tagging a new version.
 
+## [1.1.1] 2024-012-18
+### Changed
+- Command line scripts now automatically do `allow_tcb` and `allow_T2` while reading par files.
+- Updated the `plot_chains` function in `event_optimize` so that the subplots are a fixed size to prevent the subplots from being condensed in the case of many fit parameters.
+### Added
+- Time derivatives of NE_SW in `SolarWindDispersion`
+- New prefix pattern for `split_prefixed_name` to handle derivatives of NE_SW
+- Added an option `nbin` to `photonphase` to decide how many phase bins to use for the phaseogram
+- Added an option `linearize_model` to speed up the photon phases calculation within `event_optimize` through the designmatrix.
+- Added AIC and BIC calculation to be written in the post fit parfile from `event_optimize`
+- When TCB->TDB conversion info is missing, will print parameter name
+- Piecewise-constant model for chromatic variations (CMX)
+- `add_param` returns the name of the parameter (useful for numbered parameters)
+- Rerun intermittent failures in CI
+- micromamba CI environment for testing macOS-latest, without tox
+- models now have metadata dictionary
+### Fixed
+- Changed WAVE_OM units from 1/d to rad/d.
+- When EQUAD is created from TNEQ, has proper TCB->TDB conversion info
+- TOA selection masks will work when only TOA is the first one
+- Condense code in Glitch model and add test coverage.
+- `find_empty_masks` will now search through `CMX` parameters
+- Fixed some docstrings for binary models.
+### Removed
+- macOS 12 CI 
+
 ## [1.1] 2024-11-05
 ### Changed
 * Bump oldest python to 3.9

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -548,7 +548,7 @@ class PLDMNoise(NoiseComponent):
 
         return amp, gam, n_lin, n_log, f_min_ratio
 
-    def get_time_frequencies(self, toas: TOAs) -> np.ndarray:
+    def get_time_frequencies(self, toas: TOAs) -> Tuple[np.ndarray, np.ndarray]:
         """Return the frequencies of the noise model"""
 
         tbl = toas.table
@@ -1000,7 +1000,7 @@ def get_rednoise_freqs(
     logmode: Optional[int] = None,
     f_min: Optional[float] = None,
     nlog: Optional[int] = None,
-):
+) -> np.ndarray:
     """
     Compute an array of red-noise frequencies, optionally mixing log- and
     linearly spaced frequencies.
@@ -1091,7 +1091,7 @@ def get_rednoise_freqs(
     return freqs
 
 
-def create_fourier_design_matrix(t, f):
+def create_fourier_design_matrix(t, f) -> np.ndarray:
     """
     Construct a Fourier design matrix from a given set of frequencies.
     The matrix alternates sine and cosine columns.

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -800,7 +800,7 @@ class PLRedNoise(NoiseComponent):
         """
         n_lin = int(self.TNREDC.value) if self.TNREDC.value is not None else 30
         n_log = int(self.TNREDFLOG.value) if (self.TNREDFLOG.value is not None) else 10
-        red_log_factor = self.TNREDFLOG_FACTOR if (self.TNREDFLOG_FACTOR is not None) else 2
+        red_log_factor = self.TNREDFLOG_FACTOR.value if (self.TNREDFLOG_FACTOR.value is not None) else 2
 
         if self.TNREDAMP.value is not None and self.TNREDGAM.value is not None:
             amp, gam = 10**self.TNREDAMP.value, self.TNREDGAM.value
@@ -1060,7 +1060,7 @@ def create_fourier_design_matrix(t, f):
     F[:, 0::2] = np.sin(2.0 * np.pi * t[:, None] * f)
     F[:, 1::2] = np.cos(2.0 * np.pi * t[:, None] * f)
 
-    return F, f
+    return F
 
 
 def powerlaw(f, A: float = 1e-16, gamma: float = 5.0, f_low_cut: Optional[float] = None):
@@ -1074,7 +1074,7 @@ def powerlaw(f, A: float = 1e-16, gamma: float = 5.0, f_low_cut: Optional[float]
     """
 
     f_low_cut = f_low_cut if f_low_cut is not None else np.min(f)
-    above_fl = np.array(f >= f_low_cut, dtype=np.float)
+    above_fl = np.array(f >= f_low_cut, dtype=float)
 
     fyr = 1 / 3.16e7
     return A**2 / 12.0 / np.pi**2 * fyr ** (gamma - 3) * f ** (-gamma) * above_fl

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -515,7 +515,7 @@ class PLDMNoise(NoiseComponent):
             floatParameter(
                 name="TNDMFLOG",
                 units="",
-                description="Number of logarithmic DM noise frequencies in the basis.",
+                description="Number of logarithmically spaced DM noise frequencies in the basis.",
                 convert_tcb2tdb=False,
             )
         )
@@ -678,7 +678,7 @@ class PLChromNoise(NoiseComponent):
             floatParameter(
                 name="TNCHROMFLOG",
                 units="",
-                description="Number of logarithmic chromatic noise frequencies in the basis.",
+                description="Number of logarithmically spaced chromatic noise frequencies in the basis.",
                 convert_tcb2tdb=False,
             )
         )
@@ -859,7 +859,7 @@ class PLRedNoise(NoiseComponent):
             floatParameter(
                 name="TNREDFLOG",
                 units="",
-                description="Number of logarithmic red noise frequencies in the basis.",
+                description="Number of logarithmically spaced red noise frequencies in the basis.",
                 convert_tcb2tdb=False,
             )
         )

--- a/tests/test_noise_models.py
+++ b/tests/test_noise_models.py
@@ -26,7 +26,7 @@ correlated_noise_component_labels = [
 def add_DM_noise_to_model(model):
     all_components = Component.component_types
     model.add_component(all_components["PLDMNoise"](), validate=False)
-    model["TNDMAMP"].quantity = 1e-13
+    model["TNDMAMP"].quantity = -13
     model["TNDMGAM"].quantity = 1.2
     model["TNDMC"].value = 30
     model["TNDMFLOG"].value = 4
@@ -37,7 +37,7 @@ def add_DM_noise_to_model(model):
 def add_chrom_noise_to_model(model):
     all_components = Component.component_types
     model.add_component(all_components["PLChromNoise"](), validate=False)
-    model["TNCHROMAMP"].quantity = 1e-14
+    model["TNCHROMAMP"].quantity = -14
     model["TNCHROMGAM"].quantity = 1.2
     model["TNCHROMC"].value = 30
     model["TNCHROMFLOG"].value = 4

--- a/tests/test_noise_models.py
+++ b/tests/test_noise_models.py
@@ -29,6 +29,8 @@ def add_DM_noise_to_model(model):
     model["TNDMAMP"].quantity = 1e-13
     model["TNDMGAM"].quantity = 1.2
     model["TNDMC"].value = 30
+    model["TNDMFLOG"].value = 4
+    model["TNDMFLOG_FACTOR"].value = 2
     model.validate()
 
 
@@ -38,6 +40,8 @@ def add_chrom_noise_to_model(model):
     model["TNCHROMAMP"].quantity = 1e-14
     model["TNCHROMGAM"].quantity = 1.2
     model["TNCHROMC"].value = 30
+    model["TNCHROMFLOG"].value = 4
+    model["TNCHROMFLOG_FACTOR"].value = 2
 
     model.add_component(all_components["ChromaticCM"](), validate=False)
     model["TNCHROMIDX"].value = 4

--- a/tests/test_plchromnoise.py
+++ b/tests/test_plchromnoise.py
@@ -51,6 +51,8 @@ parfile_contents = """
     TNChromAMP -14.2
     TNChromGAM 0.624
     TNChromC 70
+    TNChromFlog 4
+    TNChromFlog_Factor 2
     TNChromIdx 4
     CM0 0 1
     CM1 0 1
@@ -74,7 +76,14 @@ def test_read_PLChromNoise_component_type(modelJ0023p0923):
 
 
 def test_read_PLChromNoise_params(modelJ0023p0923):
-    params = ["TNCHROMAMP", "TNCHROMGAM", "TNCHROMC", "TNCHROMIDX"]
+    params = [
+        "TNCHROMAMP",
+        "TNCHROMGAM",
+        "TNCHROMC",
+        "TNCHROMIDX",
+        "TNCHROMFLOG",
+        "TNCHROMFLOG_FACTOR",
+    ]
     for param in params:
         assert (
             hasattr(modelJ0023p0923, param)
@@ -102,6 +111,8 @@ def test_PLRedNoise_recovery():
         TNRedAmp -11
         TNRedGam 3
         TNRedC 30
+        TNRedFlog 4
+        TNRedFlog_Factor 2
         """
         )
     )
@@ -125,6 +136,8 @@ def test_PLRedNoise_recovery():
     A = model["TNREDAMP"].value
     gam = model["TNREDGAM"].value
     c = model["TNREDC"].value
+    flog = model["TNREDFLOG"].value
+    flog_factor = model["TNREDFLOG_FACTOR"].value
     model.remove_component("PLRedNoise")
 
     # create and add PLChromNoise component
@@ -137,6 +150,8 @@ def test_PLRedNoise_recovery():
     model["TNCHROMAMP"].quantity = A
     model["TNCHROMGAM"].quantity = gam
     model["TNCHROMC"].value = c
+    model["TNCHROMFLOG"].value = flog
+    model["TNCHROMFLOG_FACTOR"].value = flog_factor
     model.validate()
 
     # get chromatic noise basis and weights

--- a/tests/test_pldmnoise.py
+++ b/tests/test_pldmnoise.py
@@ -56,6 +56,8 @@ parfile_contents = """
     TNDMAMP -14.2
     TNDMGAM 0.624
     TNDMC 70
+    TNDMFLOG 4
+    TNDMFLOG_FACTOR 2
 """
 
 
@@ -75,7 +77,7 @@ def test_read_PLDMNoise_component_type(modelJ0023p0923):
 
 
 def test_read_PLDMNoise_params(modelJ0023p0923):
-    params = ["TNDMAMP", "TNDMGAM", "TNDMC"]
+    params = ["TNDMAMP", "TNDMGAM", "TNDMC", "TNDMFLOG", "TNDMFLOG_FACTOR"]
     for param in params:
         assert (
             hasattr(modelJ0023p0923, param)
@@ -103,6 +105,8 @@ def test_PLRedNoise_recovery():
         TNRedAmp -11
         TNRedGam 3
         TNRedC 30
+        TNRedFlog 4
+        TNRedFlog_Factor 2
         """
         )
     )
@@ -126,6 +130,8 @@ def test_PLRedNoise_recovery():
     A = model["TNREDAMP"].value
     gam = model["TNREDGAM"].value
     c = model["TNREDC"].value
+    flog = model["TNREDFLOG"].value
+    flog_factor = model["TNREDFLOG_FACTOR"].value
     model.remove_component("PLRedNoise")
 
     # create and add PLDMNoise component
@@ -136,6 +142,8 @@ def test_PLRedNoise_recovery():
     model["TNDMAMP"].quantity = A
     model["TNDMGAM"].quantity = gam
     model["TNDMC"].value = c
+    model["TNDMFLOG"].value = flog
+    model["TNDMFLOG_FACTOR"].value = flog_factor
     model.validate()
 
     # get DM noise basis and weights


### PR DESCRIPTION
Has a dependency on #1896 

The existing low-rank expansions for red noise and related processes are based on the Lentati et al. (2014) expansion which uses a diagonal prior for frequency modes at 1/T. This is only approximately correct when fitting for quadratic spindown. For DM variations, which use the same model, contemporary analyses now consequently also include a DM2 term to "make the analysis work". DM2 is not necessarily physical when doing a fully unconstrained fit, so it is more correct to let this term be modeled by the stochastic process.

A low-rank expansion with frequencies below 1/T can improve the expansion while keeping the prior matrix diagonal. This is explored in van Haasteren & Vallisneri (2014): https://doi.org/10.1093/mnras/stu2157

This PR implements that model. Note that newer and more accurate expansions are in development that have a nondiagonal prior matrix. The design idea is that the models in this PR will also be implemented as part of the Classes in this PR: they represent the same model, namely a correct powerlaw. The Lentati expansion is a physically different model with spectral leakage explicitly not present, so that is different.

We have coordinated with the tempo2 devs, and the additional parameters are:

- TNDMFLOG, TNDMFLOG_FACTOR
- TNCHROMFLOG, TNCHROMFLOG_FACTOR
- TNREDFLOG, TNREDFLOG_FACTOR

The FLOG parameters dictate how many log-frequency-spaced extra bins we need below 1/T. The _FACTOR parameters dictate by what fraction the frequency needs to shrink every frequency bin. So setting both to 2 will lead to two new frequency bins: 1/(2T) and 1/(4T)