### PR TITLE
Fix binary128 MJD strings and document Apple Silicon containers

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -22,6 +22,7 @@ the released changes.
 - `ssb_to_psb_xyz_ECL` and `ssb_to_psb_xyz_ICRS` are now cached
 ### Fixed
 - Precision tests / MJD string length on platforms with true `float128` `longdouble` (e.g. Linux aarch64): stop truncating via a fixed `U30` dtype and emit enough digits for `str(longdouble)`
+- Binary-convert roundtrip tests and START/FINISH MJD checks: stop requiring bit-identical `longdouble`/`Time` equality on binary128 (TASC↔T0 goes through float64; MJDParameter stores via jd1/jd2)
 - `WidebandTOAFitter` raises a warning if the model has correlated errors (It used to give wrong results before).
 - Fixed bug where "include_bipm" flag was being ignored when loading Fermi TOAs with weights, now defaults to using EPHEM, CLOCK and PLANET_SHAPIRO from the timing model
 - When flags are created based off jumps uses strings instead of None

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -15,10 +15,13 @@ the released changes.
 - Updated GMRT coordinates.
 - Replaced custom ``pint.ls`` with astropy ``u.lsec``
 - Updated code to remove deprecation warnings during CI
+- Document Apple Silicon via native ``linux/arm64`` containers (`nanograv/ng20`) instead of claiming PINT cannot run there; Rosetta/osx-64 remains an alternative
+- MJD string formatting uses enough fractional digits for the platform's `numpy.longdouble` precision (needed for IEEE binary128 on Linux aarch64)
 ### Added
 - Plot whitened DM residuals in pintk.
 - `ssb_to_psb_xyz_ECL` and `ssb_to_psb_xyz_ICRS` are now cached
 ### Fixed
+- Precision tests / MJD string length on platforms with true `float128` `longdouble` (e.g. Linux aarch64): stop truncating via a fixed `U30` dtype and emit enough digits for `str(longdouble)`
 - `WidebandTOAFitter` raises a warning if the model has correlated errors (It used to give wrong results before).
 - Fixed bug where "include_bipm" flag was being ignored when loading Fermi TOAs with weights, now defaults to using EPHEM, CLOCK and PLANET_SHAPIRO from the timing model
 - When flags are created based off jumps uses strings instead of None

--- a/README.rst
+++ b/README.rst
@@ -62,12 +62,19 @@ IMPORTANT Notes!
 PINT has a naming conflict with the `pint <https://pypi.org/project/Pint/>`_ units package available from PyPI (i.e. using pip) and conda.  
 Do **NOT** ``pip install pint`` or ``conda install pint``!  See below!
 
-PINT requires ``longdouble`` (80- or 128-bit floating point) arithmetic within ``numpy``, which is currently not supported natively on M1/M2/M3 Macs. 
-However, you can use an x86 version of ``conda`` even on an M1/M2/M3 Mac (which will run under Rosetta emulation): 
-see `instructions for using Apple Intel packages on Apple 
-silicon <https://conda-forge.org/docs/user/tipsandtricks.html#installing-apple-intel-packages-on-apple-silicon>`_. 
-It's possible to have `parallel versions of conda for x86 and 
-ARM <https://towardsdatascience.com/python-conda-environments-for-both-arm64-and-x86-64-on-m1-apple-silicon-147b943ffa55>`_.
+PINT requires ``longdouble`` (80- or 128-bit floating point) arithmetic within
+``numpy``. On native macOS ARM Python builds, ``numpy.longdouble`` is usually
+just ``float64``, which is not enough for high-precision timing. Prefer one of:
+
+* **Linux containers on Apple Silicon (recommended):** a multi-arch image such as
+  `nanograv/ng20:cpu <https://hub.docker.com/r/nanograv/ng20>`_ provides a native
+  ``linux/arm64`` environment with true IEEE binary128 ``longdouble`` — full
+  PINT precision at native speed (no Rosetta). See the installation docs for
+  short usage examples, including optional ``pintk`` GUI setup.
+* **Rosetta / osx-64 conda or Pixi:** an x86_64 Python stack under Rosetta also
+  works (80-bit ``longdouble``), but is slower than a native arm64 Linux
+  container. See `conda-forge tips for Apple Intel packages on Apple
+  silicon <https://conda-forge.org/docs/user/tipsandtricks.html#installing-apple-intel-packages-on-apple-silicon>`_.
 
 
 Installing

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -67,18 +67,22 @@ is that ``numpy`` provides floating-point types, for example,
    >>> (10*u.year*np.finfo(np.longdouble).eps).to(u.ns)
    <Quantity 0.03421482 ns>
 
