### PR TITLE
Remove some duplicated code in photon phasoegrams.

### DIFF
--- a/src/pint/plot_utils.py
+++ b/src/pint/plot_utils.py
@@ -91,11 +91,13 @@ def phaseogram(
 
     if not binned:
         if weights is None:
-            for ph in [phss, phss+1.0]:
+            for ph in [phss, phss + 1.0]:
                 ax2.scatter(ph, mjds, s=size, color="k", alpha=alpha)
         else:
-            for ph in [phss, phss+1.0]:
-                ax2.scatter(ph, mjds, s=size, c=weights, cmap="binary", edgecolors="None")
+            for ph in [phss, phss + 1.0]:
+                ax2.scatter(
+                    ph, mjds, s=size, c=weights, cmap="binary", edgecolors="None"
+                )
     else:
         profile = np.zeros(bins, dtype=np.float64)
         ntoa = 64
@@ -180,9 +182,20 @@ def phaseogram_binned(
         Phases for each photon, assumes range is [0,1)
 
     """
-    phaseogram(mjds_in,phases,weights=weights,title=title,bins=bins,
-            rotate=rotate,size=size,alpha=alpha,width=width,
-            maxphs=maxphs,plotfile=plotfile)
+    phaseogram(
+        mjds_in,
+        phases,
+        weights=weights,
+        title=title,
+        bins=bins,
+        rotate=rotate,
+        size=size,
+        alpha=alpha,
+        width=width,
+        maxphs=maxphs,
+        plotfile=plotfile,
+    )
+
 
 def plot_priors(
     model,

--- a/src/pint/plot_utils.py
+++ b/src/pint/plot_utils.py
@@ -20,11 +20,11 @@ def phaseogram(
     width=6,
     maxphs=2.0,
     plotfile=None,
+    binned=False,
 ):
     """Make a nice 2-panel phaseogram
 
-    Makes a phaseogram of photons with phases, with a point for each photon that can
-    have a transparency determined by an array of weights.
+    Makes a phaseogram of photons with phases, with a point for each photon that can have a transparency determined by an array of weights.
 
     Parameters
     ----------
@@ -33,7 +33,26 @@ def phaseogram(
         will convert Quantity or Time into days.
     phases : array
         Phases for each photon, assumes range is [0,1)
-
+    weights : array
+        A [0,1] probability weight for each photon.
+    title : string
+        The title for the upper (histogram) axis.
+    bins : integer
+        The number of bins to include in the histogram(s).
+    rotate : float
+        An optional [0,1] phase shift for display.
+    size : integer
+        The marker size for the 2-d scatter plot (if not binned).
+    alpha : float
+        If weights aren't provided, a transparency parameter.
+    width : float
+        Figure width in inches.
+    maxphs : float
+        The maximum x-range to plot.
+    plotfile : str
+        An output file name for the histogram.
+    binned : boolean
+        Either bin the 2-d portion of the plot of scatter plot each photon.
     """
     # If mjds_in is a Time() then pull out the MJD values and make a quantity
     if type(mjds_in) == astropy.time.core.Time:
@@ -69,13 +88,51 @@ def phaseogram(
         ax1.set_ylabel("Counts")
     if title is not None:
         ax1.set_title(title)
-    if weights is None:
-        ax2.scatter(phss, mjds, s=size, color="k", alpha=alpha)
-        ax2.scatter(phss + 1.0, mjds, s=size, color="k", alpha=alpha)
+
+    if not binned:
+        if weights is None:
+            for ph in [phss, phss+1.0]:
+                ax2.scatter(ph, mjds, s=size, color="k", alpha=alpha)
+        else:
+            for ph in [phss, phss+1.0]:
+                ax2.scatter(ph, mjds, s=size, c=weights, cmap="binary", edgecolors="None")
     else:
-        colarray = np.array([[0.0, 0.0, 0.0, w] for w in weights])
-        ax2.scatter(phss, mjds, s=size, color=colarray)
-        ax2.scatter(phss + 1.0, mjds, s=size, color=colarray)
+        profile = np.zeros(bins, dtype=np.float64)
+        ntoa = 64
+        toadur = (mjds.max() - mjds.min()) / ntoa
+        mjdstarts = mjds.min() + toadur * np.arange(ntoa, dtype=np.float64)
+        mjdstops = mjdstarts + toadur
+        # Loop over blocks to process
+        a = []
+        for tstart, tstop in zip(mjdstarts, mjdstops):
+            # Clear profile array
+            profile = profile * 0.0
+
+            idx = (mjds > tstart) & (mjds < tstop)
+
+            if weights is not None:
+                for ph, ww in zip(phases[idx], weights[idx]):
+                    ibin = int(ph * bins)
+                    profile[ibin] += ww
+            else:
+                for ph in phases[idx]:
+                    ibin = int(ph * bins)
+                    profile[ibin] += 1
+
+            a.extend(profile[i] for i in range(bins))
+
+            a = np.array(a)
+            b = a.reshape(ntoa, bins)
+            c = np.hstack([b, b])
+            ax2.imshow(
+                c,
+                interpolation="nearest",
+                origin="lower",
+                cmap=plt.cm.binary,
+                extent=[0, 2.0, mjds.min().value, mjds.max().value],
+                aspect="auto",
+            )
+
     ax2.set_xlim([0.0, maxphs])  # show 1 or more pulses
     ax2.set_ylim([mjds.min().value, mjds.max().value])
     ax2.set_ylabel("MJD")
@@ -123,104 +180,9 @@ def phaseogram_binned(
         Phases for each photon, assumes range is [0,1)
 
     """
-    # If mjds_in is a Time() then pull out the MJD values and make a quantity
-    if type(mjds_in) == astropy.time.core.Time:
-        mjds = mjds_in.mjd * u.d
-    # If mjds_in has no units, assume days
-    elif type(mjds_in) != astropy.units.quantity.Quantity:
-        mjds = mjds_in * u.d
-    else:
-        mjds = mjds_in
-
-    years = (mjds.to(u.d).value - 51544.0) / 365.25 + 2000.0
-    phss = phases + rotate
-    phss[phss >= 1.0] -= 1.0
-    plt.figure(figsize=(width, 8))
-    ax1 = plt.subplot2grid((3, 1), (0, 0))
-    ax2 = plt.subplot2grid((3, 1), (1, 0), rowspan=2)
-    wgts = None if weights is None else np.concatenate((weights, weights))
-    h, x, p = ax1.hist(
-        np.concatenate((phss, phss + 1.0)),
-        int(maxphs * bins),
-        range=[0, maxphs],
-        weights=wgts,
-        color="k",
-        histtype="step",
-        fill=False,
-        lw=2,
-    )
-    ax1.set_xlim([0.0, maxphs])  # show 1 or more pulses
-    ax1.set_ylim([0.0, 1.1 * h.max()])
-    if weights is not None:
-        ax1.set_ylabel("Weighted Counts")
-    else:
-        ax1.set_ylabel("Counts")
-    if title is not None:
-        ax1.set_title(title)
-    SCATTER = False
-    if SCATTER:
-        if weights is None:
-            ax2.scatter(phss, mjds, s=size, color="k", alpha=alpha)
-            ax2.scatter(phss + 1.0, mjds, s=size, color="k", alpha=alpha)
-        else:
-            colarray = np.array([[0.0, 0.0, 0.0, w] for w in weights])
-            ax2.scatter(phss, mjds, s=size, color=colarray)
-            ax2.scatter(phss + 1.0, mjds, s=size, color=colarray)
-    else:
-        profile = np.zeros(bins, dtype=np.float64)
-        ntoa = 64
-        toadur = (mjds.max() - mjds.min()) / ntoa
-        mjdstarts = mjds.min() + toadur * np.arange(ntoa, dtype=np.float64)
-        mjdstops = mjdstarts + toadur
-        # Loop over blocks to process
-        a = []
-        for tstart, tstop in zip(mjdstarts, mjdstops):
-            # Clear profile array
-            profile = profile * 0.0
-
-            idx = (mjds > tstart) & (mjds < tstop)
-
-            if weights is not None:
-                for ph, ww in zip(phases[idx], weights[idx]):
-                    ibin = int(ph * bins)
-                    profile[ibin] += ww
-            else:
-                for ph in phases[idx]:
-                    ibin = int(ph * bins)
-                    profile[ibin] += 1
-
-            a.extend(profile[i] for i in range(bins))
-
-        a = np.array(a)
-        b = a.reshape(ntoa, bins)
-        c = np.hstack([b, b])
-        ax2.imshow(
-            c,
-            interpolation="nearest",
-            origin="lower",
-            cmap=plt.cm.binary,
-            extent=[0, 2.0, mjds.min().value, mjds.max().value],
-            aspect="auto",
-        )
-
-    ax2.set_xlim([0.0, maxphs])  # show 1 or more pulses
-    ax2.set_ylim([mjds.min().value, mjds.max().value])
-    ax2.set_ylabel("MJD")
-    ax2.get_yaxis().get_major_formatter().set_useOffset(False)
-    ax2.get_yaxis().get_major_formatter().set_scientific(False)
-    ax2r = ax2.twinx()
-    ax2r.set_ylim([years.min(), years.max()])
-    ax2r.set_ylabel("Year")
-    ax2r.get_yaxis().get_major_formatter().set_useOffset(False)
-    ax2r.get_yaxis().get_major_formatter().set_scientific(False)
-    ax2.set_xlabel("Pulse Phase")
-    plt.tight_layout()
-    if plotfile is not None:
-        plt.savefig(plotfile)
-        plt.close()
-    else:
-        plt.show()
-
+    phaseogram(mjds_in,phases,weights=weights,title=title,bins=bins,
+            rotate=rotate,size=size,alpha=alpha,width=width,
+            maxphs=maxphs,plotfile=plotfile)
 
 def plot_priors(
     model,

--- a/src/pint/plot_utils.py
+++ b/src/pint/plot_utils.py
@@ -123,17 +123,17 @@ def phaseogram(
 
             a.extend(profile[i] for i in range(bins))
 
-            a = np.array(a)
-            b = a.reshape(ntoa, bins)
-            c = np.hstack([b, b])
-            ax2.imshow(
-                c,
-                interpolation="nearest",
-                origin="lower",
-                cmap=plt.cm.binary,
-                extent=[0, 2.0, mjds.min().value, mjds.max().value],
-                aspect="auto",
-            )
+        a = np.array(a)
+        b = a.reshape(ntoa, bins)
+        c = np.hstack([b, b])
+        ax2.imshow(
+            c,
+            interpolation="nearest",
+            origin="lower",
+            cmap=plt.cm.binary,
+            extent=[0, 2.0, mjds.min().value, mjds.max().value],
+            aspect="auto",
+        )
 
     ax2.set_xlim([0.0, maxphs])  # show 1 or more pulses
     ax2.set_ylim([mjds.min().value, mjds.max().value])
@@ -194,6 +194,7 @@ def phaseogram_binned(
         width=width,
         maxphs=maxphs,
         plotfile=plotfile,
+        binned=True,
     )
 
 

--- a/tests/test_fermiphase.py
+++ b/tests/test_fermiphase.py
@@ -49,9 +49,6 @@ def test_GEO_Htest_result(tmp_path):
         os.chdir(p)
 
 
-@pytest.mark.skipif(
-    "DISPLAY" not in os.environ, reason="Needs an X server, xvfb counts"
-)
 def test_process_and_accuracy():
     # Checks that instantiating an observatory and phasing of
     # topocentric times works.  Verifies accuracy to the sub-mus

--- a/tests/test_phaseogram.py
+++ b/tests/test_phaseogram.py
@@ -1,0 +1,37 @@
+import os
+import pytest
+from tempfile import NamedTemporaryFile
+
+from astropy.io import fits
+from astropy import units as u
+from astropy.time import Time
+import numpy as np
+
+from pint import plot_utils
+
+
+def test_phaseogram():
+
+    # just make up some data
+    mjds = np.random.rand(1000) * 1000 + 58000
+    ph_pulse = np.random.rand(500) * 0.1 + 0.4
+    ph_offpulse = np.random.rand(500)
+    we_pulse = np.random.rand(500) * 0.25 + 0.75
+    we_offpulse = np.random.rand(500) * 0.25 + 0.25
+    ph = np.append(ph_pulse, ph_offpulse)
+    we = np.append(we_pulse, we_offpulse)
+
+    with NamedTemporaryFile("w") as plotfile:
+        # test with different time format inputs
+        plot_utils.phaseogram(
+            mjds, ph, weights=we, title="test", plotfile=plotfile.name
+        )
+        plot_utils.phaseogram(
+            mjds * u.d, ph, weights=we, plotfile=plotfile.name, bins=200
+        )
+        plot_utils.phaseogram(
+            Time(mjds * u.d, format="mjd"), ph, weights=we, plotfile=plotfile.name
+        )
+        plot_utils.phaseogram_binned(
+            mjds, ph, weights=we, plotfile=plotfile.name, bins=20
+        )


### PR DESCRIPTION
The previous implementations had a lot of shared code.  I've now moved most of the code into a single method, and the other (binned) signature calls the fundamental unbinned version.  I added some docstrings too.  The new code should be functionally and API equivalent to the old code.