### PR TITLE
Fix random model bug related to how flag columns are created

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -11,4 +11,5 @@ the released changes.
 ### Changed
 ### Added
 ### Fixed
+- When flags are created based off jumps uses strings instead of None
 ### Removed

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -2158,7 +2158,7 @@ class maskParameter(floatParameter):
             # The flags are recomputed every time. If don't
             # recompute, flags can only be added to the toa table once and then never update,
             # making it impossible to add additional jump parameters after the par file is read in (pintk)
-            flag_col = [x.get(key, None) for x in tbl["flags"]]
+            flag_col = [x.get(key, "") for x in tbl["flags"]]
             tbl[key] = flag_col
             col = tbl[key]
         else:


### PR DESCRIPTION
When flag columns are created to track JUMP selection, if none of the TOAs match that flag then they are all `None`, which means the column type is `object`, not `str`.  This led to errors in `pintk` when using random models since the table merge failed.  Now the default is `""` so the column is still `str`.  This fixes the `pintk` error.  