### PR TITLE
Fixed `gridutils` behavior for 1 CPU

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -24,4 +24,5 @@ the released changes.
 - Make `get_prefix_timeranges` work for SWX.
 - Some of the `gridutils` functions had improper logging behavior
 - Fixed bug in changing epoch for ELL1k model
+- Fixed `gridutils` behavior for 1 CPU
 ### Removed

--- a/src/pint/gridutils.py
+++ b/src/pint/gridutils.py
@@ -769,7 +769,11 @@ def tuple_chisq(
 
         for i in indices:
             for parnum, parname in enumerate(parnames):
-                getattr(ftr.model, parname).quantity = parvalues[i[0]][parnum]
+                if parvalues[i[0]][parnum] is not None:
+                    getattr(ftr.model, parname).quantity = parvalues[i[0]][parnum]
+                    getattr(ftr.model, parname).frozen = True
+                else:
+                    getattr(ftr.model, parname).frozen = False
             ftr.fit_toas(**fitargs)
             chi2[i[0]] = ftr.resids.chi2
             dof[i[0]] = ftr.resids.dof


### PR DESCRIPTION
When using `gridutils` with `ncpu=1` in some situations, there was a bug if a parameter was meant to be free.  Now fixed