### PR TITLE
fix(FDJUMPDM): use Tempo2-consistent positive DM offset sign (BREAKING CHANGE)

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -19,6 +19,7 @@ the released changes.
 - Plot whitened DM residuals in pintk.
 - `ssb_to_psb_xyz_ECL` and `ssb_to_psb_xyz_ICRS` are now cached
 ### Fixed
+- FDJUMPDM sign convention: a positive FDJUMPDM now adds a positive DM (and delay) on selected TOAs, matching Tempo2.
 - `WidebandTOAFitter` raises a warning if the model has correlated errors (It used to give wrong results before).
 - Fixed bug where "include_bipm" flag was being ignored when loading Fermi TOAs with weights, now defaults to using EPHEM, CLOCK and PLANET_SHAPIRO from the timing model
 - When flags are created based off jumps uses strings instead of None

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -270,7 +270,9 @@ Here are some examples for `DMJUMP` parameters in a par file:
 
 Similar offsets also arise in the case of narrowband TOAs. Unlike the wideband case, these offsets 
 manifest as system-dependent corrections to the DM delay. They are modeled using the `FDJUMPDM` parameters
-(see see :class:`pint.models.dispersion_model.FDJumpDM`)
+(see :class:`pint.models.dispersion_model.FDJumpDM`).
+A positive `FDJUMPDM` contributes a positive DM (and thus a positive dispersion delay) on the
+selected TOAs, matching the Tempo2 convention.
 
 Here are some examples for `FDJUMPDM` parameters in a par file:
     `FDJUMPDM   -f 430_PUPPI       1e-4  1   1e-5`

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -822,6 +822,10 @@ class FDJumpDM(Dispersion):
     the fact that the templates may not adequately model the frequency-dependent
     profile evolution.
 
+    Sign convention: a positive ``FDJUMPDM`` contributes a positive DM (and thus a
+    positive dispersion delay) on the selected TOAs, matching Tempo2's FDJUMPDM
+    implementation (``+FDJUMPDM`` acts like ``+DM`` on the mask).
+
     Parameters supported:
 
     .. paramtable::
@@ -862,15 +866,15 @@ class FDJumpDM(Dispersion):
     def fdjump_dm(self, toas):
         """Return the system-dependent DM offset.
 
-        The delay value is determined by FDJUMPDM parameter
-        value in the unit of pc / cm ** 3.
+        A positive FDJUMPDM adds a positive DM on the selected TOAs (Tempo2-
+        consistent convention). Units are pc / cm ** 3.
         """
         tbl = toas.table
         jdm = np.zeros(len(tbl))
         for fdjumpdm in self.fdjump_dms:
             fdjumpdm_par = getattr(self, fdjumpdm)
             mask = fdjumpdm_par.select_toa_mask(toas)
-            jdm[mask] += -fdjumpdm_par.value
+            jdm[mask] += fdjumpdm_par.value
         return jdm * fdjumpdm_par.units
 
     def fdjump_dm_delay(self, toas, acc_delay=None):
@@ -883,5 +887,5 @@ class FDJumpDM(Dispersion):
         d_dm_d_j = np.zeros(len(tbl))
         jpar = getattr(self, jump_param)
         mask = jpar.select_toa_mask(toas)
-        d_dm_d_j[mask] = -1.0
+        d_dm_d_j[mask] = 1.0
         return d_dm_d_j * u.dimensionless_unscaled

--- a/tests/test_fdjump.py
+++ b/tests/test_fdjump.py
@@ -141,4 +141,5 @@ def test_fdjumpdm_offset(model_and_toas):
     dm2 = model2.total_dm(toas)
 
     assert np.allclose((dm1 - dm2)[not_mask], 0)
-    assert np.allclose((dm1 - dm2)[mask], -model.FDJUMPDM1.quantity)
+    # Positive FDJUMPDM adds positive DM (Tempo2-consistent convention).
+    assert np.allclose((dm1 - dm2)[mask], model.FDJUMPDM1.quantity)

