### PR TITLE
Normalize hybrid/sparse binary FB expansions and allow signed-H3 DDH fits

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -15,10 +15,15 @@ the released changes.
 - Updated GMRT coordinates.
 - Replaced custom ``pint.ls`` with astropy ``u.lsec``
 - Updated code to remove deprecation warnings during CI
+- Every active FBX model now uses FB coefficients as its complete orbital-phase representation. An ordinary `PBDOT` supplied with `FB0` is converted to `FB1` instead of being silently ignored. `PB` and applicable `PBDOT` values are exposed as derived views, so `as_parfile()` gains commented `# PB`/`# PBDOT` lines for existing pure-FBX models and no longer exposes an unset writable `PBDOT` that the FBX orbit would ignore.
+- DDGR+FBX is now rejected explicitly before normalization. The new general PB/FB bridge does not broaden DDGR into a partially supported configuration or rely on incidental missing-FB0/PB-conflict failures. Correct support requires dynamic synchronization of DDGR's PB-dependent post-Keplerian quantities and their analytic `PB(FB0)` chain-rule derivatives.
+- `BinaryDDH` now accepts a negative fitted `H3` with a warning when `STIGMA` is finite and positive. The DDH delay is smooth in the signed amplitude `H3`, but the resulting negative derived `M2` is not physically interpretable. Validation of free `M2`, generic `SINI`, and non-DDH binary models is unchanged.
 ### Added
 - Plot whitened DM residuals in pintk.
 - `ssb_to_psb_xyz_ECL` and `ssb_to_psb_xyz_ICRS` are now cached
+- Binary orbital-phase normalization now accepts `PB` (and optionally ordinary `PBDOT`) together with `FBn` while `FB0` is omitted. PINT converts the nominal model to a canonical FBX Taylor series, inserts frozen zero coefficients for sparse indices, and exposes `PB`/`PBDOT` as read-only derived views. Every valued FB coefficient is now guaranteed to contribute to orbital phase or produce a clear error.
 ### Fixed
+- Sparse FBX series no longer silently ignore coefficients after the first missing index.
 - `WidebandTOAFitter` raises a warning if the model has correlated errors (It used to give wrong results before).
 - Fixed bug where "include_bipm" flag was being ignored when loading Fermi TOAs with weights, now defaults to using EPHEM, CLOCK and PLANET_SHAPIRO from the timing model
 - When flags are created based off jumps uses strings instead of None

--- a/src/pint/binaryconvert.py
+++ b/src/pint/binaryconvert.py
@@ -21,6 +21,7 @@ from pint.models.binary_bt import BinaryBT
 from pint.models.binary_dd import BinaryDD, BinaryDDH, BinaryDDS
 from pint.models.binary_ddk import BinaryDDK
 from pint.models.binary_ell1 import BinaryELL1, BinaryELL1H, BinaryELL1k
+from pint.models.parameter import funcParameter
 
 # output types
 # DDGR is not included as there is not a well-defined way to get a unique output
@@ -28,6 +29,19 @@ binary_types = ["DD", "DDK", "DDS", "DDH", "BT", "ELL1", "ELL1H", "ELL1k"]
 
 
 __all__ = ["convert_binary"]
+
+
+def _ordinary_pb_frozen(model: pint.models.TimingModel) -> bool:
+    """Return the freeze flag for the independent orbital-period parameter.
+
+    Under canonical FBX, ``PB`` is a derived ``funcParameter`` and is always
+    frozen; the independent period information lives on ``FB0``.
+    """
+    if model.PB.quantity is not None and not isinstance(model.PB, funcParameter):
+        return model.PB.frozen
+    if hasattr(model, "FB0") and model.FB0.quantity is not None:
+        return model.FB0.frozen
+    return model.PB.frozen
 
 
 def _M2SINI_to_orthometric(model: pint.models.TimingModel) -> Tuple[u.Quantity]:
