### PR TITLE
feat: updated accuracy of TCB-->TDB conversion

### DIFF
--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -13,7 +13,9 @@ the released changes.
   keeps radio frequency undilated, converts FD/FDJUMP and order-aware DM
   coefficients, leaves PX and UTC/data-span selectors explicitly invariant,
   and reports unsupported active deterministic terms. Converted epochs and DM
-  values therefore differ from the previous legacy-IFTE conversion.
+  values therefore differ from the previous legacy-IFTE conversion. The
+  compatibility alias `IFTE_K` now denotes the IAU/ERFA rate; the obsolete
+  `IFTE_MJD0` and `IFTE_KM1` module constants have been removed.
 ### Added
 - Time-domain solar wind GP noise components: ridge, squared-exponential, Matérn, and quasi-periodic kernels
 - Documentation page explaining the time-domain solar wind noise model, its interpolation basis, and how it differs from the Fourier-basis noise models

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -21,4 +21,7 @@ the released changes.
 - Documentation page explaining the time-domain solar wind noise model, its interpolation basis, and how it differs from the Fourier-basis noise models
 - `TOAs.get_tdb_seconds()`, returning the TDB times of the TOAs in seconds with a selectable dtype
 ### Fixed
+- TCB/TDB parameter scaling uses ``x + x (K^n-1)`` with ``K^n-1`` formed
+  from ``L_B``, so a float64 rounding of ``K`` (a factor near 1) cannot
+  put a ~10 ns error into ``F0`` over 1250 d.
 ### Removed

--- a/CHANGELOG-unreleased.md
+++ b/CHANGELOG-unreleased.md
@@ -9,6 +9,11 @@ the released changes.
 
 ## Unreleased
 ### Changed
+- TCB/TDB conversion now matches PINT's IAU 2006/Astropy TDB forward model,
+  keeps radio frequency undilated, converts FD/FDJUMP and order-aware DM
+  coefficients, leaves PX and UTC/data-span selectors explicitly invariant,
+  and reports unsupported active deterministic terms. Converted epochs and DM
+  values therefore differ from the previous legacy-IFTE conversion.
 ### Added
 - Time-domain solar wind GP noise components: ridge, squared-exponential, Matérn, and quasi-periodic kernels
 - Documentation page explaining the time-domain solar wind noise model, its interpolation basis, and how it differs from the Fourier-basis noise models

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -151,14 +151,18 @@ in, and what kind of time you're asking for::
 
 The conventional time scale for working with pulsars, and the one PINT
 uses, is Barycentric Dynamical Time (TDB). You should be aware that there
-is another time scale, not yet fully supported in PINT, called Barycentric
-Coordinate Time (TCB). Because of different handling of relativistic 
-corrections, the TCB timescale does not advance at the same rate as TDB
-(there is also a many-second offset). TEMPO2 uses TCB by default, so
-you may encounter pulsar timing models or even measurements that use
-TCB. PINT provides a command line tool `tcb2tdb` to approximately convert
-TCB timing models to TDB. PINT can also optionally convert TCB timing models
-to TDB (approximately) upon read.
+is another time scale, not evaluated directly by PINT, called Barycentric
+Coordinate Time (TCB). TCB does not advance at the same rate as TDB and has a
+different origin. TEMPO2 uses TCB by default, so you may encounter pulsar
+timing models or measurements that use TCB.
+
+PINT's ``tcb2tdb`` tool and ``allow_tcb=True`` reader convert every supported
+parameter onto PINT's TDB forward model. Coordinate epochs use
+``astropy.time.Time``/ERFA's IAU 2006 transformation, radio frequency remains
+undilated (``DILATEFREQ N``), and PX is explicitly unchanged because PINT
+implements no corresponding spatial-coordinate scaling. Unsupported active
+deterministic terms are left unchanged and reported. A report is accepted
+only when the model is covered by PINT's tested no-refit conversion surface.
 
 Note that the need for leap seconds is because the Earth's rotation is
 somewhat erratic - no, we're not about to be thrown off, but its

--- a/docs/tcb2tdb-factors.rst
+++ b/docs/tcb2tdb-factors.rst
@@ -1,22 +1,25 @@
 .. highlight:: shell
 
-How to determine the scaling factor for TCB <-> TDB conversion for a parameter
-------------------------------------------------------------------------------
+How PINT converts TCB and TDB parameters
+----------------------------------------
 
-The TCB and TDB timescales differ by a constant factor in the definition of the second.
-This means that the epochs and TOAs must be scaled according to the following expression::
-    
-    t_tdb = (t_tcb - IFTE_MJD0) / IFTE_K + IFTE_MJD0
+PINT evaluates timing models in TDB and does not evaluate ``UNITS TCB``
+models directly. The converter therefore maps a TCB parameterization onto
+PINT's existing TDB forward model.
 
-Similarly, a time difference will be scaled as::
-    
-    dt_tdb = dt_tcb / IFTE_K
+Coordinate epochs are converted with :class:`astropy.time.Time`, which uses
+ERFA's IAU 2006 TCB/TDB realization, including the defining ``TDB0`` offset.
+The implementation does not duplicate the IAU constants.
+
+For intervals, define ``F = d(TDB)/d(TCB) = 1 - L_B`` and ``K = 1/F``::
+
+    dt_tdb = F * dt_tcb
 
 Since the definition of the second is changing, all parameters involved in the timing model
 must also be transformed. In the simplest case, if a quantity x has dimensions of [T^n], it
 will be transformed as::
     
-    x_tdb = x_tcb / IFTE_K^n
+    x_tdb = x_tcb / K^n
 
 This rule applies to the majority of parameters.
 
@@ -25,22 +28,19 @@ by some constants. Examples include
 
     1. DM appears as DMconst * DM
     2. A1 appears as A1 / c
-    3. PX appears as PX * c / AU 
-    4. M2 appears as M2 * G / c^3
+    3. M2 appears as M2 * G / c^3
 
-In these cases, it is customary to keep the multiplication factor numerically constant during 
-TCB <-> TDB conversion, and to absorb the effect of converting this constant into the parameter
-itself. If a parameter has such a factor, it must be specified using the `tcb2tdb_scale_factor`
+In these cases, PINT keeps the multiplication factor numerically constant during
+TCB <-> TDB conversion and absorbs the conversion into the parameter. If a
+parameter has such a factor, specify it using the ``tcb2tdb_scale_factor``
 argument while constructing the `Parameter` object. For example, DM will have 
 `tcb2tdb_scale_factor=DMconst`.
 
 Note that the parameter multiplied by the constant in these cases has dimensions of the 
 form [T^n]. In the above cases, the value of n is as follows.
 
-    1. DM has n = -1
-    2. A1 has n = 1
-    3. PX has n = -1
-    4. M2 has n = 1
+    1. A1 has n = 1
+    2. M2 has n = 1
 
 In general, if a parameter x appears in the timing model as C*x and if C*x has dimensionality of
 the form [T^n], the scaling should be done with the "effective dimensionality" n.
@@ -49,11 +49,33 @@ If a parameter doesn't have a dimensionality of [T^n], a general rule is to reor
 factors in the equation such that each group has a dimensionality [T^n]. This is ALWAYS possible
 because the timing model components produce either a delay ([T^1]) or a phase ([T^0]).
 
-A useful trick for doing this type of transformation is to express the parameters in geometrized 
-units, where everything has dimensions of [T^n]. For example, a mass M will be expressed as M*(G/c^3)
-(e.g., M2, MTOT), and a distance L will be expressed as L/c (e.g., A1). Please note that this may not 
-work in every case, and each parameter should be treated in a case-by-case basis depending on the 
-delay/phase expression they appear in.
+A useful trick is to express parameters in geometrized units, where everything
+has dimensions of ``T^n``. This is only the default: component-owned conversion
+metadata overrides it when the forward model fixes an independent variable.
+
+Radio-frequency decision
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+PINT supports ``DILATEFREQ N``. Its barycentric radio frequency applies the
+Earth-motion Doppler correction but is not dilated by ``K`` during unit
+conversion. The converter holds that frequency numerically fixed.
+
+Consequently, deterministic dispersion delays scale by ``F``. For the DM
+Taylor series, order ``q`` scales as::
+
+    DM_tdb^(q) = K^(q-1) DM_tcb^(q)
+
+Thus DM scales by ``F``, DM1 is unchanged, and DM2 scales by ``K``. This
+order-aware rule is represented by component-owned metadata rather than a
+global parameter-name table.
+
+Explicit invariants
+~~~~~~~~~~~~~~~~~~~
+
+PX is left numerically unchanged because PINT does not implement a matching
+TCB/TDB spatial-coordinate transformation. ``START`` and ``FINISH`` are
+data-span selectors and are also unchanged. UTC interval selectors such as
+DMX range boundaries remain UTC and are not coordinate epochs.
 
 Exceptions to this are noise parameters. The TOA uncertainties are measured in the observatory 
 timescale and are not converted into TCB or TDB before computing the likelihood function/
@@ -62,10 +84,10 @@ EQUADs. Since we are not converting TOA variances, it doesn't make sense to conv
 either. Hence, ECORRs and red and DM noise parameters are not converted. This means that 
 the noise parameters must ALWAYS be re-estimated after a TCB <-> TDB conversion.
 
-Another exception to this are FD parameters and FD jumps, which involve polynomials of logarithms.
-Such functions transform in a non-linear fashion during TCB <-> TDB conversion, and we have chosen
-not to apply the conversion to such parameters. They too must be re-estimated after a TCB <-> TDB 
-conversion.
+FD and FDJUMP coefficients are time-valued amplitudes evaluated at PINT's
+fixed radio frequency, so every coefficient scales by ``F``. No logarithmic
+coefficient mixing is needed.
 
-In such cases, the parameter can be excluded from TCB <-> TDB conversion by passing `convert_tcb2tdb=False`
-into the `Parameter` class constructor.
+Unsupported active deterministic terms are left unchanged and reported. They
+do not prevent supported parameters from being converted. A conversion is
+covered by the no-refit accuracy contract only when its report is accepted.

--- a/src/pint/models/absolute_phase.py
+++ b/src/pint/models/absolute_phase.py
@@ -27,7 +27,6 @@ class AbsPhase(PhaseComponent):
 
     register = True
     category = "absolute_phase"
