### PR TITLE
Show logs in the correct Jupyter notebook cell

### DIFF
--- a/src/pint/logging.py
+++ b/src/pint/logging.py
@@ -324,7 +324,6 @@ def setup(
         filter=filter,
         format=format,
         colorize=usecolors,
-        enqueue=True,
     )
     # change default colors
     for level in colors:


### PR DESCRIPTION
Fixes #1951. The problem where logging messages were shown in the incorrect cell (the cell where `pint.logging.setup()` was called) seems to have been caused by passing the `enqueue=True` option to Loguru's `logger.add()` function. This PR simply removes the option. I've confirmed that this works both in a newer environment that showed the issue, and in an older one, which didn't have this issue, even with `enqueue=True`.

I'm not sure why we were using `enqueue=True` to begin with. The docstring for `logger.add()` says this about it:
```
enqueue : |bool|, optional
    Whether the messages to be logged should first pass through a multiprocessing-safe queue
    before reaching the sink. This is useful while logging to a file through multiple
    processes. This also has the advantage of making logging calls non-blocking.
```
Hopefully getting rid of this option (and switching back to `enqueue=False`, which is the default in Loguru) will not cause issues in some use case I'm not aware of involving multiple PINT processes trying to log to a single file. But I think most likely this option was originally added in an attempt to get logging in a Jupyter notebook to work better, which is now backfiring.