### PR TITLE
Include DM information in `TOAs.get_summary()` for wideband TOAs

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -35,5 +35,6 @@ the released changes.
 - `find_empty_masks` can now handle SWX models
 - `photonphase` crash when launched with `--absphase --polycos`
 - Removed ORBWAVE parameters from `BinaryBTPiecewise` 
+- `TOAs.get_summary()` now includes DM information for wideband TOAs.
 ### Removed
 - Broken script `event_optimize_multiple`

--- a/src/pint/toa.py
+++ b/src/pint/toa.py
@@ -38,7 +38,7 @@ from astropy.coordinates import (
 from loguru import logger as log
 
 import pint
-from pint import utils
+from pint import dmu, utils
 from pint.observatory import Observatory, bipm_default, get_observatory
 from pint.observatory.satellite_obs import SatelliteObs
 from pint.observatory.special_locations import T2SpacecraftObs
@@ -1935,6 +1935,7 @@ class TOAs:
         but is never more than a few lines regardless of how many TOAs there are.
         """
         s = f"Number of TOAs:  {self.ntoas}\n"
+        s += f"Paradigm: {'wideband' if self.wideband else 'narrowband'}\n"
         if len(self.commands) and type(self.commands[0]) is list:
             s += f"Number of commands:  {[len(x) for x in self.commands]}\n"
         else:
@@ -1949,6 +1950,13 @@ class TOAs:
             s += f"  Min error:     {np.min(self['error'][grp].to(u.us)):.3g}\n"
             s += f"  Max error:     {np.max(self['error'][grp].to(u.us)):.3g}\n"
             s += f"  Median error:  {np.median(self['error'][grp].to(u.us)):.3g}\n"
+
+            if self.wideband:
+                s += f"  Median DM:        {np.median(self.get_dms()[grp].to(dmu)):.3g}\n"
+                s += f"  Min DM error:     {np.min(self.get_dm_errors()[grp].to(dmu)):.3g}\n"
+                s += f"  Max DM error:     {np.max(self.get_dm_errors()[grp].to(dmu)):.3g}\n"
+                s += f"  Median DM error:  {np.median(self.get_dm_errors()[grp].to(dmu)):.3g}\n"
+
         return s
 
     def print_summary(self) -> None:

--- a/tests/test_widebandTOA_fitting.py
+++ b/tests/test_widebandTOA_fitting.py
@@ -24,6 +24,9 @@ class TestWidebandTOAFitter:
             "J1614-2230_NANOGrav_12yv3.wb.tempo_test", comments="#"
         )
 
+    def test_toa_summary(self):
+        assert "Median DM" in self.toas.get_summary()
+
     def test_fitter_init(self):
         fitter = WidebandTOAFitter([self.toas], self.model, additional_args={})
 


### PR DESCRIPTION
Sample output:

> Number of TOAs:  313
> Paradigm: wideband
> Number of commands:  2
> Number of observatories: 1 ['arecibo']
> MJD span:  53358.727 to 57915.275
> Date span: 2004-12-19 17:27:32.962695618 to 2017-06-11 06:35:52.509524973
> arecibo TOAs (313):
>   Min freq:      425.121 MHz
>   Max freq:      1601.755 MHz
>   Min error:     0.019 us
>   Max error:     3.32 us
>   Median error:  0.375 us
>   Median DM:        13.3 dmu
>   Min DM error:     5.11e-05 dmu
>   Max DM error:     0.0303 dmu
>   Median DM error:  0.000958 dmu