--- a/tests/test_fdjump.py
+++ b/tests/test_fdjump.py
@@ -143,3 +143,29 @@ def test_fdjumpdm_offset(model_and_toas):
     assert np.allclose((dm1 - dm2)[not_mask], 0)
     # Positive FDJUMPDM adds positive DM (Tempo2-consistent convention).
     assert np.allclose((dm1 - dm2)[mask], model.FDJUMPDM1.quantity)
+
+
+@pytest.mark.parametrize("param", ["FDJUMPDM1", "FDJUMPDM2"])
+def test_fdjumpdm_derivative(model_and_toas, param):
+    """Analytic FDJUMPDM derivatives must have the Tempo2-consistent sign.
+
+    ``d(DM)/d(FDJUMPDM)`` is +1 on selected TOAs (0 elsewhere), and the delay
+    derivative must match a symmetric finite difference.
+    """
+    model, toas = model_and_toas
+    mask = getattr(model, param).select_toa_mask(toas)
+    not_mask = np.setdiff1d(np.arange(len(toas)), mask)
+
+    d_dm = model.d_dm_d_param(toas, param)
+    assert np.allclose(d_dm[mask].value, 1.0)
+    assert np.allclose(d_dm[not_mask].value, 0.0)
+
+    analytic = model.d_delay_d_param(toas, param)
+    numerical = model.d_delay_d_param_num(toas, param)
+    # Off-mask TOAs are independent of this FDJUMPDM.
+    assert np.allclose(analytic[not_mask].value, 0.0)
+    assert np.all(analytic[mask].value > 0)
+
+    mean_der = (analytic[mask] + numerical[mask]) / 2.0
+    relative_diff = np.abs(analytic[mask] - numerical[mask]) / np.abs(mean_der)
+    assert np.nanmax(relative_diff).value < 1e-3


### PR DESCRIPTION
## Summary

Flip the `FDJUMPDM` sign convention so that a **positive** `FDJUMPDM` contributes a **positive** DM (and thus a positive dispersion delay) on the selected TOAs.

This matches Tempo2 and is the more natural definition: `+FDJUMPDM` on a mask should act like `+DM` on those TOAs.

### Motivation

PINT previously applied the opposite sign:

```python
jdm[mask] += -fdjumpdm_par.value
```

so a positive fitted `FDJUMPDM` *decreased* DM/delay. That is opposite to Tempo2, where `FDJUMPDM` (implemented as `fdjumpIdx == -2`) enters the residual/phase calculation with the same sense as a positive DM contribution (`formResiduals.C` / `t2FitFunc_fdjump`).

That mismatch made fitted `FDJUMPDM` values non-portable between engines: a solution from Tempo2/libstempo would need a global sign flip to be interpreted correctly in PINT (and vice versa). There is no strong reason for PINT to keep the inverted convention; Tempo2’s definition is both prior art and more logical (“positive parameter → positive DM on the mask”).

This change aligns PINT with Tempo2 rather than documenting or papering over the difference.

### Changes

- `src/pint/models/dispersion_model.py`
  - `fdjump_dm`: `jdm[mask] += fdjumpdm_par.value` (was `+= -…`)
  - `d_dm_d_fdjumpdm`: derivative mask is `+1` (was `-1`)
  - Docstring/class docs state the Tempo2-consistent sign convention explicitly
- `tests/test_fdjump.py`: expectation updated so a positive `FDJUMPDM` increases total DM on the mask
- `docs/explanation.rst`: document the convention
- `CHANGELOG-unreleased.md`: note under Fixed

### Breaking change / migration

**Yes — intentional.** Existing par files (or posteriors) that were fitted with PINT’s old inverted convention need:

```text
FDJUMPDM → -FDJUMPDM
```

when reloading under this fix (or when comparing to Tempo2 fits that already used the positive convention). Values produced by Tempo2/libstempo should now load and fit without a manual sign flip.

If you have hybrid workflows that previously negated PINT vs Tempo2 `FDJUMPDM` by hand, remove that workaround after this lands.

### Test plan

- [x] Unit test `test_fdjumpdm_offset` updated for the new sign
- [x] `pytest tests/test_fdjump.py -v`
- [x] Optional: load a Tempo2-fitted par with non-zero `FDJUMPDM` and confirm PINT’s `total_dm` / residuals match Tempo2 on the selected TOAs without flipping the parameter