-    tcb2tdb_certified = True
 
     def __init__(self):
         super().__init__()
@@ -48,10 +47,7 @@ class AbsPhase(PhaseComponent):
             floatParameter(
                 name="TZRFRQ",
                 units=u.MHz,
-                description=(
-                    "The undilated frequency of the zero phase TOA "
-                    "(invariant under TCB/TDB conversion)."
-                ),
+                description="Frequency of the zero phase TOA.",
                 convert_tcb2tdb=False,
                 tcb2tdb_scale_factor=u.Quantity(1),
                 tcb2tdb_invariant=True,
@@ -77,7 +73,7 @@ class AbsPhase(PhaseComponent):
             self.TZRSITE.value = "ssb"
         if self.TZRSITE.value == "ssb":
             # A barycentric TZRMJD follows the model's coordinate time scale.
-            self.TZRMJD.time_scale = self._parent.UNITS.value.lower()
+            self.TZRMJD.time_scale = (self._parent.UNITS.value or "TDB").lower()
             log.info("The TZRSITE is set at the solar system barycenter.")
 
         if (self.TZRFRQ.value is None) or (self.TZRFRQ.value == 0.0):

--- a/src/pint/models/absolute_phase.py
+++ b/src/pint/models/absolute_phase.py
@@ -27,6 +27,7 @@ class AbsPhase(PhaseComponent):
 
     register = True
     category = "absolute_phase"
+    tcb2tdb_certified = True
 
     def __init__(self):
         super().__init__()
@@ -35,7 +36,7 @@ class AbsPhase(PhaseComponent):
                 name="TZRMJD",
                 description="Epoch of the zero phase TOA.",
                 time_scale="utc",
-                convert_tcb2tdb=False,
+                tcb2tdb_scale_factor=u.Quantity(1),
             )
         )
         self.add_param(
@@ -47,8 +48,13 @@ class AbsPhase(PhaseComponent):
             floatParameter(
                 name="TZRFRQ",
                 units=u.MHz,
-                description="The frequency of the zero phase TOA.",
+                description=(
+                    "The undilated frequency of the zero phase TOA "
+                    "(invariant under TCB/TDB conversion)."
+                ),
                 convert_tcb2tdb=False,
+                tcb2tdb_scale_factor=u.Quantity(1),
+                tcb2tdb_invariant=True,
             )
         )
         self.tz_cache = None
@@ -69,8 +75,9 @@ class AbsPhase(PhaseComponent):
             )
         if self.TZRSITE.value is None:
             self.TZRSITE.value = "ssb"
-            # update the TZRMJD to new time scale
-            self.TZRMJD.time_scale = "tdb"
+        if self.TZRSITE.value == "ssb":
+            # A barycentric TZRMJD follows the model's coordinate time scale.
+            self.TZRMJD.time_scale = self._parent.UNITS.value.lower()
             log.info("The TZRSITE is set at the solar system barycenter.")
 
         if (self.TZRFRQ.value is None) or (self.TZRFRQ.value == 0.0):

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -57,6 +57,7 @@ class Astrometry(DelayComponent):
 
     register = False
     category = "astrometry"
+    tcb2tdb_certified = True
 
     def __init__(self):
         super().__init__()
@@ -74,8 +75,13 @@ class Astrometry(DelayComponent):
                 name="PX",
                 units="mas",
                 value=0.0,
-                description="Parallax",
+                description=(
+                    "Parallax (left invariant by TCB/TDB conversion because "
+                    "PINT implements no corresponding spatial-coordinate scaling)"
+                ),
+                convert_tcb2tdb=False,
                 tcb2tdb_scale_factor=(consts.c / u.au),
+                tcb2tdb_invariant=True,
             )
         )
 

--- a/src/pint/models/astrometry.py
+++ b/src/pint/models/astrometry.py
@@ -75,10 +75,7 @@ class Astrometry(DelayComponent):
                 name="PX",
                 units="mas",
                 value=0.0,
-                description=(
-                    "Parallax (left invariant by TCB/TDB conversion because "
-                    "PINT implements no corresponding spatial-coordinate scaling)"
-                ),
+                description="Parallax",
                 convert_tcb2tdb=False,
                 tcb2tdb_scale_factor=(consts.c / u.au),
                 tcb2tdb_invariant=True,

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -25,6 +25,11 @@ from pint.utils import split_prefixed_name, taylor_horner, taylor_horner_deriv
 # DMconst = 1.0 / 2.41e-4 * u.MHz * u.MHz * u.s * u.cm**3 / u.pc
 
 
+def _dm_derivative_tcb2tdb_scale_exponent(param):
+    """Scale DM derivatives as K**(order-1) at PINT's fixed radio frequency."""
+    return param.index - 1
+
+
 class Dispersion(DelayComponent):
     """A base dispersion timing model.
 
@@ -140,6 +145,7 @@ class DispersionDM(Dispersion):
 
     register = True
     category = "dispersion_constant"
+    tcb2tdb_certified = True
 
     def __init__(self):
         super().__init__()
@@ -151,6 +157,7 @@ class DispersionDM(Dispersion):
                 description="Dispersion measure",
                 long_double=True,
                 tcb2tdb_scale_factor=DMconst,
+                tcb2tdb_scale_exponent=-1,
             )
         )
         self.add_param(
@@ -163,6 +170,7 @@ class DispersionDM(Dispersion):
                 type_match="float",
                 long_double=True,
                 tcb2tdb_scale_factor=DMconst,
+                tcb2tdb_scale_exponent=_dm_derivative_tcb2tdb_scale_exponent,
             )
         )
         self.add_param(
@@ -318,6 +326,7 @@ class DispersionDMX(Dispersion):
 
     register = True
     category = "dispersion_dmx"
+    tcb2tdb_certified = True
 
     def __init__(self):
         super().__init__()
@@ -331,6 +340,7 @@ class DispersionDMX(Dispersion):
                 value=0.0,
                 description="Dispersion measure",
                 convert_tcb2tdb=False,
+                tcb2tdb_invariant=True,
             )
         )
 
@@ -401,6 +411,7 @@ class DispersionDMX(Dispersion):
                 parameter_type="float",
                 frozen=frozen,
                 tcb2tdb_scale_factor=DMconst,
+                tcb2tdb_scale_exponent=-1,
             )
         )
         self.add_param(
@@ -411,7 +422,8 @@ class DispersionDMX(Dispersion):
                 parameter_type="MJD",
                 time_scale="utc",
                 value=mjd_start,
-                tcb2tdb_scale_factor=u.Quantity(1),
+                convert_tcb2tdb=False,
+                tcb2tdb_invariant=True,
             )
         )
         self.add_param(
@@ -422,7 +434,8 @@ class DispersionDMX(Dispersion):
                 parameter_type="MJD",
                 time_scale="utc",
                 value=mjd_end,
-                tcb2tdb_scale_factor=u.Quantity(1),
+                convert_tcb2tdb=False,
+                tcb2tdb_invariant=True,
             )
         )
         self.setup()

--- a/src/pint/models/dispersion_model.py
+++ b/src/pint/models/dispersion_model.py
@@ -533,6 +533,7 @@ class DispersionDMX(Dispersion):
                     parameter_type="float",
                     frozen=frozen,
                     tcb2tdb_scale_factor=DMconst,
+                    tcb2tdb_scale_exponent=-1,
                 )
             )
             self.add_param(
@@ -544,6 +545,8 @@ class DispersionDMX(Dispersion):
                     time_scale="utc",
                     value=mjd_start,
                     tcb2tdb_scale_factor=u.Quantity(1),
+                    convert_tcb2tdb=False,
+                    tcb2tdb_invariant=True,
                 )
             )
             self.add_param(
@@ -555,6 +558,8 @@ class DispersionDMX(Dispersion):
                     time_scale="utc",
                     value=mjd_end,
                     tcb2tdb_scale_factor=u.Quantity(1),
+                    convert_tcb2tdb=False,
+                    tcb2tdb_invariant=True,
                 )
             )
         self.setup()

--- a/src/pint/models/fdjump.py
+++ b/src/pint/models/fdjump.py
@@ -59,6 +59,7 @@ class FDJump(DelayComponent):
 
     register = True
     category = "fdjump"
+    tcb2tdb_certified = True
 
     def __init__(self):
         super().__init__()
@@ -79,7 +80,8 @@ class FDJump(DelayComponent):
                     name=f"FD{j}JUMP",
                     units="second",
                     description=f"System-dependent FD parameter of polynomial index {j}",
-                    convert_tcb2tdb=False,
+                    tcb2tdb_scale_factor=u.Quantity(1),
+                    tcb2tdb_scale_exponent=-1,
                 )
             )
 

--- a/src/pint/models/frequency_dependent.py
+++ b/src/pint/models/frequency_dependent.py
@@ -30,6 +30,7 @@ class FD(DelayComponent):
 
     register = True
     category = "frequency_dependent"
+    tcb2tdb_certified = True
 
     def __init__(self):
         super().__init__()
@@ -45,7 +46,8 @@ class FD(DelayComponent):
                 descriptionTplt=self._description_template,
                 # unitTplt=lambda x: "second",
                 type_match="float",
-                convert_tcb2tdb=False,
+                tcb2tdb_scale_factor=u.Quantity(1),
+                tcb2tdb_scale_exponent=-1,
             )
         )
 

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -657,6 +657,10 @@ class floatParameter(Parameter):
     tcb2tdb_scale_factor: astropy.units.Quantity
         The scaling factor to be applied while computing the effective
         dimensionality. The default is 1.
+    tcb2tdb_scale_exponent: int or callable, optional
+        Explicit power of the TCB/TDB rate, overriding effective dimensionality.
+    tcb2tdb_invariant: bool, optional
+        Whether this parameter is explicitly unchanged by conversion.
 
     Example
     -------
@@ -682,6 +686,8 @@ class floatParameter(Parameter):
         scale_threshold=None,
         convert_tcb2tdb=True,
         tcb2tdb_scale_factor=None,
+        tcb2tdb_scale_exponent=None,
+        tcb2tdb_invariant=False,
         **kwargs,
     ):
         self.long_double = long_double
@@ -714,6 +720,8 @@ class floatParameter(Parameter):
         ), f"Please specify the tcb2tdb_scale_factor explicitly for {name}."
         self.convert_tcb2tdb = convert_tcb2tdb
         self.tcb2tdb_scale_factor = tcb2tdb_scale_factor
+        self.tcb2tdb_scale_exponent = tcb2tdb_scale_exponent
+        self.tcb2tdb_invariant = tcb2tdb_invariant
 
     @property
     def long_double(self):
@@ -1094,6 +1102,8 @@ class MJDParameter(Parameter):
         be accepted for this parameter.
     time_scale : str, optional, default 'tdb'
         MJD parameter time scale.
+    tcb2tdb_invariant : bool, optional
+        Whether this MJD is a selector that remains numerically unchanged.
 
     Example
     -------
@@ -1115,6 +1125,7 @@ class MJDParameter(Parameter):
         time_scale="tdb",
         convert_tcb2tdb=True,
         tcb2tdb_scale_factor=None,
+        tcb2tdb_invariant=False,
         **kwargs,
     ):
         self._time_scale = time_scale
@@ -1138,6 +1149,7 @@ class MJDParameter(Parameter):
         ), f"Please specify the tcb2tdb_scale_factor explicitly for {name}."
         self.convert_tcb2tdb = convert_tcb2tdb
         self.tcb2tdb_scale_factor = tcb2tdb_scale_factor
+        self.tcb2tdb_invariant = tcb2tdb_invariant
 
     def str_quantity(self, quan):
         return time_to_mjd_string(quan)
@@ -1284,6 +1296,10 @@ class AngleParameter(Parameter):
     tcb2tdb_scale_factor: astropy.units.Quantity
         The scaling factor to be applied while computing the effective
         dimensionality. The default is 1.
+    tcb2tdb_scale_exponent: int or callable, optional
+        Explicit power of the TCB/TDB rate, overriding effective dimensionality.
+    tcb2tdb_invariant: bool, optional
+        Whether this parameter is explicitly unchanged by conversion.
 
     Example
     -------
@@ -1488,6 +1504,11 @@ class prefixParameter:
         The scaling factor to be applied while computing the effective
         dimensionality. If this is a function, it should take the prefix as
         argument and return the scaling factor. The default is 1.
+    tcb2tdb_scale_exponent: int or callable, optional
+        Explicit power of the TCB/TDB rate. A callable receives the concrete
+        parameter, allowing order-aware prefixed families.
+    tcb2tdb_invariant: bool, optional
+        Whether the parameter is explicitly unchanged by TCB/TDB conversion.
     """
 
     def __init__(
@@ -1510,6 +1531,8 @@ class prefixParameter:
         time_scale="utc",
         convert_tcb2tdb=True,
         tcb2tdb_scale_factor=None,
+        tcb2tdb_scale_exponent=None,
+        tcb2tdb_invariant=False,
         **kwargs,
     ):
         # Split prefixed name, if the name is not in the prefixed format, error
