### PR TITLE
Fix log-separated frequency computation

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -35,4 +35,5 @@ the released changes.
 - `make_fake_toas_fromMJDs` now does not assume `PLANET_SHAPIRO` is in the model - it checks.
 - Make VLBI frame rotation work correctly when proper motion is present.
 - Changed some API to pass Mac CI
+- Log-separated frequency computation for red noise components.
 ### Removed

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -1318,7 +1318,7 @@ def get_rednoise_freqs(
 
     use_log = all([have_logmode, have_nlog, have_fmin])
 
-    if (not use_log) and (have_logmode or have_nlog):
+    if (not use_log) and have_nlog:
         log.warning(
             "Log-linear frequency spacing appears to be "
             "incorrectly specified. Got logmode={logmode}, "

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -1318,7 +1318,7 @@ def get_rednoise_freqs(
 
     use_log = all([have_logmode, have_nlog, have_fmin])
 
-    if not use_log and (have_logmode or have_nlog):
+    if (not use_log) and (have_logmode or have_nlog):
         log.warning(
             "Log-linear frequency spacing appears to be "
             "incorrectly specified. Got logmode={logmode}, "

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -1141,11 +1141,11 @@ class PLRedNoise(CorrelatedNoiseComponent):
         """Return the frequencies of the noise model"""
 
         tbl = toas.table
-        t = (tbl["tdbld"].quantity * u.day).to(u.s).value
+        t = (tbl["tdbld"].quantity * u.day).to_value(u.s)
         T = (
-            (np.max(t) - np.min(t)) * u.day
+            (np.max(t) - np.min(t))
             if self.TNREDTSPAN.quantity is None
-            else self.TNREDTSPAN.quantity
+            else self.TNREDTSPAN.quantity.to_value(u.s)
         )
 
         (_, _, n_lin, n_log, f_min_ratio) = self.get_plc_vals()
@@ -1302,14 +1302,11 @@ def get_rednoise_freqs(
         f_lin = np.linspace(f_min_lin, f_min_lin + (n_lin - 1) * df_lin, n_lin)
 
         # Log portion
-        f_log = (
-            np.logspace(
-                np.log10(f_min_.to_value(f_min_lin.unit)),
-                np.log10(f_min_lin.value),
-                n_log,
-                endpoint=False,
-            )
-            * f_min_lin.unit
+        f_log = np.logspace(
+            np.log10(f_min_),
+            np.log10(f_min_lin),
+            n_log,
+            endpoint=False,
         )
 
         # Combine log + linear

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -1143,7 +1143,7 @@ class PLRedNoise(CorrelatedNoiseComponent):
         tbl = toas.table
         t = (tbl["tdbld"].quantity * u.day).to(u.s).value
         T = (
-            np.max(t) - np.min(t)
+            (np.max(t) - np.min(t)) * u.day
             if self.TNREDTSPAN.quantity is None
             else self.TNREDTSPAN.quantity
         )

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -598,11 +598,11 @@ class PLDMNoise(CorrelatedNoiseComponent):
         """Return the frequencies of the noise model"""
 
         tbl = toas.table
-        t = (tbl["tdbld"].quantity * u.day).to(u.s).value
+        t = (tbl["tdbld"].quantity * u.day).to_value(u.s)
         T = (
             np.max(t) - np.min(t)
             if self.TNDMTSPAN.quantity is None
-            else self.TNDMTSPAN.quantity
+            else self.TNDMTSPAN.quantity.to_value(u.s)
         )
 
         (_, _, n_lin, n_log, f_min_ratio) = self.get_plc_vals()
@@ -942,11 +942,11 @@ class PLChromNoise(CorrelatedNoiseComponent):
         """Return the frequencies of the noise model"""
 
         tbl = toas.table
-        t = (tbl["tdbld"].quantity * u.day).to(u.s).value
+        t = (tbl["tdbld"].quantity * u.day).to_value
         T = (
             np.max(t) - np.min(t)
             if self.TNCHROMTSPAN.quantity is None
-            else self.TNCHROMTSPAN.quantity
+            else self.TNCHROMTSPAN.quantity.to_value(u.s)
         )
 
         (_, _, n_lin, n_log, f_min_ratio) = self.get_plc_vals()

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -1302,14 +1302,20 @@ def get_rednoise_freqs(
         f_lin = np.linspace(f_min_lin, f_min_lin + (n_lin - 1) * df_lin, n_lin)
 
         # Log portion
-        f_log = np.logspace(
-            np.log10(f_min_), np.log10((1 + logmode_) / T), n_log, endpoint=False
+        f_log = (
+            np.logspace(
+                np.log10(f_min_.to_value(f_min_lin.unit)),
+                np.log10(f_min_lin.value),
+                n_log,
+                endpoint=False,
+            )
+            * f_min_lin.unit
         )
 
         # Combine log + linear
         return np.concatenate((f_log, f_lin))
 
-    have_logmode = logmode is not None and logmode > 0
+    have_logmode = logmode is not None and logmode >= 0
     have_nlog = nlog is not None and nlog > 0
     have_fmin = f_min is not None and f_min > 0
 

--- a/src/pint/models/noise_model.py
+++ b/src/pint/models/noise_model.py
@@ -942,7 +942,7 @@ class PLChromNoise(CorrelatedNoiseComponent):
         """Return the frequencies of the noise model"""
 
         tbl = toas.table
-        t = (tbl["tdbld"].quantity * u.day).to_value
+        t = (tbl["tdbld"].quantity * u.day).to_value(u.s)
         T = (
             np.max(t) - np.min(t)
             if self.TNCHROMTSPAN.quantity is None

--- a/tests/test_noise_models.py
+++ b/tests/test_noise_models.py
@@ -9,6 +9,7 @@ from pint.models.timing_model import Component
 from pint.models.noise_model import NoiseComponent
 from pint.simulation import make_fake_toas_uniform
 from io import StringIO
+import astropy.units as u
 
 
 noise_component_labels = [
@@ -181,19 +182,22 @@ def test_white_noise_model_derivs():
     )
 
 
-def test_log_frequencies():
-    par = """
+@pytest.mark.parametrize("gp", ["Red", "DM"])
+def test_log_frequencies(gp):
+    GP = gp.upper()
+    par = f"""
         PSR         TEST
         RAJ         05:00:00
         DECJ        15:00:00
         F0          100
         F1          -1e-15
+        DM          15
         PEPOCH      55000
-        TNREDAMP    -15
-        TNREDGAM    3.5
-        TNREDC      4
-        TNREDFLOG   2
-        TNREDFLOG_FACTOR 2
+        TN{GP}AMP    -15
+        TN{GP}GAM    3.5
+        TN{GP}C      4
+        TN{GP}FLOG   2
+        TN{GP}FLOG_FACTOR 2
         TZRMJD      55000
         TZRFRQ      inf
         TZRSITE     ssb
@@ -211,7 +215,14 @@ def test_log_frequencies():
         add_correlated_noise=True,
     )
     assert np.allclose(
-        m.components["PLRedNoise"].get_time_frequencies(t)[1]
+        m.components[f"PL{gp}Noise"].get_time_frequencies(t)[1]
         * t.get_Tspan().to_value("s"),
         np.array([0.25, 0.5, 1, 2, 3, 4]),
     )
+
+    M0 = m.noise_model_designmatrix(t)
+
+    t_ = t.table["tdbld"].quantity * u.day
+    m[f"TN{GP}TSPAN"].quantity = np.max(t_) - np.min(t_)
+    M1 = m.noise_model_designmatrix(t)
+    assert np.allclose(M0, M1)

--- a/tests/test_noise_models.py
+++ b/tests/test_noise_models.py
@@ -179,3 +179,39 @@ def test_white_noise_model_derivs():
     assert np.isclose(
         dq2[-1], sigma[-1] * m.EQUAD2.quantity * (m.EFAC2.quantity / sigma[-1]) ** 2
     )
+
+
+def test_log_frequencies():
+    par = """
+        PSR         TEST
+        RAJ         05:00:00
+        DECJ        15:00:00
+        F0          100
+        F1          -1e-15
+        PEPOCH      55000
+        TNREDAMP    -15
+        TNREDGAM    3.5
+        TNREDC      4
+        TNREDFLOG   2
+        TNREDFLOG_FACTOR 2
+        TZRMJD      55000
+        TZRFRQ      inf
+        TZRSITE     ssb
+        EPHEM       DE440
+        CLOCK       TT(BIPM2023)
+        UNITS       TDB
+    """
+    m = get_model(StringIO(par))
+    t = make_fake_toas_uniform(
+        54000,
+        56000,
+        100,
+        m,
+        add_noise=True,
+        add_correlated_noise=True,
+    )
+    assert np.allclose(
+        m.components["PLRedNoise"].get_time_frequencies(t)[1]
+        * t.get_Tspan().to_value("s"),
+        np.array([0.25, 0.5, 1, 2, 3, 4]),
+    )

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -366,7 +366,7 @@ def test_wideband_chi2_updating(wideband_fake):
     assert_allclose(f2.model.F0.value, 1)
     assert 1e-3 > abs(WidebandTOAResiduals(toas, f2.model).chi2 - ftc2) > 1e-5
     ftc2 = f2.fit_toas(maxiter=10)
-    assert_allclose(WidebandTOAResiduals(toas, f2.model).chi2, ftc2)
+    assert_allclose(WidebandTOAResiduals(toas, f2.model).chi2, ftc2, atol=1e-5)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
There were two issues.
1. The `have_logmode` criterion had `logmode > 0` instead of `logmode >= 0`. This resulted in log-spaced frequencies not being added correctly.
2. `np.log10` was called on astropy quantities. This gives a `UnitTypeError`. 