@@ -800,20 +814,12 @@ def convert_binary(
             outmodel.OM.frozen = model.EPS1.frozen or model.EPS2.frozen
             outmodel.T0.quantity = T0
             outmodel.T0.uncertainty = T0_unc
-            if model.PB.quantity is not None:
-                outmodel.T0.frozen = (
-                    model.EPS1.frozen
-                    or model.EPS2.frozen
-                    or model.TASC.frozen
-                    or model.PB.frozen
-                )
-            elif model.FB0.quantity is not None:
-                outmodel.T0.frozen = (
-                    model.EPS1.frozen
-                    or model.EPS2.frozen
-                    or model.TASC.frozen
-                    or model.FB0.frozen
-                )
+            outmodel.T0.frozen = (
+                model.EPS1.frozen
+                or model.EPS2.frozen
+                or model.TASC.frozen
+                or _ordinary_pb_frozen(model)
+            )
             if EDOT is not None:
                 outmodel.EDOT.quantity = EDOT
             if EDOT_unc is not None:
@@ -1156,7 +1162,7 @@ def convert_binary(
             outmodel.TASC.frozen = (
                 model.ECC.frozen
                 or model.OM.frozen
-                or model.PB.frozen
+                or _ordinary_pb_frozen(model)
                 or model.T0.frozen
             )
             if EPS1DOT is not None and output != "ELL1k":
@@ -1271,7 +1277,10 @@ def convert_binary(
                     f"Setting KIN={outmodel.KIN} from SINI={model.SINI}: check that the sign is correct"
                 )
                 outmodel.KIN.frozen = model.SINI.frozen
-    outmodel.validate()
+    # Match ModelBuilder ordering: normalize/setup before validate so that
+    # BinaryDD/BT defaults (e.g. PBDOT=0) are not invented before FBX
+    # canonicalization removes an unset PBDOT.
     outmodel.setup()
+    outmodel.validate()
 
     return outmodel

--- a/src/pint/models/binary_bt.py
+++ b/src/pint/models/binary_bt.py
@@ -69,9 +69,10 @@ class BinaryBT(PulsarBinary):
             if getattr(self, p).value is None:
                 raise MissingParameter("BT", p, f"{p} is required for BT")
 
-        # If any *DOT is set, we need T0
+        # If any *DOT is set, we need T0. Under canonical FBX, unset PBDOT may
+        # be absent entirely; skip missing attributes (same pattern as BinaryDD).
         for p in ("PBDOT", "OMDOT", "EDOT", "A1DOT"):
-            if getattr(self, p).value is None:
+            if hasattr(self, p) and getattr(self, p).value is None:
                 getattr(self, p).value = "0"
                 getattr(self, p).frozen = True
 
@@ -400,13 +401,18 @@ class BinaryBTPiecewise(PulsarBinary):
             if getattr(self, p).value is None:
                 raise MissingParameter("BT", p, f"{p} is required for BT")
 
-        # If any *DOT is set, we need T0
+        # If any *DOT is set, we need T0. Under canonical FBX, unset PBDOT may
+        # be absent entirely; skip missing attributes (same pattern as BinaryDD).
         for p in ("PBDOT", "OMDOT", "EDOT", "A1DOT"):
-            if getattr(self, p).value is None:
+            if hasattr(self, p) and getattr(self, p).value is None:
                 getattr(self, p).value = 0
                 getattr(self, p).frozen = True
 
-            if getattr(self, p).value is not None and self.T0.value is None:
+            if (
+                hasattr(self, p)
+                and getattr(self, p).value is not None
+                and self.T0.value is None
+            ):
                 raise MissingParameter("BT", "T0", "T0 is required if *DOT is set")
 
         if self.GAMMA.value is None:

--- a/src/pint/models/binary_dd.py
+++ b/src/pint/models/binary_dd.py
@@ -395,6 +395,12 @@ class BinaryDDH(BinaryDD):
     This uses the full expression for the Shapiro delay, not the harmonic
     decomposition used in :class:`pint.models.stand_alone_psr_binaries.ELL1H_model.ELL1Hmodel`.
 
+    A negative ``H3`` (equivalently a negative derived companion mass ``M2``)
+    is accepted with a warning: in the orthometric parameterization a weak
+    Shapiro-delay measurement can legitimately have a best-fit ``H3 < 0``,
+    and wherever the ordinary DD logarithm is valid the delay remains smooth
+    through ``H3=0``. Finite positive ``STIGMA`` is still required.
+
     References
     ----------
     - Freire & Wex (2010), MNRAS, 409 (1), 199-212 [1]_
@@ -405,6 +411,7 @@ class BinaryDDH(BinaryDD):
     """
 
     register = True
+    _allow_negative_derived_m2 = True
 
     def __init__(self):
         super().__init__()
@@ -458,7 +465,12 @@ class BinaryDDH(BinaryDD):
         self.update_binary_object(None)
 
     def validate(self):
-        """Parameter validation."""
+        """Validate the native DDH domain before evaluating derived values."""
+        if self.H3.value is not None and not np.isfinite(self.H3.value):
+            raise ValueError(f"H3 must be finite ({self.H3.quantity})")
+        if self.STIGMA.value is not None:
+            if not np.isfinite(self.STIGMA.value):
+                raise ValueError(f"STIGMA must be finite ({self.STIGMA.quantity})")
+            if self.STIGMA.value <= 0:
+                raise ValueError(f"STIGMA must be positive ({self.STIGMA.quantity})")
         super().validate()
-        # if self.H3.quantity is None:
-        #     raise MissingParameter("ELL1H", "H3", "'H3' is required for ELL1H model")

--- a/src/pint/models/binary_ell1.py
+++ b/src/pint/models/binary_ell1.py
@@ -253,7 +253,7 @@ class BinaryELL1(PulsarBinary):
         # make sure that the PB is the base parameter
         if self.PB.quantity is not None and not isinstance(self.PB, funcParameter):
             PB = self.PB.quantity
-            if self.PBDOT.quantity is not None:
+            if hasattr(self, "PBDOT") and self.PBDOT.quantity is not None:
                 PBDOT = self.PBDOT.quantity
             else:
                 PBDOT = 0.0 * u.Unit("")

--- a/src/pint/models/pulsar_binary.py
+++ b/src/pint/models/pulsar_binary.py
@@ -24,12 +24,17 @@ from pint.models.timing_model import DelayComponent
 from pint.pulsar_ecliptic import PulsarEcliptic
 from pint.utils import parse_time, taylor_horner_deriv
 
-# def _p_to_f(p):
-#     return 1 / p
+_SECS_PER_DAY = np.longdouble(86400)
 
 
-# def _pdot_to_fdot(p, pdot):
-#     return -pdot / p**2
+def _pb_from_fb0(fb0):
+    """Derived orbital period in days from FB0."""
+    return (1 / fb0).to(u.day)
+
+
+def _pbdot_from_fb0_fb1(fb0, fb1):
+    """Derived orbital-period derivative from FB0 and FB1."""
+    return (-fb1 / fb0**2).to(u.day / u.day)
 
 
 class PulsarBinary(DelayComponent):
@@ -57,6 +62,13 @@ class PulsarBinary(DelayComponent):
         - SINI - system inclination (0<=SINI<=1)
         - FB0 - orbital frequency (1/s, alternative to PB, non-negative)
         - FBn - time derivatives of orbital frequency (1/s**(n+1))
+
+    If any ``FBn`` (n>=1) is provided together with ``PB`` but without ``FB0``
+    (a hybrid parameterization accepted by tempo2), ``PB`` (and ordinary
+    ``PBDOT``, when present) are converted to ``FB0`` (and ``FB1``) on setup.
+    Missing interior FB coefficients are inserted as frozen zeros. ``PB`` and,
+    when ``FB1`` is present, ``PBDOT`` remain available as read-only derived
+    parameters.
 
     The following ORBWAVEs parameters define a Fourier series model for orbital phase
     variations, as an alternative to the FBn Taylor series expansion:
@@ -86,6 +98,7 @@ class PulsarBinary(DelayComponent):
     """
 
     category = "pulsar_system"
+    _allow_negative_derived_m2 = False
 
     def __init__(self):
         super().__init__()
@@ -259,7 +272,227 @@ class PulsarBinary(DelayComponent):
         # Set up delay function
         self.delay_funcs_component += [self.binarymodel_delay]
 
+    def _fbx_mapping(self):
+        """Return the component's ordered FB-index mapping."""
+        return self.get_prefix_mapping_component("FB")
+
+    def _add_or_get_fbx(self, index):
+        """Return FB[index], creating its prefix parameter when absent."""
+        mapping = self._fbx_mapping()
+        if index not in mapping:
+            self.add_param(self.FB0.new_param(index))
+            mapping = self._fbx_mapping()
+        return getattr(self, mapping[index])
+
+    def _set_fbx_frozen_zero(self, index):
+        """Set an absent or valueless FB coefficient to an exact frozen zero."""
+        par = self._add_or_get_fbx(index)
+        if par.quantity is None:
+            par.value = np.longdouble(0)
+            par.frozen = True
+            par.uncertainty = None
+            return True
+        return False
+
+    def _bridge_pb_to_fb0(self):
+        """Convert hybrid PB + higher-FBn input to an FB0 coefficient."""
+        mapping = self._fbx_mapping()
+        higher_fbn_set = any(
+            index >= 1 and getattr(self, name).quantity is not None
+            for index, name in mapping.items()
+        )
+        if not (
+            higher_fbn_set
+            and self.FB0.quantity is None
+            and self.PB.quantity is not None
+            and not isinstance(self.PB, funcParameter)
+        ):
+            return
+
+        pb_days = np.longdouble(self.PB.quantity.to_value(u.day))
+        if pb_days <= 0:
+            raise ValueError(f"Binary period PB must be positive ({self.PB.quantity})")
+
+        self.FB0.value = 1 / (pb_days * _SECS_PER_DAY)
+        self.FB0.frozen = self.PB.frozen
+        self.FB0.uncertainty = None
+        if self.PB.uncertainty is not None:
+            sigma_pb_days = np.longdouble(self.PB.uncertainty.to_value(u.day))
+            self.FB0.uncertainty_value = abs(sigma_pb_days) / (
+                pb_days**2 * _SECS_PER_DAY
+            )
+
+        log.warning(
+            f"Converting PB={self.PB.quantity} to FB0={self.FB0.quantity}; "
+            "FBX supplies the complete orbital phase."
+        )
+
+    def _convert_pbdot_to_fb1(self):
+        """Resolve ordinary or derived PBDOT under the complete-FBX policy."""
+        if "PBDOT" not in self.params:
+            return
+
+        pbdot = self.PBDOT
+        if isinstance(pbdot, funcParameter):
+            if pbdot._func is _pbdot_from_fb0_fb1:
+                # Already canonicalized by an earlier setup() call.
+                return
+            raise ValueError(
+                "FBX is not supported for a binary model with a non-FBX "
+                f"derived PBDOT ({self.binary_model_name}); use the PB "
+                "parameterization or implement the required dynamic PB/FB "
+                "chain rule."
+            )
+
+        if pbdot.quantity is None:
+            return
+
+        if "FB1" in self.params and self.FB1.quantity is not None:
+            log.warning(
+                f"Both PBDOT={pbdot.quantity} and FB1={self.FB1.quantity} "
+                "are set; explicit FB1 wins and PBDOT is discarded."
+            )
+            return
+
+        fb0 = np.longdouble(self.FB0.quantity.to_value(1 / u.s))
+        pbdot_value = np.longdouble(pbdot.quantity.to_value(u.s / u.s))
+        fb1 = self._add_or_get_fbx(1)
+        fb1.value = -pbdot_value * fb0**2
+        fb1.frozen = pbdot.frozen
+        fb1.uncertainty = None
+
+        variance_terms = []
+        if pbdot.uncertainty is not None:
+            sigma_pbdot = np.longdouble(pbdot.uncertainty.to_value(u.s / u.s))
+            variance_terms.append((fb0**2 * sigma_pbdot) ** 2)
+        if self.FB0.uncertainty is not None:
+            sigma_fb0 = np.longdouble(self.FB0.uncertainty.to_value(1 / u.s))
+            variance_terms.append((2 * pbdot_value * fb0 * sigma_fb0) ** 2)
+        if variance_terms:
+            fb1.uncertainty_value = np.sqrt(
+                np.sum(np.asarray(variance_terms, dtype=np.longdouble))
+            )
+
+        log.warning(
+            f"Converting PBDOT={pbdot.quantity} to FB1={fb1.quantity}; "
+            "FBX supplies the complete orbital phase."
+        )
+
+    def _fill_sparse_fbx_terms(self):
+        """Insert frozen zeros for missing coefficients below the maximum FBn."""
+        mapping = self._fbx_mapping()
+        valued_indices = [
+            index
+            for index, name in mapping.items()
+            if getattr(self, name).quantity is not None
+        ]
+        if not valued_indices:
+            return
+
+        inserted = [
+            index
+            for index in range(max(valued_indices) + 1)
+            if self._set_fbx_frozen_zero(index)
+        ]
+        if inserted:
+            names = ", ".join(f"FB{index}" for index in inserted)
+            log.warning(
+                f"Inserted frozen zero FB coefficients for sparse series: {names}."
+            )
+
+    def _canonicalize_fbx_views(self):
+        """Install idempotent PB/PBDOT views derived from active FB coefficients."""
+        pb_is_canonical = (
+            isinstance(self.PB, funcParameter) and self.PB._func is _pb_from_fb0
+        )
+        if not pb_is_canonical:
+            self.remove_param("PB")
+            self.add_param(
+                funcParameter(
+                    name="PB",
+                    units=u.day,
+                    description="Orbital period",
+                    long_double=True,
+                    params=("FB0",),
+                    func=_pb_from_fb0,
+                )
+            )
+
+        have_fb1 = "FB1" in self.params and self.FB1.quantity is not None
+        pbdot_is_canonical = (
+            "PBDOT" in self.params
+            and isinstance(self.PBDOT, funcParameter)
+            and self.PBDOT._func is _pbdot_from_fb0_fb1
+        )
+        if have_fb1 and not pbdot_is_canonical:
+            if "PBDOT" in self.params:
+                self.remove_param("PBDOT")
+            self.add_param(
+                funcParameter(
+                    name="PBDOT",
+                    units=u.day / u.day,
+                    description="Orbital period derivative respect to time",
+                    unit_scale=True,
+                    scale_factor=1e-12,
+                    scale_threshold=1e-7,
+                    params=("FB0", "FB1"),
+                    func=_pbdot_from_fb0_fb1,
+                )
+            )
+        elif not have_fb1 and "PBDOT" in self.params:
+            # Do not expose a writable parameter that OrbitFBX would ignore.
+            self.remove_param("PBDOT")
+
+    def _setup_fbx_parameterization(self):
+        """Normalize all active FBX models before ordinary component setup."""
+        ordinary_pb = not isinstance(self.PB, funcParameter)
+        if (
+            ordinary_pb
+            and self.PB.quantity is not None
+            and self.FB0.quantity is not None
+        ):
+            raise ValueError("Model cannot have values for both FB0 and PB")
+
+        mapping = self._fbx_mapping()
+        using_fbx = any(
+            getattr(self, name).quantity is not None for name in mapping.values()
+        )
+        if not using_fbx:
+            return
+
+        # All unsupported combinations are rejected before bridge mutation.
+        if hasattr(self, "XPBDOT") and self.XPBDOT.quantity is not None:
+            raise ValueError(
+                "XPBDOT is not supported together with the FBX orbital-phase "
+                "parameterization; encode the complete orbital-frequency "
+                "evolution in FBn or remove the FBn parameters."
+            )
+        if (
+            "PBDOT" in self.params
+            and isinstance(self.PBDOT, funcParameter)
+            and self.PBDOT._func is not _pbdot_from_fb0_fb1
+        ):
+            raise ValueError(
+                "FBX is not supported for a binary model with a non-FBX "
+                f"derived PBDOT ({self.binary_model_name}); use the PB "
+                "parameterization or implement the required dynamic PB/FB "
+                "chain rule."
+            )
+
+        self._bridge_pb_to_fb0()
+        if self.FB0.quantity is None:
+            raise ValueError("Some FBn parameters are set but FB0 is not.")
+        if self.FB0.value <= 0:
+            raise ValueError(
+                f"Binary frequency FB0 must be positive ({self.FB0.quantity})"
+            )
+
+        self._convert_pbdot_to_fb1()
+        self._fill_sparse_fbx_terms()
+        self._canonicalize_fbx_views()
+
     def setup(self):
+        self._setup_fbx_parameterization()
         super().setup()
         for bpar in self.params:
             self.register_deriv_funcs(self.d_binary_delay_d_xxxx, bpar)
@@ -268,42 +501,17 @@ class PulsarBinary(DelayComponent):
         # Setup the FBX orbits if FB is set.
         # TODO this should use a smarter way to set up orbit.
         FBX_mapping = self.get_prefix_mapping_component("FB")
-        FBXs = {fbn: getattr(self, fbn).quantity for fbn in FBX_mapping.values()}
-        if any(v is not None for v in FBXs.values()):
-            if self.FB0.value is None:
-                raise ValueError("Some FBn parameters are set but FB0 is not.")
+        FBXs = {
+            fbn: getattr(self, fbn).quantity
+            for fbn in FBX_mapping.values()
+            if getattr(self, fbn).quantity is not None
+        }
+        if FBXs:
             for fb_name, fb_value in FBXs.items():
                 self.binary_instance.add_binary_params(fb_name, fb_value)
             self.binary_instance.orbits_cls = bo.OrbitFBX(
                 self.binary_instance, list(FBXs.keys())
             )
-            # Note: if we are happy to use these to show alternate parameterizations then this can be uncommented
-
-            # # remove the PB parameterization, replace with functions
-            # self.remove_param("PB")
-            # self.remove_param("PBDOT")
-            # self.add_param(
-            #     funcParameter(
-            #         name="PB",
-            #         units=u.day,
-            #         description="Orbital period",
-            #         long_double=True,
-            #         params=("FB0",),
-            #         func=_p_to_f,
-            #     )
-            # )
-            # self.add_param(
-            #     funcParameter(
-            #         name="PBDOT",
-            #         units=u.day / u.day,
-            #         description="Orbital period derivative respect to time",
-            #         unit_scale=True,
-            #         scale_factor=1e-12,
-            #         scale_threshold=1e-7,
-            #         params=("FB0", "FB1"),
-            #         func=_pdot_to_fdot,
-            #     )
-            # )
 
         ORBWAVES_mapping = self.get_prefix_mapping_component("ORBWAVES")
         ORBWAVES = {
@@ -324,7 +532,7 @@ class PulsarBinary(DelayComponent):
             for k in ORBWAVEC.keys():
                 self.binary_instance.add_binary_params(k, ORBWAVEC[k])
 
-            using_FBX = any(v is not None for v in FBXs.values())
+            using_FBX = bool(FBXs)
             if using_FBX:
                 fbx = sorted(list(FBXs.keys()))
                 if len(fbx) > 2:
@@ -346,32 +554,6 @@ class PulsarBinary(DelayComponent):
                     + list(ORBWAVEC.keys()),
                 )
 
-        # Note: if we are happy to use these to show alternate parameterizations then this can be uncommented
-        # else:
-        #     # remove the FB parameterization, replace with functions
-        #     self.remove_param("FB0")
-        #     self.add_param(
-        #         funcParameter(
-        #             name="FB0",
-        #             units="1/s^1",
-        #             description="0th time derivative of frequency of orbit",
-        #             aliases=["FB"],
-        #             long_double=True,
-        #             params=("PB",),
-        #             func=_p_to_f,
-        #         )
-        #     )
-        #     self.add_param(
-        #         funcParameter(
-        #             name="FB1",
-        #             units="1/s^2",
-        #             description="1st time derivative of frequency of orbit",
-        #             long_double=True,
-        #             params=("PB", "PBDOT"),
-        #             func=_pdot_to_fdot,
-        #         )
-        #     )
-
         # Update the parameters in the stand alone binary
         self.update_binary_object(None)
 
@@ -386,9 +568,15 @@ class PulsarBinary(DelayComponent):
                 f"Sine of inclination angle must be between zero and one ({self.SINI.quantity})"
             )
         if hasattr(self, "M2") and self.M2.value is not None and self.M2.value < 0:
-            raise ValueError(
-                f"Companion mass M2 cannot be negative ({self.M2.quantity})"
-            )
+            if self._allow_negative_derived_m2 and isinstance(self.M2, funcParameter):
+                log.warning(
+                    f"DDH signed H3 gives M2={self.M2.quantity}; this is a "
+                    "valid signed H3 fit but not a physical companion mass."
+                )
+            else:
+                raise ValueError(
+                    f"Companion mass M2 cannot be negative ({self.M2.quantity})"
+                )
         if (
             hasattr(self, "ECC")
             and self.ECC.value is not None
@@ -620,7 +808,7 @@ class PulsarBinary(DelayComponent):
         # Get PB and PBDOT from model
         if self.PB.quantity is not None and not isinstance(self.PB, funcParameter):
             PB = self.PB.quantity
-            if self.PBDOT.quantity is not None:
+            if hasattr(self, "PBDOT") and self.PBDOT.quantity is not None:
                 PBDOT = self.PBDOT.quantity
             else:
                 PBDOT = 0.0 * u.Unit("")
@@ -689,7 +877,9 @@ class PulsarBinary(DelayComponent):
         else:
             t0 = self.T0.quantity
         t = t0 if t is None else parse_time(t)
-        if self.PB.quantity is not None:
+        # Derived PB (funcParameter) means the active phase is the FBX series;
+        # do not treat it as an independent OrbitPB parameterization.
+        if self.PB.quantity is not None and not isinstance(self.PB, funcParameter):
             if self.PBDOT.quantity is None and (
                 not hasattr(self, "XPBDOT")
                 or getattr(self, "XPBDOT").quantity is not None

--- a/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
+++ b/src/pint/models/stand_alone_psr_binaries/binary_orbits.py
@@ -159,17 +159,23 @@ class OrbitPB(Orbit):
 class OrbitFBX(Orbit):
     """Orbits expressed in terms of orbital frequency and its derivatives FB0, FB1, FB2..."""
 
-    def __init__(self, parent, orbit_params=["FB0"]):
+    def __init__(self, parent, orbit_params=None):
+        if orbit_params is None:
+            orbit_params = ["FB0"]
+        orbit_params = list(orbit_params)
         super().__init__("orbitFBX", parent, orbit_params)
-        # add the rest of FBX parameters.
-        indices = set()
-        for k in self.binary_params:
-            if re.match(r"FB\d+", k) is not None and k not in self.orbit_params:
-                self.orbit_params += [k]
-                indices.add(int(k[2:]))
-        if indices != set(range(len(indices))):
+
+        for name in self.binary_params:
+            if re.fullmatch(r"FB\d+", name) and name not in self.orbit_params:
+                self.orbit_params.append(name)
+
+        indices = {
+            int(name[2:]) for name in self.orbit_params if re.fullmatch(r"FB\d+", name)
+        }
+        expected = set(range(max(indices) + 1)) if indices else set()
+        if indices != expected:
             raise ValueError(
-                f"Indices must be 0 up to some number k without gaps "
+                "Indices must be 0 up to some number k without gaps "
                 f"but are {indices}."
             )
 

--- a/tests/test_binconvert.py
+++ b/tests/test_binconvert.py
@@ -146,6 +146,44 @@ EPS2DOT           -1e-10 1 1e-11
 kwargs = {"ELL1H": {"NHARMS": 3, "useSTIGMA": True}, "DDK": {"KOM": 0 * u.deg}}
 
 
+def _assert_roundtrip_param(m, mback, p):
+    """Compare one parameter after a binary-model roundtrip.
+
+    ``MJDParameter.quantity`` is an ``astropy.time.Time``, but ``.value`` is a
+    long-double MJD. ELL1↔DD epoch transforms have ULP-level noise (~1e-15 d),
+    so Time/MJD parameters use a tight absolute tolerance rather than exact
+    equality or the default ``np.isclose`` relative tolerance (which would
+    allow ~0.5 d error at MJD 55631).
+    """
+    left = getattr(m, p)
+    right = getattr(mback, p)
+    if left.value is None:
+        return
+    if isinstance(left.quantity, (str, bool)):
+        assert (
+            left.value == right.value
+        ), f"{p}: {left.value} does not match {right.value}"
+        return
+    if isinstance(left.quantity, astropy.time.Time):
+        assert np.isclose(
+            left.value, right.value, rtol=0, atol=1e-12
+        ), f"{p}: {left.value} does not match {right.value}"
+        return
+    assert np.isclose(
+        left.value, right.value
+    ), f"{p}: {left.value} does not match {right.value}"
+    if left.uncertainty is not None:
+        # some precision may be lost in uncertainty conversion
+        assert np.isclose(
+            left.uncertainty_value,
+            right.uncertainty_value,
+            rtol=0.2,
+        ), (
+            f"{p} uncertainty: {left.uncertainty_value} does not match "
+            f"{right.uncertainty_value}"
+        )
+
+
 @pytest.mark.parametrize(
     "output", ["ELL1", "ELL1H", "ELL1k", "DD", "BT", "DDS", "DDK", "DDH"]
 )
@@ -179,23 +217,7 @@ def test_ELL1_roundtrip(output):
         if output == "BT" and p in ["M2", "SINI"]:
             # these are not in BT
             continue
-        if getattr(m, p).value is None:
-            continue
-        if not isinstance(getattr(m, p).quantity, (str, bool, astropy.time.Time)):
-            assert np.isclose(
-                getattr(m, p).value, getattr(mback, p).value
-            ), f"{p}: {getattr(m, p).value} does not match {getattr(mback, p).value}"
-            if getattr(m, p).uncertainty is not None:
-                # some precision may be lost in uncertainty conversion
-                assert np.isclose(
-                    getattr(m, p).uncertainty_value,
-                    getattr(mback, p).uncertainty_value,
-                    rtol=0.2,
-                ), f"{p} uncertainty: {getattr(m, p).uncertainty_value} does not match {getattr(mback, p).uncertainty_value}"
-        else:
-            assert (
-                getattr(m, p).value == getattr(mback, p).value
-            ), f"{p}: {getattr(m, p).value} does not match {getattr(mback, p).value}"
+        _assert_roundtrip_param(m, mback, p)
 
 
 @pytest.mark.parametrize("output", ["ELL1", "ELL1H", "ELL1k", "DD", "BT", "DDS", "DDK"])
@@ -215,23 +237,7 @@ def test_ELL1_roundtripFB0(output):
         if output == "BT" and p in ["M2", "SINI"]:
             # these are not in BT
             continue
-        if getattr(m, p).value is None:
-            continue
-        if not isinstance(getattr(m, p).quantity, (str, bool, astropy.time.Time)):
-            assert np.isclose(
-                getattr(m, p).value, getattr(mback, p).value
-            ), f"{p}: {getattr(m, p).value} does not match {getattr(mback, p).value}"
-            if getattr(m, p).uncertainty is not None:
-                # some precision may be lost in uncertainty conversion
-                assert np.isclose(
-                    getattr(m, p).uncertainty_value,
-                    getattr(mback, p).uncertainty_value,
-                    rtol=0.2,
-                ), f"{p} uncertainty: {getattr(m, p).uncertainty_value} does not match {getattr(mback, p).uncertainty_value}"
-        else:
-            assert (
-                getattr(m, p).value == getattr(mback, p).value
-            ), f"{p}: {getattr(m, p).value} does not match {getattr(mback, p).value}"
+        _assert_roundtrip_param(m, mback, p)
 
 
 @pytest.mark.parametrize(
@@ -265,24 +271,14 @@ def test_DD_roundtrip(output):
             continue
         if getattr(m, p).value is None:
             continue
-        # print(getattr(m, p), getattr(mback, p))
-        if not isinstance(getattr(m, p).quantity, (str, bool, astropy.time.Time)):
+        # Value still checked; skip loose uncertainty for known precision losses.
+        if output in ["ELL1", "ELL1H", "ELL1k"] and p == "ECC":
             assert np.isclose(getattr(m, p).value, getattr(mback, p).value)
-            if getattr(m, p).uncertainty is not None:
-                # some precision may be lost in uncertainty conversion
-                if output in ["ELL1", "ELL1H", "ELL1k"] and p in ["ECC"]:
-                    # we lose precision on ECC since it also contains a contribution from OM now
-                    continue
-                if output in ["ELL1H", "DDH"] and p == "M2":
-                    # this also loses precision
-                    continue
-                assert np.isclose(
-                    getattr(m, p).uncertainty_value,
-                    getattr(mback, p).uncertainty_value,
-                    rtol=0.2,
-                ), f"Parameter '{p}' failed: initial uncertainty {getattr(m, p).uncertainty_value} but returned {getattr(mback, p).uncertainty_value}"
-        else:
-            assert getattr(m, p).value == getattr(mback, p).value
+            continue
+        if output in ["ELL1H", "DDH"] and p == "M2":
+            assert np.isclose(getattr(m, p).value, getattr(mback, p).value)
+            continue
+        _assert_roundtrip_param(m, mback, p)
 
 
 @pytest.mark.parametrize("output", ["ELL1", "ELL1H", "ELL1k", "DD", "BT", "DDS", "DDK"])
@@ -331,24 +327,13 @@ def test_DDFB0_roundtrip(output):
             continue
         if getattr(m, p).value is None:
             continue
-        # print(getattr(m, p), getattr(mback, p))
-        if not isinstance(getattr(m, p).quantity, (str, bool, astropy.time.Time)):
+        if output in ["ELL1", "ELL1H", "ELL1k"] and p == "ECC":
             assert np.isclose(getattr(m, p).value, getattr(mback, p).value)
-            if getattr(m, p).uncertainty is not None:
-                # some precision may be lost in uncertainty conversion
-                if output in ["ELL1", "ELL1H", "ELL1k"] and p in ["ECC"]:
-                    # we lose precision on ECC since it also contains a contribution from OM now
-                    continue
-                if output == "ELL1H" and p == "M2":
-                    # this also loses precision
-                    continue
-                assert np.isclose(
-                    getattr(m, p).uncertainty_value,
-                    getattr(mback, p).uncertainty_value,
-                    rtol=0.2,
-                )
-        else:
-            assert getattr(m, p).value == getattr(mback, p).value
+            continue
+        if output == "ELL1H" and p == "M2":
+            assert np.isclose(getattr(m, p).value, getattr(mback, p).value)
+            continue
+        _assert_roundtrip_param(m, mback, p)
 
 
 def test_ELL1_ELL1H():

--- a/tests/test_change_epoch.py
+++ b/tests/test_change_epoch.py
@@ -178,10 +178,12 @@ def test_change_binary_epoch(binary_model):
     epoch_name = "TASC" if model_kind in ["ELL1", "ELL1H"] else "T0"
     orig_epoch = getattr(model, epoch_name).quantity
 
-    # Get PB and PBDOT from model
-    if model.PB.quantity is not None:
+    # Get PB and PBDOT from model. Derived PB means the active phase is FBX.
+    from pint.models.parameter import funcParameter
+
+    if model.PB.quantity is not None and not isinstance(model.PB, funcParameter):
         PB = model.PB.quantity
-        if model.PBDOT.quantity is not None:
+        if hasattr(model, "PBDOT") and model.PBDOT.quantity is not None:
             PBDOT = model.PBDOT.quantity
         else:
             PBDOT = 0.0 * u.Unit("")

--- a/tests/test_ddh.py
+++ b/tests/test_ddh.py
@@ -9,6 +9,10 @@ from pinttestdata import datadir
 import pint.binaryconvert
 import pint.derived_quantities
 import pint.simulation
+from pint.residuals import Residuals
+from loguru import logger as log
+from contextlib import contextmanager
+import pytest
 
 parDD = """
 PSRJ           1855+09
@@ -94,3 +98,159 @@ def test_ddh_sim():
     assert np.isclose(f.resids.calc_chi2(), f2.resids.calc_chi2(), atol=0.5)
     assert np.isclose(f.model.M2.value, f2.model.M2.value, atol=0.01)
     assert np.isclose(f.model.SINI.value, f2.model.SINI.value, atol=0.01)
+
+
+# ---- signed-H3 DDH validation ----
+
+parDDH = """
+PSR J1234+5678
+ELAT 0
+ELONG 0
+PEPOCH 57000
+F0 1
+BINARY DDH
+PB 1
+A1 10
+T0 57000
+ECC 0.1
+OM 45
+H3 H3_VALUE
+STIG STIG_VALUE
+"""
+
+
+def make_ddh_par(h3="1e-7", stigma="0.5"):
+    return parDDH.replace("H3_VALUE", str(h3)).replace("STIG_VALUE", str(stigma))
+
+
+@contextmanager
+def captured_warnings():
+    messages = []
+    sink = log.add(
+        lambda message: messages.append(str(message)),
+        level="WARNING",
+        format="{message}",
+    )
+    try:
+        yield messages
+    finally:
+        log.remove(sink)
+
+
+@pytest.mark.parametrize("h3", [-1e-7, 0.0, 1e-7])
+def test_ddh_signed_h3_is_evaluable(h3):
+    model = get_model(io.StringIO(make_ddh_par(h3=h3)))
+    toas = pint.simulation.make_fake_toas_uniform(
+        58000, 58100, 32, model, add_noise=False
+    )
+    assert np.all(np.isfinite(Residuals(toas, model).time_resids))
+
+
+@pytest.mark.parametrize("stigma", [0.0, -0.5])
+def test_ddh_nonpositive_stigma_raises(stigma):
+    with pytest.raises(ValueError, match="STIGMA must be positive"):
+        get_model(io.StringIO(make_ddh_par(stigma=stigma)))
+
+
+@pytest.mark.parametrize(
+    ("name", "h3", "stigma"),
+    [
+        ("H3", "nan", "0.5"),
+        ("H3", "inf", "0.5"),
+        ("STIGMA", "1e-7", "nan"),
+        ("STIGMA", "1e-7", "inf"),
+    ],
+)
+def test_ddh_nonfinite_native_parameter_raises(name, h3, stigma):
+    with pytest.raises(ValueError, match=rf"{name}.*finite"):
+        get_model(io.StringIO(make_ddh_par(h3=h3, stigma=stigma)))
+
+
+def test_ddh_negative_h3_warning_contract():
+    with captured_warnings() as messages:
+        model = get_model(io.StringIO(make_ddh_par(h3="-1e-7")))
+
+    assert model.M2.value < 0
+    assert any(
+        "signed H3" in message and "not a physical companion mass" in message
+        for message in messages
+    )
+
+
+def test_ddh_h3_delay_is_continuous_through_zero():
+    models = [
+        get_model(io.StringIO(make_ddh_par(h3=value)))
+        for value in ("-1e-7", "0", "1e-7")
+    ]
+    toas = pint.simulation.make_fake_toas_uniform(
+        58000, 58100, 32, models[1], add_noise=False
+    )
+    delays = [model.binarymodel_delay(toas, None) for model in models]
+
+    for model, delay in zip(models, delays):
+        assert np.all(np.isfinite(delay))
+        assert np.all(np.isfinite(model.d_delay_d_param(toas, "H3")))
+    assert u.allclose(delays[0] + delays[2], 2 * delays[1], atol=1e-15 * u.s)
+
+
+def test_ddh_fit_can_cross_h3_zero():
+    model = get_model(io.StringIO(make_ddh_par(h3="-1e-7")))
+    toas = pint.simulation.make_fake_toas_uniform(
+        58000, 58100, 64, model, add_noise=True
+    )
+    for name in model.free_params:
+        if name != "H3":
+            getattr(model, name).frozen = True
+    model.H3.value = -1e-7
+    f = pint.fitter.Fitter.auto(toas, model)
+    f.fit_toas()
+    assert np.isfinite(f.resids.calc_chi2())
+
+
+def test_positive_h3_is_unchanged():
+    model = get_model(io.StringIO(make_ddh_par(h3="1e-7")))
+    assert model.M2.value > 0
+    assert model.BINARY.value == "DDH"
+
+
+def test_free_negative_m2_still_raises():
+    par = """
+PSR J1234+5678
+ELAT 0
+ELONG 0
+PEPOCH 57000
+F0 1
+BINARY DD
+PB 1
+A1 10
+T0 57000
+ECC 0.1
+OM 45
+M2 -0.3
+SINI 0.8
+"""
+    with pytest.raises(ValueError, match="M2 cannot be negative"):
+        get_model(io.StringIO(par))
+
+
+def test_invalid_ddk_derived_sini_still_raises():
+    par = """
+PSR J1234+5678
+ELAT 0
+ELONG 0
+PEPOCH 57000
+F0 1
+PMELONG 0
+PMELAT 0
+BINARY DDK
+PB 1
+A1 10
+T0 57000
+ECC 0.1
+OM 45
+M2 0.3
+KIN -10
+KOM 0
+"""
+    with pytest.raises(ValueError, match="Sine of inclination angle"):
+        get_model(io.StringIO(par))

--- a/tests/test_fbx.py
+++ b/tests/test_fbx.py
@@ -13,6 +13,17 @@ from pint.models import get_model_and_toas
 import pint.models.model_builder as mb
 import pint.toa as toa
 from pint.residuals import Residuals
+from pint.models.tcb_conversion import convert_tcb_tdb
+from pint.models.stand_alone_psr_binaries.DD_model import DDmodel
+from pint.models.stand_alone_psr_binaries.binary_orbits import OrbitFBX
+from pint.models.parameter import funcParameter
+from pint.models.binary_ell1 import BinaryELL1
+from pint.models.binary_dd import BinaryDDGR
+import pint.simulation
+from loguru import logger as log
+from copy import deepcopy
+from contextlib import contextmanager
+import io
 
 parfileJ0023 = os.path.join(datadir, "J0023+0923_NANOGrav_11yv0.gls.par")
 parJ0023ell1 = os.path.join(datadir, "J0023+0923_ell1_simple.par")
@@ -97,3 +108,507 @@ def test_summary_FB():
     f.print_summary()
 
     assert "PB" in f.get_summary()
+
+
+# ---- hybrid/sparse FBX normalization ----
+
+hybridbase = """
+PSR J1234+5678
+ELAT 0
+ELONG 0
+PEPOCH 57000
+F0 1
+BINARY ELL1
+A1 10
+TASC 57000
+EPS1 0
+EPS2 0
+"""
+
+genericbase = """
+PSR J1234+5678
+ELAT 0
+ELONG 0
+PEPOCH 57000
+F0 1
+"""
+
+PB_DAYS = np.longdouble("0.5")
+FB0_FROM_PB = 1 / (PB_DAYS * np.longdouble(86400))
+DT = np.asarray([0, 1.0e5, 2.0e5], dtype=np.longdouble)
+
+
+@contextmanager
+def captured_warnings():
+    messages = []
+    sink = log.add(
+        lambda message: messages.append(str(message)),
+        level="WARNING",
+        format="{message}",
+    )
+    try:
+        yield messages
+    finally:
+        log.remove(sink)
+
+
+def orbit_count(model, dt_seconds):
+    binary = model.components[
+        next(name for name in model.components if name.startswith("Binary"))
+    ].binary_instance
+    reference_epoch = binary.TASC if hasattr(binary, "TASC") else binary.T0
+    binary.t = reference_epoch + np.atleast_1d(dt_seconds) * u.s
+    return binary.orbits_cls.orbits().to_value(u.dimensionless_unscaled)
+
+
+def test_pb_fb2_inserts_zero_and_uses_fb2():
+    fb2 = np.longdouble("1e-27")
+    with captured_warnings() as messages:
+        model = mb.get_model(io.StringIO(hybridbase + f"PB {PB_DAYS}\nFB2 {fb2}\n"))
+
+    assert model.FB1.value == 0
+    assert model.FB1.frozen
+    expected = FB0_FROM_PB * DT + fb2 * DT**3 / 6
+    assert np.allclose(orbit_count(model, DT), expected, rtol=1e-14, atol=0)
+    assert any("frozen zero" in message for message in messages)
+
+
+def test_pb_pbdot_fb2_uses_both_derivatives():
+    pbdot = np.longdouble("1e-12")
+    fb2 = np.longdouble("1e-27")
+    model = mb.get_model(
+        io.StringIO(hybridbase + f"PB {PB_DAYS}\nPBDOT {pbdot}\nFB2 {fb2}\n")
+    )
+
+    fb1 = -pbdot * FB0_FROM_PB**2
+    expected = FB0_FROM_PB * DT + fb1 * DT**2 / 2 + fb2 * DT**3 / 6
+    assert np.allclose(orbit_count(model, DT), expected, rtol=1e-14, atol=0)
+
+
+def test_explicit_fb0_pbdot_is_not_ignored():
+    pbdot = np.longdouble("1e-12")
+    model = mb.get_model(
+        io.StringIO(hybridbase + f"FB0 {FB0_FROM_PB}\nPBDOT {pbdot}\n")
+    )
+
+    expected_fb1 = -pbdot * FB0_FROM_PB**2
+    assert np.isclose(np.longdouble(str(model.FB1.value)), expected_fb1, rtol=1e-14)
+    expected = FB0_FROM_PB * DT + expected_fb1 * DT**2 / 2
+    assert np.allclose(orbit_count(model, DT), expected, rtol=1e-14, atol=0)
+
+
+def test_pb_fb1_bridges_to_fb0():
+    with captured_warnings() as messages:
+        model = mb.get_model(
+            io.StringIO(hybridbase + f"PB {PB_DAYS} 1 1e-10\nFB1 1e-21\n")
+        )
+    assert np.isclose(np.longdouble(str(model.FB0.value)), FB0_FROM_PB, rtol=1e-14)
+    assert isinstance(model.PB, funcParameter)
+    assert any("PB" in message and "FB0" in message for message in messages)
+
+
+def test_pb_fb1_existing_pbdot_fb1_wins():
+    with captured_warnings() as messages:
+        model = mb.get_model(
+            io.StringIO(hybridbase + f"PB {PB_DAYS}\nPBDOT 1e-12\nFB1 3e-21\n")
+        )
+    assert np.isclose(np.longdouble(str(model.FB1.value)), 3e-21, rtol=1e-14)
+    assert any("PBDOT" in message and "FB1" in message for message in messages)
+    expected_pbdot = -3e-21 / FB0_FROM_PB**2
+    assert np.isclose(
+        model.PBDOT.quantity.to_value(u.s / u.s), expected_pbdot, rtol=1e-10
+    )
+
+
+def test_pb_fb1_fb3_inserts_fb2_zero():
+    with captured_warnings() as messages:
+        model = mb.get_model(
+            io.StringIO(hybridbase + f"PB {PB_DAYS}\nFB1 1e-21\nFB3 1e-40\n")
+        )
+    assert model.FB2.value == 0
+    assert model.FB2.frozen
+    assert any("frozen zero" in message for message in messages)
+    expected = (
+        FB0_FROM_PB * DT
+        + np.longdouble("1e-21") * DT**2 / 2
+        + np.longdouble("1e-40") * DT**4 / 24
+    )
+    assert np.allclose(orbit_count(model, DT), expected, rtol=1e-14, atol=0)
+
+
+def test_explicit_fb0_fb2_inserts_fb1_zero():
+    model = mb.get_model(io.StringIO(hybridbase + f"FB0 {FB0_FROM_PB}\nFB2 1e-27\n"))
+    assert model.FB1.value == 0
+    assert model.FB1.frozen
+    expected = FB0_FROM_PB * DT + np.longdouble("1e-27") * DT**3 / 6
+    assert np.allclose(orbit_count(model, DT), expected, rtol=1e-14, atol=0)
+
+
+def test_hybrid_matches_manual_contiguous_fbx_phase():
+    hybrid = mb.get_model(io.StringIO(hybridbase + f"PB {PB_DAYS}\nFB2 1e-27\n"))
+    manual = mb.get_model(
+        io.StringIO(hybridbase + f"FB0 {FB0_FROM_PB}\nFB1 0\nFB2 1e-27\n")
+    )
+    assert np.allclose(
+        orbit_count(hybrid, DT), orbit_count(manual, DT), rtol=1e-14, atol=0
+    )
+
+
+def test_fb1_uncertainty_uses_pbdot_and_fb0_terms():
+    pb = np.longdouble("0.5")
+    sigma_pb = np.longdouble("2e-7")
+    pbdot = np.longdouble("1e-12")
+    sigma_pbdot = np.longdouble("3e-14")
+    model = mb.get_model(
+        io.StringIO(
+            hybridbase
+            + f"PB {pb} 1 {sigma_pb}\n"
+            + f"PBDOT {pbdot} 1 {sigma_pbdot}\n"
+            + "FB2 1e-27\n"
+        )
+    )
+
+    fb0 = 1 / (pb * np.longdouble(86400))
+    sigma_fb0 = sigma_pb / (pb**2 * np.longdouble(86400))
+    expected = np.sqrt((fb0**2 * sigma_pbdot) ** 2 + (2 * pbdot * fb0 * sigma_fb0) ** 2)
+    assert np.isclose(model.FB0.uncertainty_value, sigma_fb0, rtol=1e-12)
+    assert np.isclose(model.FB1.uncertainty_value, expected, rtol=1e-12)
+    assert not model.FB0.frozen
+    assert not model.FB1.frozen
+
+
+def test_pb_fit_flag_transfers_to_fb0():
+    model = mb.get_model(io.StringIO(hybridbase + f"PB {PB_DAYS} 1 1e-10\nFB2 1e-27\n"))
+    assert not model.FB0.frozen
+    assert "FB0" in model.free_params
+    assert "PB" not in model.free_params
+
+
+def test_pure_pb_is_unchanged():
+    model = mb.get_model(io.StringIO(hybridbase + f"PB {PB_DAYS} 1 1e-10\n"))
+    assert not isinstance(model.PB, funcParameter)
+    assert model.FB0.quantity is None
+    assert "PB" in model.free_params
+
+
+def test_higher_fbn_without_pb_or_fb0_raises():
+    with pytest.raises(ValueError, match="FB0"):
+        mb.get_model(io.StringIO(hybridbase + "FB1 1e-21\n"))
+
+
+def test_nonpositive_hybrid_pb_raises():
+    with pytest.raises(ValueError, match="PB must be positive"):
+        mb.get_model(io.StringIO(hybridbase + "PB -0.5\nFB2 1e-27\n"))
+
+
+def test_xpbdot_with_fbx_raises():
+    component = BinaryDDGR()
+    component.PB.value = np.longdouble("0.5")
+    component.XPBDOT.value = np.longdouble("1e-12")
+    component.add_param(component.FB0.new_param(2))
+    component.FB2.value = np.longdouble("1e-27")
+    with pytest.raises(ValueError, match=r"XPBDOT.*FBX"):
+        component._setup_fbx_parameterization()
+
+
+def test_fb0_pb_conflict_raises_before_mutation():
+    component = BinaryELL1()
+    component.PB.value = np.longdouble("0.5")
+    component.FB0.value = np.longdouble("2.3148148148148148e-5")
+    original_pb = component.PB
+    original_fb0 = component.FB0.value
+    original_params = list(component.params)
+
+    with pytest.raises(
+        ValueError, match="Model cannot have values for both FB0 and PB"
+    ):
+        component._setup_fbx_parameterization()
+
+    assert component.PB is original_pb
+    assert component.FB0.value == original_fb0
+    assert component.params == original_params
+
+
+def test_fbx_canonicalization_is_idempotent():
+    model = mb.get_model(io.StringIO(hybridbase + "PB 0.5\nFB2 1e-27\n"))
+    pb_object = model.PB
+    pbdot_object = model.PBDOT
+    params = list(model.params)
+    values = {name: getattr(model, name).value for name in ("FB0", "FB1", "FB2")}
+
+    with captured_warnings() as messages:
+        model.setup()
+        model.setup()
+
+    assert model.PB is pb_object
+    assert model.PBDOT is pbdot_object
+    assert model.params == params
+    assert {
+        name: getattr(model, name).value for name in ("FB0", "FB1", "FB2")
+    } == values
+    assert not any("Converting PB" in message for message in messages)
+    assert not any("frozen zero" in message for message in messages)
+
+
+def test_all_fbx_models_expose_derived_pb():
+    model = mb.get_model(io.StringIO(hybridbase + f"FB0 {FB0_FROM_PB}\nFB1 0\n"))
+    assert isinstance(model.PB, funcParameter)
+    assert np.isclose(model.PB.quantity.to_value(u.day), float(PB_DAYS), rtol=1e-14)
+
+
+def test_fbx_roundtrip_preserves_derived_view_api():
+    first = mb.get_model(io.StringIO(hybridbase + "PB 0.5\nPBDOT 1e-12\nFB2 1e-27\n"))
+    second = mb.get_model(io.StringIO(first.as_parfile()))
+
+    assert isinstance(first.PB, funcParameter)
+    assert isinstance(second.PB, funcParameter)
+    assert isinstance(first.PBDOT, funcParameter)
+    assert isinstance(second.PBDOT, funcParameter)
+    for name in ("FB0", "FB1", "FB2"):
+        assert getattr(second, name).frozen == getattr(first, name).frozen
+        assert np.isclose(
+            getattr(second, name).value,
+            getattr(first, name).value,
+            rtol=1e-14,
+        )
+    assert "# PB" in first.as_parfile()
+    assert "# PBDOT" in first.as_parfile()
+
+
+def test_fbx_fit_uses_only_fbx_coefficients():
+    model = mb.get_model(io.StringIO(hybridbase + f"PB {PB_DAYS} 1 1e-10\nFB2 1e-27\n"))
+    toas = pint.simulation.make_fake_toas_uniform(
+        54000, 56000, 80, model, add_noise=True
+    )
+    for name in model.free_params:
+        if name != "FB0":
+            getattr(model, name).frozen = True
+    f = fitter.Fitter.auto(toas, model)
+    f.fit_toas()
+    assert "FB0" in f.model.free_params
+    assert "PB" not in f.model.free_params
+    assert np.isfinite(f.resids.calc_chi2())
+
+
+def test_tcb_conversion_commutes_with_fbx_normalization():
+    text = hybridbase + "UNITS TCB\nPB 0.5\nPBDOT 1e-12\nFB2 1e-27\n"
+    raw = mb.get_model(io.StringIO(text), allow_tcb="raw")
+    converted = deepcopy(raw)
+    convert_tcb_tdb(converted)
+    automatic = mb.get_model(io.StringIO(text), allow_tcb=True)
+
+    for name in ("FB0", "FB1", "FB2", "PB", "PBDOT"):
+        assert np.isclose(
+            getattr(converted, name).value,
+            getattr(automatic, name).value,
+            rtol=1e-14,
+        )
+    assert isinstance(converted.PB, funcParameter)
+    assert isinstance(converted.PBDOT, funcParameter)
+
+
+def test_orbitfbx_rejects_caller_supplied_gap():
+    parent = DDmodel()
+    parent.FB0 = 1e-5 / u.s
+    parent.add_binary_params("FB2", 1e-27 / u.s**3)
+    with pytest.raises(
+        ValueError, match="Indices must be 0 up to some number k without gaps"
+    ):
+        OrbitFBX(parent, ["FB0", "FB2"])
+
+
+@pytest.mark.parametrize(
+    "binary_block",
+    [
+        """
+BINARY ELL1
+A1 10
+TASC 57000
+EPS1 0
+EPS2 0
+""",
+        """
+BINARY DD
+A1 10
+T0 57000
+ECC 0.1
+OM 45
+""",
+        """
+BINARY BT
+A1 10
+T0 57000
+ECC 0.1
+OM 45
+""",
+    ],
+)
+def test_fbx_normalization_binary_model_independent(binary_block):
+    fb2 = np.longdouble("1e-27")
+    model = mb.get_model(
+        io.StringIO(genericbase + binary_block + f"\nPB {PB_DAYS}\nFB2 {fb2}\n")
+    )
+    expected = FB0_FROM_PB * DT + fb2 * DT**3 / 6
+    assert np.allclose(orbit_count(model, DT), expected, rtol=1e-14, atol=0)
+
+
+@pytest.mark.parametrize("extra", ["FB2 1e-27", "FB1 -1e-18"])
+def test_ddgr_fbx_rejected_before_mutation(extra):
+    component = BinaryDDGR()
+    component.PB.value = np.longdouble("0.5")
+    component.M2.value = np.longdouble("0.3")
+    component.MTOT.value = np.longdouble("1.7")
+    name, value = extra.split()
+    component.add_param(component.FB0.new_param(int(name[2:])))
+    getattr(component, name).value = np.longdouble(value)
+
+    original_pb = component.PB
+    original_pbdot = component.PBDOT
+    original_fb0 = component.FB0.value
+    original_params = list(component.params)
+
+    with pytest.raises(ValueError, match=r"FBX.*derived PBDOT"):
+        component._setup_fbx_parameterization()
+
+    assert component.PB is original_pb
+    assert component.PBDOT is original_pbdot
+    assert component.FB0.value == original_fb0
+    assert component.params == original_params
+
+
+def test_ddgr_pb_only_is_unchanged():
+    # Use masses/A1 consistent with an inclination that keeps derived SINI in range.
+    from pint import derived_quantities
+
+    mp = 1.4 * u.Msun
+    mc = 0.3 * u.Msun
+    pb = 0.5 * u.day
+    a1 = derived_quantities.a1sini(mp, mc, pb, 75 * u.deg)
+    text = f"""
+PSR J1234+5678
+ELAT 0
+ELONG 0
+PEPOCH 57000
+F0 1
+BINARY DDGR
+A1 {a1.value}
+T0 57000
+ECC 0.1
+OM 45
+PB {pb.value}
+M2 {mc.value}
+MTOT {(mp + mc).value}
+"""
+    model = mb.get_model(io.StringIO(text))
+    assert not isinstance(model.PB, funcParameter)
+    assert model.FB0.quantity is None
+    assert isinstance(model.PBDOT, funcParameter)
+
+
+# ---- pure-FB0 consumer compatibility (API fallout from derived PB / absent PBDOT) ----
+
+pure_fb0_ell1 = """
+PSR J1234+5678
+ELAT 0
+ELONG 0
+PEPOCH 57000
+F0 1
+BINARY ELL1
+A1 10
+TASC 57000
+EPS1 0
+EPS2 0
+FB0 2.3148148148148148e-5
+"""
+
+
+@pytest.mark.parametrize(
+    "binary_block",
+    [
+        """
+BINARY ELL1
+A1 10
+TASC 57000
+EPS1 0
+EPS2 0
+""",
+        """
+BINARY DD
+A1 10
+T0 57000
+ECC 0.1
+OM 45
+""",
+        """
+BINARY BT
+A1 10
+T0 57000
+ECC 0.1
+OM 45
+""",
+        """
+BINARY BT_piecewise
+A1 10
+T0 57000
+ECC 0.1
+OM 45
+""",
+    ],
+)
+def test_pure_fb0_loads_without_writable_pbdot(binary_block):
+    model = mb.get_model(
+        io.StringIO(genericbase + binary_block + f"\nFB0 {FB0_FROM_PB}\n")
+    )
+    assert isinstance(model.PB, funcParameter)
+    assert "PBDOT" not in model.params
+    assert np.isclose(model.PB.quantity.to_value(u.day), float(PB_DAYS), rtol=1e-14)
+
+
+def test_pure_fb0_pb_uses_fbx_coefficients():
+    model = mb.get_model(io.StringIO(pure_fb0_ell1))
+    period, _ = model.pb()
+    assert np.isclose(period.to_value(u.s), 1 / float(FB0_FROM_PB), rtol=1e-14)
+
+
+def test_hybrid_with_fb2_pb_uses_full_fb_series_not_pbdot_only():
+    # pb() must use the FB Taylor branch so FB2 contributes at later times.
+    model = mb.get_model(io.StringIO(hybridbase + f"PB {PB_DAYS}\nFB2 1e-20\n"))
+    t = model.TASC.quantity + (2.0e7 * u.s)
+    period, _ = model.pb(t)
+    # Instantaneous period from dN/dt with FB0 and FB2 (FB1=0):
+    # f(t) = FB0 + FB2 t^2 / 2 ; P = 1/f
+    dt = 2.0e7
+    freq = float(FB0_FROM_PB) + float(np.longdouble("1e-20")) * dt**2 / 2
+    assert np.isclose(period.to_value(u.s), 1 / freq, rtol=1e-12)
+
+
+def test_convert_binary_pure_fb0_ell1_to_dd():
+    import pint.binaryconvert
+
+    # Uncertainties on EPS1/EPS2 are required so ELL1→DD OM conversion is defined.
+    par = """
+PSR J1234+5678
+ELAT 0
+ELONG 0
+PEPOCH 57000
+F0 1
+BINARY ELL1
+A1 10 0 1e-6
+TASC 57000 0 1e-8
+EPS1 -2e-5 0 1e-8
+EPS2 2e-6 0 1e-8
+SINI 0.9 0 0.01
+M2 0.2 0 0.01
+FB0 2.3148148148148148e-5 1 1e-18
+"""
+    model = mb.get_model(io.StringIO(par))
+    assert isinstance(model.PB, funcParameter)
+    assert "PBDOT" not in model.params
+    converted = pint.binaryconvert.convert_binary(model, "DD")
+    assert converted.BINARY.value == "DD"
+    assert isinstance(converted.PB, funcParameter)
+    # setup-before-validate must not invent PBDOT=0 → FB1=0.
+    assert "FB1" not in converted.params
+    assert "PBDOT" not in converted.params
+    period, _ = converted.pb()
+    assert np.isclose(period.to_value(u.d), model.pb()[0].to_value(u.d), rtol=1e-14)


### PR DESCRIPTION
### Description

Two classes of published PTA timing models are mathematically well-defined but
currently rejected or incompletely represented by PINT (issue #2022 ).

#### 1. Canonical orbital-frequency Taylor series

The binary orbital phase can be written as the number of elapsed orbits

```text
N(dt) = FB0 dt
      + FB1 dt² / 2!
      + FB2 dt³ / 3!
      + ...
      + FBn dt^(n+1) / (n+1)! ,
```

where `dt = t - Tref` in seconds. The period representation supplies the first
two coefficients through

```text
FB0 = 1 / (PB × 86400)
FB1 = -PBDOT × FB0².
```

Some published tempo2 par files use `PB` for the constant term while supplying
`FB1`, `FB2`, ... directly. PPTA DR2/DR3 J2241−5236, for example, provides
`PB + FB1...FB17` but no `FB0`. Tempo2 evaluates that file by using
`1/PB` as the constant orbital frequency. PINT previously rejected it because
its FBX implementation required an explicit `FB0`.

This PR normalizes every such model to one canonical FBX representation:

- `PB` is converted exactly to the nominal `FB0`;
- an ordinary `PBDOT` is converted to `FB1` when no explicit `FB1` exists;
- explicit `FB1` wins over redundant `PBDOT`, with a warning;
- missing interior Taylor coefficients are inserted as frozen zeros;
- `PB` and, when `FB1` is present, `PBDOT` remain available as read-only
  derived views.

An explicitly valued ordinary `PB` together with an explicitly valued ordinary
`FB0` remains an error and is rejected before normalization mutates the model.
For an existing pure-FBX model, this canonicalization is an API/output change:
`PB` and applicable `PBDOT` values become derived views,
`as_parfile()` gains commented `# PB`/`# PBDOT` lines, and an unset writable
`PBDOT` that the FBX orbit would ignore is removed.

Treating a missing interior coefficient as zero is important physically. For
example,

```text
PB + FB2
```

means

```text
FB0 = 1/(PB × 86400),   FB1 = 0,   FB2 = supplied value,
```

not “ignore FB2.” PINT's previous `OrbitFBX` implementation could silently
drop `FB2+` after a missing index. This PR fixes that independent bug and adds
equation-level phase tests ensuring that every supplied coefficient actually
contributes.

Tempo2 ELL1 currently uses the presence of `FB1` as a sentinel for the entire
higher-FB branch, so it ignores `FB2+` when `FB1` is omitted. PINT intentionally
uses the complete Taylor-series interpretation instead. The published
J2241−5236 model has a contiguous series and therefore remains exactly
tempo2-compatible.

The intentional timing deviations from current tempo2 are limited and
explicit:

- `PB + FB2` and `FB0 + FB2`: PINT uses `FB2` with an inserted `FB1=0`;
  tempo2 ELL1 currently ignores `FB2`;
- `PB + PBDOT + FB2`: PINT applies both the equivalent `FB1` and `FB2`;
  tempo2 applies only the PBDOT-equivalent term;
- non-ELL1 use is a deliberate PINT generalization of its existing FBX phase
  machinery;
- DDGR+FBX is rejected by PINT, whereas current tempo2 DDGR silently uses
  `PB` and ignores `FBn`. The companion tempo2 PR should reject this
  unsupported combination too.

Conversely, `FB0 + PBDOT` has the same nominal phase in tempo2 ELL1 and in the
new PINT representation: PINT now converts it to `FB1` instead of silently
ignoring it as current PINT does. A companion tempo2 issue/PR will replace the
`FB1` sentinel with the same complete-series rule so the sparse cases converge
back to compatibility.

FBX is treated as the complete orbital-phase parameterization for every PINT
binary model that supports it, not as an additive correction to PB/PBDOT.
Accordingly, dynamically derived values such as DDGR's GR prediction for
`PBDOT` are never evaluated once and copied into an independent `FB1`; doing so
would become stale when masses change.

This PR explicitly rejects DDGR+FBX. A tempting normalization is to insert
`FB1=0` and expose FB-derived `PBDOT=0`, but that fixes only the phase label:
DDGR derives post-Keplerian quantities directly from `PB`, and its analytic
derivatives are expressed with respect to `PB`. A physically correct FBX
implementation must keep those quantities synchronized through
`PB=1/(86400 FB0)` and add

```text
d(PK)/d(FB0) = d(PK)/d(PB) × d(PB)/d(FB0),
d(PB)/d(FB0) = -1/(86400 FB0²).
```

Until that larger change is implemented and derivative-tested, accepting the
combination would produce an internally inconsistent timing model. A valued
`XPBDOT` with FBX is likewise rejected until a dynamic combination rule is
explicitly designed.

The nominal phase transformation is exact. Reported marginal uncertainties are
mapped with the first-order Jacobian:

```text
sigma_FB0 = sigma_PB / (PB² × 86400)

sigma_FB1² =
    (FB0² sigma_PBDOT)²
  + (2 PBDOT FB0 sigma_FB0)².
```

The nonlinear change also creates `FB0`–`FB1` covariance that a par file cannot
represent; this PR does not claim lossless covariance transfer.

#### 2. DDH with a signed weak-signal H3 estimate

The DDH orthometric parameters map to the traditional Shapiro quantities as

```text
SINI = 2 STIGMA / (1 + STIGMA²)
M2   = H3 / (Tsun STIGMA³).
```

For finite positive `STIGMA`, the Shapiro delay is

```text
DeltaS = -2 H3 / STIGMA³ × log(B),
```

where `B` is the usual DD orbital geometry term. Wherever `B>0`, the delay is
linear and smooth in `H3`, including through `H3=0`; changing the sign of `H3`
does not change the logarithm's domain.

For a weak or absent Shapiro signal, an unconstrained amplitude estimate can
legitimately cross zero. MPTA DR2 J1825−0319 has such a best fit:

```text
H3   < 0
STIG > 0.
```

The corresponding derived `M2` is negative. That is not a physical companion
mass, but rejecting the model also rejects a finite, differentiable signed
amplitude fit that tempo2 can evaluate. It prevents faithful residual
comparison and can prevent a fitter from crossing the zero-signal point.

This PR therefore allows negative `H3` in `BinaryDDH` and warns that the
negative derived `M2` has no physical mass interpretation. The exception is
specific to DDH's smooth signed-`H3` extension:

- free negative `M2` still raises;
- generic derived `SINI` validation is unchanged;
- `STIGMA` must remain finite and positive;
- `STIGMA=0` is rejected because the model contains inverse powers of it;
- other binary models receive no blanket `funcParameter` exemption.

Tempo2 evaluates negative `H3` without PINT's derived-mass gate, so the nominal
DDH delay remains compatible. PINT intentionally remains stricter for
`STIGMA<=0`: negative values are outside the adopted physical domain and zero
is singular.

With the prototype normalization, the published PPTA DR3 J2241−5236 dataset
loads with finite residuals at approximately 0.821 µs RMS, and the MPTA DR2
J1825−0319 dataset loads as DDH with approximately 5.677 µs RMS, matching the
tempo2/libstempo timing evidence used to motivate the change.

#### Scope and tests

The implementation is confined to binary-parameter normalization, FBX gap
validation, DDH-native validation, documentation, and tests. Tests cover sparse
series, phase equivalence, uncertainties, fit flags, serialization,
idempotency, TCB conversion, general binary models, DDGR+FBX rejection before
mutation, negative-H3 continuity and fitting, and unchanged free-M2/SINI
validation.

Reported by Wang-Wei Yu @Wang-weiYu  during IPTA DR3 / 5-PTA combination testing with
the updated MetaPulsar version.
