### PR TITLE
fix(astrometry): propagate sky uncertainties by covariance rotation

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -20,6 +20,7 @@ the released changes.
 - `ssb_to_psb_xyz_ECL` and `ssb_to_psb_xyz_ICRS` are now cached
 - ELL1H with H3+STIGMA: add opt-in ``ell1h_shapiro="absorbed"`` to select Freire & Wex Eq. (28) (Tempo2 ELL1H/T2 mode 1). Default remains Eq. (29) ``"full"`` (`get_model` / `get_model_and_toas` / `ModelBuilder`).
 ### Fixed
+- Propagate one-way astrometric marginal uncertainties in ``as_ECL`` / ``as_ICRS`` by diagonal covariance rotation instead of a signed "fake proper motion" vector. The old ``as_ECL`` path could assign a negative ELONG/ELAT uncertainty (breaking model construction) after an ecliptic↔ICRS round trip, and both directions returned the wrong marginal σ after a non-trivial frame rotation. Correlations induced by conversion are not retained because timing-model parameters store only marginal uncertainties.
 - Remove spurious ``/ Tsun`` factor from analytic DDH ``∂delay/∂STIGMA`` (design matrix / GLS for free ``STIGMA`` was wrong by ``1/Tsun`` since the Maple rewrite in PINT ≥ 1.0).
 - Align ``d_delayS3p_H3_STIGMA_exact_d_STIGMA`` with Eq. (28): ``cos(2*Phi)``.
 - Prefer DD over BT when guessing the binary model for Tempo2 `T2` par files (`allow_T2`), matching Tempo2's `allTerms=1` behavior

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -29,13 +29,97 @@ from pint.types import time_like
 from pint.utils import add_dummy_distance, remove_dummy_distance
 
 astropy_version = sys.modules["astropy"].__version__
-mas_yr = u.mas / u.yr
 
 __all__ = [
     "AstrometryEquatorial",
     "AstrometryEcliptic",
     "Astrometry",
 ]
