### PR TITLE
Make `find_prefix_bytime()` work for SWX

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -12,4 +12,5 @@ the released changes.
 ### Added
 ### Fixed
 - When flags are created based off jumps uses strings instead of None
+- Make `get_prefix_timeranges` work for SWX.
 ### Removed

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -1273,7 +1273,9 @@ def get_prefix_timeranges(
     """
     if prefixname.endswith("_"):
         prefixname = prefixname[:-1]
-    prefix_mapping = model.get_prefix_mapping(f"{prefixname}_")
+    prefix_mapping = model.get_prefix_mapping(
+        f"{prefixname}DM_" if prefixname == "SWX" else f"{prefixname}_"
+    )
     r1 = np.zeros(len(prefix_mapping))
     r2 = np.zeros(len(prefix_mapping))
     indices = np.zeros(len(prefix_mapping), dtype=np.int32)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -825,6 +825,29 @@ def test_find_dmx():
     assert len(find_prefix_bytime(model, "DMX", 53500)) == 0
 
 
+def test_find_swx():
+    par = """
+    PSR J1234+5678
+    F0 1
+    DM 10
+    ELAT 10
+    ELONG 0
+    PEPOCH 54000
+    SWXR1_0001 54000
+    SWXR2_0001 55000
+    SWXDM_0001 1
+    SWXP_0001 2
+    SWXR1_0002 55000
+    SWXR2_0002 56000
+    SWXDM_0002 2
+    SWXP_0002 2
+    """
+
+    model = tm.get_model(io.StringIO(par))
+    assert find_prefix_bytime(model, "SWX", 54500) == 1
+    assert len(find_prefix_bytime(model, "SWX", 53500)) == 0
+
+
 def test_merge_dmx():
     par = """
     PSR J1234+5678


### PR DESCRIPTION
This function was not working earlier for SWX, since the SWX parameter is called "SWXDM_" and not "SWX_". This breaks the pattern of "DMX_" and "CMX_". I have added a special case to handle SWX here. 

The actual issue was in the `get_prefix_timeranges()` function.

This is required for including SolarWindX in Vela.jl.