-These numbers are represented with 80 bits, and most desktop and server
-machines have hardware for computing with these numbers, so they are not
-much slower than ordinary ("double-precision", 64-bit) floating-point
-numbers. Let me warn you about one point of possible confusion: modern
-computers have very complicated cache setups that prefer data to be
-aligned just so in memory, so ``numpy`` generally pads these numbers out
-with zeroes and stores them in larger memory spaces. Thus you will often
-see ``np.float96`` and ``np.float128`` types; these contain only
-numbers with 80-bit precision. Actual 128-bit precision is not currently
-available in ``numpy``, in part because on almost all current machines all
-calculations must be carried out in software, which takes 20-50 times as
-long.
+On typical x86_64 machines these values use 80-bit extended precision, with
+hardware support so they are not much slower than ordinary
+("double-precision", 64-bit) floating-point numbers. Modern CPUs have
+complicated cache alignment preferences, so ``numpy`` often pads these
+numbers in memory; you will therefore often see ``np.float96`` or
+``np.float128`` *dtypes* that still hold only 80-bit precision.
+
+True IEEE binary128 (about 33 decimal digits) *is* available as
+``numpy.longdouble`` on some platforms — notably Linux on aarch64 (including
+Apple Silicon hosts running a native ``linux/arm64`` container). Those
+operations are usually implemented in software and can be slower per
+operation than 80-bit hardware ``longdouble``, but they provide more
+precision. By contrast, native macOS ARM Python builds typically make
+``numpy.longdouble`` an alias of ``float64``, which is not enough for PINT;
+use a Linux arm64 container or an x86_64 (Rosetta) environment instead (see
+:ref:`Installation`).
 
 An alternative approach to dealing with more precision than your machine's
 floating-point numbers natively support is to represent numbers as a pair

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,15 +30,66 @@ Naming conflict
 PINT has a naming conflict with the `pint <https://pypi.org/project/Pint/>`_ units package available from PyPI (i.e. using pip) and conda.  
 Do **NOT** ``pip install pint`` or ``conda install pint``!  See :ref:`Basic Install via pip` or :ref:`Install with Anaconda`.
 
-Apple Silicon (M1/M2/M3 ...) processors
-'''''''''''''''''''''''''''''''''''''''
+Apple Silicon (M1/M2/M3/M4 ...) processors
+'''''''''''''''''''''''''''''''''''''''''
 