@@ -1580,6 +1603,8 @@ class prefixParameter:
             scale_threshold=scale_threshold,
             convert_tcb2tdb=convert_tcb2tdb,
             tcb2tdb_scale_factor=tcb2tdb_scale_factor_val,
+            tcb2tdb_scale_exponent=tcb2tdb_scale_exponent,
+            tcb2tdb_invariant=tcb2tdb_invariant,
         )
         self.is_prefix = True
         self.time_scale = time_scale
@@ -1688,6 +1713,14 @@ class prefixParameter:
     def tcb2tdb_scale_factor(self):
         return self.param_comp.tcb2tdb_scale_factor
 
+    @property
+    def tcb2tdb_scale_exponent(self):
+        return getattr(self.param_comp, "tcb2tdb_scale_exponent", None)
+
+    @property
+    def tcb2tdb_invariant(self):
+        return getattr(self.param_comp, "tcb2tdb_invariant", False)
+
     def __repr__(self):
         return self.param_comp.__repr__()
 
@@ -1749,6 +1782,8 @@ class prefixParameter:
                 "parameter_type",
                 "convert_tcb2tdb",
                 "tcb2tdb_scale_factor",
+                "tcb2tdb_scale_exponent",
+                "tcb2tdb_invariant",
             ]
             if hasattr(self, key) and (key != "frozen" or inheritfrozen)
         }
@@ -1859,6 +1894,8 @@ class maskParameter(floatParameter):
         aliases=[],
         convert_tcb2tdb=True,
         tcb2tdb_scale_factor=None,
+        tcb2tdb_scale_exponent=None,
+        tcb2tdb_invariant=False,
     ):
         self.is_mask = True
         # {key_name: (keyvalue parse function, keyvalue length)}
@@ -1911,6 +1948,8 @@ class maskParameter(floatParameter):
             long_double=long_double,
             convert_tcb2tdb=convert_tcb2tdb,
             tcb2tdb_scale_factor=tcb2tdb_scale_factor,
+            tcb2tdb_scale_exponent=tcb2tdb_scale_exponent,
+            tcb2tdb_invariant=tcb2tdb_invariant,
         )
 
         # For the first mask parameter, add name to aliases for the reading

--- a/src/pint/models/parameter.py
+++ b/src/pint/models/parameter.py
@@ -1321,6 +1321,8 @@ class AngleParameter(Parameter):
         aliases=None,
         convert_tcb2tdb=True,
         tcb2tdb_scale_factor=None,
+        tcb2tdb_scale_exponent=None,
+        tcb2tdb_invariant=False,
         **kwargs,
     ):
         self._str_unit = units
@@ -1355,6 +1357,8 @@ class AngleParameter(Parameter):
         ), f"Please specify the tcb2tdb_scale_factor explicitly for {name}."
         self.convert_tcb2tdb = convert_tcb2tdb
         self.tcb2tdb_scale_factor = tcb2tdb_scale_factor
+        self.tcb2tdb_scale_exponent = tcb2tdb_scale_exponent
+        self.tcb2tdb_invariant = tcb2tdb_invariant
 
     def _get_value(self, quan):
         # return Angle(x * self.unit_identifier[units.lower()][0])
@@ -1620,6 +1624,14 @@ class prefixParameter:
     @units.setter
     def units(self, unt):
         self.param_comp.units = unt
+
+    @property
+    def time_scale(self):
+        return self.param_comp.time_scale
+
+    @time_scale.setter
+    def time_scale(self, val):
+        self.param_comp.time_scale = val
 
     @property
     def quantity(self):
@@ -2149,6 +2161,8 @@ class maskParameter(floatParameter):
                 aliases=self.prefix_aliases,
                 convert_tcb2tdb=self.convert_tcb2tdb,
                 tcb2tdb_scale_factor=self.tcb2tdb_scale_factor,
+                tcb2tdb_scale_exponent=self.tcb2tdb_scale_exponent,
+                tcb2tdb_invariant=self.tcb2tdb_invariant,
             )
             if copy_all
             else maskParameter(
@@ -2159,6 +2173,8 @@ class maskParameter(floatParameter):
                 aliases=self.prefix_aliases,
                 convert_tcb2tdb=self.convert_tcb2tdb,
                 tcb2tdb_scale_factor=self.tcb2tdb_scale_factor,
+                tcb2tdb_scale_exponent=self.tcb2tdb_scale_exponent,
+                tcb2tdb_invariant=self.tcb2tdb_invariant,
             )
         )
 

--- a/src/pint/models/solar_system_shapiro.py
+++ b/src/pint/models/solar_system_shapiro.py
@@ -30,6 +30,7 @@ class SolarSystemShapiro(DelayComponent):
 
     register = True
     category = "solar_system_shapiro"
+    tcb2tdb_certified = True
 
     def __init__(self):
         super().__init__()

--- a/src/pint/models/spindown.py
+++ b/src/pint/models/spindown.py
@@ -36,6 +36,7 @@ class Spindown(SpindownBase):
 
     register = True
     category = "spindown"
+    tcb2tdb_certified = True
 
     def __init__(self):
         super().__init__()

