### PR TITLE
Fix matrix printing

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -25,4 +25,5 @@ the released changes.
 - Some of the `gridutils` functions had improper logging behavior
 - Fixed bug in changing epoch for ELL1k model
 - Fixed bug in `GaussianRV_gen`, where the probability distribution function was not normalized correctly. Changed to use `scipy.stats.truncnorm` instead of the custom `GaussianRV_gen`.
+- Fixed bug in printing of parameter correlation/covariance matrices
 ### Removed

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -1,5 +1,4 @@
-""" pint_matrix module defines the pint matrix base class, the design matrix .  and the covariance matrix
-"""
+"""pint_matrix module defines the pint matrix base class, the design matrix .  and the covariance matrix"""
 
 import copy
 from collections import OrderedDict
@@ -749,7 +748,7 @@ class CovarianceMatrix(PintMatrix):
                 cm = self.matrix
         else:
             cm = self.matrix
-        if offset == False:
+        if offset == False and "Offset" in fps:
             nfps = fps.remove("Offset")
             cm = self.get_label_matrix(fps).matrix
         if self.matrix_type == "covariance":

--- a/tests/test_parameter_covariance_matrix.py
+++ b/tests/test_parameter_covariance_matrix.py
@@ -132,3 +132,8 @@ def test_downhillwb_covmatrix(wb):
             dwb.parameter_covariance_matrix.get_label_matrix([param]).matrix[0, 0]
         )
         assert np.isclose(uncertainties[param], matrix_uncertainty)
+
+
+def test_wls_covmatrix_print(wls):
+    m = wls.parameter_covariance_matrix.get_label_matrix(["F0", "F1"])
+    s = str(m)


### PR DESCRIPTION
Pretty-printing of correlation/covariance matrices wasn't tested, and it seemed to be broken for extracted matrices without the `Offset` parameter.  This fixes it and introduces a test.