-PINT requires ``longdouble`` (80- or 128-bit floating point) arithmetic within ``numpy``, which is currently not supported natively on Apple Silicon Macs. 
-However, you can use an x86 version of ``conda`` even on an Apple Silicon Mac (which runs under Rosetta). This can be managed most easily 
-using `Pixi <https://pixi.prefix.dev/latest/>`_ 
-by putting ``platforms = ["osx-64"]`` in your ``pixi.toml`` or you can do it manually 
-(see `instructions for using Apple Intel packages on Apple silicon <https://conda-forge.org/docs/user/tipsandtricks.html#installing-apple-intel-packages-on-apple-silicon>`_ and note that
-it is possible to have `parallel versions of conda for x86 and ARM <https://towardsdatascience.com/python-conda-environments-for-both-arm64-and-x86-64-on-m1-apple-silicon-147b943ffa55>`_).
+PINT requires ``longdouble`` (80- or 128-bit floating point) arithmetic within
+``numpy``. On **native macOS ARM** Python builds, ``numpy.longdouble`` is usually
+aliased to ``float64``, which is not enough for high-precision timing.
+
+**Recommended: native-speed Linux containers (arm64)**
+
+Use a multi-arch Linux container. On Apple Silicon Docker pulls the
+``linux/arm64`` image and runs it at native speed (not Rosetta). Such images
+provide true IEEE binary128 ``numpy.longdouble`` — more precision than typical
+x86_64 80-bit ``longdouble``::
+
+    # NANOGrav 20-year analysis environment
+    docker pull nanograv/ng20:cpu
+    docker run --rm -it \
+      -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) \
+      -v "$PWD":/work -w /work \
+      nanograv/ng20:cpu bash
+
+Quick check inside the container::
+
+    python -c "import numpy as np; print(np.finfo(np.longdouble))"
+
+You should see a ``float128`` / binary128-class result (eps around ``1e-34``),
+not ``float64``.
+
+Image and further docs:
+
+* `nanograv/ng20 <https://hub.docker.com/r/nanograv/ng20>`_
+
+This image also works as a VS Code / Cursor Dev Container.
+
+**Optional: ``pintk`` GUI via X11**
+
+To display ``pintk`` from the container on a Mac, run an X server (e.g. XQuartz),
+allow local connections (``xhost + 127.0.0.1``), and pass ``DISPLAY`` into the
+container, for example::
+
+    docker run --rm -it \
+      -e HOST_UID=$(id -u) -e HOST_GID=$(id -g) \
+      -e DISPLAY=host.docker.internal:0 \
+      -v "$PWD":/work -w /work \
+      nanograv/ng20:cpu \
+      pintk your.par your.tim
+
+For Dev Containers, set the same ``DISPLAY`` value (and any needed X11 mounts)
+in a local override such as ``.devcontainer/devcontainer.local.json``; keep that
+file untracked.
+
+
+**Alternative: Rosetta / osx-64 conda or Pixi**
+
+An x86_64 Python stack under Rosetta also provides 80-bit ``longdouble``, but
+is slower than a native arm64 Linux container. With Pixi, set
+``platforms = ["osx-64"]`` in ``pixi.toml``, or follow
+`conda-forge tips for Apple Intel packages on Apple silicon
+<https://conda-forge.org/docs/user/tipsandtricks.html#installing-apple-intel-packages-on-apple-silicon>`_
+(parallel arm64 and x86 conda installs are possible).
 
 
 Basic Install via pip

--- a/src/pint/pulsar_mjd.py
+++ b/src/pint/pulsar_mjd.py
@@ -503,6 +503,14 @@ def str_to_mjds(s):
         return it.operands[1], it.operands[2]
 
 
+# Fractional digits for MJD strings: enough that len(mjd_string) covers
+# str(np.longdouble) on this platform. 16 was enough for 80-bit longdouble;
+# true IEEE binary128 (e.g. Linux aarch64) needs ~33 significant digits.
+_mjd_frac_digits = max(16, int(np.finfo(np.longdouble).precision))
+# Room for sign, integer MJD digits, decimal point, and fractional digits.
+_mjd_str_dtype = np.dtype(f"U{_mjd_frac_digits + 20}")
+
+
 def _mjds_to_str(mjd1, mjd2):
     (imjd, fmjd) = day_frac(mjd1, mjd2)
     imjd = int(imjd)
@@ -511,11 +519,11 @@ def _mjds_to_str(mjd1, mjd2):
         imjd -= 1
         fmjd += 1.0
     assert 0 <= fmjd < 1
-    return str(imjd) + "{:.16f}".format(fmjd)[1:]
+    return str(imjd) + f"{{:.{_mjd_frac_digits}f}}".format(fmjd)[1:]
     # return str(imjd) + str(1+fmjd)[1:]
 
 
-_v_mjds_to_str = np.vectorize(_mjds_to_str, otypes=[np.dtype("U30")])
+_v_mjds_to_str = np.vectorize(_mjds_to_str, otypes=[_mjd_str_dtype])
 
 
 def mjds_to_str(mjd1, mjd2):

--- a/tests/test_binconvert.py
+++ b/tests/test_binconvert.py
@@ -10,6 +10,32 @@ import pint.simulation
 import pint.fitter
 import pint.binaryconvert
 