--- a/src/pint/models/tcb_conversion.py
+++ b/src/pint/models/tcb_conversion.py
@@ -35,10 +35,40 @@ __all__ = [
 # from ERFA rather than maintaining another decimal copy here.
 TCB_TDB_F = np.longdouble(1) - np.longdouble(erfa.ELB)
 TCB_TDB_K = np.longdouble(1) / TCB_TDB_F
+_TCB_TDB_L = np.longdouble(erfa.ELB)
 
 # Backwards-compatible public alias. This is now the IAU/ERFA rate, not the
 # historical IFTE common-origin epoch map.
 IFTE_K = TCB_TDB_K
+
+
+def _k_power_minus_one(exponent: int) -> np.longdouble:
+    """Return ``K**exponent - 1`` from ``L_B``, not from a factor near 1.
+
+    ``K = 1/(1-L_B)`` differs from 1 by ``~1.55e-8``. Forming ``K**n`` and
+    subtracting 1 (or multiplying ``x`` by ``K`` when ``x`` is O(10–100))
+    parks that correction in the last bits of a number near ``x``. Then a
+    float64 rounding of the factor is a ``~1e-16`` relative error, which is
+    ``~10 ns`` after ``F0`` accumulates for 1250 d.
+
+    The increment is O(``n L_B``) and is well resolved even in float64::
+
+        K**n - 1 = (1 - F**n) / F**n    n > 0
+        K**n - 1 = F**(-n) - 1          n < 0
+
+    with ``1 - F**n`` built from ``L_B`` so nothing near 1 is subtracted.
+    """
+    if exponent == 0:
+        return np.longdouble(0)
+    n = abs(exponent)
+    one_minus_fn = _TCB_TDB_L
+    fn = TCB_TDB_F
+    for _ in range(1, n):
+        one_minus_fn = _TCB_TDB_L + TCB_TDB_F * one_minus_fn
+        fn *= TCB_TDB_F
+    if exponent > 0:
+        return one_minus_fn / fn
+    return -one_minus_fn
 
 
 @dataclass(frozen=True)
@@ -62,7 +92,10 @@ class TCBTDBConversionReport:
 def scale_parameter(model: TimingModel, param: str, n: int, backwards: bool) -> None:
     """Scale a parameter x by a power of the IAU TCB/TDB rate K.
 
-        x_tdb = x_tcb * K**n
+        x_tdb = x_tcb * K**n = x_tcb + x_tcb * (K**n - 1)
+
+    The second form is what is applied: ``K**n - 1`` is O(n L_B) and is
+    obtained from ``L_B`` rather than by subtracting two values near 1.
 
     The power n depends on the "effective dimensionality" of
     the parameter as it appears in the timing model. Some examples
@@ -90,14 +123,17 @@ def scale_parameter(model: TimingModel, param: str, n: int, backwards: bool) -> 
     assert isinstance(n, int), "The power must be an integer."
 
     p = -1 if backwards else 1
-
-    factor = TCB_TDB_K ** (p * n)
+    delta = _k_power_minus_one(p * n)
 
     if (param in model) and model[param].quantity is not None:
         par = model[param]
-        par.value *= factor
+        # x * K**n = x + x*(K**n - 1). The increment is ~1e-8 relative, so
+        # this stays accurate if K itself would round to a number near 1.
+        x = np.longdouble(par.value)
+        par.value = x + x * delta
         if par.uncertainty_value is not None:
-            par.uncertainty_value *= factor
+            ux = np.longdouble(par.uncertainty_value)
+            par.uncertainty_value = ux + ux * delta
 
 
 def transform_mjd_parameter(model: TimingModel, param: str, backwards: bool) -> None:

--- a/src/pint/models/tcb_conversion.py
+++ b/src/pint/models/tcb_conversion.py
@@ -141,6 +141,47 @@ def _scale_exponent(param) -> int:
     return -param.effective_dimensionality
 
 
+def _parameter_conversion_plan(
+    model: TimingModel,
+) -> tuple[set[str], set[str], set[str]]:
+    """Classify set parameters without changing the model."""
+    convertible: set[str] = set()
+    invariant: set[str] = set()
+    unsupported: set[str] = set()
+
+    for name in model.params:
+        param = model[name]
+        if param.quantity is None:
+            continue
+        if getattr(param, "tcb2tdb_invariant", False):
+            invariant.add(name)
+            continue
+        if not getattr(param, "convert_tcb2tdb", False):
+            continue
+        if isinstance(param, (floatParameter, AngleParameter, maskParameter)) or (
+            isinstance(param, prefixParameter)
+            and isinstance(param.param_comp, (floatParameter, AngleParameter))
+        ):
+            if _scale_exponent(param) == 0:
+                invariant.add(name)
+            else:
+                convertible.add(name)
+        elif isinstance(param, MJDParameter) or (
+            isinstance(param, prefixParameter)
+            and isinstance(param.param_comp, MJDParameter)
+        ):
+            if param.time_scale == "utc":
+                invariant.add(name)
+            elif param.time_scale in {"tcb", "tdb"}:
+                convertible.add(name)
+            else:
+                unsupported.add(name)
+        else:
+            unsupported.add(name)
+
+    return convertible, invariant, unsupported
+
+
 def _active_unsupported_components(
     model: TimingModel, converted: set[str], invariant: set[str]
 ) -> tuple[set[str], set[str]]:
@@ -190,61 +231,40 @@ def convert_tcb_tdb(
 
     target_units = "TCB" if backwards else "TDB"
     source_units = "TDB" if backwards else "TCB"
+    convertible, invariant, unsupported = _parameter_conversion_plan(model)
 
     if model["UNITS"].value == target_units or (
         model["UNITS"].value is None and not backwards
     ):
         log.warning("The input par file is already in the target units. Doing nothing.")
+        graph_unsupported, unaudited_components = _active_unsupported_components(
+            model, convertible, invariant
+        )
+        unsupported.update(graph_unsupported)
         report = TCBTDBConversionReport(
             source_units=target_units,
             target_units=target_units,
             convention="iau2006-undilated-frequency",
             converted=(),
-            invariant=(),
-            unsupported=(),
-            unaudited_components=(),
+            invariant=tuple(sorted(invariant)),
+            unsupported=tuple(sorted(unsupported)),
+            unaudited_components=tuple(sorted(unaudited_components)),
         )
         model.tcb_tdb_conversion_report = report
         return report
 
-    converted: set[str] = set()
-    invariant: set[str] = set()
-    unsupported: set[str] = set()
-
-    for par in model.params:
-        param = model[par]
-        if param.quantity is None:
-            continue
-        if getattr(param, "tcb2tdb_invariant", False):
-            invariant.add(par)
-            continue
-        if hasattr(param, "convert_tcb2tdb") and param.convert_tcb2tdb:
-            if isinstance(param, (floatParameter, AngleParameter, maskParameter)) or (
-                isinstance(param, prefixParameter)
-                and isinstance(param.param_comp, (floatParameter, AngleParameter))
-            ):
-                exponent = _scale_exponent(param)
-                if exponent == 0:
-                    invariant.add(par)
-                else:
-                    scale_parameter(model, par, exponent, backwards)
-                    converted.add(par)
-            elif isinstance(param, MJDParameter) or (
-                isinstance(param, prefixParameter)
-                and isinstance(param.param_comp, MJDParameter)
-            ):
-                if param.time_scale == "utc":
-                    invariant.add(par)
-                elif param.time_scale in {"tcb", "tdb"}:
-                    transform_mjd_parameter(model, par, backwards)
-                    converted.add(par)
-                else:
-                    unsupported.add(par)
-            else:
-                unsupported.add(par)
+    for name in convertible:
+        param = model[name]
+        if isinstance(param, (floatParameter, AngleParameter, maskParameter)) or (
+            isinstance(param, prefixParameter)
+            and isinstance(param.param_comp, (floatParameter, AngleParameter))
+        ):
+            scale_parameter(model, name, _scale_exponent(param), backwards)
+        else:
+            transform_mjd_parameter(model, name, backwards)
 
     graph_unsupported, unaudited_components = _active_unsupported_components(
-        model, converted, invariant
+        model, convertible, invariant
     )
     unsupported.update(graph_unsupported)
 
@@ -256,7 +276,7 @@ def convert_tcb_tdb(
         source_units=source_units,
         target_units=target_units,
         convention="iau2006-undilated-frequency",
-        converted=tuple(sorted(converted)),
+        converted=tuple(sorted(convertible)),
         invariant=tuple(sorted(invariant)),
         unsupported=tuple(sorted(unsupported)),
         unaudited_components=tuple(sorted(unaudited_components)),

--- a/src/pint/models/tcb_conversion.py
+++ b/src/pint/models/tcb_conversion.py
@@ -1,5 +1,13 @@
-"""TCB to TDB conversion of a timing model."""
+"""TCB/TDB conversion consistent with PINT's TDB forward model.
 
+Coordinate epochs use Astropy/ERFA's IAU 2006 realization. Radio frequencies
+remain undilated, matching PINT's supported ``DILATEFREQ N`` behavior.
+Unsupported active deterministic terms are reported but do not stop conversion.
+"""
+
+from dataclasses import dataclass
+
+import erfa
 import numpy as np
 from loguru import logger as log
 
@@ -11,24 +19,50 @@ from pint.models.parameter import (
     prefixParameter,
 )
 from pint.models.timing_model import TimingModel
+from pint.pulsar_mjd import time_from_longdouble
 
 __all__ = [
+    "TCB_TDB_F",
+    "TCB_TDB_K",
     "IFTE_K",
+    "TCBTDBConversionReport",
     "scale_parameter",
     "transform_mjd_parameter",
     "convert_tcb_tdb",
 ]
 
-# These constants are taken from Irwin & Fukushima 1999.
-# These are the same as the constants used in tempo2 as of 10 Feb 2023.
-IFTE_MJD0 = np.longdouble("43144.0003725")
-IFTE_KM1 = np.longdouble("1.55051979176e-8")
-IFTE_K = 1 + IFTE_KM1
+# PINT evaluates its forward model in IAU 2006 TDB. Obtain the defining rate
+# from ERFA rather than maintaining another decimal copy here.
+TCB_TDB_F = np.longdouble(1) - np.longdouble(erfa.ELB)
+TCB_TDB_K = np.longdouble(1) / TCB_TDB_F
+
+# Backwards-compatible public alias. This is now the IAU/ERFA rate, not the
+# historical IFTE common-origin epoch map.
+IFTE_K = TCB_TDB_K
+
+
+@dataclass(frozen=True)
+class TCBTDBConversionReport:
+    """Summary of operations performed during TCB/TDB conversion."""
+
+    source_units: str
+    target_units: str
+    convention: str
+    converted: tuple[str, ...]
+    invariant: tuple[str, ...]
+    unsupported: tuple[str, ...]
+    unaudited_components: tuple[str, ...]
+
+    @property
+    def accepted(self) -> bool:
+        """Whether the conversion satisfies the tested no-refit contract."""
+        return not self.unsupported and not self.unaudited_components
 
 
 def scale_parameter(model: TimingModel, param: str, n: int, backwards: bool) -> None:
-    """Scale a parameter x by a power of IFTE_K
-        x_tdb = x_tcb * IFTE_K**n
+    """Scale a parameter x by a power of the IAU TCB/TDB rate K.
+
+        x_tdb = x_tcb * K**n
 
     The power n depends on the "effective dimensionality" of
     the parameter as it appears in the timing model. Some examples
@@ -38,8 +72,8 @@ def scale_parameter(model: TimingModel, param: str, n: int, backwards: bool) -> 
         2. F1 has effective dimensionality of frequency^2 and n = 2
         3. A1 has effective dimensionality of time because it appears as
            A1/c in the timing model. Therefore, its n = -1
-        4. DM has effective dimensionality of frequency because it appears
-           as DM*DMconst in the timing model. Therefore, its n = 1
+        4. Constant DM has an explicit n = -1 override because PINT keeps
+           radio frequency fixed during conversion
         5. PBDOT is dimensionless and has n = 0. i.e., it is not scaled.
 
     Parameter
@@ -49,7 +83,7 @@ def scale_parameter(model: TimingModel, param: str, n: int, backwards: bool) -> 
     param : str
         The parameter name to be converted
     n : int
-        The power of IFTE_K in the scaling factor
+        The power of TCB_TDB_K in the scaling factor
     backwards : bool
         Whether to do TDB to TCB conversion.
     """
@@ -57,7 +91,7 @@ def scale_parameter(model: TimingModel, param: str, n: int, backwards: bool) -> 
 
     p = -1 if backwards else 1
 
-    factor = IFTE_K ** (p * n)
+    factor = TCB_TDB_K ** (p * n)
 
     if (param in model) and model[param].quantity is not None:
         par = model[param]
@@ -67,9 +101,7 @@ def scale_parameter(model: TimingModel, param: str, n: int, backwards: bool) -> 
 
 
 def transform_mjd_parameter(model: TimingModel, param: str, backwards: bool) -> None:
-    """Convert an MJD from TCB to TDB or vice versa.
-        t_tdb = (t_tcb - IFTE_MJD0) / IFTE_K + IFTE_MJD0
-        t_tcb = (t_tdb - IFTE_MJD0) * IFTE_K + IFTE_MJD0
+    """Convert a coordinate epoch between TCB and IAU 2006 TDB.
 
     Parameters
     ----------
@@ -80,9 +112,6 @@ def transform_mjd_parameter(model: TimingModel, param: str, backwards: bool) -> 
     backwards : bool
         Whether to do TDB to TCB conversion.
     """
-    factor = IFTE_K if backwards else 1 / IFTE_K
-    tref = IFTE_MJD0
-
     if (param in model) and model[param].quantity is not None:
         par = model[param]
         assert isinstance(par, MJDParameter) or (
@@ -90,29 +119,60 @@ def transform_mjd_parameter(model: TimingModel, param: str, backwards: bool) -> 
             and isinstance(par.param_comp, MJDParameter)
         )
 
-        par.value = (par.value - tref) * factor + tref
+        source = "tdb" if backwards else "tcb"
+        target = "tcb" if backwards else "tdb"
+        converted = getattr(time_from_longdouble(par.value, source), target)
+
+        # Re-label before assigning the already-converted two-part Time so the
+        # old numeric MJD is not silently reinterpreted in the target scale.
+        par.time_scale = target
+        par.quantity = converted
         if par.uncertainty_value is not None:
-            par.uncertainty_value *= factor
+            par.uncertainty_value *= TCB_TDB_K if backwards else TCB_TDB_F
 
 
-def convert_tcb_tdb(model: TimingModel, backwards: bool = False) -> None:
-    """This function performs a partial conversion of a model
-    specified in TCB to TDB. While this should be sufficient as
-    a starting point, the resulting parameters are only approximate
-    and the model should be re-fit.
+def _scale_exponent(param) -> int:
+    """Return the conversion exponent, honoring component-owned overrides."""
+    override = getattr(param, "tcb2tdb_scale_exponent", None)
+    if callable(override):
+        override = override(param)
+    if override is not None:
+        return int(override)
+    return -param.effective_dimensionality
 
-    This is roughly based on the `transform` plugin of tempo2, but uses
-    a different algorithm and does a more complete conversion.
 
-    The following parameters are NOT converted although they are
-    in fact affected by the TCB to TDB conversion:
-        1. TZRMJD and TZRFRQ
-        2. DMJUMPs (the wideband kind)
-        3. FD parameters and FD jumps
-        4. EQUADs and ECORRs.
-        5. GP Red noise and GP DM noise parameters
-        6. Pair parameters such as Wave and IFunc parameters
-        7. Variable-index chromatic delay parameters
+def _active_unsupported_components(
+    model: TimingModel, converted: set[str], invariant: set[str]
+) -> tuple[set[str], set[str]]:
+    """Find unhandled parameters from PINT's actual delay/phase graph."""
+    unsupported: set[str] = set()
+    components: set[str] = set()
+    forward_components = model.DelayComponent_list + model.PhaseComponent_list
+
+    for component in forward_components:
+        component_unsupported = set()
+        for name in component.params:
+            par = model[name]
+            if par.quantity is None or name in converted or name in invariant:
+                continue
+            if hasattr(par, "convert_tcb2tdb"):
+                component_unsupported.add(name)
+        if component_unsupported:
+            unsupported.update(component_unsupported)
+        if component_unsupported or not component.tcb2tdb_certified:
+            components.add(component.__class__.__name__)
+
+    return unsupported, components
+
+
+def convert_tcb_tdb(
+    model: TimingModel, backwards: bool = False
+) -> TCBTDBConversionReport:
+    """Convert every supported parameter between TCB and TDB.
+
+    The conversion follows PINT's IAU 2006 TDB, undilated-radio-frequency
+    forward model. Unsupported active deterministic terms are left unchanged
+    and reported; they never prevent supported operations from completing.
 
     Parameters
     ----------
@@ -120,40 +180,96 @@ def convert_tcb_tdb(model: TimingModel, backwards: bool = False) -> None:
        Timing model to be converted.
     backwards : bool
         Whether to do TDB to TCB conversion. The default is TCB to TDB.
+
+    Returns
+    -------
+    TCBTDBConversionReport
+        Actual converted, invariant, and unsupported model terms. An accepted
+        report is covered by PINT's tested no-refit conversion contract.
     """
 
     target_units = "TCB" if backwards else "TDB"
+    source_units = "TDB" if backwards else "TCB"
 
     if model["UNITS"].value == target_units or (
         model["UNITS"].value is None and not backwards
     ):
         log.warning("The input par file is already in the target units. Doing nothing.")
-        return
+        report = TCBTDBConversionReport(
+            source_units=target_units,
+            target_units=target_units,
+            convention="iau2006-undilated-frequency",
+            converted=(),
+            invariant=(),
+            unsupported=(),
+            unaudited_components=(),
+        )
+        model.tcb_tdb_conversion_report = report
+        return report
 
-    log.warning(
-        "Converting this timing model from TCB to TDB. "
-        "Please note that the TCB to TDB conversion is only approximate and "
-        "the resulting timing model should be re-fit to get reliable results."
-    )
+    converted: set[str] = set()
+    invariant: set[str] = set()
+    unsupported: set[str] = set()
 
     for par in model.params:
         param = model[par]
-        if (
-            param.quantity is not None
-            and hasattr(param, "convert_tcb2tdb")
-            and param.convert_tcb2tdb
-        ):
+        if param.quantity is None:
+            continue
+        if getattr(param, "tcb2tdb_invariant", False):
+            invariant.add(par)
+            continue
+        if hasattr(param, "convert_tcb2tdb") and param.convert_tcb2tdb:
             if isinstance(param, (floatParameter, AngleParameter, maskParameter)) or (
                 isinstance(param, prefixParameter)
                 and isinstance(param.param_comp, (floatParameter, AngleParameter))
             ):
-                scale_parameter(model, par, -param.effective_dimensionality, backwards)
+                exponent = _scale_exponent(param)
+                if exponent == 0:
+                    invariant.add(par)
+                else:
+                    scale_parameter(model, par, exponent, backwards)
+                    converted.add(par)
             elif isinstance(param, MJDParameter) or (
                 isinstance(param, prefixParameter)
                 and isinstance(param.param_comp, MJDParameter)
             ):
-                transform_mjd_parameter(model, par, backwards)
+                if param.time_scale == "utc":
+                    invariant.add(par)
+                elif param.time_scale in {"tcb", "tdb"}:
+                    transform_mjd_parameter(model, par, backwards)
+                    converted.add(par)
+                else:
+                    unsupported.add(par)
+            else:
+                unsupported.add(par)
+
+    graph_unsupported, unaudited_components = _active_unsupported_components(
+        model, converted, invariant
+    )
+    unsupported.update(graph_unsupported)
 
     model["UNITS"].value = target_units
 
     model.validate(allow_tcb=backwards)
+
+    report = TCBTDBConversionReport(
+        source_units=source_units,
+        target_units=target_units,
+        convention="iau2006-undilated-frequency",
+        converted=tuple(sorted(converted)),
+        invariant=tuple(sorted(invariant)),
+        unsupported=tuple(sorted(unsupported)),
+        unaudited_components=tuple(sorted(unaudited_components)),
+    )
+    model.tcb_tdb_conversion_report = report
+
+    if not report.accepted:
+        log.warning(
+            "TCB/TDB conversion completed, but the no-refit accuracy contract "
+            "does not cover this model. Unsupported parameters: {}. "
+            "Unaudited components: {}.",
+            ", ".join(report.unsupported) or "none",
+            ", ".join(report.unaudited_components) or "none",
+        )
+
+    return report

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -274,13 +274,19 @@ class TimingModel:
         )
         self.add_param_from_top(
             MJDParameter(
-                name="START", description="Start MJD for fitting", convert_tcb2tdb=False
+                name="START",
+                description="Start MJD for fitting",
+                convert_tcb2tdb=False,
+                tcb2tdb_invariant=True,
             ),
             "",
         )
         self.add_param_from_top(
             MJDParameter(
-                name="FINISH", description="End MJD for fitting", convert_tcb2tdb=False
+                name="FINISH",
+                description="End MJD for fitting",
+                convert_tcb2tdb=False,
+                tcb2tdb_invariant=True,
             ),
             "",
         )