+
+
+def _sky_pm_components(coord):
+    """Return ``(pm_lon_coslat, pm_lat, lat)`` for ICRS or PulsarEcliptic."""
+    if hasattr(coord, "pm_ra_cosdec"):
+        return coord.pm_ra_cosdec, coord.pm_dec, coord.dec
+    return coord.pm_lon_coslat, coord.pm_lat, coord.lat
+
+
+def _propagate_diagonal_sky_uncertainties(
+    make_skycoord,
+    out_frame,
+    sigma_lon,
+    sigma_lat,
+    *,
+    lat_in=None,
+    lon_includes_coslat: bool,
+    dt: u.Quantity = 1 * u.yr,
+):
+    """Propagate independent sky-plane uncertainties through a frame transform.
+
+    Astrometric uncertainties are treated as a diagonal 2×2 covariance in the
+    tangent plane (zero correlation, matching the previous helpers). The old
+    "fake proper motion" code transformed the vector ``(σ_lon, σ_lat)`` as a
+    single displacement, which can yield a signed — even negative — value and
+    the wrong marginal σ after a non-trivial rotation. Transforming each axis
+    separately and combining in quadrature gives the correct one-way marginal
+    uncertainties. Any covariance induced by the rotation is not retained,
+    because timing-model parameters store only marginal uncertainties.
+
+    Parameters
+    ----------
+    make_skycoord : callable
+        ``make_skycoord(pm_lon_coslat, pm_lat) -> SkyCoord`` in the source frame.
+    out_frame : coordinate frame
+        Destination frame.
+    sigma_lon, sigma_lat : Quantity or None
+        Input 1-σ uncertainties. Lon convention follows ``lon_includes_coslat``
+        (``False`` for RAJ/ELONG, ``True`` for PMRA/PMELONG).
+    lat_in : Quantity
+        Source-frame latitude; required when ``lon_includes_coslat`` is False.
+    lon_includes_coslat : bool
+        Whether ``sigma_lon`` already includes ``cos(lat)``.
+    dt : Quantity
+        Dummy interval used to encode a position uncertainty as a proper motion.
+
+    Returns
+    -------
+    sigma_lon_out, sigma_lat_out : Quantity
+        Non-negative marginal uncertainties in the destination frame, using the
+        same ``lon_includes_coslat`` convention as the inputs. Both are ``None``
+        if either input uncertainty is unavailable.
+    """
+    # A rotated marginal generally depends on both input axes. Treating an
+    # unavailable uncertainty as zero would assert that axis is known exactly
+    # and underestimate both outputs.
+    if sigma_lon is None or sigma_lat is None:
+        return None, None
+
+    if lon_includes_coslat:
+        unit = sigma_lon.unit
+        pm_lon = sigma_lon
+        pm_lat = sigma_lat
+        c1o = make_skycoord(pm_lon, 0 * unit).transform_to(out_frame)
+        c2o = make_skycoord(0 * unit, pm_lat).transform_to(out_frame)
+        lon_1, lat_1, _ = _sky_pm_components(c1o)
+        lon_2, lat_2, _ = _sky_pm_components(c2o)
+        return np.hypot(lon_1, lon_2), np.hypot(lat_1, lat_2)
+
+    if lat_in is None:
+        raise ValueError("lat_in is required when lon_includes_coslat is False")
+    # Position uncertainties: RAJ/ELONG do not include cos(lat).
+    sig_lon = sigma_lon
+    sig_lat = sigma_lat
+    pm_lon = sig_lon * np.cos(lat_in) / dt
+    pm_lat = sig_lat / dt
+    # Both PM components share a common angular/time unit after the encode.
+    pm_unit = pm_lon.unit
+    c1o = make_skycoord(pm_lon, 0 * pm_unit).transform_to(out_frame)
+    c2o = make_skycoord(0 * pm_unit, pm_lat.to(pm_unit)).transform_to(out_frame)
+    lon_1, lat_1, lat_out = _sky_pm_components(c1o)
+    lon_2, lat_2, _ = _sky_pm_components(c2o)
+    sigma_lon_out = np.hypot(lon_1, lon_2) * dt / np.cos(lat_out)
+    sigma_lat_out = np.hypot(lat_1, lat_2) * dt
+    return sigma_lon_out, sigma_lat_out
 
 
 def _epoch_fingerprint(epoch: Optional[time_like]) -> Tuple[Tuple, bytes]:
@@ -884,51 +968,41 @@ class AstrometryEquatorial(Astrometry):
         m_ecl.PMELAT.quantity = c.pm_lat
         m_ecl.ECL.value = ecl
 