+
+def _assert_roundtrip_value(p, m, mback):
+    """Compare one parameter after a binary-model roundtrip.
+
+    Numeric parameters use ``np.isclose``.  MJD/``Time`` parameters cannot use
+    exact ``==``: ``convert_binary`` propagates TASC↔T0 through
+    ``uncertainties`` (float64), and platforms with IEEE binary128
+    ``numpy.longdouble`` (e.g. Linux aarch64) expose sub-ns residuals that
+    still matched under 80-bit x87 longdouble bit-equality by coincidence.
+    Allow about one float64 ulp at the MJD magnitude.
+    """
+    q = getattr(m, p).quantity
+    v0, v1 = getattr(m, p).value, getattr(mback, p).value
+    if isinstance(q, (str, bool)):
+        assert v0 == v1, f"{p}: {v0} does not match {v1}"
+    elif isinstance(q, astropy.time.Time):
+        a = np.longdouble(v0)
+        b = np.longdouble(v1)
+        atol = np.finfo(np.float64).eps * max(abs(float(a)), abs(float(b)), 1.0)
+        assert np.isclose(a, b, rtol=0.0, atol=atol), (
+            f"{p}: {v0} does not match {v1}"
+        )
+    else:
+        assert np.isclose(v0, v1), f"{p}: {v0} does not match {v1}"
+
+
 parDD = """
 PSRJ           1855+09
 RAJ             18:57:36.3932884         0  0.00002602730280675029
@@ -181,21 +207,17 @@ def test_ELL1_roundtrip(output):
             continue
         if getattr(m, p).value is None:
             continue
-        if not isinstance(getattr(m, p).quantity, (str, bool, astropy.time.Time)):
+        _assert_roundtrip_value(p, m, mback)
+        if (
+            not isinstance(getattr(m, p).quantity, (str, bool, astropy.time.Time))
+            and getattr(m, p).uncertainty is not None
+        ):
+            # some precision may be lost in uncertainty conversion
             assert np.isclose(
-                getattr(m, p).value, getattr(mback, p).value
-            ), f"{p}: {getattr(m, p).value} does not match {getattr(mback, p).value}"
-            if getattr(m, p).uncertainty is not None:
-                # some precision may be lost in uncertainty conversion
-                assert np.isclose(
-                    getattr(m, p).uncertainty_value,
-                    getattr(mback, p).uncertainty_value,
-                    rtol=0.2,
-                ), f"{p} uncertainty: {getattr(m, p).uncertainty_value} does not match {getattr(mback, p).uncertainty_value}"
-        else:
-            assert (
-                getattr(m, p).value == getattr(mback, p).value
-            ), f"{p}: {getattr(m, p).value} does not match {getattr(mback, p).value}"
+                getattr(m, p).uncertainty_value,
+                getattr(mback, p).uncertainty_value,
+                rtol=0.2,
+            ), f"{p} uncertainty: {getattr(m, p).uncertainty_value} does not match {getattr(mback, p).uncertainty_value}"
 
 
 @pytest.mark.parametrize("output", ["ELL1", "ELL1H", "ELL1k", "DD", "BT", "DDS", "DDK"])
@@ -217,21 +239,17 @@ def test_ELL1_roundtripFB0(output):
             continue
         if getattr(m, p).value is None:
             continue
-        if not isinstance(getattr(m, p).quantity, (str, bool, astropy.time.Time)):
+        _assert_roundtrip_value(p, m, mback)
+        if (
+            not isinstance(getattr(m, p).quantity, (str, bool, astropy.time.Time))
+            and getattr(m, p).uncertainty is not None
+        ):
+            # some precision may be lost in uncertainty conversion
             assert np.isclose(
-                getattr(m, p).value, getattr(mback, p).value
-            ), f"{p}: {getattr(m, p).value} does not match {getattr(mback, p).value}"
-            if getattr(m, p).uncertainty is not None:
-                # some precision may be lost in uncertainty conversion
-                assert np.isclose(
-                    getattr(m, p).uncertainty_value,
-                    getattr(mback, p).uncertainty_value,
-                    rtol=0.2,
-                ), f"{p} uncertainty: {getattr(m, p).uncertainty_value} does not match {getattr(mback, p).uncertainty_value}"
-        else:
-            assert (
-                getattr(m, p).value == getattr(mback, p).value
-            ), f"{p}: {getattr(m, p).value} does not match {getattr(mback, p).value}"
+                getattr(m, p).uncertainty_value,
+                getattr(mback, p).uncertainty_value,
+                rtol=0.2,
+            ), f"{p} uncertainty: {getattr(m, p).uncertainty_value} does not match {getattr(mback, p).uncertainty_value}"
 
 
 @pytest.mark.parametrize(
@@ -266,23 +284,23 @@ def test_DD_roundtrip(output):
         if getattr(m, p).value is None:
             continue
         # print(getattr(m, p), getattr(mback, p))
-        if not isinstance(getattr(m, p).quantity, (str, bool, astropy.time.Time)):
-            assert np.isclose(getattr(m, p).value, getattr(mback, p).value)
-            if getattr(m, p).uncertainty is not None:
-                # some precision may be lost in uncertainty conversion
-                if output in ["ELL1", "ELL1H", "ELL1k"] and p in ["ECC"]:
-                    # we lose precision on ECC since it also contains a contribution from OM now
-                    continue
-                if output in ["ELL1H", "DDH"] and p == "M2":
-                    # this also loses precision
-                    continue
-                assert np.isclose(
-                    getattr(m, p).uncertainty_value,
-                    getattr(mback, p).uncertainty_value,
-                    rtol=0.2,
-                ), f"Parameter '{p}' failed: initial uncertainty {getattr(m, p).uncertainty_value} but returned {getattr(mback, p).uncertainty_value}"
-        else:
-            assert getattr(m, p).value == getattr(mback, p).value
+        _assert_roundtrip_value(p, m, mback)
+        if (
+            not isinstance(getattr(m, p).quantity, (str, bool, astropy.time.Time))
+            and getattr(m, p).uncertainty is not None
+        ):
+            # some precision may be lost in uncertainty conversion
+            if output in ["ELL1", "ELL1H", "ELL1k"] and p in ["ECC"]:
+                # we lose precision on ECC since it also contains a contribution from OM now
+                continue
+            if output in ["ELL1H", "DDH"] and p == "M2":
+                # this also loses precision
+                continue
+            assert np.isclose(
+                getattr(m, p).uncertainty_value,
+                getattr(mback, p).uncertainty_value,
+                rtol=0.2,
+            ), f"Parameter '{p}' failed: initial uncertainty {getattr(m, p).uncertainty_value} but returned {getattr(mback, p).uncertainty_value}"
 
 
 @pytest.mark.parametrize("output", ["ELL1", "ELL1H", "ELL1k", "DD", "BT", "DDS", "DDK"])
@@ -332,23 +350,23 @@ def test_DDFB0_roundtrip(output):
         if getattr(m, p).value is None:
             continue
         # print(getattr(m, p), getattr(mback, p))
-        if not isinstance(getattr(m, p).quantity, (str, bool, astropy.time.Time)):
-            assert np.isclose(getattr(m, p).value, getattr(mback, p).value)
-            if getattr(m, p).uncertainty is not None:
-                # some precision may be lost in uncertainty conversion
-                if output in ["ELL1", "ELL1H", "ELL1k"] and p in ["ECC"]:
-                    # we lose precision on ECC since it also contains a contribution from OM now
-                    continue
-                if output == "ELL1H" and p == "M2":
-                    # this also loses precision
-                    continue
-                assert np.isclose(
-                    getattr(m, p).uncertainty_value,
-                    getattr(mback, p).uncertainty_value,
-                    rtol=0.2,
-                )
-        else:
-            assert getattr(m, p).value == getattr(mback, p).value
+        _assert_roundtrip_value(p, m, mback)
+        if (
+            not isinstance(getattr(m, p).quantity, (str, bool, astropy.time.Time))
+            and getattr(m, p).uncertainty is not None
+        ):
+            # some precision may be lost in uncertainty conversion
+            if output in ["ELL1", "ELL1H", "ELL1k"] and p in ["ECC"]:
+                # we lose precision on ECC since it also contains a contribution from OM now
+                continue
+            if output == "ELL1H" and p == "M2":
+                # this also loses precision
+                continue
+            assert np.isclose(
+                getattr(m, p).uncertainty_value,
+                getattr(mback, p).uncertainty_value,
+                rtol=0.2,
+            )
 
 
 def test_ELL1_ELL1H():

--- a/tests/test_binconvert.py
+++ b/tests/test_binconvert.py
@@ -29,9 +29,7 @@ def _assert_roundtrip_value(p, m, mback):
         a = np.longdouble(v0)
         b = np.longdouble(v1)
         atol = np.finfo(np.float64).eps * max(abs(float(a)), abs(float(b)), 1.0)
-        assert np.isclose(a, b, rtol=0.0, atol=atol), (
-            f"{p}: {v0} does not match {v1}"
-        )
+        assert np.isclose(a, b, rtol=0.0, atol=atol), f"{p}: {v0} does not match {v1}"
     else:
         assert np.isclose(v0, v1), f"{p}: {v0} does not match {v1}"
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -348,8 +348,10 @@ class TestParameters:
         m1 = self.m
         t1 = get_TOAs("B1855+09_NANOGrav_dfg+12.tim")
 
-        start_preval = 53358.726464889485214
-        finish_preval = 55108.922917417192366
+        # Par-file digits as longdouble (not float64 literals): on IEEE binary128
+        # platforms, MJDParameter keeps more precision than a Python float.
+        start_preval = np.longdouble("53358.726464889485214")
+        finish_preval = np.longdouble("55108.922917417192366")
         start_postval = 53358.7274648895  # from Tempo2
         finish_postval = 55108.9219174172  # from Tempo2
 
@@ -359,8 +361,10 @@ class TestParameters:
         assert hasattr(m1, "FINISH")
         assert isinstance(m1.FINISH, MJDParameter)
 
-        assert m1.START.value == start_preval
-        assert m1.FINISH.value == finish_preval
+        # MJDParameter stores via Time (jd1/jd2); allow ~1 float64 ulp at this MJD
+        _mjd_atol = np.finfo(float).eps * float(start_preval)
+        assert m1.START.value == pytest.approx(start_preval, abs=_mjd_atol)
+        assert m1.FINISH.value == pytest.approx(finish_preval, abs=_mjd_atol)
         assert m1.START.frozen == True
         assert m1.FINISH.frozen == True
 


### PR DESCRIPTION
## Summary

- Document Apple Silicon via native `linux/arm64` containers (e.g. `nanograv/ng20`) at native speed; keep Rosetta/`osx-64` as a slower alternative; add succinct `pintk`/X11 usage.
- Format MJD strings with enough fractional digits for the platform `numpy.longdouble` precision, and widen the vectorize string dtype (was `U30`), so precision tests pass on IEEE binary128 (Linux aarch64).
- Lightly update the numerical-precision explanation for real `float128` on aarch64 Linux vs `float64`-aliased macOS ARM.
- Fix follow-on test brittleness exposed by binary128 / higher MJD precision:
  - `convert_binary` roundtrips: stop requiring bit-identical `Time`/MJD equality for TASC/T0 (propagation uses `uncertainties`/float64; sub-ns residuals show up under binary128).
  - `START`/`FINISH` par-file checks: compare against `np.longdouble` digit strings with a ~1 float64-ulp tolerance (MJDParameter stores via jd1/jd2; Python `float` literals truncate).

Fixes #2024

## Test plan

- [x] `pytest tests/test_precision.py` on `linux/arm64` — 91 passed, 6 xfailed
- [x] Related `tests/test_utils.py` MJD/longdouble cases
- [x] Targeted binary128 follow-ups on `linux/arm64`:
  ```bash
  pytest tests/test_binconvert.py::test_ELL1_roundtrip \
         tests/test_binconvert.py::test_ELL1_roundtripFB0 \
         tests/test_binconvert.py::test_DD_roundtrip \
         tests/test_binconvert.py::test_DDFB0_roundtrip \
         tests/test_parameters.py::TestParameters::test_start_finish_in_par -q
  ```
  (31 passed)
- [x] CI on x86_64 still green (80-bit `longdouble` path unchanged in spirit; digit count stays ≥ 16)
