### PR TITLE
fix(observatory): use Tempo2 clock chains for Jodrell Mark II sites

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -20,6 +20,7 @@ the released changes.
 - `ssb_to_psb_xyz_ECL` and `ssb_to_psb_xyz_ICRS` are now cached
 - ELL1H with H3+STIGMA: add opt-in ``ell1h_shapiro="absorbed"`` to select Freire & Wex Eq. (28) (Tempo2 ELL1H/T2 mode 1). Default remains Eq. (29) ``"full"`` (`get_model` / `get_model_and_toas` / `ModelBuilder`).
 ### Fixed
+- Jodrell Bank Mark II sites (``jbmk2`` / ``jbmk2roach`` / ``jbmk2dfb``) now follow TEMPO2's clock routing (equivalent to ``jbafb`` / ``jbroach`` / ``jbdfb``) instead of the default empty TEMPO clock path.
 - Align ``d_delayS3p_H3_STIGMA_exact_d_STIGMA`` with Eq. (28): ``cos(2*Phi)``.
 - Prefer DD over BT when guessing the binary model for Tempo2 `T2` par files (`allow_T2`), matching Tempo2's `allTerms=1` behavior
 - `WidebandTOAFitter` raises a warning if the model has correlated errors (It used to give wrong results before).

--- a/src/pint/data/runtime/observatories.json
+++ b/src/pint/data/runtime/observatories.json
@@ -1409,37 +1409,73 @@
         ],
         "tempo_code": "h",
         "itoa_code": "J2",
+        "clock_file": "",
+        "clock_fmt": "tempo2",
+        "apply_gps2utc": true,
+        "bogus_last_correction": true,
         "itrf_xyz": [
             3822846.76,
             -153802.28,
             5086285.9
         ],
         "fullname": "The Mark II telescope at Jodrell Bank Observatory",