@@ -427,8 +433,10 @@ class TimingModel:
                 
                     $ tcb2tdb J1234+6789_tcb.par J1234+6789_tdb.par
                 
-                However, this conversion is not exact and a fit must be performed to obtain 
-                reliable results. Note that PINT only supports writing TDB par files. 
+                The converter processes every supported parameter and reports
+                unsupported active deterministic terms. Accepted conversions
+                satisfy PINT's tested no-refit accuracy contract. Note that
+                PINT only supports writing TDB par files.
                 """
                 raise ValueError(error_message)
             else:
@@ -3717,6 +3725,9 @@ class Component(metaclass=ModelMeta):
     """
 
     component_types = {}
+    # Opt in only after the component's real delay/phase method has a
+    # discriminating TCB/TDB conversion test.
+    tcb2tdb_certified = False
 
     def __init__(self):
         self.params = []

--- a/src/pint/models/timing_model.py
+++ b/src/pint/models/timing_model.py
@@ -3725,8 +3725,7 @@ class Component(metaclass=ModelMeta):
     """
 
     component_types = {}
-    # Opt in only after the component's real delay/phase method has a
-    # discriminating TCB/TDB conversion test.
+    # True when conversion is covered by a discriminating delay/phase test.
     tcb2tdb_certified = False
 
     def __init__(self):

--- a/src/pint/scripts/tcb2tdb.py
+++ b/src/pint/scripts/tcb2tdb.py
@@ -15,16 +15,11 @@ __all__ = ["main"]
 def main(argv=None):
     parser = argparse.ArgumentParser(
         description="""`tcb2tdb` converts TCB par files to TDB.
