### PR TITLE
fix(model_builder): prefer DD over BT when guessing T2 binary model

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -19,6 +19,7 @@ the released changes.
 - Plot whitened DM residuals in pintk.
 - `ssb_to_psb_xyz_ECL` and `ssb_to_psb_xyz_ICRS` are now cached
 ### Fixed
+- Prefer DD over BT when guessing the binary model for Tempo2 `T2` par files (`allow_T2`), matching Tempo2's `allTerms=1` behavior
 - `WidebandTOAFitter` raises a warning if the model has correlated errors (It used to give wrong results before).
 - Fixed bug where "include_bipm" flag was being ignored when loading Fermi TOAs with weights, now defaults to using EPHEM, CLOCK and PLANET_SHAPIRO from the timing model
 - When flags are created based off jumps uses strings instead of None

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -35,10 +35,14 @@ from pint.utils import get_unit, interesting_lines, lines_of, split_prefixed_nam
 __all__ = ["ModelBuilder", "get_model", "get_model_and_toas"]
 
 default_models = ["StandardTimingModel"]
+# Prefer the most specific model that still covers every binary parameter in the
+# par file. Order matters when several models are allowed: Tempo2's T2 with
+# Keplerian parameters (T0/ECC/OM) matches DD (allTerms=1), not BT, so DD must
+# precede BT. DD-family extensions (DDK/DDGR/DDS/DDH) must follow bare DD so a
+# plain Keplerian T2 does not map to DDK/DDH merely because those models also
+# accept T0/ECC/OM.
 _binary_model_priority = [
     "Isolated",
-    "BT",
-    "BT_piecewise",
     "ELL1",
     "ELL1H",
     "ELL1k",
@@ -47,6 +51,8 @@ _binary_model_priority = [
     "DDGR",
     "DDS",
     "DDH",
+    "BT",
+    "BT_piecewise",
 ]
 
 

--- a/tests/test_process_parfile.py
+++ b/tests/test_process_parfile.py
@@ -183,6 +183,23 @@ SINI KIN
 #SINI 0.95
 """
 
+# Keplerian T2: BT and DD both cover these parameters, but Tempo2 T2
+# (allTerms=1) matches DD, so DD must win over BT.
+dd_par = """
+PSR J1234+5678
+ELAT 0 1 2
+ELONG 0 1 3
+F0 1 1 5
+DM 10 0 3
+PEPOCH 57000
+BINARY T2
+PB 60
+T0 54300
+A1 30
+OM 150
+ECC 8.0e-05
+"""
+
 ell1h_par = """
 PSR J1234+5678
 ELAT 0 1 2
@@ -222,9 +239,9 @@ H4 1.0e-07
 
 
 def test_guess_binary_model():
-    parfiles = [base_par, ddk_par, ell1h_par, nobinarymodel_par]
-    binary_models = ["Isolated", "DDK", "ELL1H", None]
-    trip_raise = [False, True, True, True]
+    parfiles = [base_par, ddk_par, dd_par, ell1h_par, nobinarymodel_par]
+    binary_models = ["Isolated", "DDK", "DD", "ELL1H", None]
+    trip_raise = [False, True, True, True, True]
 
     for parfile, binary_model, trip in zip(parfiles, binary_models, trip_raise):
         par_dict = parse_parfile(StringIO(parfile))


### PR DESCRIPTION
## Summary
- Reorder `_binary_model_priority` so Keplerian Tempo2 `BINARY T2` pars (`T0`/`ECC`/`OM`/…) map to **DD** instead of **BT**.
- Keep DD-family extensions (`DDK`/`DDGR`/`DDS`/`DDH`) *after* bare DD so plain Keplerian T2 does not mis-map to those models.
- Add a regression case: Keplerian T2 → `DD` in `test_guess_binary_model`.

This fixes #2027 

## Motivation
Tempo2’s T2 model with default `allTerms=1` is effectively the Damour–Deruelle (DD) delay, not the BT truncation. Under `allow_T2`, both BT and DD are often allowed for the same Keplerian parameter set; the old priority put BT first, so PINT silently chose the wrong model (~ns-level residual mismatch vs Tempo2 T2).

Existing ELL1/ELL1H/DDK guesses are unchanged: those parameter sets still exclude DD/BT as appropriate.

## Test plan
- [x] `pytest tests/test_process_parfile.py::test_guess_binary_model tests/test_t2binary2pint.py -v`
- [x] Confirm a Keplerian T2 par with `allow_T2=True` loads as `BINARY DD`
- [x] Confirm DDK (KOM/KIN) and ELL1H (EPS/H3) still guess correctly