### PR TITLE
Fix DDH analytic STIGMA delay derivative scaling by T_⊙ ​

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -20,6 +20,7 @@ the released changes.
 - `ssb_to_psb_xyz_ECL` and `ssb_to_psb_xyz_ICRS` are now cached
 - ELL1H with H3+STIGMA: add opt-in ``ell1h_shapiro="absorbed"`` to select Freire & Wex Eq. (28) (Tempo2 ELL1H/T2 mode 1). Default remains Eq. (29) ``"full"`` (`get_model` / `get_model_and_toas` / `ModelBuilder`).
 ### Fixed
+- Remove spurious ``/ Tsun`` factor from analytic DDH ``∂delay/∂STIGMA`` (design matrix / GLS for free ``STIGMA`` was wrong by ``1/Tsun`` since the Maple rewrite in PINT ≥ 1.0).
 - Align ``d_delayS3p_H3_STIGMA_exact_d_STIGMA`` with Eq. (28): ``cos(2*Phi)``.
 - Prefer DD over BT when guessing the binary model for Tempo2 `T2` par files (`allow_T2`), matching Tempo2's `allTerms=1` behavior
 - `WidebandTOAFitter` raises a warning if the model has correlated errors (It used to give wrong results before).

--- a/src/pint/models/stand_alone_psr_binaries/DDH_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/DDH_model.py
@@ -99,37 +99,20 @@ class DDHmodel(DDmodel):
         cOmega = np.cos(self.omega())
         TM2 = self.M2.value * Tsun
 
-        logNum = (
-            1
-            - e * cE
-            - self.SINI * (sOmega * (cE - e) + (1 - e**2) ** 0.5 * cOmega * sE)
-        )
+        # Geometric factor in the Shapiro log argument (same as DD).
+        geo = sOmega * (cE - e) + (1 - e**2) ** 0.5 * cOmega * sE
+        logNum = 1 - e * cE - self.SINI * geo
         with u.set_enabled_equivalencies(u.dimensionless_angles()):
             dH3_dpar = self.prtl_der("H3", par)
             dsDelay_dH3 = -2 * np.log(logNum) / self.STIGMA**3
             dSTIGMA_dpar = self.prtl_der("STIGMA", par)