-        Please note that this conversion is not exact and the timing model 
-        should be re-fit to the TOAs. 
-       
-        The following parameters are NOT converted although they are 
-        in fact affected by the TCB to TDB conversion:
-            1. TZRMJD and TZRFRQ
-            2. DM Jumps (the wideband kind)
-            3. FD parameters and FD jumps
-            4. EQUADs and ECORRs
-            5. GP Red noise parameters and GP DM noise parameters
+        Coordinate epochs follow Astropy/ERFA's IAU 2006 TDB, and radio
+        frequency remains undilated as in PINT's forward model. The command
+        converts every supported term and warns about unsupported active
+        deterministic terms. A fully accepted conversion satisfies PINT's
+        tested no-refit accuracy contract.
         """,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
@@ -41,5 +36,9 @@ def main(argv=None):
     mb = ModelBuilder()
     model = mb(args.input_par, allow_tcb=True, allow_T2=args.allow_T2)
     model.write_parfile(args.output_par)
+
+    report = getattr(model, "tcb_tdb_conversion_report", None)
+    if report is not None and report.accepted:
+        log.info("Conversion satisfies the no-refit accuracy contract.")
 
     log.info(f"Output written to {args.output_par}.")

--- a/tests/test_tcb2tdb.py
+++ b/tests/test_tcb2tdb.py
@@ -3,13 +3,16 @@
 import os
 from copy import deepcopy
 from io import StringIO
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
+import astropy.units as u
 
 from pint import DMconst, dmu
 from pint.models.model_builder import ModelBuilder, get_model
-from pint.models.tcb_conversion import convert_tcb_tdb
+from pint.models.tcb_conversion import TCB_TDB_F, TCB_TDB_K, convert_tcb_tdb
+from pint.pulsar_mjd import time_from_longdouble
 from pint.scripts import tcb2tdb
 
 simplepar = """
@@ -68,6 +71,181 @@ def test_convert_units_roundtrip():
             assert getattr(m, par).value == getattr(m_, par).value
         else:
             assert np.isclose(getattr(m, par).value, getattr(m_, par).value)
+
+
+def test_coordinate_epoch_uses_astropy_iau_tdb():
+    m = ModelBuilder()(StringIO(simplepar), allow_tcb="raw")
+    original = time_from_longdouble(m.PEPOCH.value, "tcb")
+    expected = original.tdb
+    m.PEPOCH.uncertainty_value = 1
+
+    report = convert_tcb_tdb(m)
+
+    assert abs((m.PEPOCH.quantity - expected).to_value(u.ns)) < 0.01
+    assert np.isclose(m.PEPOCH.uncertainty_value, TCB_TDB_F)
+    assert m.PEPOCH.time_scale == "tdb"
+    assert "PEPOCH" in report.converted
+
+    convert_tcb_tdb(m, backwards=True)
+    assert abs((m.PEPOCH.quantity - original).to_value(u.ns)) < 0.01
+    assert m.PEPOCH.time_scale == "tcb"
+
+
+def test_coordinate_epoch_includes_tdb0():
+    reference_mjd = np.longdouble("43144.0003725")
+    converted = time_from_longdouble(reference_mjd, "tcb").tdb
+    numeric_offset = (converted.mjd_long - reference_mjd) * u.day
+
+    assert np.isclose(numeric_offset.to_value(u.us), -65.5, atol=0.01)
+
+
+def test_fixed_frequency_dm_and_fd_scaling():
+    m = ModelBuilder()(
+        StringIO(
+            simplepar.replace(
+                "DM              223.9  1",
+                "DM              223.9  1\nDM1 1e-3\nDM2 2e-5\nDMEPOCH 53750",
+            )
+        ),
+        allow_tcb="raw",
+    )
+    dm0, dm1, dm2 = m.DM.value, m.DM1.value, m.DM2.value
+    frequencies = np.array([0.7, 1.4, 3.0]) * u.GHz
+    fd_delay = m.FD_delay_frequency(frequencies)
+    tcb_mjds = np.array([53750.0, 54000.0, 55000.0], dtype=np.longdouble)
+    tdb_mjds = np.array(
+        [time_from_longdouble(t, "tcb").tdb.mjd_long for t in tcb_mjds],
+        dtype=np.longdouble,
+    )
+    dm_component = m.components["DispersionDM"]
+    dm_tcb = dm_component.base_dm({"tdbld": tcb_mjds})
+    dm_delay_tcb = dm_component.dispersion_time_delay(dm_tcb, frequencies)
+
+    convert_tcb_tdb(m)
+
+    assert np.isclose(m.DM.value / dm0, TCB_TDB_F)
+    assert np.isclose(m.DM1.value / dm1, 1)
+    assert np.isclose(m.DM2.value / dm2, TCB_TDB_K)
+    fd_error = m.FD_delay_frequency(frequencies) - fd_delay * TCB_TDB_F
+    assert np.max(np.abs(fd_error.to_value(u.ns))) < 0.01
+
+    dm_tdb = dm_component.base_dm({"tdbld": tdb_mjds})
+    dm_delay_tdb = dm_component.dispersion_time_delay(dm_tdb, frequencies)
+    dm_error = dm_delay_tdb - dm_delay_tcb * TCB_TDB_F
+    assert np.max(np.abs(dm_error.to_value(u.ns))) < 0.01
+
+
+def test_spindown_phase_closes_without_refitting():
+    m = ModelBuilder()(StringIO(simplepar), allow_tcb="raw")
+    tcb_mjds = np.array([53750.0, 54000.0, 55000.0], dtype=np.longdouble)
+    tdb_mjds = np.array(
+        [time_from_longdouble(t, "tcb").tdb.mjd_long for t in tcb_mjds],
+        dtype=np.longdouble,
+    )
+    zero_delay = np.zeros(len(tcb_mjds)) * u.s
+    phase_tcb = m.components["Spindown"].spindown_phase(
+        SimpleNamespace(table={"tdbld": tcb_mjds}), zero_delay
+    )
+
+    convert_tcb_tdb(m)
+
+    phase_tdb = m.components["Spindown"].spindown_phase(
+        SimpleNamespace(table={"tdbld": tdb_mjds}), zero_delay
+    )
+    time_error = (phase_tdb - phase_tcb) / m.F0.quantity
+    assert np.max(np.abs(time_error.to_value(u.ns))) < 0.01
+
+
+def test_astrometric_position_closes_at_same_physical_epoch():
+    m = ModelBuilder()(
+        StringIO(
+            """
+PSR TEST
+RAJ 12:00:00
+DECJ 20:00:00
+PMRA 8
+PMDEC -5
+POSEPOCH 55000
+F0 100
+PEPOCH 55000
+DM 10
+UNITS TCB
+"""
+        ),
+        allow_tcb="raw",
+    )
+    # A raw TCB model is intentionally not evaluable by PINT, so label the
+    # source epoch explicitly for this component-level physical-instant test.
+    m.POSEPOCH.time_scale = "tcb"
+    epoch_tcb = time_from_longdouble(np.longdouble("57000"), "tcb")
+    position_tcb = m.coords_as_ICRS(epoch=epoch_tcb)
+
+    convert_tcb_tdb(m)
+
+    position_tdb = m.coords_as_ICRS(epoch=epoch_tcb.tdb)
+    assert position_tdb.separation(position_tcb).to_value(u.uas) < 1e-3
+
+
+def test_fdjump_coefficients_scale_as_time_at_fixed_frequency():
+    m = ModelBuilder()(
+        StringIO(simplepar + "\nFD1JUMP -sys backend 0.01\n"),
+        allow_tcb="raw",
+    )
+    original = m.FD1JUMP1.value
+
+    convert_tcb_tdb(m)
+
+    assert np.isclose(m.FD1JUMP1.value / original, TCB_TDB_F)
+
+
+def test_utc_selectors_and_parallax_are_explicit_invariants():
+    m = ModelBuilder()(
+        StringIO(
+            simplepar
+            + """
+PX 1.2
+START 53000
+FINISH 54000
+DMXR1_0001 53500
+DMXR2_0001 53600
+DMX_0001 0.1
+"""
+        ),
+        allow_tcb="raw",
+    )
+    values = {
+        name: m[name].value
+        for name in ("PX", "START", "FINISH", "DMXR1_0001", "DMXR2_0001")
+    }
+
+    report = convert_tcb_tdb(m)
+
+    assert {name: m[name].value for name in values} == values
+    assert set(values) <= set(report.invariant)
+    assert np.isclose(m.DMX_0001.value, 0.1 * TCB_TDB_F)
+
+
+def test_report_accepts_only_audited_forward_components():
+    m = ModelBuilder()(
+        StringIO(
+            """
+PSR TEST
+RAJ 12:00:00
+DECJ 20:00:00
+F0 100
+PEPOCH 55000
+DM 12.5
+UNITS TCB
+"""
+        ),
+        allow_tcb="raw",
+    )
+    assert convert_tcb_tdb(m).accepted
+
+    binary = ModelBuilder()(StringIO(simplepar), allow_tcb="raw")
+    report = convert_tcb_tdb(binary)
+    assert not report.accepted
+    assert "BinaryBT" in report.unaudited_components
 
 
 def test_effective_dimensionality():

--- a/tests/test_tcb2tdb.py
+++ b/tests/test_tcb2tdb.py
@@ -8,9 +8,12 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 import astropy.units as u
+from astropy.table import Table
 
 from pint import DMconst, dmu
+from pint.config import examplefile
 from pint.models.model_builder import ModelBuilder, get_model
+from pint.models.parameter import AngleParameter
 from pint.models.tcb_conversion import TCB_TDB_F, TCB_TDB_K, convert_tcb_tdb
 from pint.pulsar_mjd import time_from_longdouble
 from pint.scripts import tcb2tdb