-        # use fake proper motions to convert uncertainties on ELONG, ELAT
-        # assume that ELONG uncertainty does not include cos(ELAT)
-        # and that the RA uncertainty does not include cos(DEC)
-        # put it in here as pm_ra_cosdec since astropy complains otherwise
-        dt = 1 * u.yr
-        c = coords.SkyCoord(
-            ra=self.RAJ.quantity,
-            dec=self.DECJ.quantity,
-            obstime=self.POSEPOCH.quantity,
-            pm_ra_cosdec=(
-                self.RAJ.uncertainty * np.cos(self.DECJ.quantity) / dt
-                if self.RAJ.uncertainty is not None
-                else 0 * self.RAJ.units / dt
-            ),
-            pm_dec=(
-                self.DECJ.uncertainty / dt
-                if self.DECJ.uncertainty is not None
-                else 0 * self.DECJ.units / dt
-            ),
-            frame=coords.ICRS,
+        # Propagate diagonal uncertainties via covariance rotation (not a
+        # signed-vector "fake PM" transform). RAJ/ELONG uncertainties do not
+        # include cos(lat); PMRA/PMELONG do.
+        source_c = self.coords_as_ICRS(epoch=epoch)
+
+        def _icrs_sky(pm_ra_cosdec, pm_dec):
+            return coords.SkyCoord(
+                ra=source_c.ra,
+                dec=source_c.dec,
+                obstime=source_c.obstime,
+                pm_ra_cosdec=pm_ra_cosdec,
+                pm_dec=pm_dec,
+                frame=coords.ICRS,
+            )
+
+        out_ecl = PulsarEcliptic(ecl=ecl)
+        elong_unc, elat_unc = _propagate_diagonal_sky_uncertainties(
+            _icrs_sky,
+            out_ecl,
+            self.RAJ.uncertainty,
+            self.DECJ.uncertainty,
+            lat_in=source_c.dec,
+            lon_includes_coslat=False,
         )
-        c_ECL = c.transform_to(PulsarEcliptic(ecl=ecl))
-        m_ecl.ELONG.uncertainty = c_ECL.pm_lon_coslat * dt / np.cos(c_ECL.lat)
-        m_ecl.ELAT.uncertainty = c_ECL.pm_lat * dt
-        # use fake proper motions to convert uncertainties on proper motion
-        # assume that the PM_RA _does_ include cos(DEC)
-        c = coords.SkyCoord(
-            ra=self.RAJ.quantity,
-            dec=self.DECJ.quantity,
-            obstime=self.POSEPOCH.quantity,
-            pm_ra_cosdec=(
-                self.PMRA.uncertainty
-                if self.PMRA.uncertainty is not None
-                else 0 * self.PMRA.units
-            ),
-            pm_dec=(
-                self.PMDEC.uncertainty
-                if self.PMDEC.uncertainty is not None
-                else 0 * self.PMDEC.units
-            ),
-            frame=coords.ICRS,
+        m_ecl.ELONG.uncertainty = elong_unc
+        m_ecl.ELAT.uncertainty = elat_unc
+        pmelong_unc, pmelat_unc = _propagate_diagonal_sky_uncertainties(
+            _icrs_sky,
+            out_ecl,
+            self.PMRA.uncertainty,
+            self.PMDEC.uncertainty,
+            lon_includes_coslat=True,
         )
-        c_ECL = c.transform_to(PulsarEcliptic(ecl=ecl))
-        m_ecl.PMELONG.uncertainty = c_ECL.pm_lon_coslat
-        m_ecl.PMELAT.uncertainty = c_ECL.pm_lat
+        m_ecl.PMELONG.uncertainty = pmelong_unc
+        m_ecl.PMELAT.uncertainty = pmelat_unc
         # freeze comparable parameters
         m_ecl.ELONG.frozen = self.RAJ.frozen
         m_ecl.ELAT.frozen = self.DECJ.frozen
@@ -1481,53 +1555,39 @@ class AstrometryEcliptic(Astrometry):
         m_ecl.PMELAT.quantity = c.pm_lat
         m_ecl.ECL.value = ecl
 
-        # use fake proper motions to convert uncertainties on ELONG, ELAT
-        # assume that ELONG uncertainty does not include cos(ELAT)
-        # and that the RA uncertainty does not include cos(DEC)
-        # put it in here as pm_ra_cosdec since astropy complains otherwise
-        dt = 1 * u.yr
-        c = coords.SkyCoord(
-            lon=self.ELONG.quantity,
-            lat=self.ELAT.quantity,
-            obliquity=OBL[self.ECL.value],
-            obstime=self.POSEPOCH.quantity,
-            pm_lon_coslat=(
-                self.ELONG.uncertainty * np.cos(self.ELAT.quantity) / dt
-                if self.ELONG.uncertainty is not None
-                else 0 * self.ELONG.units / dt
-            ),
-            pm_lat=(
-                self.ELAT.uncertainty / dt
-                if self.ELAT.uncertainty is not None
-                else 0 * self.ELAT.units / dt
-            ),
-            frame=PulsarEcliptic,
+        source_c = self.coords_as_ECL(epoch=epoch, ecl=self.ECL.value)
+
+        def _ecl_sky(pm_lon_coslat, pm_lat):
+            return coords.SkyCoord(
+                lon=source_c.lon,
+                lat=source_c.lat,
+                obliquity=OBL[self.ECL.value],
+                obstime=source_c.obstime,
+                pm_lon_coslat=pm_lon_coslat,
+                pm_lat=pm_lat,
+                frame=PulsarEcliptic,
+            )
+
+        out_ecl = PulsarEcliptic(ecl=ecl)
+        elong_unc, elat_unc = _propagate_diagonal_sky_uncertainties(
+            _ecl_sky,
+            out_ecl,
+            self.ELONG.uncertainty,
+            self.ELAT.uncertainty,
+            lat_in=source_c.lat,
+            lon_includes_coslat=False,
         )
-        c_ECL = c.transform_to(PulsarEcliptic(ecl=ecl))
-        m_ecl.ELONG.uncertainty = c_ECL.pm_lon_coslat * dt / np.cos(c_ECL.lat)
-        m_ecl.ELAT.uncertainty = c_ECL.pm_lat * dt
-        # use fake proper motions to convert uncertainties on proper motion
-        # assume that PMELONG uncertainty includes cos(DEC)
-        c = coords.SkyCoord(
-            lon=self.ELONG.quantity,
-            lat=self.ELAT.quantity,
-            obliquity=OBL[self.ECL.value],
-            obstime=self.POSEPOCH.quantity,
-            pm_lon_coslat=(
-                self.PMELONG.uncertainty
-                if self.PMELONG.uncertainty is not None
-                else 0 * self.PMELONG.units
-            ),
-            pm_lat=(
-                self.PMELAT.uncertainty
-                if self.PMELAT.uncertainty is not None
-                else 0 * self.PMELAT.units
-            ),
-            frame=PulsarEcliptic,
+        m_ecl.ELONG.uncertainty = elong_unc
+        m_ecl.ELAT.uncertainty = elat_unc
+        pmelong_unc, pmelat_unc = _propagate_diagonal_sky_uncertainties(
+            _ecl_sky,
+            out_ecl,
+            self.PMELONG.uncertainty,
+            self.PMELAT.uncertainty,
+            lon_includes_coslat=True,
         )
-        c_ECL = c.transform_to(PulsarEcliptic(ecl=ecl))
-        m_ecl.PMELONG.uncertainty = c_ECL.pm_lon_coslat
-        m_ecl.PMELAT.uncertainty = c_ECL.pm_lat
+        m_ecl.PMELONG.uncertainty = pmelong_unc
+        m_ecl.PMELAT.uncertainty = pmelat_unc
         # freeze comparable parameters
         m_ecl.ELONG.frozen = self.ELONG.frozen
         m_ecl.ELAT.frozen = self.ELAT.frozen
@@ -1560,54 +1620,38 @@ class AstrometryEcliptic(Astrometry):
         m_eq.PMRA.quantity = c.pm_ra_cosdec
         m_eq.PMDEC.quantity = c.pm_dec
 
-        # use fake proper motions to convert uncertainties on RA,Dec
-        # assume that RA uncertainty does not include cos(Dec)
-        # and neither does the ELONG uncertainty
-        # put it in as pm_lon_coslat since astropy complains otherwise
-        dt = 1 * u.yr
-        c = coords.SkyCoord(
-            lon=self.ELONG.quantity,
-            lat=self.ELAT.quantity,
-            obliquity=OBL[self.ECL.value],
-            obstime=self.POSEPOCH.quantity,
-            pm_lon_coslat=(
-                self.ELONG.uncertainty * np.cos(self.ELAT.quantity) / dt
-                if self.ELONG.uncertainty is not None
-                else 0 * self.ELONG.units / dt
-            ),
-            pm_lat=(
-                self.ELAT.uncertainty / dt
-                if self.ELAT.uncertainty is not None
-                else 0 * self.ELAT.units / dt
-            ),
-            frame=PulsarEcliptic,
-        )
-        c_ICRS = c.transform_to(coords.ICRS)
+        source_c = self.coords_as_ECL(epoch=epoch, ecl=self.ECL.value)
 
-        m_eq.RAJ.uncertainty = np.abs(c_ICRS.pm_ra_cosdec * dt / np.cos(c_ICRS.dec))
-        m_eq.DECJ.uncertainty = np.abs(c_ICRS.pm_dec * dt)
-        # use fake proper motions to convert uncertainties on proper motion
-        # assume that PMELONG uncertainty includes cos(DEC)
-        c = coords.SkyCoord(
-            lon=self.ELONG.quantity,
-            lat=self.ELAT.quantity,
-            obliquity=OBL[self.ECL.value],
-            obstime=self.POSEPOCH.quantity,
-            pm_lon_coslat=(
-                self.PMELONG.uncertainty
-                if self.PMELONG.uncertainty is not None
-                else 0 * self.PMELONG.units
-            ),
-            pm_lat=(
-                self.PMELAT.uncertainty
-                if self.PMELAT.uncertainty is not None
-                else 0 * self.PMELAT.units
-            ),
-            frame=PulsarEcliptic,
+        def _ecl_sky(pm_lon_coslat, pm_lat):
+            return coords.SkyCoord(
+                lon=source_c.lon,
+                lat=source_c.lat,
+                obliquity=OBL[self.ECL.value],
+                obstime=source_c.obstime,
+                pm_lon_coslat=pm_lon_coslat,
+                pm_lat=pm_lat,
+                frame=PulsarEcliptic,
+            )
+
+        raj_unc, decj_unc = _propagate_diagonal_sky_uncertainties(
+            _ecl_sky,
+            coords.ICRS(),
+            self.ELONG.uncertainty,
+            self.ELAT.uncertainty,
+            lat_in=source_c.lat,
+            lon_includes_coslat=False,
         )
-        c_ICRS = c.transform_to(coords.ICRS)
-        m_eq.PMRA.uncertainty = np.abs(c_ICRS.pm_ra_cosdec)
-        m_eq.PMDEC.uncertainty = np.abs(c_ICRS.pm_dec)
+        m_eq.RAJ.uncertainty = raj_unc
+        m_eq.DECJ.uncertainty = decj_unc
+        pmra_unc, pmdec_unc = _propagate_diagonal_sky_uncertainties(
+            _ecl_sky,
+            coords.ICRS(),
+            self.PMELONG.uncertainty,
+            self.PMELAT.uncertainty,
+            lon_includes_coslat=True,
+        )
+        m_eq.PMRA.uncertainty = pmra_unc
+        m_eq.PMDEC.uncertainty = pmdec_unc
         # freeze comparable parameters
         m_eq.RAJ.frozen = self.ELONG.frozen
         m_eq.DECJ.frozen = self.ELAT.frozen

--- a/tests/test_modelconversions.py
+++ b/tests/test_modelconversions.py
@@ -81,8 +81,11 @@ def test_ICRS_to_ECL_nouncertainties():
         MJDStart, MJDStop, NTOA, model=model_ICRS, error=1 * u.us, add_noise=True
     )
     r_ICRS = pint.residuals.Residuals(toas, model_ICRS)
-    r_ECL = pint.residuals.Residuals(toas, model_ICRS.as_ECL())
+    converted = model_ICRS.as_ECL()
+    r_ECL = pint.residuals.Residuals(toas, converted)
     assert np.allclose(r_ECL.resids, r_ICRS.resids)
+    assert converted.PMELONG.uncertainty is None
+    assert converted.PMELAT.uncertainty is None
     # assert model_ICRS.as_ECL(ecl).ECL.value == ecl
 
 
@@ -97,8 +100,11 @@ def test_ECL_to_ICRS_nouncertainties():
         MJDStart, MJDStop, NTOA, model=model_ECL, error=1 * u.us, add_noise=True
     )
     r_ECL = pint.residuals.Residuals(toas, model_ECL)
-    r_ICRS = pint.residuals.Residuals(toas, model_ECL.as_ICRS())
+    converted = model_ECL.as_ICRS()
+    r_ICRS = pint.residuals.Residuals(toas, converted)
     assert np.allclose(r_ECL.resids, r_ICRS.resids)
+    assert converted.PMRA.uncertainty is None
+    assert converted.PMDEC.uncertainty is None
 
 
 def test_ECL_to_ECL():
@@ -197,3 +203,140 @@ def test_ECL_to_allECL(ecl):
     assert model_ECL2.ECL.value == ecl
     # note that coord.separation() will transform between frames when needed
     assert np.isclose(model_ECL.get_psr_coords().separation(coords_ECL2).arcsec, 0)
+
+
+# High-|ELAT| ecliptic astrometry: the old signed-vector uncertainty transform
+# returned a negative ELONG σ on the ICRS→ECL leg (PPTA J0711-6830 / J1017-7156).
+modelstring_ECL_high_lat = """
+PSR J0711-6830
+ELONG  204.06115135931555  1  5.698305032154e-08
+ELAT   -82.88863150271472  1  5.66560917129e-09
+PMELONG -12.03829529527527 1  0.003414889229688632
+PMELAT  -17.28185806109565 1  0.003068280695947412
+F0 182.11723462004737 1
+PEPOCH 55636
+POSEPOCH 55636
+ECL IERS2010
+"""
+
+
+def test_ecliptic_obliquity_uncertainty_roundtrip():
+    """ECL→ECL obliquity change must preserve diagonal uncertainties.
+
+    The IERS2003/IERS2010 obliquities differ by only 1e-4 arcsec, so the
+    tangent-frame rotation is tiny, so the induced correlation discarded by
+    the parameter-only representation is negligible and the input marginal
+    uncertainties return to numerical precision. This is not an assertion
+    that a general frame round trip preserves a full covariance matrix.
+    """
+    model = get_model(io.StringIO(modelstring_ECL_high_lat))
+    roundtrip = model.as_ECL(ecl="IERS2003").as_ECL(ecl="IERS2010")
+    for name in ("ELONG", "ELAT", "PMELONG", "PMELAT"):
+        assert np.isclose(
+            getattr(model, name).uncertainty.to_value(
+                getattr(roundtrip, name).uncertainty.unit
+            ),
+            getattr(roundtrip, name).uncertainty.value,
+            rtol=1e-12,
+            atol=0,
+        ), name
+
+
+def test_icrs_to_ecliptic_uncertainties_match_covariance_rotation():
+    """Check one-way marginals against an analytic tangent-plane rotation."""
+    model = get_model(
+        io.StringIO(
+            """
+PSR TEST
+RAJ 00:00:00
+DECJ +00:00:00
+PMRA 1
+PMDEC 1
+F0 100
+PEPOCH 55000
+POSEPOCH 55000
+"""
+        )
+    )
+    model.RAJ.uncertainty = 1 * u.mas
+    model.DECJ.uncertainty = 100 * u.mas
+    model.PMRA.uncertainty = 2 * u.mas / u.yr
+    model.PMDEC.uncertainty = 50 * u.mas / u.yr
+
+    converted = model.as_ECL(ecl="IERS2010")
+    obliquity = OBL["IERS2010"]
+
+    def expected(sigma_lon, sigma_lat):
+        return (
+            np.hypot(
+                np.cos(obliquity) * sigma_lon,
+                np.sin(obliquity) * sigma_lat,
+            ),
+            np.hypot(
+                np.sin(obliquity) * sigma_lon,
+                np.cos(obliquity) * sigma_lat,
+            ),
+        )
+
+    elong, elat = expected(1 * u.mas, 100 * u.mas)
+    pmelong, pmelat = expected(2 * u.mas / u.yr, 50 * u.mas / u.yr)
+    assert u.isclose(converted.ELONG.uncertainty, elong)
+    assert u.isclose(converted.ELAT.uncertainty, elat)
+    assert u.isclose(converted.PMELONG.uncertainty, pmelong)
+    assert u.isclose(converted.PMELAT.uncertainty, pmelat)
+
+
+def test_as_ecl_uncertainties_use_requested_epoch_frame():
+    """Rotate uncertainties in the tangent frame used for converted values."""
+    par = """
+PSR TEST
+RAJ 00:00:00 1 0.001
+DECJ +70:00:00 1 0.01
+PMRA 100000 1 10
+PMDEC -50000 1 20
+F0 100
+PEPOCH 55000
+POSEPOCH 55000
+"""
+    model = get_model(io.StringIO(par))
+    target_epoch = 65000
+    propagated = model.coords_as_ICRS(epoch=target_epoch)
+
+    # Construct the equivalent source model directly at the requested epoch.
+    at_epoch = get_model(io.StringIO(par))
+    at_epoch.RAJ.quantity = propagated.ra
+    at_epoch.DECJ.quantity = propagated.dec
+    at_epoch.PMRA.quantity = propagated.pm_ra_cosdec
+    at_epoch.PMDEC.quantity = propagated.pm_dec
+    at_epoch.POSEPOCH.value = target_epoch
+
+    converted = model.as_ECL(epoch=target_epoch)
+    expected = at_epoch.as_ECL()
+    for name in ("ELONG", "ELAT", "PMELONG", "PMELAT"):
+        assert u.allclose(
+            getattr(converted, name).uncertainty,
+            getattr(expected, name).uncertainty,
+        ), name
+
+
+def test_as_ecl_uncertainties_are_nonnegative():
+    """ICRS→ECL must not assign a signed/negative uncertainty.
+
+    High-|ELAT| sources (e.g. PPTA J0711-6830) previously failed here with
+    ``Uncertainties cannot be negative`` because ``as_ECL`` transformed
+    ``(σ_lon, σ_lat)`` as a signed vector while ``as_ICRS`` wrapped the
+    reverse transform in ``np.abs``.
+    """
+    model = get_model(io.StringIO(modelstring_ECL_high_lat))
+    ecl = model.as_ICRS().as_ECL(ecl="IERS2010")
+    for name in ("ELONG", "ELAT", "PMELONG", "PMELAT"):
+        unc = getattr(ecl, name).uncertainty
+        assert unc is not None
+        assert unc.value >= 0, name
+    # The old signed-vector path produced |σ_ELONG| ≈ 6.68e-8 deg here;
+    # covariance rotation must stay near the input 5.70e-8 deg.
+    assert np.isclose(
+        model.ELONG.uncertainty.to_value(u.deg),
+        ecl.ELONG.uncertainty.to_value(u.deg),
+        rtol=0.02,
+    )


### PR DESCRIPTION
## Summary
`AstrometryEquatorial.as_ECL` and `AstrometryEcliptic.as_ICRS` (and the ECL→ECL obliquity path) propagate position/PM uncertainties with the "fake proper motion" trick. That treated `(σ_lon, σ_lat)` as a **signed vector**. `as_ICRS` wrapped the result in `np.abs`; `as_ECL` did not. On high-`|ELAT|` pulsars an ECL→ICRS→ECL round trip can therefore assign a **negative** ELONG uncertainty and raise:

`ValueError: Uncertainties cannot be negative but -6.68e-08 deg was supplied`

(seen on PPTA DR3 J0711-6830 / J1017-7156). Even with `abs` on both sides, a vector rotation is the wrong marginal σ after a non-trivial frame change.

This PR replaces the signed-vector path with a **diagonal covariance rotation**: transform each uncertainty axis separately and combine in quadrature (still assuming zero correlation, as before). Uncertainties are always non-negative, and an IERS2010↔IERS2003 obliquity round trip recovers the input σ to numerical precision.

## Test plan
- [x] `pytest tests/test_modelconversions.py -v`
- [x] New regression: high-`|ELAT|` model survives `as_ICRS().as_ECL()` with non-negative σ near the input
- [x] New regression: ECL obliquity round trip preserves diagonal uncertainties
- [ ] Confirm CI green

## Notes
A full ECL→ICRS→ECL identity still cannot recover σ exactly under a diagonal-only assumption (the intermediate frame acquires correlation that we drop). That is unchanged in spirit from the previous helpers; the obliquity-only path MetaPulsar uses is exact.