### PR TITLE
Change diff/unc calculation for pintk

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -10,6 +10,7 @@ the released changes.
 ## Unreleased
 ### Changed
 - `WidebandDownhillFitter` now handles correlated noise correctly.
+- `pintk` Diff/Unc calculation now uses post-fit uncertainties.
 ### Added
 - Plot whitened DM residuals in pintk.
 ### Fixed

--- a/src/pint/pintk/pulsar.py
+++ b/src/pint/pintk/pulsar.py
@@ -368,8 +368,8 @@ class Pulsar:
                         line += "%18s" % ""
                     diff = post.value - pre.value
                     line += "%16.8g  " % diff
-                    if pre.uncertainty is not None and pre.uncertainty.value != 0.0:
-                        line += "%16.8g" % (diff / pre.uncertainty.value)
+                    if post.uncertainty is not None and post.uncertainty.value != 0.0:
+                        line += "%16.8g" % (diff / post.uncertainty.value)
                 print(line)
         else:
             log.warning("Pulsar has not been fitted yet!")


### PR DESCRIPTION
Previously `Diff/Unc` used the pre-fit uncertainties.  Now it uses the post-fit

#1963