### PR TITLE
Store correlated noise amplitudes instead of the residuals

### DIFF
--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -1553,19 +1553,16 @@ class DownhillGLSFitter(DownhillFitter):
         # Compute the noise realizations if possible
         if not self.full_cov:
             noise_dims = self.model.noise_model_dimensions(self.toas)
-            noise_resids = {}
+            noise_ampls = {}
             ntmpar = len(self.model.free_params)
             for comp in noise_dims:
                 # The first column of designmatrix is "offset", add 1 to match
                 # the indices of noise designmatrix
                 p0 = noise_dims[comp][0] + ntmpar + 1
                 p1 = p0 + noise_dims[comp][1]
-                noise_resids[comp] = (
-                    np.dot(
-                        self.current_state.M[:, p0:p1], self.current_state.xhat[p0:p1]
-                    )
-                    * u.s
-                )
+                noise_ampls[comp] = (self.current_state.xhat / self.current_state.norm)[
+                    p0:p1
+                ] * u.s
                 if debug:
                     setattr(
                         self.resids,
@@ -1576,7 +1573,7 @@ class DownhillGLSFitter(DownhillFitter):
                         ),
                     )
                     setattr(self.resids, f"{comp}_M_index", (p0, p1))
-            self.resids.noise_resids = noise_resids
+            self.resids.noise_ampls = noise_ampls
             if debug:
                 setattr(self.resids, "norm", self.current_state.norm)
 

--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -2243,17 +2243,17 @@ class GLSFitter(Fitter):
             # Compute the noise realizations if possible
             if not full_cov:
                 noise_dims = self.model.noise_model_dimensions(self.toas)
-                noise_resids = {}
+                noise_ampls = {}
                 for comp in noise_dims:
                     # The first column of designmatrix is "offset", add 1 to match
                     # the indices of noise designmatrix
                     p0 = noise_dims[comp][0] + ntmpar + 1
                     p1 = p0 + noise_dims[comp][1]
-                    noise_resids[comp] = np.dot(M[:, p0:p1], xhat[p0:p1]) * u.s
+                    noise_ampls[comp] = (xhat / norm)[p0:p1] * u.s
                     if debug:
                         setattr(self.resids, f"{comp}_M", (M[:, p0:p1], xhat[p0:p1]))
                         setattr(self.resids, f"{comp}_M_index", (p0, p1))
-                self.resids.noise_resids = noise_resids
+                self.resids.noise_ampls = noise_ampls
                 if debug:
                     setattr(self.resids, "norm", norm)
 

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -9,7 +9,7 @@ dispersion measures (:class:`pint.residuals.WidebandTOAResiduals`).
 
 import collections
 import copy
-from typing import Literal, Optional, Union
+from typing import Dict, Literal, Optional, Union
 import warnings
 
 import astropy.units as u
@@ -158,7 +158,6 @@ class Residuals:
         # also it's expensive
         # only relevant if there are correlated errors
         self._chi2 = None
-        self.noise_resids = {}
         # For residual debugging
         self.debug_info = {}
         # We should be carefully for the other type of residuals
@@ -166,6 +165,13 @@ class Residuals:
         # A flag to identify if this residual object is combined with residual
         # class.
         self._is_combined = False
+
+        self.noise_ampls: Dict[str, u.Quantity] = {}
+        for component in model.NoiseComponent_list:
+            if component.introduces_correlated_errors:
+                self.noise_ampls[component.category] = (
+                    np.zeros_like(component.get_noise_weights(toas)) << u.s
+                )
 
     @property
     def resids(self) -> u.Quantity:
@@ -178,6 +184,17 @@ class Residuals:
     def resids_value(self) -> np.ndarray:
         """Residuals in seconds, with the units stripped."""
         return self.resids.to_value(self.unit)
+
+    @property
+    def noise_resids(self) -> Dict[str, u.Quantity]:
+        return {
+            component.category: (
+                component.get_noise_basis(self.toas)
+                @ self.noise_ampls[component.category]
+            )
+            for component in self.model.NoiseComponent_list
+            if component.introduces_correlated_errors
+        }
 
     def update(self) -> None:
         """Recalculate everything in residuals class after changing model or TOAs"""


### PR DESCRIPTION
Residuals can be computed from the amplitudes easily, but vice versa is hard.