### PR TITLE
feat(ELL1H): opt-in ell1h_shapiro=absorbed for Freire & Wex Eq. 28

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -18,7 +18,9 @@ the released changes.
 ### Added
 - Plot whitened DM residuals in pintk.
 - `ssb_to_psb_xyz_ECL` and `ssb_to_psb_xyz_ICRS` are now cached
+- ELL1H with H3+STIGMA: add opt-in ``ell1h_shapiro="absorbed"`` to select Freire & Wex Eq. (28) (Tempo2 ELL1H/T2 mode 1). Default remains Eq. (29) ``"full"`` (`get_model` / `get_model_and_toas` / `ModelBuilder`).
 ### Fixed
+- Align ``d_delayS3p_H3_STIGMA_exact_d_STIGMA`` with Eq. (28): ``cos(2*Phi)``.
 - `WidebandTOAFitter` raises a warning if the model has correlated errors (It used to give wrong results before).
 - Fixed bug where "include_bipm" flag was being ignored when loading Fermi TOAs with weights, now defaults to using EPHEM, CLOCK and PLANET_SHAPIRO from the timing model
 - When flags are created based off jumps uses strings instead of None

--- a/src/pint/models/binary_ell1.py
+++ b/src/pint/models/binary_ell1.py
@@ -19,6 +19,8 @@ from pint.models.stand_alone_psr_binaries.ELL1H_model import ELL1Hmodel
 from pint.models.stand_alone_psr_binaries.ELL1k_model import ELL1kmodel
 from pint.utils import taylor_horner_deriv
 
+_ELL1H_SHAPIRO_MODES = ("full", "absorbed")
+
 
 def _eps_to_e(eps1, eps2):
     return np.sqrt(eps1**2 + eps2**2)
@@ -325,7 +327,7 @@ class BinaryELL1H(BinaryELL1):
     When `H3` and `H4` are supplied, `NHARMS` is taken to be `max(7,NHARMS)`, and the approximate version is used (Eqn. 19) appropriate for medium inclinations.
     Note that the default value in `pint` for `NHARMS` is 7, while in `tempo2` it is 4.
 
-    When `H3` and `STIGMA` are supplied, `NHARMS` is ignored since the exact version is used (Eqn. 29) appropriate for very high inclinations.
+    When `H3` and `STIGMA` are supplied, `NHARMS` is ignored and an exact Freire & Wex form is used. PINT's default is Eqn. (29) (``ell1h_shapiro="full"``), which keeps all harmonics inside the Shapiro term. Tempo2's ELL1H / T2 mode 1 uses Eqn. (28) (``ell1h_shapiro="absorbed"``), which leaves harmonics 1–2 to be absorbed into the ELL1 Roemer delay. Select the Tempo2-compatible form via ``get_model(..., ell1h_shapiro="absorbed")``. The default is unchanged for compatibility with existing PINT solutions.
 
     References
     ----------
@@ -340,6 +342,11 @@ class BinaryELL1H(BinaryELL1):
         super().__init__()
         self.binary_model_name = "ELL1H"
         self.binary_model_class = ELL1Hmodel
