### PR TITLE
`find_empty_masks` can now handle models with SWX

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -27,4 +27,5 @@ the released changes.
 - TN*C parameter are now `intParameters`
 - Bug in `Fitter.plot()`
 - `np.NaN` -> `np.nan`
+- `find_empty_masks` can now handle SWX models
 ### Removed

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -991,9 +991,15 @@ def xxxselections(
     if not any(p.startswith(f"{prefix}X") for p in model.params):
         return {}
     toas_selector = TOASelect(is_range=True)
-    X_mapping = model.get_prefix_mapping(f"{prefix}X_")
-    XR1_mapping = model.get_prefix_mapping(f"{prefix}XR1_")
-    XR2_mapping = model.get_prefix_mapping(f"{prefix}XR2_")
+    if prefix in ["SW"]:
+        # need a special case here since it looks like SWXDM_
+        X_mapping = model.get_prefix_mapping(f"{prefix}XDM_")
+        XR1_mapping = model.get_prefix_mapping(f"{prefix}XR1_")
+        XR2_mapping = model.get_prefix_mapping(f"{prefix}XR2_")
+    else:
+        X_mapping = model.get_prefix_mapping(f"{prefix}X_")
+        XR1_mapping = model.get_prefix_mapping(f"{prefix}XR1_")
+        XR2_mapping = model.get_prefix_mapping(f"{prefix}XR2_")
     condition = {}
     for ii in X_mapping:
         r1 = getattr(model, XR1_mapping[ii]).quantity

--- a/tests/test_solar_wind.py
+++ b/tests/test_solar_wind.py
@@ -1,5 +1,4 @@
-""" Test for pint solar wind module
-"""
+"""Test for pint solar wind module"""
 
 import os
 import copy
@@ -143,6 +142,24 @@ def test_swx_frozen():
     model.add_swx_range(54000, 54180, swxdm=10, swxp=1.5, frozen=False)
     assert model.SWXP_0002.frozen is True
     assert model.SWXDM_0002.frozen is False
+
+
+def test_swx_empty():
+    model = get_model(
+        StringIO(
+            "\n".join(
+                [
+                    par2,
+                    "SWXDM_0001 1\nSWXP_0001 2 1\nSWXR1_0001 54000\nSWXR2_0001 55000",
+                ]
+            )
+        )
+    )
+    model.add_swx_range(55000, 55500, swxdm=10, swxp=1.5, frozen=False)
+    model.add_swx_range(55500, 55501, swxdm=10, swxp=1.5, frozen=False)
+    t = make_fake_toas_uniform(54000, 56000, 100, model)
+    tofreeze = model.find_empty_masks(t)
+    assert "SWXDM_0003" in tofreeze
 
 
 def test_swx_minmax():


### PR DESCRIPTION
Previously running `find_empty_masks` on a model with `SWX` would fail.  Now it runs correctly.