@@ -89,6 +92,30 @@ def test_coordinate_epoch_uses_astropy_iau_tdb():
     convert_tcb_tdb(m, backwards=True)
     assert abs((m.PEPOCH.quantity - original).to_value(u.ns)) < 0.01
     assert m.PEPOCH.time_scale == "tcb"
+
+
+def test_prefix_coordinate_epoch_keeps_inner_time_scale_consistent():
+    model = ModelBuilder()(
+        StringIO(
+            """
+PSR TEST
+F0 100
+PEPOCH 55000
+GLEP_1 55100
+GLF0_1 1e-6
+UNITS TDB
+"""
+        )
+    )
+
+    convert_tcb_tdb(model, backwards=True)
+
+    assert model.GLEP_1.time_scale == "tcb"
+    assert model.GLEP_1.param_comp.time_scale == "tcb"
+    assert model.GLEP_1.quantity.scale == "tcb"
+    value = model.GLEP_1.value
+    model.GLEP_1.value = value
+    assert model.GLEP_1.quantity.scale == "tcb"
 
 
 def test_coordinate_epoch_includes_tdb0():
@@ -186,6 +213,39 @@ UNITS TCB
     assert position_tdb.separation(position_tcb).to_value(u.uas) < 1e-3
 
 
+def test_solar_system_shapiro_closes_without_refitting():
+    class FakeToas:
+        def __init__(self, mjds):
+            self.table = Table(
+                {
+                    "tdbld": mjds,
+                    "obs_sun_pos": np.tile([1.0, 0.0, 0.0], (len(mjds), 1)) * u.au,
+                }
+            )
+
+        def __len__(self):
+            return len(self.table)
+
+        def get_obss(self):
+            return np.full(len(self), "gbt")
+
+    model = ModelBuilder()(StringIO(simplepar), allow_tcb="raw")
+    model.PLANET_SHAPIRO.value = False
+    tcb_mjds = np.array([53750.0, 54000.0, 55000.0], dtype=np.longdouble)
+    tdb_mjds = np.array(
+        [time_from_longdouble(t, "tcb").tdb.mjd_long for t in tcb_mjds],
+        dtype=np.longdouble,
+    )
+    component = model.components["SolarSystemShapiro"]
+    delay_tcb = component.solar_system_shapiro_delay(FakeToas(tcb_mjds))
+
+    convert_tcb_tdb(model)
+
+    delay_tdb = component.solar_system_shapiro_delay(FakeToas(tdb_mjds))
+    error = delay_tdb - delay_tcb * TCB_TDB_F
+    assert np.max(np.abs(error.to_value(u.ns))) < 0.01
+
+
 def test_fdjump_coefficients_scale_as_time_at_fixed_frequency():
     m = ModelBuilder()(
         StringIO(simplepar + "\nFD1JUMP -sys backend 0.01\n"),
@@ -196,6 +256,35 @@ def test_fdjump_coefficients_scale_as_time_at_fixed_frequency():
     convert_tcb_tdb(m)
 
     assert np.isclose(m.FD1JUMP1.value / original, TCB_TDB_F)
+
+
+def test_new_mask_parameters_preserve_conversion_metadata():
+    model = ModelBuilder()(
+        StringIO(
+            simplepar
+            + "\nFD1JUMP -sys backend1 0.01\n"
+            + "FD1JUMP -sys backend2 0.02\n"
+        ),
+        allow_tcb="raw",
+    )
+
+    assert model.FD1JUMP2.tcb2tdb_scale_exponent == -1
+    assert not model.FD1JUMP2.tcb2tdb_invariant
+
+
+def test_angle_parameter_stores_conversion_metadata():
+    parameter = AngleParameter(
+        name="TEST",
+        value=1,
+        units="rad",
+        convert_tcb2tdb=False,
+        tcb2tdb_scale_factor=u.Quantity(1),
+        tcb2tdb_scale_exponent=2,
+        tcb2tdb_invariant=True,
+    )
+
+    assert parameter.tcb2tdb_scale_exponent == 2
+    assert parameter.tcb2tdb_invariant
 
 
 def test_utc_selectors_and_parallax_are_explicit_invariants():
@@ -246,6 +335,61 @@ UNITS TCB
     report = convert_tcb_tdb(binary)
     assert not report.accepted
     assert "BinaryBT" in report.unaudited_components
+
+
+def test_noop_conversion_preserves_model_acceptance_status():
+    model = ModelBuilder()(StringIO(simplepar), allow_tcb="raw")
+    first_report = convert_tcb_tdb(model)
+    second_report = convert_tcb_tdb(model)
+
+    assert not first_report.accepted
+    assert not second_report.accepted
+    assert "BinaryBT" in second_report.unaudited_components
+
+
+def test_absolute_phase_is_not_certified_without_closure_test():
+    model = ModelBuilder()(
+        StringIO(
+            """
+PSR TEST
+RAJ 12:00:00
+DECJ 20:00:00
+F0 100
+PEPOCH 55000
+DM 10
+TZRMJD 55000
+TZRSITE ssb
+TZRFRQ 1400
+UNITS TCB
+"""
+        ),
+        allow_tcb="raw",
+    )
+
+    report = convert_tcb_tdb(model)
+
+    assert "AbsPhase" in report.unaudited_components
+
+
+def test_absolute_phase_loads_without_units():
+    model = get_model(examplefile("test-wb-0.par"))
+    assert model.TZRMJD.time_scale == "tdb"
+
+    minimal = get_model(
+        StringIO(
+            """
+PSR TEST
+RAJ 12:00:00
+DECJ 20:00:00
+F0 100
+PEPOCH 55000
+DM 10
+TZRMJD 55001
+"""
+        )
+    )
+    assert minimal.TZRSITE.value == "ssb"
+    assert minimal.TZRMJD.time_scale == "tdb"
 
 
 def test_effective_dimensionality():

--- a/tests/test_tcb2tdb.py
+++ b/tests/test_tcb2tdb.py
@@ -4,16 +4,21 @@ import os
 from copy import deepcopy
 from io import StringIO
 
+import astropy.units as u
 import numpy as np
 import pytest
-import astropy.units as u
 from astropy.table import Table
 
 from pint import DMconst, dmu
 from pint.config import examplefile
 from pint.models.model_builder import ModelBuilder, get_model
 from pint.models.parameter import AngleParameter
-from pint.models.tcb_conversion import TCB_TDB_F, TCB_TDB_K, convert_tcb_tdb
+from pint.models.tcb_conversion import (
+    TCB_TDB_F,
+    TCB_TDB_K,
+    _k_power_minus_one,
+    convert_tcb_tdb,
+)
 from pint.pulsar_mjd import time_from_longdouble
 from pint.scripts import tcb2tdb
 
@@ -59,8 +64,22 @@ def _delta_seconds(t1, t2):
     return np.longdouble(delta.jd1) * day + np.longdouble(delta.jd2) * day
 
 
-def _spin_phase(f0, f1, dt_s):
-    return f0 * dt_s + np.longdouble("0.5") * f1 * dt_s * dt_s
+def _spin_phase_difference(f0_tcb, f1_tcb, f0_tdb, f1_tdb, dt_tcb, dt_tdb):
+    """``φ_tdb - φ_tcb`` from increments, so ``F0 Δt`` does not cancel.
+
+    ``F0 Δt`` is ~10^9 turns here. Subtracting two such phases spends the
+    mantissa on the large term. Split ``F0_tdb = F0_tcb + dF0`` and
+    ``Δt_tdb = Δt_tcb + dΔt`` instead; the two ~100-turn pieces are the
+    TCB/TDB rate correction and they cancel at the size of that correction.
+    """
+    df0 = f0_tdb - f0_tcb
+    df1 = f1_tdb - f1_tcb
+    ddt = dt_tdb - dt_tcb
+    dphi = f0_tcb * ddt + df0 * dt_tdb
+    dphi += np.longdouble("0.5") * (
+        f1_tcb * ddt * (dt_tdb + dt_tcb) + df1 * dt_tdb * dt_tdb
+    )
+    return dphi
 
 
 @pytest.mark.parametrize("backwards", [True, False])
@@ -179,29 +198,41 @@ def test_fixed_frequency_dm_and_fd_scaling():
     assert np.max(np.abs(dm_error.to_value(u.ns))) < 0.01
 
 
+def test_k_power_minus_one_is_the_small_increment():
+    # K-1 from L_B/(1-L_B), not from a float64 value sitting next to 1.
+    L = np.longdouble(1) - TCB_TDB_F
+    dk = L / TCB_TDB_F
+    assert _k_power_minus_one(0) == 0
+    assert _k_power_minus_one(1) == dk
+    assert _k_power_minus_one(-1) == -L
+    assert _k_power_minus_one(2) == L * (np.longdouble(2) - L) / (TCB_TDB_F * TCB_TDB_F)
+    naive = np.longdouble(np.float64(TCB_TDB_K) - np.float64(1))
+    assert abs(_k_power_minus_one(1) - dk) < abs(naive - dk)
+
+
 def test_spindown_phase_closes_without_refitting():
-    # Evaluate F0/F1 against Astropy two-part JD intervals, not PINT's
-    # tdbld/Quantity/Horner path. That path downcasts to float64 on conda
-    # osx-64 (~10 ns over 1250 d) even when arrays still report float128.
     m = ModelBuilder()(StringIO(simplepar), allow_tcb="raw")
     tcb_times = [
         time_from_longdouble(np.longdouble(t), "tcb")
         for t in (53750.0, 54000.0, 55000.0)
     ]
-    f0 = np.longdouble(m.F0.value)
-    f1 = np.longdouble(m.F1.value)
+    f0_tcb = np.longdouble(m.F0.value)
+    f1_tcb = np.longdouble(m.F1.value)
     pepoch_tcb = time_from_longdouble(m.PEPOCH.value, "tcb")
-    dt_tcb = np.array([_delta_seconds(t, pepoch_tcb) for t in tcb_times])
-    phase_tcb = _spin_phase(f0, f1, dt_tcb)
+    dt_tcb = np.array(
+        [_delta_seconds(t, pepoch_tcb) for t in tcb_times], dtype=np.longdouble
+    )
 
     convert_tcb_tdb(m)
 
-    f0 = np.longdouble(m.F0.value)
-    f1 = np.longdouble(m.F1.value)
+    f0_tdb = np.longdouble(m.F0.value)
+    f1_tdb = np.longdouble(m.F1.value)
     pepoch_tdb = m.PEPOCH.quantity
-    dt_tdb = np.array([_delta_seconds(t.tdb, pepoch_tdb) for t in tcb_times])
-    phase_tdb = _spin_phase(f0, f1, dt_tdb)
-    time_error_ns = np.abs((phase_tdb - phase_tcb) / f0) * 1e9
+    dt_tdb = np.array(
+        [_delta_seconds(t.tdb, pepoch_tdb) for t in tcb_times], dtype=np.longdouble
+    )
+    dphi = _spin_phase_difference(f0_tcb, f1_tcb, f0_tdb, f1_tdb, dt_tcb, dt_tdb)
+    time_error_ns = np.abs(dphi / f0_tdb) * 1e9
     assert np.max(time_error_ns) < _TCB_TDB_ROUNDTRIP_NS
 
 

--- a/tests/test_tcb2tdb.py
+++ b/tests/test_tcb2tdb.py
@@ -302,9 +302,18 @@ DMX_0001 0.1
         ),
         allow_tcb="raw",
     )
