### PR TITLE
Getting rid of deprecation warnings by casting matrices to 64bit for linear algebra

### DIFF
--- a/src/pint/fitter.py
+++ b/src/pint/fitter.py
@@ -2608,6 +2608,9 @@ def get_gls_mtcm_mtcy_fullcov(
     given the data covariance matrix (`cov`), timing model design matrix (`M`),
     and residuals y (`residuals`).
     """
+    cov = cov.astype(np.float64)
+    M = M.astype(np.float64)
+    residuals = residuals.astype(np.float64)
     cf = scipy.linalg.cho_factor(cov)
     cm = scipy.linalg.cho_solve(cf, M)
     mtcm = np.dot(M.T, cm)
@@ -2629,6 +2632,11 @@ def get_gls_mtcm_mtcy(
     full design matrix (`M`) containing the timing model design matrix and the
     correlated noise basis, and residuals y (`residuals`).
     """
+    phiinv = phiinv.astype(np.float64)
+    Nvec = Nvec.astype(np.float64)
+    M = M.astype(np.float64)
+    residuals = residuals.astype(np.float64)
+
     cinv = 1 / Nvec
     mtcmplain = np.dot(M.T, cinv[:, None] * M)
     mtcm = mtcmplain + np.diag(phiinv)

--- a/src/pint/residuals.py
+++ b/src/pint/residuals.py
@@ -655,13 +655,13 @@ class Residuals:
         assert self.model.has_correlated_errors
 
         s = self.time_resids.to_value(u.s)
-        Ndiag = self.get_data_error().to_value(u.s) ** 2
-        U = self.model.noise_model_designmatrix(self.toas)
-        Phidiag = self.model.noise_model_basis_weight(self.toas)
+        Ndiag = (self.get_data_error().to_value(u.s) ** 2).astype(np.float64)
+        U = self.model.noise_model_designmatrix(self.toas).astype(np.float64)
+        Phidiag = self.model.noise_model_basis_weight(self.toas).astype(np.float64)
 
         if "PHOFF" not in self.model.free_params:
-            U = np.append(U, np.ones((len(self.toas), 1)), axis=1)
-            Phidiag = np.append(Phidiag, [1e40])
+            U = np.append(U, np.ones((len(self.toas), 1)), axis=1).astype(np.float64)
+            Phidiag = np.append(Phidiag, [1e40]).astype(np.float64)
 
         chi2, logdet_C = woodbury_dot(Ndiag, U, Phidiag, s, s)
 
@@ -1450,6 +1450,11 @@ def whiten_residuals(
     Similar computation is done by the following methods: `pint.fitter.GLSFitter.fit_toas()`,
     `pint.fitter.WidebandTOAFitter.fit_toas()`, `pint.fitter.GLSState.step()`,
     `pint.fitter.WidebandState.step()`."""
+    y = y.astype(np.float64)
+    yerr = yerr.astype(np.float64)
+    U = U.astype(np.float64)
+    Phidiag = Phidiag.astype(np.float64)
+
     Ndiag = yerr**2
     Ninv_U = U / Ndiag[:, None]
     UT_Ninv_U = U.T @ Ninv_U

--- a/src/pint/utils.py
+++ b/src/pint/utils.py
@@ -3079,6 +3079,12 @@ def sherman_morrison_dot(
     logdetC: float
         log-determinant of C
     """
+    Ndiag = Ndiag.astype(np.float64)
+    v = v.astype(np.float64)
+    w = w.astype(np.float64)
+    x = x.astype(np.float64)
+    y = y.astype(np.float64)
+
     Ninv = 1 / Ndiag
 
     Ninv_v = Ninv * v
@@ -3131,6 +3137,11 @@ def woodbury_dot(
     logdetC: float
         log-determinant of C
     """
+    Ndiag = Ndiag.astype(np.float64)
+    U = U.astype(np.float64)
+    Phidiag = Phidiag.astype(np.float64)
+    x = x.astype(np.float64)
+    y = y.astype(np.float64)
 
     x_Ninv_y = np.sum(x * y / Ndiag)
     x_Ninv_U = (x / Ndiag) @ U

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -23,14 +23,18 @@ os.chdir(datadir)
 
 @pytest.fixture
 def wideband_fake():
-    model = get_model(StringIO("""
+    model = get_model(
+        StringIO(
+            """
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
             DM 10
             F0 1
             PEPOCH 58000
-            """))
+            """
+        )
+    )
     toas = make_fake_toas_uniform(
         57000,
         59000,
@@ -132,7 +136,9 @@ class TestResidualBuilding:
 
 
 def test_residuals_scaled_uncertainties():
-    model = get_model(StringIO("""
+    model = get_model(
+        StringIO(
+            """
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
@@ -140,7 +146,9 @@ def test_residuals_scaled_uncertainties():
             F0 1
             PEPOCH 58000
             EFAC mjd 57000 58000 2
-            """))
+            """
+        )
+    )
     toas = make_fake_toas_uniform(57000, 59000, 20, model=model, error=1 * u.us)
     r = Residuals(toas, model)
     e = r.get_data_error(scaled=True)
@@ -151,7 +159,9 @@ def test_residuals_scaled_uncertainties():
 
 
 def test_residuals_fake_wideband():
-    model = get_model(StringIO("""
+    model = get_model(
+        StringIO(
+            """
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
@@ -159,7 +169,9 @@ def test_residuals_fake_wideband():
             F0 1
             PEPOCH 58000
             EFAC mjd 57000 58000 2
-            """))
+            """
+        )
+    )
     toas = make_fake_toas_uniform(
         57000, 59000, 20, model=model, error=1 * u.us, wideband=True
     )
@@ -172,14 +184,18 @@ def test_residuals_fake_wideband():
 
 
 def test_residuals_wls_chi2():
-    model = get_model(StringIO("""
+    model = get_model(
+        StringIO(
+            """
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
             DM 10
             F0 1
             PEPOCH 58000
-            """))
+            """
+        )
+    )
     toas = make_fake_toas_uniform(57000, 59000, 20, model=model, error=1 * u.us)
     np.random.seed(0)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
@@ -189,7 +205,9 @@ def test_residuals_wls_chi2():
 
 
 def test_residuals_gls_chi2():
-    model = get_model(StringIO("""
+    model = get_model(
+        StringIO(
+            """
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
@@ -197,7 +215,9 @@ def test_residuals_gls_chi2():
             F0 1
             PEPOCH 58000
             ECORR mjd 57000 58000 2
-            """))
+            """
+        )
+    )
     toas = make_fake_toas_uniform(57000, 59000, 20, model=model, error=1 * u.us)
     np.random.seed(0)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
@@ -242,7 +262,9 @@ def test_residuals_get_PSR_freq(wideband_fake, calctype):
 # )
 @pytest.mark.parametrize("full_cov", [True, False])
 def test_gls_chi2_reasonable(full_cov):
-    model = get_model(StringIO("""
+    model = get_model(
+        StringIO(
+            """
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
@@ -252,7 +274,9 @@ def test_gls_chi2_reasonable(full_cov):
             TNRedAmp -14.227505410948254
             TNRedGam 4.91353
             TNRedC 45
-            """))
+            """
+        )
+    )
     toas = make_fake_toas_uniform(57000, 59000, 40, model=model, error=1 * u.us)
     np.random.seed(0)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
@@ -289,7 +313,9 @@ def test_gls_chi2_reasonable(full_cov):
 
 
 def test_gls_chi2_behaviour():
-    model = get_model(StringIO("""
+    model = get_model(
+        StringIO(
+            """
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
@@ -299,7 +325,9 @@ def test_gls_chi2_behaviour():
             TNRedAmp -14.227505410948254
             TNRedGam 4.91353
             TNRedC 45
-            """))
+            """
+        )
+    )
     model.free_params = ["F0", "ELAT", "ELONG"]
     toas = make_fake_toas_uniform(57000, 59000, 40, model=model, error=1 * u.us)
     np.random.seed(0)
@@ -352,7 +380,9 @@ def test_wideband_chi2_updating(wideband_fake):
     ],
 )
 def test_toa_adjust(d):
-    model = get_model(StringIO("""
+    model = get_model(
+        StringIO(
+            """
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
@@ -360,7 +390,9 @@ def test_toa_adjust(d):
             F0 1
             PEPOCH 58000
             EFAC mjd 57000 58000 2
-            """))
+            """
+        )
+    )
     toas = make_fake_toas_uniform(57000, 59000, 20, model=model, error=1 * u.us)
     toas2 = copy.deepcopy(toas)
     toas2.adjust_TOAs(d)
@@ -374,7 +406,9 @@ def test_toa_adjust(d):
 
 
 def test_resid_mean():
-    model = get_model(StringIO("""
+    model = get_model(
+        StringIO(
+            """
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
@@ -382,7 +416,9 @@ def test_resid_mean():
             F0 1
             PEPOCH 58000
             EFAC mjd 57000 58000 2
-            """))
+            """
+        )
+    )
     toas = make_fake_toas_uniform(57000, 59000, 20, model=model, error=1 * u.us)
     r = Residuals(toas, model, subtract_mean=False)
     r2 = Residuals(toas, model)
@@ -394,7 +430,9 @@ def test_resid_mean():
 
 
 def test_resid_mean_phase():
-    model = get_model(StringIO("""
+    model = get_model(
+        StringIO(
+            """
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
@@ -402,7 +440,9 @@ def test_resid_mean_phase():
             F0 1
             PEPOCH 58000
             EFAC mjd 57000 58000 2
-            """))
+            """
+        )
+    )
     toas = make_fake_toas_uniform(57000, 59000, 20, model=model, error=1 * u.us)
     r = Residuals(toas, model, subtract_mean=False)
     r2 = Residuals(toas, model)
@@ -459,7 +499,9 @@ def test_whitened_res(par):
 
 
 def test_ecorr_chi2():
-    m = get_model(StringIO("""
+    m = get_model(
+        StringIO(
+            """
             RAJ    05:00:00
             DECJ   20:00:00
             F0     100     1 
@@ -470,7 +512,9 @@ def test_ecorr_chi2():
             EFAC tel ao 1.3
             ECORR tel ao 0.9
             EPHEM  DE440
-            """))
+            """
+        )
+    )
 
     t_tmpl = get_TOAs(datadir / "B1855+09_NANOGrav_9yv1.tim")
     t = make_fake_toas_fromMJDs(

--- a/tests/test_residuals.py
+++ b/tests/test_residuals.py
@@ -23,18 +23,14 @@ os.chdir(datadir)
 
 @pytest.fixture
 def wideband_fake():
-    model = get_model(
-        StringIO(
-            """
+    model = get_model(StringIO("""
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
             DM 10
             F0 1
             PEPOCH 58000
-            """
-        )
-    )
+            """))
     toas = make_fake_toas_uniform(
         57000,
         59000,
@@ -136,9 +132,7 @@ class TestResidualBuilding:
 
 
 def test_residuals_scaled_uncertainties():
-    model = get_model(
-        StringIO(
-            """
+    model = get_model(StringIO("""
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
@@ -146,9 +140,7 @@ def test_residuals_scaled_uncertainties():
             F0 1
             PEPOCH 58000
             EFAC mjd 57000 58000 2
-            """
-        )
-    )
+            """))
     toas = make_fake_toas_uniform(57000, 59000, 20, model=model, error=1 * u.us)
     r = Residuals(toas, model)
     e = r.get_data_error(scaled=True)
@@ -159,9 +151,7 @@ def test_residuals_scaled_uncertainties():
 
 
 def test_residuals_fake_wideband():
-    model = get_model(
-        StringIO(
-            """
+    model = get_model(StringIO("""
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
@@ -169,9 +159,7 @@ def test_residuals_fake_wideband():
             F0 1
             PEPOCH 58000
             EFAC mjd 57000 58000 2
-            """
-        )
-    )
+            """))
     toas = make_fake_toas_uniform(
         57000, 59000, 20, model=model, error=1 * u.us, wideband=True
     )
@@ -184,18 +172,14 @@ def test_residuals_fake_wideband():
 
 
 def test_residuals_wls_chi2():
-    model = get_model(
-        StringIO(
-            """
+    model = get_model(StringIO("""
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
             DM 10
             F0 1
             PEPOCH 58000
-            """
-        )
-    )
+            """))
     toas = make_fake_toas_uniform(57000, 59000, 20, model=model, error=1 * u.us)
     np.random.seed(0)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
@@ -205,9 +189,7 @@ def test_residuals_wls_chi2():
 
 
 def test_residuals_gls_chi2():
-    model = get_model(
-        StringIO(
-            """
+    model = get_model(StringIO("""
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
@@ -215,9 +197,7 @@ def test_residuals_gls_chi2():
             F0 1
             PEPOCH 58000
             ECORR mjd 57000 58000 2
-            """
-        )
-    )
+            """))
     toas = make_fake_toas_uniform(57000, 59000, 20, model=model, error=1 * u.us)
     np.random.seed(0)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
@@ -262,9 +242,7 @@ def test_residuals_get_PSR_freq(wideband_fake, calctype):
 # )
 @pytest.mark.parametrize("full_cov", [True, False])
 def test_gls_chi2_reasonable(full_cov):
-    model = get_model(
-        StringIO(
-            """
+    model = get_model(StringIO("""
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
@@ -274,9 +252,7 @@ def test_gls_chi2_reasonable(full_cov):
             TNRedAmp -14.227505410948254
             TNRedGam 4.91353
             TNRedC 45
-            """
-        )
-    )
+            """))
     toas = make_fake_toas_uniform(57000, 59000, 40, model=model, error=1 * u.us)
     np.random.seed(0)
     toas.adjust_TOAs(TimeDelta(np.random.randn(len(toas)) * u.us))
@@ -313,9 +289,7 @@ def test_gls_chi2_reasonable(full_cov):
 
 
 def test_gls_chi2_behaviour():
-    model = get_model(
-        StringIO(
-            """
+    model = get_model(StringIO("""
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
@@ -325,9 +299,7 @@ def test_gls_chi2_behaviour():
             TNRedAmp -14.227505410948254
             TNRedGam 4.91353
             TNRedC 45
-            """
-        )
-    )
+            """))
     model.free_params = ["F0", "ELAT", "ELONG"]
     toas = make_fake_toas_uniform(57000, 59000, 40, model=model, error=1 * u.us)
     np.random.seed(0)
@@ -359,7 +331,9 @@ def test_wideband_chi2_updating(wideband_fake):
         toas, model, toa_resid_args=dict(track_mode="use_pulse_numbers")
     ).chi2
     f2 = WidebandTOAFitter(
-        toas, model, additional_args=dict(toa=dict(track_mode="use_pulse_numbers"))
+        toas,
+        model,
+        additional_args=dict(toa=dict(track_mode="use_pulse_numbers"), atol=1e-4),
     )
     ftc2 = f2.fit_toas()
     assert abs(ftc2 - c2) > 100
@@ -378,9 +352,7 @@ def test_wideband_chi2_updating(wideband_fake):
     ],
 )
 def test_toa_adjust(d):
-    model = get_model(
-        StringIO(
-            """
+    model = get_model(StringIO("""
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
@@ -388,9 +360,7 @@ def test_toa_adjust(d):
             F0 1
             PEPOCH 58000
             EFAC mjd 57000 58000 2
-            """
-        )
-    )
+            """))
     toas = make_fake_toas_uniform(57000, 59000, 20, model=model, error=1 * u.us)
     toas2 = copy.deepcopy(toas)
     toas2.adjust_TOAs(d)
@@ -404,9 +374,7 @@ def test_toa_adjust(d):
 
 
 def test_resid_mean():
-    model = get_model(
-        StringIO(
-            """
+    model = get_model(StringIO("""
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
@@ -414,9 +382,7 @@ def test_resid_mean():
             F0 1
             PEPOCH 58000
             EFAC mjd 57000 58000 2
-            """
-        )
-    )
+            """))
     toas = make_fake_toas_uniform(57000, 59000, 20, model=model, error=1 * u.us)
     r = Residuals(toas, model, subtract_mean=False)
     r2 = Residuals(toas, model)
@@ -428,9 +394,7 @@ def test_resid_mean():
 
 
 def test_resid_mean_phase():
-    model = get_model(
-        StringIO(
-            """
+    model = get_model(StringIO("""
             PSRJ J1234+5678
             ELAT 0
             ELONG 0
@@ -438,9 +402,7 @@ def test_resid_mean_phase():
             F0 1
             PEPOCH 58000
             EFAC mjd 57000 58000 2
-            """
-        )
-    )
+            """))
     toas = make_fake_toas_uniform(57000, 59000, 20, model=model, error=1 * u.us)
     r = Residuals(toas, model, subtract_mean=False)
     r2 = Residuals(toas, model)
@@ -497,9 +459,7 @@ def test_whitened_res(par):
 
 
 def test_ecorr_chi2():
-    m = get_model(
-        StringIO(
-            """
+    m = get_model(StringIO("""
             RAJ    05:00:00
             DECJ   20:00:00
             F0     100     1 
@@ -510,9 +470,7 @@ def test_ecorr_chi2():
             EFAC tel ao 1.3
             ECORR tel ao 0.9
             EPHEM  DE440
-            """
-        )
-    )
+            """))
 
     t_tmpl = get_TOAs(datadir / "B1855+09_NANOGrav_9yv1.tim")
     t = make_fake_toas_fromMJDs(


### PR DESCRIPTION
#2016 

This probably isn't a great fix - it does the casting inside various subroutines, so it may be repeated, rather than where the various matrices are created.  But this meant I didn't have to comprehensively find those instances.  If this isn't a good approach I can scrap this PR.