-        "origin": "Imported from TEMPO2 observatories.dat 2021 June 7."
+        "origin": [
+            "Imported from TEMPO2 observatories.dat 2021 June 7.",
+            "TEMPO2 routes this site through the zero-offset alias jbmk22jb.clk to jbafb;",
+            "jbafb has no additional instrument clock file, so PINT applies only GPS/BIPM."
+        ]
     },
     "jb_mkii_rch": {
         "aliases": [
             "jbmk2roach"
         ],
+        "clock_file": [
+            {
+                "name": "jbroach2jb.clk",
+                "valid_beyond_ends": true
+            },
+            "jb2gps.clk"
+        ],
+        "clock_fmt": "tempo2",
+        "apply_gps2utc": true,
+        "bogus_last_correction": true,
         "itrf_xyz": [
             3822846.76,
             -153802.28,
             5086285.9
         ],
         "fullname": "The Mark II telescope at Jodrell Bank Observatory with the Roach backend",
-        "origin": "Imported from TEMPO2 observatories.dat 2021 June 7."
+        "origin": [
+            "Imported from TEMPO2 observatories.dat 2021 June 7.",
+            "TEMPO2 routes this site through the zero-offset alias jbmk2roach2jbroach.clk",
+            "onto the Lovell Roach chain; PINT uses that jbroach2jb.clk + jb2gps.clk chain directly."
+        ]
     },
     "jb_mkii_dfb": {
         "aliases": [
             "jbmk2dfb"
         ],
+        "clock_file": [
+            {
+                "name": "jbdfb2jb.clk",
+                "valid_beyond_ends": true
+            },
+            "jb2gps.clk"
+        ],
+        "clock_fmt": "tempo2",
+        "apply_gps2utc": true,
+        "bogus_last_correction": true,
         "itrf_xyz": [
             3822846.76,
             -153802.28,
             5086285.9
         ],
         "fullname": "The Mark II telescope at Jodrell Bank Observatory with the DFB backend",
-        "origin": "Imported from TEMPO2 observatories.dat 2021 June 7."
+        "origin": [
+            "Imported from TEMPO2 observatories.dat 2021 June 7.",
+            "TEMPO2 routes this site through the zero-offset alias jbmk2dfb2jbdfb.clk",
+            "onto the Lovell DFB chain; PINT uses that jbdfb2jb.clk + jb2gps.clk chain directly."
+        ]
     },
     "lwa_sv": {
         "aliases": [

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -137,6 +137,9 @@ good_observatories = [
     "jodrell",
     "jbroach",
     "jbdfb",
+    "jbmk2roach",
+    "jbmk2dfb",
+    "jbmk2",
     "wsrt",
     "parkes",
 ]
@@ -321,6 +324,40 @@ def test_valid_past_end():
     o = pint.observatory.get_observatory("jbroach")
     o.last_clock_correction_mjd()
     o.clock_corrections(o._clock[0].time[-1] + 1 * u.d, limits="error")
+
+
+def _clock_file_names(obs):
+    return [f["name"] if isinstance(f, dict) else f for f in obs.clock_files]
+
+
+def test_jb_mkii_sites_use_tempo2_clock_chains():
+    """Mark II aliases must follow TEMPO2's zero-offset redirects onto Lovell chains."""
+    assert get_observatory("jbmk2roach").clock_fmt == "tempo2"
+    assert _clock_file_names(get_observatory("jbmk2roach")) == _clock_file_names(
+        get_observatory("jbroach")
+    )
+    assert get_observatory("jbmk2dfb").clock_fmt == "tempo2"
+    assert _clock_file_names(get_observatory("jbmk2dfb")) == _clock_file_names(
+        get_observatory("jbdfb")
+    )
+    jbmk2 = get_observatory("jbmk2")
+    assert jbmk2.clock_fmt == "tempo2"
+    assert _clock_file_names(jbmk2) == [] or _clock_file_names(jbmk2) == [""]
+
+
+def test_jbmk2roach_matches_jbroach_clock_corrections():
+    """TEMPO2's jbmk2roach->jbroach alias is zero, so corrections must match jbroach."""
+    t = Time(np.linspace(56000, 58000, num=25), scale="utc", format="pulsar_mjd")
+    jbmk2 = get_observatory("jbmk2roach").clock_corrections(t, limits="error")
+    jbroach = get_observatory("jbroach").clock_corrections(t, limits="error")
+    assert np.allclose(jbmk2.to(u.us), jbroach.to(u.us), atol=1e-6 * u.us)
+
+
+def test_jbmk2dfb_matches_jbdfb_clock_corrections():
+    t = Time(np.linspace(56000, 58000, num=25), scale="utc", format="pulsar_mjd")
+    a = get_observatory("jbmk2dfb").clock_corrections(t, limits="error")
+    b = get_observatory("jbdfb").clock_corrections(t, limits="error")
+    assert np.allclose(a.to(u.us), b.to(u.us), atol=1e-6 * u.us)
 
 
 def test_names_and_aliases():


### PR DESCRIPTION
## Summary
- Wire `jbmk2` / `jbmk2roach` / `jbmk2dfb` to the same Tempo2-format clock paths as `jbafb` / `jbroach` / `jbdfb`.
- These sites were imported from `observatories.dat` without `clock_file` / `clock_fmt`, so PINT fell back to an empty TEMPO clock path and applied only a near-constant ~27 µs correction.
- Tempo2 instead routes them through zero-offset aliases (`jbmk2roach2jbroach.clk`, etc.) onto the Lovell backend chains; PINT now uses those equivalent chains directly (alias files are identity and are not in PINT's global clock index).

## Impact
On EPTA DR2 `J1713+0747` (288 `jbmk2roach` TOAs), PINT−Tempo2 residual RMS falls from ~656 ns to ~3 ns after this change. The remaining budget is consistent with other EPTA sites.

## Test plan
- [x] `pytest tests/test_observatory.py::test_jb_mkii_sites_use_tempo2_clock_chains tests/test_observatory.py::test_jbmk2roach_matches_jbroach_clock_corrections tests/test_observatory.py::test_jbmk2dfb_matches_jbdfb_clock_corrections tests/test_observatory.py::test_can_compute_corrections tests/test_observatory.py::test_last_mjd`
- [x] Confirm `jbmk2roach` clock corrections match `jbroach` over MJD 56000–58000
- [x] Spot-check a dataset with `jbmk2roach` TOAs for PINT/Tempo2 residual parity