-            dsDelay_dSTIGMA = 6 * self.H3 / self.STIGMA**4 / Tsun.value * np.log(
-                1
-                - e * cE
-                - 2
-                * self.STIGMA
-                / (self.STIGMA**2 + 1)
-                * (sOmega * (cE - e) + (-(e**2) + 1) ** 0.5e0 * cOmega * sE)
-            ) - 2 * self.H3 / self.STIGMA**3 / Tsun.value * (
-                -2
-                / (self.STIGMA**2 + 1)
-                * (sOmega * (cE - e) + (-(e**2) + 1) ** 0.5e0 * cOmega * sE)
-                + 4
-                * self.STIGMA**2
-                / (self.STIGMA**2 + 1) ** 2
-                * (sOmega * (cE - e) + (-(e**2) + 1) ** 0.5e0 * cOmega * sE)
-            ) / (
-                1
-                - e * cE
-                - 2
-                * self.STIGMA
-                / (self.STIGMA**2 + 1)
-                * (sOmega * (cE - e) + (-(e**2) + 1) ** 0.5e0 * cOmega * sE)
+            # H3 is already in seconds; do not divide by Tsun here.
+            # d(logNum)/dSTIGMA via SINI = 2*STIGMA/(1+STIGMA**2).
+            dSINI_dSTIGMA = 2 * (1 - self.STIGMA**2) / (1 + self.STIGMA**2) ** 2
+            d_logNum_d_STIGMA = -dSINI_dSTIGMA * geo
+            dsDelay_dSTIGMA = (
+                6 * self.H3 / self.STIGMA**4 * np.log(logNum)
+                - 2 * self.H3 / self.STIGMA**3 * d_logNum_d_STIGMA / logNum
             )
 
             decc_dpar = self.prtl_der("ecc", par)

--- a/src/pint/models/stand_alone_psr_binaries/DDH_model.py
+++ b/src/pint/models/stand_alone_psr_binaries/DDH_model.py
@@ -106,8 +106,6 @@ class DDHmodel(DDmodel):
             dH3_dpar = self.prtl_der("H3", par)
             dsDelay_dH3 = -2 * np.log(logNum) / self.STIGMA**3
             dSTIGMA_dpar = self.prtl_der("STIGMA", par)
-            # H3 is already in seconds; do not divide by Tsun here.
-            # d(logNum)/dSTIGMA via SINI = 2*STIGMA/(1+STIGMA**2).
             dSINI_dSTIGMA = 2 * (1 - self.STIGMA**2) / (1 + self.STIGMA**2) ** 2
             d_logNum_d_STIGMA = -dSINI_dSTIGMA * geo
             dsDelay_dSTIGMA = (

--- a/tests/test_ddh.py
+++ b/tests/test_ddh.py
@@ -94,3 +94,29 @@ def test_ddh_sim():
     assert np.isclose(f.resids.calc_chi2(), f2.resids.calc_chi2(), atol=0.5)
     assert np.isclose(f.model.M2.value, f2.model.M2.value, atol=0.01)
     assert np.isclose(f.model.SINI.value, f2.model.SINI.value, atol=0.01)
+
+
+def test_ddh_stigma_derivative_matches_finite_difference():
+    """Analytic ∂delay/∂STIGMA (and H3) must match PINT's numerical derivative.
+
+    Regression for a spurious ``/ Tsun.value`` factor formerly present in
+    ``DDHmodel.d_delayS_d_par`` for STIGMA (analytic column was ~1/Tsun too
+    large). H3 is a non-regression control. Compare RMS ratios so a few
+    superior-conjunction TOAs do not dominate the check.
+    """
+    m = get_model(
+        io.StringIO(
+            f"{parDD}\nBINARY DD\nSINI {np.sin(i).value}\nA1 {A1.value}\n"
+            f"PB {PB.value}\nM2 {Mc.value}\n"
+        )
+    )
+    t = pint.simulation.make_fake_toas_uniform(
+        50000, 51000, 200, m, add_noise=False, error=1 * u.us
+    )
+    m2 = pint.binaryconvert.convert_binary(m, "DDH")
+
+    for param in ("STIGMA", "H3"):
+        analytic = m2.d_delay_d_param(t, param)
+        numerical = m2.d_delay_d_param_num(t, param)
+        rms_ratio = np.sqrt(np.mean(analytic**2)) / np.sqrt(np.mean(numerical**2))
+        assert abs(rms_ratio - 1.0) < 1e-3


### PR DESCRIPTION
## Summary

- Remove the spurious `/ Tsun.value` factors from analytic `∂delay/∂STIGMA` in `DDHmodel.d_delayS_d_par` (bug since Maple rewrite `733cf704`, PINT ≥ 1.0).
- Rewrite the STIGMA branch in terms of the shared Shapiro `logNum` / `geo` / `dSINI/dSTIGMA` so it cannot drift from the delay expression again.
- Add `test_ddh_stigma_derivative_matches_finite_difference`: analytic vs `d_delay_d_param_num` RMS ratio for `STIGMA` and `H3` (control).

The delay itself, ∂/∂`H3`, and ELL1H STIGMA derivatives were already correct. This only repairs the analytic DDH `STIGMA` design-matrix column (too large by 1/T⊙, which had inflated Fisher information and produced absurdly small formal σ(STIG) in GLS fits with free `STIGMA`.

Ping here for @dlakaplan, who originally derived the derivative so best to confirm

NANOGrav was not using this derivative in their work. Other PTAs would, but they are using the tempo2 equivalent.

## Test plan
- [x] `pytest tests/test_ddh.py::test_ddh_stigma_derivative_matches_finite_difference -v`
- [x] `black --check` on touched files
- [x] CI green

## Minimal reproduction

```python
import io
import numpy as np
from astropy import units as u
import pint.binaryconvert
import pint.derived_quantities
import pint.simulation
from pint import Tsun
from pint.models import get_model
Mp, Mc, i, PB = 1.4 * u.Msun, 1.1 * u.Msun, 85 * u.deg, 0.5 * u.day
A1 = pint.derived_quantities.a1sini(Mp, Mc, PB, i)
par = f"""
PSRJ X
RAJ 18:57:36
DECJ +09:43:17
F0 186.5
PEPOCH 49453
DM 13
BINARY DD
PB {PB.value}
A1 {A1.value}
T0 49452.94
OM 276.55
ECC 0.1
SINI {np.sin(i).value}
M2 {Mc.value}
TZRMJD 54177.5
TZRFRQ 424
TZRSITE ao
CLK TT(TAI)
UNITS TDB
EPHEM DE405
TIMEEPH FB90
"""
m = get_model(io.StringIO(par))
t = pint.simulation.make_fake_toas_uniform(
    50000, 51000, 200, m, add_noise=False, error=1 * u.us
)
m2 = pint.binaryconvert.convert_binary(m, "DDH")
an = m2.d_delay_d_param(t, "STIGMA")
num = m2.d_delay_d_param_num(t, "STIGMA")
ratio = np.sqrt(np.mean(an**2)) / np.sqrt(np.mean(num**2))
print("analytic/numerical", ratio)
print("1/Tsun.value", 1 / Tsun.value)
# Expect (buggy): ratio ≈ 1/Tsun.value ≈ 2.03e5
# After fix: ratio ≈ 1
```
