### PR TITLE
Removed code that triggers deprecation warnings during CI

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -14,6 +14,7 @@ the released changes.
 - `pintk` Diff/Unc calculation now uses post-fit uncertainties.
 - Updated GMRT coordinates.
 - Replaced custom ``pint.ls`` with astropy ``u.lsec``
+- Updated code to remove deprecation warnings during CI
 ### Added
 - Plot whitened DM residuals in pintk.
 - `ssb_to_psb_xyz_ECL` and `ssb_to_psb_xyz_ICRS` are now cached

--- a/src/pint/models/binary_bt.py
+++ b/src/pint/models/binary_bt.py
@@ -403,14 +403,14 @@ class BinaryBTPiecewise(PulsarBinary):
         # If any *DOT is set, we need T0
         for p in ("PBDOT", "OMDOT", "EDOT", "A1DOT"):
             if getattr(self, p).value is None:
-                getattr(self, p).set("0")
+                getattr(self, p).value = 0
                 getattr(self, p).frozen = True
 
             if getattr(self, p).value is not None and self.T0.value is None:
                 raise MissingParameter("BT", "T0", "T0 is required if *DOT is set")
 
         if self.GAMMA.value is None:
-            self.GAMMA.set("0")
+            self.GAMMA.value = 0
             self.GAMMA.frozen = True
 
         dct_plb = self.get_prefix_mapping_component("XR1_")

--- a/src/pint/pint_matrix.py
+++ b/src/pint/pint_matrix.py
@@ -596,7 +596,7 @@ def combine_design_matrices_by_param(matrix1, matrix2, padding=0.0):
     append_offset = matrix1.shape[0]
     base_matrix = matrix1.matrix
     for d_quantity in matrix2.derivative_quantity:
-        quantity_label = matrix2.get_label_along_axis(0, d_quantity)
+        quantity_label = matrix2.get_label(d_quantity, axis=0)[0]
         if d_quantity in base_quantity_index.keys():
             # Check quantity size
             d_quantity_size = quantity_label[3] - quantity_label[2]
@@ -637,7 +637,7 @@ def combine_design_matrices_by_param(matrix1, matrix2, padding=0.0):
     new_matrix.fill(padding)
     # Fill up the new_matrix with matrix2
     for new_idx in new_quantity_index.values():
-        old_idx = matrix2.get_label_along_axis(0, d_quantity)[2:4]
+        old_idx = matrix2.get_label(d_quantity, axis=0)[0][2:4]
         new_matrix[new_idx[0] : new_idx[1], :] = matrix2.matrix[
             old_idx[0] : old_idx[1], :
         ]

--- a/tests/test_astrometry.py
+++ b/tests/test_astrometry.py
@@ -264,7 +264,7 @@ def test_ssb_cache_invalidates():
     xyz2 = m.ssb_to_psb_xyz_ICRS(epoch=t + 0.1 * u.d)
     cachekey2 = m.components["AstrometryEcliptic"]._ssb_cache_key_icrs
     assert cachekey != cachekey2
-    assert ~np.allclose(xyz, xyz2)
+    assert not np.allclose(xyz, xyz2)
 
 
 def test_ssb_cache_merge():

--- a/tests/test_astrometry.py
+++ b/tests/test_astrometry.py
@@ -261,10 +261,10 @@ def test_ssb_cache_invalidates():
     t = t0 + np.linspace(0, 20) * u.yr
     xyz = m.ssb_to_psb_xyz_ICRS(epoch=t)
     cachekey = m.components["AstrometryEcliptic"]._ssb_cache_key_icrs
-    xyz2 = m.ssb_to_psb_xyz_ICRS(epoch=t + 0.1 * u.d)
+    xyz2 = m.ssb_to_psb_xyz_ICRS(epoch=t + 15 * u.d)
     cachekey2 = m.components["AstrometryEcliptic"]._ssb_cache_key_icrs
     assert cachekey != cachekey2
-    assert not np.allclose(xyz, xyz2)
+    assert not np.allclose(xyz, xyz2, rtol=1e-7)
 
 
 def test_ssb_cache_merge():

--- a/tests/test_chromatic.py
+++ b/tests/test_chromatic.py
@@ -112,6 +112,6 @@ def test_cm_dm_comparison():
     ftr = WLSFitter(t, m1)
     ftr.fit_toas(maxiter=3)
 
-    assert ftr.resids.chi2_reduced < 1.5
+    assert ftr.resids.reduced_chi2 < 1.5
     assert (ftr.model.CM.value - m0.DM.value) / ftr.model.CM.uncertainty_value < 1.1
     assert np.isclose(ftr.model.CM.uncertainty_value, m0.DM.uncertainty_value, atol=0.1)

--- a/tests/test_cmx.py
+++ b/tests/test_cmx.py
@@ -74,7 +74,7 @@ def test_cmx(model_and_toas):
         3 * ftr.model.CMX_0003.uncertainty_value
     )
 
-    assert ftr.resids.chi2_reduced < 1.6
+    assert ftr.resids.reduced_chi2 < 1.6
 
     assert "CMX_0001" in str(ftr.model)
 

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -29,7 +29,7 @@ class TestCompare:
         modelcp = cp(model)
 
         for verbosity in verbosities:
-            for pn in model.params_ordered:
+            for pn in model.params:
                 if (
                     pn.startswith("DMX")
                     or pn in ["PSR", "START", "FINISH"]
@@ -78,7 +78,7 @@ class TestCompare:
         modelcp = cp(model)
 
         for verbosity in verbosities:
-            for pn in model.params_ordered:
+            for pn in model.params:
                 if (
                     pn.startswith("DMX")
                     or pn in ["PSR", "START", "FINISH"]
@@ -142,7 +142,7 @@ class TestCompare:
         model_1 = mod.get_model(io.StringIO(par_base1))
         model_2 = mod.get_model(io.StringIO(par_base2))
 
-        for pn in model_1.params_ordered[1:]:
+        for pn in model_1.params[1:]:
             param1 = getattr(model_1, pn)
             param2 = getattr(model_2, pn)
             if (

--- a/tests/test_random_models.py
+++ b/tests/test_random_models.py
@@ -98,7 +98,7 @@ def test_random_models_wb(fitter):
     assert np.all(dphase.std(axis=0) < 1e-4)
 
 
-@pytest.mark.parametrize("clock", ["UTC(NIST)", "TT(BIPM2021)", "TT(BIPM2015)"])
+@pytest.mark.parametrize("clock", ["TT(TAI)", "TT(BIPM2021)", "TT(BIPM2015)"])
 def test_random_model_clock(clock):
     m, t = get_model_and_toas(
         os.path.join(datadir, "NGC6440E.par"), os.path.join(datadir, "NGC6440E.tim")

--- a/tests/test_random_models.py
+++ b/tests/test_random_models.py
@@ -110,4 +110,4 @@ def test_random_model_clock(clock):
         ] == m.CLOCK.value.replace("TT(", "").replace(")", "")
         assert simulation.get_fake_toa_clock_versions(m)["include_bipm"]
     else:
-        assert ~simulation.get_fake_toa_clock_versions(m)["include_bipm"]
+        assert not simulation.get_fake_toa_clock_versions(m)["include_bipm"]


### PR DESCRIPTION
All except for #2016. Some of these were PINT-specific, some were numpy/scipy.