+
+        # Freire & Wex H3+STIGMA Shapiro convention. "full" = Eq. (29) (default);
+        # "absorbed" = Eq. (28) (Tempo2 ELL1H/T2 mode 1). Set by ModelBuilder /
+        # get_model before setup(); setup() must honour it.
+        self.ell1h_shapiro = "full"
 
         self.add_param(
             floatParameter(
@@ -408,7 +415,20 @@ class BinaryELL1H(BinaryELL1):
                 log.warning(
                     f"Requested NHARMS={self.NHARMS.value} will be ignored, since will use exact parameterization with STIGMA specified"
                 )
-            self.binary_instance.ds_func = self.binary_instance.delayS_H3_STIGMA_exact
+            mode = getattr(self, "ell1h_shapiro", "full")
+            if mode not in _ELL1H_SHAPIRO_MODES:
+                raise ValueError(
+                    "ell1h_shapiro must be one of "
+                    f"{_ELL1H_SHAPIRO_MODES}, got {mode!r}"
+                )
+            if mode == "absorbed":
+                self.binary_instance.ds_func = (
+                    self.binary_instance.delayS3p_H3_STIGMA_exact
+                )
+            else:
+                self.binary_instance.ds_func = (
+                    self.binary_instance.delayS_H3_STIGMA_exact
+                )
             if self.STIGMA.quantity <= 0:
                 if not self.H3.value == 0:
                     raise ValueError("STIGMA must be greater than zero.")

--- a/src/pint/models/model_builder.py
+++ b/src/pint/models/model_builder.py
@@ -121,6 +121,7 @@ class ModelBuilder:
         allow_T2=False,
         force_binary_model=None,
         toas_for_tzr=None,
+        ell1h_shapiro="full",
         **kwargs,
     ):
         """Callable object for making a timing model from .par file.
@@ -155,6 +156,11 @@ class ModelBuilder:
         toas_for_tzr : TOAs or None, optional
             If this is not None, a TZR TOA (AbsPhase) will be created using the
             given TOAs object.
+
+        ell1h_shapiro : {"full", "absorbed"}, optional
+            Freire & Wex convention for ELL1H with H3+STIGMA. "full" (default)
+            uses Eq. (29). "absorbed" uses Eq. (28), matching Tempo2 ELL1H/T2
+            mode 1. Ignored for ELL1H models that are not on the H3+STIGMA path.
 
         kwargs : dict
             Any additional parameter/value pairs that will add to or override those in the parfile.
@@ -206,6 +212,13 @@ class ModelBuilder:
         # Make timing model
         cps = [self.all_components.components[c] for c in selected]
         tm = TimingModel(components=cps)
+        if ell1h_shapiro not in ("full", "absorbed"):
+            raise ValueError(
+                "ell1h_shapiro must be 'full' or 'absorbed', " f"got {ell1h_shapiro!r}"
+            )
+        if "BinaryELL1H" in tm.components:
+            tm.components["BinaryELL1H"].ell1h_shapiro = ell1h_shapiro
+
         self._setup_model(
             tm,
             pint_param_dict,
@@ -249,6 +262,7 @@ class ModelBuilder:
         tm.meta["allow_tcb"] = allow_tcb_
         tm.meta["convert_tcb"] = convert_tcb
         tm.meta["allow_T2"] = allow_T2
+        tm.meta["ell1h_shapiro"] = ell1h_shapiro
 
         return tm
 
@@ -779,6 +793,7 @@ def get_model(
     allow_T2: bool = False,
     force_binary_model: str = None,
     toas_for_tzr: TOAs = None,
+    ell1h_shapiro: str = "full",
     **kwargs,
 ) -> TimingModel:
     """A one step function to build model from a parfile.
@@ -814,6 +829,11 @@ def get_model(
         If this is not None, a TZR TOA (AbsPhase) will be created using the
         given TOAs object.
 
+    ell1h_shapiro : {"full", "absorbed"}, optional
+        Freire & Wex convention for ELL1H with H3+STIGMA. "full" (default)
+        uses Eq. (29). "absorbed" uses Eq. (28), matching Tempo2 ELL1H/T2
+        mode 1. Ignored for ELL1H models that are not on the H3+STIGMA path.
+
     kwargs : dict
         Any additional parameter/value pairs that will add to or override those in the parfile.
 
@@ -834,6 +854,7 @@ def get_model(
             allow_T2=allow_T2,
             force_binary_model=force_binary_model,
             toas_for_tzr=toas_for_tzr,
+            ell1h_shapiro=ell1h_shapiro,
             **kwargs,
         )
 
@@ -847,6 +868,7 @@ def get_model(
         allow_T2=allow_T2,
         force_binary_model=force_binary_model,
         toas_for_tzr=toas_for_tzr,
+        ell1h_shapiro=ell1h_shapiro,
         **kwargs,
     )
     model.name = parfile
@@ -872,6 +894,7 @@ def get_model_and_toas(
     allow_T2: bool = False,
     force_binary_model: str = None,
     add_tzr_to_model: bool = True,
+    ell1h_shapiro: str = "full",
     **kwargs,
 ) -> Tuple[TimingModel, TOAs]:
     """Load a timing model and a related TOAs, using model commands as needed
@@ -928,6 +951,10 @@ def get_model_and_toas(
     add_tzr_to_model : bool, optional
         Create a TZR TOA in the timing model using the created TOAs object. Default is
         True.
+    ell1h_shapiro : {"full", "absorbed"}, optional
+        Freire & Wex convention for ELL1H with H3+STIGMA. "full" (default)
+        uses Eq. (29). "absorbed" uses Eq. (28), matching Tempo2 ELL1H/T2
+        mode 1. Ignored for ELL1H models that are not on the H3+STIGMA path.
     kwargs : dict
         Any additional parameter/value pairs that will add to or override those in the parfile.
 
@@ -942,6 +969,7 @@ def get_model_and_toas(
         allow_tcb=allow_tcb,
         allow_T2=allow_T2,
         force_binary_model=force_binary_model,
+        ell1h_shapiro=ell1h_shapiro,
         **kwargs,
     )
 

--- a/src/pint/models/stand_alone_psr_binaries/ELL1H_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/ELL1H_model.py
@@ -20,15 +20,26 @@ class ELL1Hmodel(ELL1BaseModel):
 
     .. math::
 
-        \\Delta_S = -2r \\left( \\frac{a_0}{2} + \\Sum_k (a_k \\cos k\\phi + b_k \\sin k \phi) \\right)
+        \\Delta_S = -2r \\left( \\frac{a_0}{2} + \\sum_k (a_k \\cos k\\phi + b_k \\sin k\\phi) \\right)
 
-    The first two harmonics are generlly absorbed by the ELL1 Roemer delay.
-    Thus, :class:`~pint.models.binary_ell1.BinaryELL1H` uses the series from the third
-    harmonic and higher.
+    For the approximate ``H3`` / ``H3``+``H4`` paths, the first two harmonics are
+    generally absorbed by the ELL1 Roemer delay, so those modes use the series from
+    the third harmonic and higher (Freire & Wex Eq. 19).
+
+    With ``H3`` and ``STIGMA``, two exact Freire & Wex forms are available, selected
+    by :func:`~pint.models.get_model`'s ``ell1h_shapiro`` argument (via
+    :class:`~pint.models.binary_ell1.BinaryELL1H`):
+
+    * ``"full"`` (default): Eq. (29), ``delayS_H3_STIGMA_exact`` — the full
+      orthometric log, with all harmonics kept in the Shapiro term.
+    * ``"absorbed"``: Eq. (28), ``delayS3p_H3_STIGMA_exact`` — Shapiro from the
+      third harmonic upward (Tempo2 ELL1H / T2 mode 1), leaving harmonics 1–2 to
+      be absorbed into the ELL1 Roemer delay.
 
     Notes
     -----
     Default value in `pint` for `NHARMS` is 7, while in `tempo2` it is 4.
+    ``NHARMS`` is ignored on the ``H3``+``STIGMA`` exact paths.
 
     References
     ----------
@@ -332,7 +343,7 @@ class ELL1Hmodel(ELL1BaseModel):
                 -3 * np.log(lognum)
                 + 2 * stigma * (stigma - np.sin(Phi)) / lognum
                 - 4 * stigma * np.sin(Phi)
-                + stigma**2 * np.cos(Phi)
+                + stigma**2 * np.cos(2 * Phi)
             )
         )
 

--- a/tests/test_ell1h_shapiro_mode.py
+++ b/tests/test_ell1h_shapiro_mode.py
@@ -1,0 +1,182 @@
+"""ELL1H H3+STIGMA Shapiro convention: full (Eq. 29) vs absorbed (Eq. 28)."""
+
+from io import StringIO
+
+import numpy as np
+import pytest
+
+from pint.models import get_model, get_model_and_toas
+from pint.models.stand_alone_psr_binaries.ELL1H_model import ELL1Hmodel
+from pint.simulation import make_fake_toas_uniform
+
+
+ELL1H_H3STIG = """
+PSR J1234+5678
+ELAT 0 1
+ELONG 0 1
+F0 100
+PEPOCH 57000
+BINARY ELL1H
+PB 1.0
+A1 10.0
+TASC 57000
+EPS1 1.0e-6
+EPS2 1.0e-6
+H3 1.0e-8
+STIG 0.9
+"""
+
+
+ELL1H_H3H4 = """
+PSR J1234+5678
+ELAT 0 1
+ELONG 0 1
+F0 100
+PEPOCH 57000
+BINARY ELL1H
+PB 1.0
+A1 10.0
+TASC 57000
+EPS1 1.0e-6
+EPS2 1.0e-6
+H3 1.0e-6
+H4 5.0e-7
+"""
+
+
+ELL1H_H3ONLY = """
+PSR J1234+5678
+ELAT 0 1
+ELONG 0 1
+F0 100
+PEPOCH 57000
+BINARY ELL1H
+PB 1.0
+A1 10.0
+TASC 57000
+EPS1 1.0e-6
+EPS2 1.0e-6
+H3 1.0e-6
+"""
+
+
+def _ell1h_with_phase(phi):
+    bi = ELL1Hmodel()
+    bi.H3 = 1.0e-8
+    bi.STIGMA = 0.9
+    bi.NHARMS = 7
+    bi.Phi = lambda: phi  # noqa: E731
+    return bi
+
+
+def test_default_is_full_eq29():
+    m = get_model(StringIO(ELL1H_H3STIG))
+    bi = m.components["BinaryELL1H"].binary_instance
+    assert bi.ds_func == bi.delayS_H3_STIGMA_exact
+    assert m.meta["ell1h_shapiro"] == "full"
+
+
+def test_absorbed_selects_eq28():
+    m = get_model(StringIO(ELL1H_H3STIG), ell1h_shapiro="absorbed")
+    bi = m.components["BinaryELL1H"].binary_instance
+    assert bi.ds_func == bi.delayS3p_H3_STIGMA_exact
+    assert m.meta["ell1h_shapiro"] == "absorbed"
+
+
+def test_invalid_mode_raises():
+    with pytest.raises(ValueError, match="ell1h_shapiro"):
+        get_model(StringIO(ELL1H_H3STIG), ell1h_shapiro="tempo2")
+
+
+def test_setup_preserves_absorbed():
+    m = get_model(StringIO(ELL1H_H3STIG), ell1h_shapiro="absorbed")
+    m.setup()
+    bi = m.components["BinaryELL1H"].binary_instance
+    assert bi.ds_func == bi.delayS3p_H3_STIGMA_exact
+
+
+def test_absorbed_minus_full_matches_gauge_term():
+    bi = _ell1h_with_phase(np.linspace(0.0, 2.0 * np.pi, 256))
+    h3 = bi.H3
+    stig = bi.STIGMA
+    m2 = h3 / stig**3
+    phi = bi.Phi()
+    d_full = bi.delayS_H3_STIGMA_exact(h3, stig, None)
+    d_abs = bi.delayS3p_H3_STIGMA_exact(h3, stig, None)
+    expected = -2.0 * m2 * (2.0 * stig * np.sin(phi) - stig**2 * np.cos(2.0 * phi))
+    assert np.allclose(d_abs - d_full, expected, rtol=0.0, atol=1e-18)
+
+
+def test_h3h4_unaffected_by_mode():
+    m_full = get_model(StringIO(ELL1H_H3H4), ell1h_shapiro="full")
+    m_abs = get_model(StringIO(ELL1H_H3H4), ell1h_shapiro="absorbed")
+    bi_full = m_full.components["BinaryELL1H"].binary_instance
+    bi_abs = m_abs.components["BinaryELL1H"].binary_instance
+    assert bi_full.ds_func == bi_full.delayS3p_H3_STIGMA_approximate
+    assert bi_abs.ds_func == bi_abs.delayS3p_H3_STIGMA_approximate
+
+
+@pytest.mark.parametrize("mode", ["full", "absorbed"])
+def test_h3_only_unaffected_by_mode(mode):
+    m = get_model(StringIO(ELL1H_H3ONLY), ell1h_shapiro=mode)
+    bi = m.components["BinaryELL1H"].binary_instance
+    assert bi.ds_func == bi.delayS3p_H3_STIGMA_approximate
+    assert m.meta["ell1h_shapiro"] == mode
+
+
+def test_get_model_and_toas_forwards_absorbed(tmp_path):
+    parpath = tmp_path / "psr.par"
+    timpath = tmp_path / "psr.tim"
+    parpath.write_text(ELL1H_H3STIG)
+    m0 = get_model(StringIO(ELL1H_H3STIG))
+    toas = make_fake_toas_uniform(57000, 57100, 8, m0, obs="ao")
+    toas.write_TOA_file(timpath)
+    m, _ = get_model_and_toas(parpath, timpath, ell1h_shapiro="absorbed")
+    bi = m.components["BinaryELL1H"].binary_instance
+    assert bi.ds_func == bi.delayS3p_H3_STIGMA_exact
+    assert m.meta["ell1h_shapiro"] == "absorbed"
+
+
+@pytest.mark.parametrize(
+    "deriv_name, param_name, delta",
+    [
+        ("d_delayS3p_H3_STIGMA_exact_d_STIGMA", "STIGMA", 1e-8),
+        ("d_delayS3p_H3_STIGMA_exact_d_H3", "H3", 1e-12),
+        ("d_delayS3p_H3_STIGMA_exact_d_Phi", "Phi", 1e-8),
+    ],
+)
+def test_absorbed_derivatives_match_finite_difference(deriv_name, param_name, delta):
+    phi = np.linspace(0.1, 2.0 * np.pi - 0.1, 128)
+    bi = _ell1h_with_phase(phi)
+    h3 = float(bi.H3)
+    stig = float(bi.STIGMA)
+
+    analytic = getattr(bi, deriv_name)(h3, stig, None)
+
+    if param_name == "STIGMA":
+        d_plus = bi.delayS3p_H3_STIGMA_exact(h3, stig + delta, None)
+        d_minus = bi.delayS3p_H3_STIGMA_exact(h3, stig - delta, None)
+    elif param_name == "H3":
+        d_plus = bi.delayS3p_H3_STIGMA_exact(h3 + delta, stig, None)
+        d_minus = bi.delayS3p_H3_STIGMA_exact(h3 - delta, stig, None)
+    else:  # Phi
+        bi_plus = _ell1h_with_phase(phi + delta)
+        bi_minus = _ell1h_with_phase(phi - delta)
+        d_plus = bi_plus.delayS3p_H3_STIGMA_exact(h3, stig, None)
+        d_minus = bi_minus.delayS3p_H3_STIGMA_exact(h3, stig, None)
+
+    numerical = (d_plus - d_minus) / (2.0 * delta)
+    # Relative tolerance on the bulk of the orbit; avoid exact zeros.
+    mask = np.abs(analytic) > 1e-20 * np.max(np.abs(analytic))
+    assert np.allclose(analytic[mask], numerical[mask], rtol=1e-5, atol=0.0)
+
+
+def test_absorbed_d_delayS_d_par_stigma_matches_direct():
+    """Integration through the design-matrix dispatch used for STIGMA."""
+    m = get_model(StringIO(ELL1H_H3STIG), ell1h_shapiro="absorbed")
+    toas = make_fake_toas_uniform(57000, 57100, 32, m, obs="ao")
+    m.components["BinaryELL1H"].update_binary_object(toas)
+    bi = m.components["BinaryELL1H"].binary_instance
+    direct = bi.d_delayS3p_H3_STIGMA_exact_d_STIGMA(bi.H3, bi.STIGMA, None)
+    via_par = bi.d_delayS_d_par("STIGMA")
+    assert np.allclose(via_par, direct, rtol=0.0, atol=0.0)


### PR DESCRIPTION
## Summary
- Add opt-in `ell1h_shapiro={"full","absorbed"}` on `get_model`, `get_model_and_toas`, and `ModelBuilder` (placed immediately before `**kwargs`).
- Default `"full"` keeps today’s Freire & Wex Eq. (29) behavior for `H3`+`STIGMA`.
- `"absorbed"` selects Eq. (28) (`delayS3p_H3_STIGMA_exact`), matching Tempo2 ELL1H / T2 mode 1.
- Align `d_delayS3p_H3_STIGMA_exact_d_STIGMA` with Eq. (28): `cos(2*Phi)`.
- Document both exact modes on `BinaryELL1H` and the standalone `ELL1Hmodel`.

## Motivation
With identical `(A1, EPS1, H3, STIG)`, PINT’s default Eq. (29) and Tempo2’s Eq. (28) differ by a Roemer-absorbable gauge term (harmonics 1–2). Cross-engine residual work needs an explicit, non-breaking way to evaluate the Tempo2-compatible form.

## Test plan
- [x] `pytest tests/test_ell1h_shapiro_mode.py -v` (13 passed)
- [x] Black 24 on touched files
- [x] CI matrix (Python 3.9/3.13, docs, notebooks, macOS)
- [x] Confirm default `get_model(par)` still uses Eq. (29)
- [x] Confirm `get_model(par, ell1h_shapiro="absorbed")` uses Eq. (28) and survives `setup()`