+    m.add_DMX_ranges([53400], [53500], indices=[3], dmxs=[0.3])
     values = {
         name: m[name].value
-        for name in ("PX", "START", "FINISH", "DMXR1_0001", "DMXR2_0001")
+        for name in (
+            "PX",
+            "START",
+            "FINISH",
+            "DMXR1_0001",
+            "DMXR2_0001",
+            "DMXR1_0003",
+            "DMXR2_0003",
+        )
     }
 
     report = convert_tcb_tdb(m)
@@ -312,6 +321,7 @@ DMX_0001 0.1
     assert {name: m[name].value for name in values} == values
     assert set(values) <= set(report.invariant)
     assert np.isclose(m.DMX_0001.value, 0.1 * TCB_TDB_F)
+    assert np.isclose(m.DMX_0003.value, 0.3 * TCB_TDB_F)
 
 
 def test_report_accepts_only_audited_forward_components():

--- a/tests/test_tcb2tdb.py
+++ b/tests/test_tcb2tdb.py
@@ -3,7 +3,6 @@
 import os
 from copy import deepcopy
 from io import StringIO
-from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -51,6 +50,17 @@ DILATEFREQ          N
 # few ULPs of a day, ~0.05 ns, which is still well below the 1 ns
 # no-refit bound.
 _TCB_TDB_ROUNDTRIP_NS = 0.1
+
+
+def _delta_seconds(t1, t2):
+    """Difference of two ``Time`` objects in seconds, from two-part JD."""
+    delta = t1 - t2
+    day = np.longdouble(86400)
+    return np.longdouble(delta.jd1) * day + np.longdouble(delta.jd2) * day
+
+
+def _spin_phase(f0, f1, dt_s):
+    return f0 * dt_s + np.longdouble("0.5") * f1 * dt_s * dt_s
 
 
 @pytest.mark.parametrize("backwards", [True, False])
@@ -170,24 +180,29 @@ def test_fixed_frequency_dm_and_fd_scaling():
 
 
 def test_spindown_phase_closes_without_refitting():
+    # Evaluate F0/F1 against Astropy two-part JD intervals, not PINT's
+    # tdbld/Quantity/Horner path. That path downcasts to float64 on conda
+    # osx-64 (~10 ns over 1250 d) even when arrays still report float128.
     m = ModelBuilder()(StringIO(simplepar), allow_tcb="raw")
-    tcb_mjds = np.array([53750.0, 54000.0, 55000.0], dtype=np.longdouble)
-    tdb_mjds = np.array(
-        [time_from_longdouble(t, "tcb").tdb.mjd_long for t in tcb_mjds],
-        dtype=np.longdouble,
-    )
-    zero_delay = np.zeros(len(tcb_mjds)) * u.s
-    phase_tcb = m.components["Spindown"].spindown_phase(
-        SimpleNamespace(table={"tdbld": tcb_mjds}), zero_delay
-    )
+    tcb_times = [
+        time_from_longdouble(np.longdouble(t), "tcb")
+        for t in (53750.0, 54000.0, 55000.0)
+    ]
+    f0 = np.longdouble(m.F0.value)
+    f1 = np.longdouble(m.F1.value)
+    pepoch_tcb = time_from_longdouble(m.PEPOCH.value, "tcb")
+    dt_tcb = np.array([_delta_seconds(t, pepoch_tcb) for t in tcb_times])
+    phase_tcb = _spin_phase(f0, f1, dt_tcb)
 
     convert_tcb_tdb(m)
 
-    phase_tdb = m.components["Spindown"].spindown_phase(
-        SimpleNamespace(table={"tdbld": tdb_mjds}), zero_delay
-    )
-    time_error = (phase_tdb - phase_tcb) / m.F0.quantity
-    assert np.max(np.abs(time_error.to_value(u.ns))) < _TCB_TDB_ROUNDTRIP_NS
+    f0 = np.longdouble(m.F0.value)
+    f1 = np.longdouble(m.F1.value)
+    pepoch_tdb = m.PEPOCH.quantity
+    dt_tdb = np.array([_delta_seconds(t.tdb, pepoch_tdb) for t in tcb_times])
+    phase_tdb = _spin_phase(f0, f1, dt_tdb)
+    time_error_ns = np.abs((phase_tdb - phase_tcb) / f0) * 1e9
+    assert np.max(time_error_ns) < _TCB_TDB_ROUNDTRIP_NS
 
 
 def test_astrometric_position_closes_at_same_physical_epoch():

--- a/tests/test_tcb2tdb.py
+++ b/tests/test_tcb2tdb.py
@@ -45,6 +45,13 @@ PLANET_SHAPIRO      Y
 DILATEFREQ          N
 """
 
+# Forward TCB->TDB on a single Time object matches Astropy to ~0.01 ns.
+# Independent conversions and TCB<->TDB round-trips go through ERFA's
+# two-part JD. On astropy 5.0.5 (oldest supported) that lands within a
+# few ULPs of a day, ~0.05 ns, which is still well below the 1 ns
+# no-refit bound.
+_TCB_TDB_ROUNDTRIP_NS = 0.1
+
 
 @pytest.mark.parametrize("backwards", [True, False])
 def test_convert_units(backwards):
@@ -90,7 +97,7 @@ def test_coordinate_epoch_uses_astropy_iau_tdb():
     assert "PEPOCH" in report.converted
 
     convert_tcb_tdb(m, backwards=True)
-    assert abs((m.PEPOCH.quantity - original).to_value(u.ns)) < 0.01
+    assert abs((m.PEPOCH.quantity - original).to_value(u.ns)) < _TCB_TDB_ROUNDTRIP_NS
     assert m.PEPOCH.time_scale == "tcb"
 
 
@@ -180,7 +187,7 @@ def test_spindown_phase_closes_without_refitting():
         SimpleNamespace(table={"tdbld": tdb_mjds}), zero_delay
     )
     time_error = (phase_tdb - phase_tcb) / m.F0.quantity
-    assert np.max(np.abs(time_error.to_value(u.ns))) < 0.01
+    assert np.max(np.abs(time_error.to_value(u.ns))) < _TCB_TDB_ROUNDTRIP_NS
 
 
 def test_astrometric_position_closes_at_same_physical_epoch():


### PR DESCRIPTION
### PR description

This PR updates PINT’s TCB<-->TDB converter to support auditable, no-refit conversion at approximately nanosecond accuracy for the deterministic components that PINT explicitly supports.

My motivation is automatic pulsar-data combination in MetaPulsar. Combining releases from different PTAs sometimes requires converting TCB and TDB par files across timing engines. Refitting during ingestion is undesirable: it changes the scientific product and makes automated combinations harder to reproduce. For supported models, conversion should instead preserve the same physical timing solution.

The old converter used the legacy IFTE common-origin mapping. In particular, its epoch conversion omitted the approximately 65.5 μs TDB offset and used a slightly different rate from the IAU 2006 definition. Its DM scaling also did not match PINT’s actual fixed-frequency forward model.

This implementation follows several requirements we set before writing the code:

- Match PINT’s existing TDB forward model rather than defining an independent convention.
- Use Astropy/ERFA for IAU 2006 coordinate-time conversion.
- Keep radio frequency undilated, consistent with PINT’s `DILATEFREQ N` behavior.
- Avoid duplicated parameter lists where component-owned metadata can express the conversion.
- Convert everything currently supported, while leaving unsupported terms unchanged and warning clearly.
- Distinguish “conversion completed” from “conversion satisfies the tested no-refit contract.”
- Keep PX and UTC/data-span selectors explicitly invariant.
- Require discriminating delay or phase tests before certifying a component.

The resulting converter:

- converts coordinate epochs through Astropy’s TCB/TDB scales, including `TDB0`;
- applies order-aware scaling to DM Taylor coefficients;
- converts FD and FDJUMP coefficients under PINT’s fixed-frequency convention;
- records converted, invariant, unsupported, and unaudited terms in a `TCBTDBConversionReport`;
- remains permissive when it encounters unsupported model terms;
- reports `accepted=True` only when the model lies within the tested no-refit surface;
- preserves that acceptance assessment on repeated/no-op conversion calls.

The documentation and CLI now state the convention and acceptance contract explicitly. The changelog notes that converted epochs and DM values differ from legacy-IFTE output.

MetaPulsar also ingests native tempo2 par files, some of which cannot initially be parsed by PINT. Therefore this PR is not intended to replace MetaPulsar’s tempo2 conversion path. What we actually need longer-term is a corresponding tempo2 PR: one that provides the same auditable, permissive-conversion/strict-acceptance structure, but derives its scaling rules from tempo2’s own forward model and `DILATEFREQ` semantics. I plan to work on that or coordinate with Mike separately.

Thanks to @tcromartie for bringing it to my attention again yesterday during the DWG; it had been on my radar for months. I enjoyed the discussions!

Verification performed:

- Full PINT suite before review fixes: 2,502 passed, 20 skipped, 18 xfailed.
- Updated TCB/TDB suite: 21 passed.
- Parameter and model-construction regressions: 201 passed, 2 skipped, 2 xfailed.
- Formatting, diff checks, and lint checks pass.